### PR TITLE
Lazily load the proving key at time of first pour.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -604,17 +604,8 @@ static void ZC_LoadParams()
     boost::filesystem::path pk_path = ZC_GetParamsDir() / "zc-testnet-public-alpha-proving.key";
     boost::filesystem::path vk_path = ZC_GetParamsDir() / "zc-testnet-public-alpha-verification.key";
 
-    LogPrintf("Loading proving key from %s\n", pk_path.string().c_str());
-    gettimeofday(&tv_start, 0);
     libzerocash::ZerocashParams::zerocash_pp::init_public_params();
-    auto pk_loaded = libzerocash::ZerocashParams::LoadProvingKeyFromFile(
-        pk_path.string(),
-        INCREMENTAL_MERKLE_TREE_DEPTH
-    );
-    gettimeofday(&tv_end, 0);
-    elapsed = float(tv_end.tv_sec-tv_start.tv_sec) + (tv_end.tv_usec-tv_start.tv_usec)/float(1000000);
-    LogPrintf("Loaded proving key in %fs seconds.\n", elapsed);
-
+    
 
     LogPrintf("Loading verification key from %s\n", vk_path.string().c_str());
     gettimeofday(&tv_start, 0);
@@ -628,8 +619,8 @@ static void ZC_LoadParams()
 
     pzerocashParams = new libzerocash::ZerocashParams(
         INCREMENTAL_MERKLE_TREE_DEPTH,
-        &pk_loaded,
-        &vk_loaded
+        &vk_loaded,
+        pk_path.string()
     );
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -605,7 +605,7 @@ static void ZC_LoadParams()
     boost::filesystem::path vk_path = ZC_GetParamsDir() / "zc-testnet-public-alpha-verification.key";
 
     libzerocash::ZerocashParams::zerocash_pp::init_public_params();
-    
+
 
     LogPrintf("Loading verification key from %s\n", vk_path.string().c_str());
     gettimeofday(&tv_start, 0);
@@ -619,8 +619,8 @@ static void ZC_LoadParams()
 
     pzerocashParams = new libzerocash::ZerocashParams(
         INCREMENTAL_MERKLE_TREE_DEPTH,
-        &vk_loaded,
-        pk_path.string()
+        pk_path.string(),
+        &vk_loaded
     );
 }
 

--- a/src/zerocash/PourTransaction.cpp
+++ b/src/zerocash/PourTransaction.cpp
@@ -132,6 +132,7 @@ void PourTransaction::init(uint16_t version_num,
                      const Coin& c_1_new,
                      const Coin& c_2_new)
 {
+    params.loadProvingKey();
     this->version = version_num;
 
     convertIntToBytesVector(v_pub_old, this->publicOldValue);

--- a/src/zerocash/ZerocashParams.cpp
+++ b/src/zerocash/ZerocashParams.cpp
@@ -129,6 +129,17 @@ ZerocashParams::ZerocashParams(
 
 ZerocashParams::ZerocashParams(
     const unsigned int tree_depth,
+    zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1,
+    std::string proving_key_path
+) : 
+    treeDepth(tree_depth), provingKeyPath(proving_key_path)
+{
+    params_vk_v1 = new zerocash_pour_verification_key<ZerocashParams::zerocash_pp>(*p_vk_1);
+    params_pk_v1 = NULL;
+}
+
+ZerocashParams::ZerocashParams(
+    const unsigned int tree_depth,
     zerocash_pour_proving_key<ZerocashParams::zerocash_pp>* p_pk_1,
     zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1
 ) :

--- a/src/zerocash/ZerocashParams.cpp
+++ b/src/zerocash/ZerocashParams.cpp
@@ -129,8 +129,8 @@ ZerocashParams::ZerocashParams(
 
 ZerocashParams::ZerocashParams(
     const unsigned int tree_depth,
-    zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1,
-    std::string proving_key_path
+    std::string proving_key_path,
+    zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1
 ) : 
     treeDepth(tree_depth), provingKeyPath(proving_key_path)
 {

--- a/src/zerocash/ZerocashParams.h
+++ b/src/zerocash/ZerocashParams.h
@@ -35,6 +35,12 @@ public:
         zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1
     );
 
+    ZerocashParams(
+        const unsigned int tree_depth,
+        zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1,
+        std::string proving_key_path
+    );
+
     const zerocash_pour_proving_key<zerocash_pp>& getProvingKey();
     const zerocash_pour_verification_key<zerocash_pp>& getVerificationKey();
     int getTreeDepth();
@@ -49,10 +55,21 @@ public:
     static void SaveVerificationKeyToFile(const zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1, std::string path);
     static zerocash_pour_proving_key<ZerocashParams::zerocash_pp> LoadProvingKeyFromFile(std::string path, const unsigned int tree_depth);
     static zerocash_pour_verification_key<ZerocashParams::zerocash_pp> LoadVerificationKeyFromFile(std::string path, const unsigned int tree_depth);
+
+    void loadProvingKey()
+    {
+        if (params_pk_v1 == NULL) {
+            std::cout << "loading proving key from path: " << provingKeyPath << std::endl;
+            params_pk_v1 = new zerocash_pour_proving_key<ZerocashParams::zerocash_pp>(
+                                LoadProvingKeyFromFile(provingKeyPath, treeDepth));
+            std::cout << "done loading proving key!" << std::endl;
+        }
+    }
 private:
     int treeDepth;
     zerocash_pour_proving_key<ZerocashParams::zerocash_pp>* params_pk_v1;
     zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* params_vk_v1;
+    std::string provingKeyPath;
 };
 
 } /* namespace libzerocash */

--- a/src/zerocash/ZerocashParams.h
+++ b/src/zerocash/ZerocashParams.h
@@ -37,8 +37,8 @@ public:
 
     ZerocashParams(
         const unsigned int tree_depth,
-        zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1,
-        std::string proving_key_path
+        std::string proving_key_path,
+        zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1
     );
 
     const zerocash_pour_proving_key<zerocash_pp>& getProvingKey();


### PR DESCRIPTION
This will make node initialization faster (since reading and deserializing that key takes a while) which should speed up some of our test suite.

Closes #599.