### PR TITLE
Append the preferred local filename to fallback url, rather than upstream filename.

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -23,7 +23,7 @@ define fetch_file
 (test -f $$($(1)_source_dir)/$(4) || \
   ( mkdir -p $$($(1)_download_dir) && echo Fetching $(1)... && \
   ( $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(2)/$(3)" || \
-    $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(FALLBACK_DOWNLOAD_PATH)/$(3)" ) && \
+    $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(FALLBACK_DOWNLOAD_PATH)/$(4)" ) && \
     echo "$(5)  $$($(1)_download_dir)/$(4).temp" > $$($(1)_download_dir)/.$(4).hash && \
     $(build_SHA256SUM) -c $$($(1)_download_dir)/.$(4).hash && \
     mv $$($(1)_download_dir)/$(4).temp $$($(1)_source_dir)/$(4) && \


### PR DESCRIPTION
In some cases, such as for github revision tarballs, the upstream
filename is just `$HASH.tar.gz`, but the local filename is
`${PACKAGE_NAME}-${HASH}.tar.gz`. With this patch, it's clear which
packages each URLs provides _and_ it makes the process of updating
http://z.cash/depends/sources a simple scp rather than involving some
kind of name translation.

Closes #622.
