### PR TITLE
zc.v0.10.0.ticket175.build-static-libsnark.1

### DIFF
--- a/depends/packages/libsnark.mk
+++ b/depends/packages/libsnark.mk
@@ -9,6 +9,8 @@ $(package)_git_commit=2474695678b3529841eced49ea97ca683e91996c
 $(package)_dependencies=crypto++ libgmp xbyak ate-pairing
 $(package)_patches=1_cxxflags_prefix.patch 2_fix_Wl_flag.patch 3_ldflags_prefix.patch 4_make_depinst_optional.patch
 
+$(package)_cppflags += -fPIC
+
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/1_cxxflags_prefix.patch && \
     patch -p1 < $($(package)_patch_dir)/2_fix_Wl_flag.patch && \
@@ -21,5 +23,5 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) install PREFIX=$($(package)_staging_dir)$(host_prefix) CURVE=ALT_BN128
+  $(MAKE) install STATIC=1 PREFIX=$($(package)_staging_dir)$(host_prefix) CURVE=ALT_BN128
 endef


### PR DESCRIPTION
I think this also fixes #226, because the `zerocoinpour` command runs, making one of my CPU cores run at 100%, so I think that means the SNARK stuff is working.
