### PR TITLE
zc.v0.10.0.ticket336.set-include-path-for-ac-check-header.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -760,9 +760,11 @@ CPPFLAGS="-I$LIBZEROCASH_INCDIR $CPPFLAGS"
 
 # libzerocash depends on headers in ./src/, so for the following
 # AC_CHECK_HEADER, that has to be on the include path list.
+CPPFLAGS_TEMP="$CPPFLAGS"
 CPPFLAGS="-I ./src/ $CPPFLAGS"
 AC_CHECK_HEADER([libzerocash/libzerocash/Zerocash.h],,AC_MSG_ERROR(libzerocash headers missing))
 AC_CHECK_LIB([zerocash], [main],LIBZEROCASH_LIBS="-lzerocash -lsnark -lcryptopp -lgmp -lgmpxx -lzm -lboost_system-mt -lcrypto", [AC_MSG_ERROR(libzerocash missing)], [-lsnark -lcryptopp -lgmp -lgmpxx -lzm -lboost_system-mt -lcrypto])
+CPPFLAGS="$CPPFLAGS_TEMP"
 
 CFLAGS_TEMP="$CFLAGS"
 LIBS_TEMP="$LIBS"


### PR DESCRIPTION
Proposal to fix #336. I don't really like it since it changes `CPPFLAGS` for the entire build.
