### PR TITLE
Add explicit rules for building libzerocash .o files. #228

### DIFF
--- a/src/libzerocash/Makefile
+++ b/src/libzerocash/Makefile
@@ -33,6 +33,12 @@ SRCS= \
 
 #	$(TESTUTILS)/timer.cpp # BUG: Re-enable tests in the appropriate location.
 
+TEMPLATES= \
+	$(wildcard pour_ppzksnark/*.hpp) \
+	$(wildcard pour_ppzksnark/*.tcc) \
+	$(wildcard pour_ppzksnark/hashes/*.hpp) \
+	$(wildcard pour_ppzksnark/hashes/*.tcc)
+
 EXECUTABLES= \
 	tests/test_hash \
 	tests/test_pour_ppzksnark \
@@ -110,6 +116,18 @@ banktest_library: %: bankTest.o $(OBJS)
 
 merkletest_library: %: merkleTest.o $(OBJS) 
 	$(CXX) -o $@ $^ $(CXXFLAGS_ACTUAL) $(LDFLAGS_ACTUAL) $(LDLIBS_ACTUAL) -lzerocash
+
+utils/sha256.o: utils/sha256.cpp utils/sha256.h $(TEMPLATES)
+utils/util.o: utils/util.cpp utils/util.h $(TEMPLATES)
+Node.o: Node.cpp Node.h $(TEMPLATES)
+IncrementalMerkleTree.o: IncrementalMerkleTree.cpp IncrementalMerkleTree.h $(TEMPLATES)
+MerkleTree.o: MerkleTree.cpp MerkleTree.h $(TEMPLATES)
+Address.o: Address.cpp Address.h $(TEMPLATES)
+CoinCommitment.o: CoinCommitment.cpp CoinCommitment.h $(TEMPLATES)
+Coin.o: Coin.cpp Coin.h $(TEMPLATES)
+MintTransaction.o: MintTransaction.cpp MintTransaction.h $(TEMPLATES)
+PourTransaction.o: PourTransaction.cpp PourTransaction.h $(TEMPLATES)
+ZerocashParams.o: ZerocashParams.cpp ZerocashParams.h $(TEMPLATES)
 
 .PHONY: clean
 


### PR DESCRIPTION
This fixes #228 by making all of the `.o` files depend on all of the template files. This is inefficient, in the sense that if any of the template files change, _all_ of the `.o`s will be rebuilt, even the `.o`s that don't depend on any of the templates. I think we should err on the side of rebuilding too much, rather than not rebuilding when source changes have been made.
