### PR TITLE
Added zc-raw-protect RPC.

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -35,6 +35,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "zerocoinmint", 0 }, // amount
     { "zerocoinmint", 1 }, // change amount
     { "zerocoinpour", 1 }, // bool - include snark proof?
+    { "zc-raw-protect", 2 }, // amount to protect
     { "settxfee", 0 },
     { "getreceivedbyaddress", 1 },
     { "getreceivedbyaccount", 1 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -289,6 +289,7 @@ static const CRPCCommand vRPCCommands[] =
     { "rawtransactions",    "zerocoinmint",           &zerocoinmint,           false,     false,      true },
     { "rawtransactions",    "zerocoinpour",           &zerocoinpour,           false,     false,      true },
     { "rawtransactions",    "zc-raw-keygen",          &zc_raw_keygen,          false,     false,      true },
+    { "rawtransactions",    "zc-raw-protect",         &zc_raw_protect,         false,     false,      true },
 #endif
 
     /* Raw transactions */

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -173,6 +173,7 @@ extern json_spirit::Value sendtoaddress(const json_spirit::Array& params, bool f
 extern json_spirit::Value zerocoinpour(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value zerocoinmint(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value zc_raw_keygen(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value zc_raw_protect(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value signmessage(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifymessage(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
This differs from the existing spec, in that it accepts a raw transaction which has already been populated with the inputs and change output, a `zc-raw-keygen` public address, and a value to protect, and produces a protected output raw transaction with the commitment and bucket secrets.

Nathan and Taylor and I decided that this was a superior design.
