### PR TITLE
Fix omitted undo

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -10,7 +10,7 @@
 #include <assert.h>
 
 // Zerocoin changes
-CCoinsImmuntable MakeFakeZerocoinCCoin() {
+CCoinsImmutable MakeFakeZerocoinCCoin() {
     CMutableTransaction dummy;
     {
     CScript scriptPubKey;
@@ -26,7 +26,7 @@ CCoinsImmuntable MakeFakeZerocoinCCoin() {
     CTxOut out(1,scriptPubKey);
     dummy.vout.push_back(out);
     }
-    CCoinsImmuntable fake(dummy);
+    CCoinsImmutable fake(dummy);
     return fake;
 }
 
@@ -37,8 +37,8 @@ bool isSerialSpendable(const CCoinsView &v, const uint256 &txid, const uint256 &
         return true;
     }
 }
-bool markeSerialAsSpent(CCoinsView &v, const uint256 &serial,const uint256 &txid) {
-    LogPrint("zerocoin","zerocoin markeSerialAsSpent: marking serial %s as spent by %s \n", serial.ToString(), txid.ToString());
+bool markSerialAsSpent(CCoinsView &v, const uint256 &serial,const uint256 &txid) {
+    LogPrint("zerocoin","zerocoin markSerialAsSpent: marking serial %s as spent by %s \n", serial.ToString(), txid.ToString());
     return v.SetSerial(serial, txid);
 }
 bool markSerialAsUnSpent(CCoinsView &v, const uint256 &serial) {

--- a/src/coins.h
+++ b/src/coins.h
@@ -294,11 +294,11 @@ struct CCoinsCacheEntry
 
 typedef boost::unordered_map<uint256, CCoinsCacheEntry, CCoinsKeyHasher> CCoinsMap;
 
-class CCoinsImmuntable : public CCoins
+class CCoinsImmutable : public CCoins
 {
 public:
     // remove spent outputs at the end of vout
-    CCoinsImmuntable(const CTransaction &tx) :CCoins(tx) {
+    CCoinsImmutable(const CTransaction &tx) :CCoins(tx) {
         fCoinBase = true;
     }
 
@@ -366,11 +366,11 @@ public:
     virtual ~CCoinsView() {}
 };
 
-CCoinsImmuntable MakeFakeZerocoinCCoin();
+CCoinsImmutable MakeFakeZerocoinCCoin();
 
 bool isSerialSpendable(const CCoinsView &v,const uint256 &txid, const uint256 &serial,uint256 &idOfTxThatSpentIt);
 
-bool markeSerialAsSpent(CCoinsView &v, const uint256 &serial,const uint256 &txid);
+bool markSerialAsSpent(CCoinsView &v, const uint256 &serial,const uint256 &txid);
 bool markSerialAsUnSpent(CCoinsView &v, const uint256 &serial);
 
 /** CCoinsView backed by another CCoinsView */
@@ -491,7 +491,7 @@ private:
     CCoinsMap::iterator FetchCoins(const uint256 &txid);
     CCoinsMap::const_iterator FetchCoins(const uint256 &txid) const;
 
-    CCoinsImmuntable zerocoin_input;
+    CCoinsImmutable zerocoin_input;
 };
 
 #endif // BITCOIN_COINS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1449,7 +1449,7 @@ void UpdateCoins(const CTransaction& tx, CValidationState &state, CCoinsViewCach
 
                 if (txin.IsZCPour()) {
                     BOOST_FOREACH(const uint256 serial, txin.GetZerocoinSerialNumbers()) {
-                        markeSerialAsSpent(inputs, serial, tx.GetHash());
+                        markSerialAsSpent(inputs, serial, tx.GetHash());
                     }
                 }
             } else {


### PR DESCRIPTION
We weren't pushing a CTxInUndo for our Pour/Mint transactions, and so when the client restarted and attempted to verify blocks (or in any event that would trigger a reorg) assertions were triggered. This would crash the daemon [permanently](https://github.com/Electric-Coin-Company/zerocashd/issues/284#issuecomment-145687088).

I also fixed some spelling errors I came across.
