### PR TITLE
Enable automake verbosity in the build.sh script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 ./autogen.sh
 CPPFLAGS='-I../../libzerocash -I../../libzerocash/depinst/include -I../../libzerocash/depinst/include/libsnark -DCURVE_BN128 -Wno-literal-suffix -std=c++11' ./configure --enable-hardening --with-incompatible-bdb
-make
+make AM_DEFAULT_VERBOSITY=1 "$@"


### PR DESCRIPTION
Enable automake verbosity in the build.sh script; this causes make to show each compilation/linking command prior to execution.  (Also, pass any other args to make.)
