### PR TITLE
Use EquiHash for PoW

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -241,6 +241,8 @@ libbitcoin_wallet_a_SOURCES = \
 crypto_libbitcoin_crypto_a_CPPFLAGS = $(BITCOIN_CONFIG_INCLUDES)
 crypto_libbitcoin_crypto_a_SOURCES = \
   crypto/common.h \
+  crypto/equihash.cpp \
+  crypto/equihash.h \
   crypto/hmac_sha256.cpp \
   crypto/hmac_sha256.h \
   crypto/hmac_sha512.cpp \
@@ -425,6 +427,7 @@ libzerocash_a_CPPFLAGS = -fPIC -DCURVE_ALT_BN128 -DBOOST_SPIRIT_THREADSAFE -DHAV
 if BUILD_BITCOIN_LIBS
 include_HEADERS = script/bitcoinconsensus.h
 libbitcoinconsensus_la_SOURCES = \
+  crypto/equihash.cpp \
   crypto/hmac_sha512.cpp \
   crypto/ripemd160.cpp \
   crypto/sha1.cpp \

--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -145,15 +145,33 @@ double base_uint<BITS>::getdouble() const
 }
 
 template <unsigned int BITS>
+base_blob<BITS> ArithToUint(const base_uint<BITS> &a)
+{
+    base_blob<BITS> b;
+    for(int x=0; x<a.WIDTH; ++x)
+        WriteLE32(b.begin() + x*4, a.pn[x]);
+    return b;
+}
+
+template <unsigned int BITS>
+base_uint<BITS> UintToArith(const base_blob<BITS> &a)
+{
+    base_uint<BITS> b;
+    for(int x=0; x<b.WIDTH; ++x)
+        b.pn[x] = ReadLE32(a.begin() + x*4);
+    return b;
+}
+
+template <unsigned int BITS>
 std::string base_uint<BITS>::GetHex() const
 {
-    return ArithToUint256(*this).GetHex();
+    return ArithToUint(*this).GetHex();
 }
 
 template <unsigned int BITS>
 void base_uint<BITS>::SetHex(const char* psz)
 {
-    *this = UintToArith256(uint256S(psz));
+    *this = UintToArith(uintS<BITS>(psz));
 }
 
 template <unsigned int BITS>
@@ -183,6 +201,25 @@ unsigned int base_uint<BITS>::bits() const
     return 0;
 }
 
+// Explicit instantiations for base_uint<160>
+template base_uint<160>::base_uint(const std::string&);
+template base_uint<160>& base_uint<160>::operator<<=(unsigned int);
+template base_uint<160>& base_uint<160>::operator>>=(unsigned int);
+template base_uint<160>& base_uint<160>::operator*=(uint32_t b32);
+template base_uint<160>& base_uint<160>::operator*=(const base_uint<160>& b);
+template base_uint<160>& base_uint<160>::operator/=(const base_uint<160>& b);
+template int base_uint<160>::CompareTo(const base_uint<160>&) const;
+template bool base_uint<160>::EqualTo(uint64_t) const;
+template double base_uint<160>::getdouble() const;
+template std::string base_uint<160>::GetHex() const;
+template std::string base_uint<160>::ToString() const;
+template void base_uint<160>::SetHex(const char*);
+template void base_uint<160>::SetHex(const std::string&);
+template unsigned int base_uint<160>::bits() const;
+template unsigned int base_uint<160>::GetSerializeSize(int nType, int nVersion) const;
+template<> template<typename Stream> void base_uint<160>::Serialize(Stream& s, int nType, int nVersion) const;
+template<> template<typename Stream> void base_uint<160>::Unserialize(Stream& s, int nType, int nVersion);
+
 // Explicit instantiations for base_uint<256>
 template base_uint<256>::base_uint(const std::string&);
 template base_uint<256>& base_uint<256>::operator<<=(unsigned int);
@@ -198,6 +235,9 @@ template std::string base_uint<256>::ToString() const;
 template void base_uint<256>::SetHex(const char*);
 template void base_uint<256>::SetHex(const std::string&);
 template unsigned int base_uint<256>::bits() const;
+template unsigned int base_uint<256>::GetSerializeSize(int nType, int nVersion) const;
+template<> template<typename Stream> void base_uint<256>::Serialize(Stream& s, int nType, int nVersion) const;
+template<> template<typename Stream> void base_uint<256>::Unserialize(Stream& s, int nType, int nVersion);
 
 // This implementation directly uses shifts instead of going
 // through an intermediate MPI representation.
@@ -246,15 +286,10 @@ uint32_t arith_uint256::GetCompact(bool fNegative) const
 
 uint256 ArithToUint256(const arith_uint256 &a)
 {
-    uint256 b;
-    for(int x=0; x<a.WIDTH; ++x)
-        WriteLE32(b.begin() + x*4, a.pn[x]);
-    return b;
+    return ArithToUint(a);
 }
+
 arith_uint256 UintToArith256(const uint256 &a)
 {
-    arith_uint256 b;
-    for(int x=0; x<b.WIDTH; ++x)
-        b.pn[x] = ReadLE32(a.begin() + x*4);
-    return b;
+    return UintToArith(a);
 }

--- a/src/chain.h
+++ b/src/chain.h
@@ -143,7 +143,8 @@ public:
     uint256 hashMerkleRoot;
     unsigned int nTime;
     unsigned int nBits;
-    unsigned int nNonce;
+    arith_uint160 nNonce;
+    std::vector<uint32_t> nSoln;
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
@@ -167,7 +168,8 @@ public:
         hashMerkleRoot = uint256();
         nTime          = 0;
         nBits          = 0;
-        nNonce         = 0;
+        nNonce         = arith_uint160();
+        nSoln          = std::vector<uint32_t>();
     }
 
     CBlockIndex()
@@ -184,6 +186,7 @@ public:
         nTime          = block.nTime;
         nBits          = block.nBits;
         nNonce         = block.nNonce;
+        nSoln          = block.nSoln;
     }
 
     CDiskBlockPos GetBlockPos() const {
@@ -214,6 +217,7 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.nNonce         = nNonce;
+        block.nSoln          = nSoln;
         return block;
     }
 
@@ -320,6 +324,7 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
+        READWRITE(nSoln);
     }
 
     uint256 GetBlockHash() const
@@ -331,6 +336,7 @@ public:
         block.nTime           = nTime;
         block.nBits           = nBits;
         block.nNonce          = nNonce;
+        block.nSoln           = nSoln;
         return block.GetHash();
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -79,9 +79,11 @@ public:
         genesis.nTime    = 1231006505;
         genesis.nBits    = 0x1d00ffff;
         genesis.nNonce   = 2083236893;
+        genesis.nSoln    = {0};
 
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
+        // TODO replace
+        //assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
         vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be")); // Pieter Wuille
@@ -157,7 +159,8 @@ public:
         genesis.nBits = 0x207fffff;
         genesis.nNonce = 2;
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
+        // TODO replace
+        //assert(consensus.hashGenesisBlock == uint256S("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
 
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -217,7 +220,8 @@ public:
         genesis.nNonce = 2;
         consensus.hashGenesisBlock = genesis.GetHash();
         nDefaultPort = 18444;
-        assert(consensus.hashGenesisBlock == uint256S("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
+        // TODO replace
+        //assert(consensus.hashGenesisBlock == uint256S("0x2ab106b579e385ecc94ca8490a3e74dcdec23e65f993f994a0623a50fb5bbacf"));
         nPruneAfterHeight = 1000;
 
         vFixedSeeds.clear(); //! Regtest mode doesn't have any fixed seeds.

--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2016 Jack Grigg
+// Copyright (c) 2016 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "crypto/equihash.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+
+void validate_params(int n, int k)
+{
+    if (k>=n) {
+        std::cerr << "n must be larger than k\n";
+        throw invalid_params();
+    }
+    if ((n/(k+1)) % 8 != 0) {
+        std::cerr << "Parameters must satisfy n/(k+1) = 0 mod 8\n";
+        throw invalid_params();
+    }
+}
+
+bool stepRowSorter(StepRow &lhs, StepRow &rhs)
+{
+    return lhs.hash < rhs.hash;
+}
+
+bool hasCollision(const unsigned char* ha, const unsigned char* hb, int i, int l)
+{
+    bool res = true;
+    for (int j = (i - 1) * l / 8; j < i * l / 8; j++)
+        res &= ha[j] == hb[j];
+    return res;
+}
+
+bool distinctIndices(const std::vector<uint32_t>& ia,
+        const std::vector<uint32_t>& ib)
+{
+    unsigned int i = 0, j = 0;
+    while (i < ia.size() && j < ib.size()) {
+        while (ia[i] < ia[j])
+            i++;
+        while (ia[i] > ia[j])
+            j++;
+        if (ia[i] == ib[j])
+            return false;
+    }
+    return true;
+}
+
+unsigned char* xorHashes(const unsigned char* ha, const unsigned char* hb, int len)
+{
+    unsigned char res[len];
+    for (int i = 0; i < len; i++)
+        res[i] = ha[i] ^ hb[i];
+    return res;
+}
+
+void combineIndices(const std::vector<uint32_t>& ia,
+        const std::vector<uint32_t>& ib, std::vector<uint32_t> &ic)
+{
+    ic.reserve(ia.size() + ib.size());
+    ic.insert(ic.end(), ia.begin(), ia.end());
+    ic.insert(ic.end(), ib.begin(), ib.end());
+    std::sort(ic.begin(), ic.end());
+}
+
+bool isZero(unsigned char* hash, int len)
+{
+    char res = 0;
+    for (int i = 0; i < len; i++)
+        res |= hash[i];
+    return res == 0;
+}
+
+EquiHash::EquiHash(unsigned int n, unsigned int k) :
+        n(n), k(k)
+{
+    validate_params(n, k);
+}
+
+std::vector<std::vector<uint32_t>> EquiHash::Solve(const CSHA256 base_hasher)
+{
+    unsigned int collision_length { n / (k + 1) };
+    unsigned int init_size { pow(2, (collision_length + 1)) };
+
+    // 1) Generate first list
+    std::vector<StepRow> X;
+    X.reserve(init_size);
+    for (uint32_t i = 0; i < init_size; i++) {
+        StepRow Xi;
+        // TODO truncate first list or generate correct size
+        CSHA256(base_hasher).Write((unsigned char*) &i, sizeof(uint32_t)).Finalize(
+                Xi.hash);
+        Xi.indices.push_back(i);
+        X[i] = Xi;
+    }
+
+    // 3) Repeat step 2 until 2n/(k+1) bits remain
+    for (int i = 1; i < k; i++) {
+        // 2a) Sort the list
+        std::sort(X.begin(), X.end(), stepRowSorter);
+
+        std::vector<StepRow> Xc;
+        Xc.reserve(X.size());
+        while (X.size() > 0) {
+            // 2b) Find next set of unordered pairs with collisions on first n/(k+1) bits
+            int j = 1;
+            while (j < X.size()) {
+                if (!hasCollision(X[X.size() - 1].hash,
+                        X[X.size() - 1 - j].hash, i, collision_length))
+                    break;
+                j++;
+            }
+
+            // 2c) Store tuples (X_i ^ X_j, (i, j)) on the table
+            for (int l = 0; l < j - 1; l++) {
+                for (int m = l + 1; m < j; m++) {
+                    StepRow *Xl = &X[X.size() - 1 - l];
+                    StepRow *Xm = &X[X.size() - 1 - m];
+                    if (distinctIndices(Xl->indices, Xm->indices)) {
+                        StepRow Xi;
+                        Xi.hash = xorHashes(Xl->hash, Xm->hash, n);
+                        combineIndices(Xl->indices, Xm->indices, Xi.indices);
+                        Xc.push_back(Xi);
+                    }
+                }
+            }
+
+            // 2d) Drop this set
+            X.erase(X.end() - j, X.end());
+        }
+
+        // 2e) Replace previous list with new list
+        X = Xc;
+    }
+
+    // k+1) Find a collision on last 2n(k+1) bits
+    std::vector<std::vector<uint32_t>> solns;
+    std::sort(X.begin(), X.end(), stepRowSorter);
+    for (int i = 0; i < sizeof(X) - 1; i++) {
+        unsigned char* res = xorHashes(X[i].hash, X[i + 1].hash, n);
+        if (isZero(res, n) && X[i].indices != X[i + 1].indices) {
+            std::vector<uint32_t> soln;
+            combineIndices(X[i].indices, X[i + 1].indices, soln);
+            solns.push_back(soln);
+        }
+    }
+
+    return solns;
+}

--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "crypto/equihash.h"
+#include "util.h"
 
 #include <algorithm>
 #include <cmath>
@@ -123,6 +124,7 @@ std::vector<std::vector<uint32_t>> EquiHash::Solve(const CSHA256& base_hasher)
     unsigned int init_size { pow(2, (collision_length + 1)) };
 
     // 1) Generate first list
+    LogPrint("pow", "Generating first list\n");
     std::vector<StepRow> X;
     X.reserve(init_size);
     for (uint32_t i = 0; i < init_size; i++) {
@@ -131,9 +133,12 @@ std::vector<std::vector<uint32_t>> EquiHash::Solve(const CSHA256& base_hasher)
 
     // 3) Repeat step 2 until 2n/(k+1) bits remain
     for (int i = 1; i < k; i++) {
+        LogPrint("pow", "Round %d:\n", i);
         // 2a) Sort the list
+        LogPrint("pow", "- Sorting list\n");
         std::sort(X.begin(), X.end());
 
+        LogPrint("pow", "- Finding collisions\n");
         std::vector<StepRow> Xc;
         Xc.reserve(X.size());
         while (X.size() > 0) {
@@ -162,8 +167,11 @@ std::vector<std::vector<uint32_t>> EquiHash::Solve(const CSHA256& base_hasher)
     }
 
     // k+1) Find a collision on last 2n(k+1) bits
+    LogPrint("pow", "Final round:\n");
     std::vector<std::vector<uint32_t>> solns;
+    LogPrint("pow", "- Sorting list\n");
     std::sort(X.begin(), X.end());
+    LogPrint("pow", "- Finding collisions\n");
     for (int i = 0; i < X.size() - 1; i++) {
         StepRow res = X[i] ^ X[i+1];
         if (res.IsZero())

--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2016 Jack Grigg
+// Copyright (c) 2016 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_EQUIHASH_H
+#define BITCOIN_EQUIHASH_H
+
+#include "crypto/sha256.h"
+
+#include <vector>
+
+struct StepRow
+{
+    unsigned char* hash;
+    std::vector<uint32_t> indices;
+};
+
+struct invalid_params { };
+
+class EquiHash
+{
+private:
+    unsigned int n;
+    unsigned int k;
+
+public:
+    EquiHash(unsigned int n, unsigned int k);
+    std::vector<std::vector<uint32_t>> Solve(const CSHA256 base_hasher);
+};
+
+#endif // BITCOIN_EQUIHASH_H

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -6,6 +6,7 @@
 
 #include "crypto/common.h"
 
+#include <algorithm>
 #include <string.h>
 
 // Internal implementation code.
@@ -136,6 +137,12 @@ void Transform(uint32_t* s, const unsigned char* chunk)
 CSHA256::CSHA256() : bytes(0)
 {
     sha256::Initialize(s);
+}
+
+CSHA256::CSHA256(const CSHA256 &h) : bytes(h.bytes)
+{
+    std::copy(h.s,   h.s+8,    s);
+    std::copy(h.buf, h.buf+64, buf);
 }
 
 CSHA256& CSHA256::Write(const unsigned char* data, size_t len)

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -20,6 +20,7 @@ public:
     static const size_t OUTPUT_SIZE = 32;
 
     CSHA256();
+    CSHA256(const CSHA256 &h);
     CSHA256& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     CSHA256& Reset();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -489,7 +489,9 @@ void static BitcoinMiner(CWallet *pwallet)
                     curr_hasher.Write((unsigned char*)&(pblock->nNonce), 20);
 
                     // (x_1, x_2, ...) = A(I, V, n, k)
+                    LogPrint("pow", "Running EquiHash solver with nNonce = %s\n", pblock->nNonce.ToString());
                     std::vector<std::vector<unsigned int>> solns = solver.Solve(curr_hasher);
+                    LogPrint("pow", "Solutions: %d\n", solns.size());
 
                     // Write the solution to the hash and compute the result.
                     for (auto soln : solns) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -426,6 +426,8 @@ void static BitcoinMiner(CWallet *pwallet)
     CReserveKey reservekey(pwallet);
     unsigned int nExtraNonce = 0;
 
+    EquiHash solver {96, 5};
+
     try {
         while (true) {
             if (chainparams.MiningRequiresPeers()) {
@@ -464,7 +466,6 @@ void static BitcoinMiner(CWallet *pwallet)
             //
             // Search
             //
-            EquiHash solver {96, 5};
             int64_t nStart = GetTime();
             arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
             uint256 hash;
@@ -473,8 +474,7 @@ void static BitcoinMiner(CWallet *pwallet)
             // I = the first 76 bytes of the block header.
             CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
             ss << *pblock;
-            // TODO depends on size of solution array
-            assert(ss.size() == 96);
+            assert(ss.size() >= 96);
 
             // H(I||...
             CSHA256 hasher;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -18,6 +18,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #ifdef ENABLE_WALLET
+#include "crypto/equihash.h"
 #include "wallet/wallet.h"
 #endif
 
@@ -338,7 +339,8 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
         pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
         UpdateTime(pblock, Params().GetConsensus(), pindexPrev);
         pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, Params().GetConsensus());
-        pblock->nNonce         = 0;
+        pblock->nNonce         = arith_uint160();
+        pblock->nSoln          = std::vector<uint32_t>();
         pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(pblock->vtx[0]);
 
         CValidationState state;
@@ -374,39 +376,6 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
 // Internal miner
 //
 
-//
-// ScanHash scans nonces looking for a hash with at least some zero bits.
-// The nonce is usually preserved between calls, but periodically or if the
-// nonce is 0xffff0000 or above, the block is rebuilt and nNonce starts over at
-// zero.
-//
-bool static ScanHash(const CBlockHeader *pblock, uint32_t& nNonce, uint256 *phash)
-{
-    // Write the first 76 bytes of the block header to a double-SHA256 state.
-    CHash256 hasher;
-    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-    ss << *pblock;
-    assert(ss.size() == 80);
-    hasher.Write((unsigned char*)&ss[0], 76);
-
-    while (true) {
-        nNonce++;
-
-        // Write the last 4 bytes of the block header (the nonce) to a copy of
-        // the double-SHA256 state, and compute the result.
-        CHash256(hasher).Write((unsigned char*)&nNonce, 4).Finalize((unsigned char*)phash);
-
-        // Return the nonce if the hash has at least some zero bits,
-        // caller will check if it has enough to reach the target
-        if (((uint16_t*)phash)[15] == 0)
-            return true;
-
-        // If nothing found after trying for a while, return -1
-        if ((nNonce & 0xfff) == 0)
-            return false;
-    }
-}
-
 CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey)
 {
     CPubKey pubkey;
@@ -426,7 +395,7 @@ static bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& rese
     {
         LOCK(cs_main);
         if (pblock->hashPrevBlock != chainActive.Tip()->GetBlockHash())
-            return error("BitcoinMiner: generated block is stale");
+            return error("ZcashMiner: generated block is stale");
     }
 
     // Remove key from key pool
@@ -441,16 +410,16 @@ static bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& rese
     // Process this block the same as if we had received it from another node
     CValidationState state;
     if (!ProcessNewBlock(state, NULL, pblock, true, NULL))
-        return error("BitcoinMiner: ProcessNewBlock, block not accepted");
+        return error("ZcashMiner: ProcessNewBlock, block not accepted");
 
     return true;
 }
 
 void static BitcoinMiner(CWallet *pwallet)
 {
-    LogPrintf("BitcoinMiner started\n");
+    LogPrintf("ZcashMiner started\n");
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
-    RenameThread("bitcoin-miner");
+    RenameThread("zcash-miner");
     const CChainParams& chainparams = Params();
 
     // Each thread has its own key and counter
@@ -483,34 +452,60 @@ void static BitcoinMiner(CWallet *pwallet)
             auto_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(reservekey));
             if (!pblocktemplate.get())
             {
-                LogPrintf("Error in BitcoinMiner: Keypool ran out, please call keypoolrefill before restarting the mining thread\n");
+                LogPrintf("Error in ZcashMiner: Keypool ran out, please call keypoolrefill before restarting the mining thread\n");
                 return;
             }
             CBlock *pblock = &pblocktemplate->block;
             IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
 
-            LogPrintf("Running BitcoinMiner with %u transactions in block (%u bytes)\n", pblock->vtx.size(),
+            LogPrintf("Running ZcashMiner with %u transactions in block (%u bytes)\n", pblock->vtx.size(),
                 ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION));
 
             //
             // Search
             //
+            EquiHash solver {96, 5};
             int64_t nStart = GetTime();
             arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
             uint256 hash;
-            uint32_t nNonce = 0;
+            std::vector<unsigned int> soln;
+
+            // I = the first 76 bytes of the block header.
+            CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+            ss << *pblock;
+            // TODO depends on size of solution array
+            assert(ss.size() == 96);
+
+            // H(I||...
+            CSHA256 hasher;
+            hasher.Write((unsigned char*)&ss[0], 76);
+
             while (true) {
-                // Check if something found
-                if (ScanHash(pblock, nNonce, &hash))
+                // Find valid nonce
+                while (true)
                 {
+                    // H(I||V||...
+                    CSHA256 curr_hasher { hasher };
+                    curr_hasher.Write((unsigned char*)&(pblock->nNonce), 20);
+
+                    // (x_1, x_2, ...) = A(I, V, n, k)
+                    std::vector<std::vector<unsigned int>> solns = solver.Solve(curr_hasher);
+
+                    // Write the solution to the hash and compute the result.
+                    for (auto soln : solns) {
+                        for (uint32_t xi : soln)
+                            curr_hasher.Write((unsigned char*)&xi, 4);
+                        curr_hasher.Finalize((unsigned char*)&hash);
+
+                        // Leave next block unindented for easier diff
                     if (UintToArith256(hash) <= hashTarget)
                     {
                         // Found a solution
-                        pblock->nNonce = nNonce;
+                        pblock->nSoln = soln;
                         assert(hash == pblock->GetHash());
 
                         SetThreadPriority(THREAD_PRIORITY_NORMAL);
-                        LogPrintf("BitcoinMiner:\n");
+                        LogPrintf("ZcashMiner:\n");
                         LogPrintf("proof-of-work found  \n  hash: %s  \ntarget: %s\n", hash.GetHex(), hashTarget.GetHex());
                         ProcessBlockFound(pblock, *pwallet, reservekey);
                         SetThreadPriority(THREAD_PRIORITY_LOWEST);
@@ -521,6 +516,10 @@ void static BitcoinMiner(CWallet *pwallet)
 
                         break;
                     }
+                    }
+                    pblock->nNonce += 1;
+                    if ((pblock->nNonce & 0xfff) == 0)
+                        break;
                 }
 
                 // Check for stop or if block needs to be rebuilt
@@ -528,7 +527,7 @@ void static BitcoinMiner(CWallet *pwallet)
                 // Regtest mode doesn't require peers
                 if (vNodes.empty() && chainparams.MiningRequiresPeers())
                     break;
-                if (nNonce >= 0xffff0000)
+                if (pblock->nNonce >= 0xffff0000)
                     break;
                 if (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 60)
                     break;
@@ -547,12 +546,12 @@ void static BitcoinMiner(CWallet *pwallet)
     }
     catch (const boost::thread_interrupted&)
     {
-        LogPrintf("BitcoinMiner terminated\n");
+        LogPrintf("ZcashMiner terminated\n");
         throw;
     }
     catch (const std::runtime_error &e)
     {
-        LogPrintf("BitcoinMiner runtime error: %s\n", e.what());
+        LogPrintf("ZcashMiner runtime error: %s\n", e.what());
         return;
     }
 }

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -112,12 +112,12 @@ uint256 CBlock::CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMer
 std::string CBlock::ToString() const
 {
     std::stringstream s;
-    s << strprintf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
+    s << strprintf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%s, vtx=%u)\n",
         GetHash().ToString(),
         nVersion,
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),
-        nTime, nBits, nNonce,
+        nTime, nBits, nNonce.ToString(),
         vtx.size());
     for (unsigned int i = 0; i < vtx.size(); i++)
     {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_PRIMITIVES_BLOCK_H
 #define BITCOIN_PRIMITIVES_BLOCK_H
 
+#include "arith_uint256.h"
 #include "primitives/transaction.h"
 #include "serialize.h"
 #include "uint256.h"
@@ -27,7 +28,8 @@ public:
     uint256 hashMerkleRoot;
     uint32_t nTime;
     uint32_t nBits;
-    uint32_t nNonce;
+    arith_uint160 nNonce;
+    std::vector<uint32_t> nSoln;
 
     CBlockHeader()
     {
@@ -45,6 +47,7 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
+        READWRITE(nSoln);
     }
 
     void SetNull()
@@ -54,7 +57,8 @@ public:
         hashMerkleRoot.SetNull();
         nTime = 0;
         nBits = 0;
-        nNonce = 0;
+        nNonce = arith_uint160();
+        nSoln.clear();
     }
 
     bool IsNull() const
@@ -115,6 +119,7 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.nNonce         = nNonce;
+        block.nSoln          = nSoln;
         return block;
     }
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -80,7 +80,8 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDe
     }
     result.push_back(Pair("tx", txs));
     result.push_back(Pair("time", block.GetBlockTime()));
-    result.push_back(Pair("nonce", (uint64_t)block.nNonce));
+    result.push_back(Pair("nonce", block.nNonce.GetHex()));
+    result.push_back(Pair("solution", (uint32_t*)&block.nSoln[0]));
     result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -93,6 +93,29 @@ public:
     }
 };
 
+/* base_blob<BITS> from const char *.
+ * This is a separate function because the constructor base_blob<BITS>(const char*) can result
+ * in dangerously catching base_blob<BITS>(0).
+ */
+template <unsigned int BITS>
+inline base_blob<BITS> uintS(const char *str)
+{
+    base_blob<BITS> rv;
+    rv.SetHex(str);
+    return rv;
+}
+/* base_blob<BITS> from std::string.
+ * This is a separate function because the constructor base_blob<BITS>(const std::string &str) can result
+ * in dangerously catching base_blob<BITS>(0) via std::string(const char*).
+ */
+template <unsigned int BITS>
+inline base_blob<BITS> uintS(const std::string& str)
+{
+    base_blob<BITS> rv;
+    rv.SetHex(str);
+    return rv;
+}
+
 /** 160-bit opaque blob.
  * @note This type is called uint160 for historical reasons only. It is an opaque
  * blob of 160 bits and has no integer operations.


### PR DESCRIPTION
This PR implements EquiHash and then uses it in place of the existing double-SHA256 miner. The block header is adjusted to include the EquiHash solution and increase the nonce to 160 bits.

Closes #27 (assuming we choose this PoW).