### PR TITLE
Disable comparison utility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -323,6 +323,9 @@ case $host in
 esac
 
 if test x$use_comparison_tool != xno; then
+  if test x$JAVA = x; then
+    AC_MSG_ERROR("comparison tool set but java not found")
+  fi
   AC_SUBST(JAVA_COMPARISON_TOOL, $use_comparison_tool)
 fi
 

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -17,9 +17,10 @@ fi
 if test -z $with_protoc_bindir; then
   with_protoc_bindir=$prefix/native/bin
 fi
-if test -z $with_comparison_tool; then
-  with_comparison_tool=$prefix/native/share/BitcoindComparisonTool_jar/BitcoindComparisonTool.jar
-fi
+# Disable comparison utility (#592)
+#if test -z $with_comparison_tool; then
+#  with_comparison_tool=$prefix/native/share/BitcoindComparisonTool_jar/BitcoindComparisonTool.jar
+#fi
 
 
 if test -z $enable_wallet && test -n "@no_wallet@"; then


### PR DESCRIPTION
Also fixes `configure` to check that Java is present if `--with-comparison-tool` is set.

Closes #592