### PR TITLE
Add `unsafe_speedup` to speed up tests

### DIFF
--- a/depends/packages/libsnark.mk
+++ b/depends/packages/libsnark.mk
@@ -7,10 +7,11 @@ $(package)_sha256_hash=b5ec84a836d0d305407d5f39c8176bae2bb448abe802a8d11ba0f88f1
 $(package)_git_commit=69f312f149cc4bd8def8e2fed26a7941ff41251d
 
 $(package)_dependencies=libgmp
-$(package)_patches=1_fix_Wl_flag.patch
+$(package)_patches=1_fix_Wl_flag.patch 2_unsafe_sha256_speedup.patch
 
 define $(package)_preprocess_cmds
-    patch -p1 < $($(package)_patch_dir)/1_fix_Wl_flag.patch
+    patch -p1 < $($(package)_patch_dir)/1_fix_Wl_flag.patch && \
+    patch -p1 < $($(package)_patch_dir)/2_unsafe_sha256_speedup.patch
 endef
 
 define $(package)_build_cmds

--- a/depends/patches/libsnark/2_unsafe_sha256_speedup.patch
+++ b/depends/patches/libsnark/2_unsafe_sha256_speedup.patch
@@ -1,0 +1,351 @@
+diff --git a/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp b/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp
+index 8cb6365..6efd954 100644
+--- a/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp
++++ b/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp
+@@ -41,6 +41,8 @@ public:
+     pb_variable_array<FieldT> unreduced_output;
+     pb_variable_array<FieldT> reduced_output;
+     std::vector<lastbits_gadget<FieldT> > reduce_output;
++
++    std::shared_ptr<digest_variable<FieldT>> internal_output;
+ public:
+     pb_linear_combination_array<FieldT> prev_output;
+     pb_variable_array<FieldT> new_block;
+diff --git a/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.tcc b/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.tcc
+index 82c9780..b1b3838 100644
+--- a/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.tcc
++++ b/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.tcc
+@@ -11,6 +11,8 @@
+  * @copyright  MIT license (see LICENSE file)
+  *****************************************************************************/
+ 
++#include "crypto/sha256.h"
++
+ #ifndef SHA256_GADGET_TCC_
+ #define SHA256_GADGET_TCC_
+ 
+@@ -27,125 +29,193 @@ sha256_compression_function_gadget<FieldT>::sha256_compression_function_gadget(p
+     new_block(new_block),
+     output(output)
+ {
+-    /* message schedule and inputs for it */
+-    packed_W.allocate(pb, 64, FMT(this->annotation_prefix, " packed_W"));
+-    message_schedule.reset(new sha256_message_schedule_gadget<FieldT>(pb, new_block, packed_W, FMT(this->annotation_prefix, " message_schedule")));
+-
+-    /* initalize */
+-    round_a.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 7*32, prev_output.rbegin() + 8*32));
+-    round_b.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 6*32, prev_output.rbegin() + 7*32));
+-    round_c.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 5*32, prev_output.rbegin() + 6*32));
+-    round_d.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 4*32, prev_output.rbegin() + 5*32));
+-    round_e.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 3*32, prev_output.rbegin() + 4*32));
+-    round_f.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 2*32, prev_output.rbegin() + 3*32));
+-    round_g.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 1*32, prev_output.rbegin() + 2*32));
+-    round_h.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 0*32, prev_output.rbegin() + 1*32));
+-
+-    /* do the rounds */
+-    for (size_t i = 0; i < 64; ++i)
+-    {
+-        round_h.push_back(round_g[i]);
+-        round_g.push_back(round_f[i]);
+-        round_f.push_back(round_e[i]);
+-        round_d.push_back(round_c[i]);
+-        round_c.push_back(round_b[i]);
+-        round_b.push_back(round_a[i]);
+-
+-        pb_variable_array<FieldT> new_round_a_variables;
+-        new_round_a_variables.allocate(pb, 32, FMT(this->annotation_prefix, " new_round_a_variables_%zu", i+1));
+-        round_a.emplace_back(new_round_a_variables);
+-
+-        pb_variable_array<FieldT> new_round_e_variables;
+-        new_round_e_variables.allocate(pb, 32, FMT(this->annotation_prefix, " new_round_e_variables_%zu", i+1));
+-        round_e.emplace_back(new_round_e_variables);
+-
+-        round_functions.push_back(sha256_round_function_gadget<FieldT>(pb,
+-                                                                       round_a[i], round_b[i], round_c[i], round_d[i],
+-                                                                       round_e[i], round_f[i], round_g[i], round_h[i],
+-                                                                       packed_W[i], SHA256_K[i], round_a[i+1], round_e[i+1],
+-                                                                       FMT(this->annotation_prefix, " round_functions_%zu", i)));
+-    }
+-
+-    /* finalize */
+-    unreduced_output.allocate(pb, 8, FMT(this->annotation_prefix, " unreduced_output"));
+-    reduced_output.allocate(pb, 8, FMT(this->annotation_prefix, " reduced_output"));
+-    for (size_t i = 0; i < 8; ++i)
+-    {
+-        reduce_output.push_back(lastbits_gadget<FieldT>(pb,
+-                                                        unreduced_output[i],
+-                                                        32+1,
+-                                                        reduced_output[i],
+-                                                        pb_variable_array<FieldT>(output.bits.rbegin() + (7-i) * 32, output.bits.rbegin() + (8-i) * 32),
+-                                                        FMT(this->annotation_prefix, " reduce_output_%zu", i)));
++    if (!pb.unsafe_speedup) {
++        /* message schedule and inputs for it */
++        packed_W.allocate(pb, 64, FMT(this->annotation_prefix, " packed_W"));
++        message_schedule.reset(new sha256_message_schedule_gadget<FieldT>(pb, new_block, packed_W, FMT(this->annotation_prefix, " message_schedule")));
++
++        /* initalize */
++        round_a.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 7*32, prev_output.rbegin() + 8*32));
++        round_b.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 6*32, prev_output.rbegin() + 7*32));
++        round_c.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 5*32, prev_output.rbegin() + 6*32));
++        round_d.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 4*32, prev_output.rbegin() + 5*32));
++        round_e.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 3*32, prev_output.rbegin() + 4*32));
++        round_f.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 2*32, prev_output.rbegin() + 3*32));
++        round_g.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 1*32, prev_output.rbegin() + 2*32));
++        round_h.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 0*32, prev_output.rbegin() + 1*32));
++
++        /* do the rounds */
++        for (size_t i = 0; i < 64; ++i)
++        {
++            round_h.push_back(round_g[i]);
++            round_g.push_back(round_f[i]);
++            round_f.push_back(round_e[i]);
++            round_d.push_back(round_c[i]);
++            round_c.push_back(round_b[i]);
++            round_b.push_back(round_a[i]);
++
++            pb_variable_array<FieldT> new_round_a_variables;
++            new_round_a_variables.allocate(pb, 32, FMT(this->annotation_prefix, " new_round_a_variables_%zu", i+1));
++            round_a.emplace_back(new_round_a_variables);
++
++            pb_variable_array<FieldT> new_round_e_variables;
++            new_round_e_variables.allocate(pb, 32, FMT(this->annotation_prefix, " new_round_e_variables_%zu", i+1));
++            round_e.emplace_back(new_round_e_variables);
++
++            round_functions.push_back(sha256_round_function_gadget<FieldT>(pb,
++                                                                           round_a[i], round_b[i], round_c[i], round_d[i],
++                                                                           round_e[i], round_f[i], round_g[i], round_h[i],
++                                                                           packed_W[i], SHA256_K[i], round_a[i+1], round_e[i+1],
++                                                                           FMT(this->annotation_prefix, " round_functions_%zu", i)));
++        }
++
++        /* finalize */
++        unreduced_output.allocate(pb, 8, FMT(this->annotation_prefix, " unreduced_output"));
++        reduced_output.allocate(pb, 8, FMT(this->annotation_prefix, " reduced_output"));
++        for (size_t i = 0; i < 8; ++i)
++        {
++            reduce_output.push_back(lastbits_gadget<FieldT>(pb,
++                                                            unreduced_output[i],
++                                                            32+1,
++                                                            reduced_output[i],
++                                                            pb_variable_array<FieldT>(output.bits.rbegin() + (7-i) * 32, output.bits.rbegin() + (8-i) * 32),
++                                                            FMT(this->annotation_prefix, " reduce_output_%zu", i)));
++        }
++    } else {
++        internal_output.reset(new digest_variable<FieldT>(pb, 256, "lol"));
+     }
+ }
+ 
+ template<typename FieldT>
+ void sha256_compression_function_gadget<FieldT>::generate_r1cs_constraints()
+ {
+-    message_schedule->generate_r1cs_constraints();
+-    for (size_t i = 0; i < 64; ++i)
+-    {
+-        round_functions[i].generate_r1cs_constraints();
+-    }
+-
+-    for (size_t i = 0; i < 4; ++i)
+-    {
+-        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1,
+-                                                             round_functions[3-i].packed_d + round_functions[63-i].packed_new_a,
+-                                                             unreduced_output[i]),
+-            FMT(this->annotation_prefix, " unreduced_output_%zu", i));
+-
+-        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1,
+-                                                             round_functions[3-i].packed_h + round_functions[63-i].packed_new_e,
+-                                                             unreduced_output[4+i]),
+-            FMT(this->annotation_prefix, " unreduced_output_%zu", 4+i));
+-    }
+-
+-    for (size_t i = 0; i < 8; ++i)
+-    {
+-        reduce_output[i].generate_r1cs_constraints();
++    if (!this->pb.unsafe_speedup) {
++        message_schedule->generate_r1cs_constraints();
++        for (size_t i = 0; i < 64; ++i)
++        {
++            round_functions[i].generate_r1cs_constraints();
++        }
++
++        for (size_t i = 0; i < 4; ++i)
++        {
++            this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1,
++                                                                 round_functions[3-i].packed_d + round_functions[63-i].packed_new_a,
++                                                                 unreduced_output[i]),
++                FMT(this->annotation_prefix, " unreduced_output_%zu", i));
++
++            this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1,
++                                                                 round_functions[3-i].packed_h + round_functions[63-i].packed_new_e,
++                                                                 unreduced_output[4+i]),
++                FMT(this->annotation_prefix, " unreduced_output_%zu", 4+i));
++        }
++
++        for (size_t i = 0; i < 8; ++i)
++        {
++            reduce_output[i].generate_r1cs_constraints();
++        }
++    } else {
++        // The internal output needs to equal the final output
++        // digest. This prevents another witness from overwriting
++        // the digest -- since the constraints will fail.
++
++        for (size_t i = 0; i < 256; i++) {
++            this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
++                1,
++                internal_output->bits[i],
++                output.bits[i]
++            ), "FAKE_SHA256");
++        }
+     }
+ }
+ 
+ template<typename FieldT>
+ void sha256_compression_function_gadget<FieldT>::generate_r1cs_witness()
+ {
+-    message_schedule->generate_r1cs_witness();
+-
+-#ifdef DEBUG
+-    printf("Input:\n");
+-    for (size_t j = 0; j < 16; ++j)
+-    {
+-        printf("%lx ", this->pb.val(packed_W[j]).as_ulong());
+-    }
+-    printf("\n");
+-#endif
+-
+-    for (size_t i = 0; i < 64; ++i)
+-    {
+-        round_functions[i].generate_r1cs_witness();
+-    }
+-
+-    for (size_t i = 0; i < 4; ++i)
+-    {
+-        this->pb.val(unreduced_output[i]) = this->pb.val(round_functions[3-i].packed_d) + this->pb.val(round_functions[63-i].packed_new_a);
+-        this->pb.val(unreduced_output[4+i]) = this->pb.val(round_functions[3-i].packed_h) + this->pb.val(round_functions[63-i].packed_new_e);
+-    }
+-
+-    for (size_t i = 0; i < 8; ++i)
+-    {
+-        reduce_output[i].generate_r1cs_witness();
+-    }
+-
+-#ifdef DEBUG
+-    printf("Output:\n");
+-    for (size_t j = 0; j < 8; ++j)
+-    {
+-        printf("%lx ", this->pb.val(reduced_output[j]).as_ulong());
++    if (!this->pb.unsafe_speedup) {
++        message_schedule->generate_r1cs_witness();
++
++    #ifdef DEBUG
++        printf("Input:\n");
++        for (size_t j = 0; j < 16; ++j)
++        {
++            printf("%lx ", this->pb.val(packed_W[j]).as_ulong());
++        }
++        printf("\n");
++    #endif
++
++        for (size_t i = 0; i < 64; ++i)
++        {
++            round_functions[i].generate_r1cs_witness();
++        }
++
++        for (size_t i = 0; i < 4; ++i)
++        {
++            this->pb.val(unreduced_output[i]) = this->pb.val(round_functions[3-i].packed_d) + this->pb.val(round_functions[63-i].packed_new_a);
++            this->pb.val(unreduced_output[4+i]) = this->pb.val(round_functions[3-i].packed_h) + this->pb.val(round_functions[63-i].packed_new_e);
++        }
++
++        for (size_t i = 0; i < 8; ++i)
++        {
++            reduce_output[i].generate_r1cs_witness();
++        }
++
++    #ifdef DEBUG
++        printf("Output:\n");
++        for (size_t j = 0; j < 8; ++j)
++        {
++            printf("%lx ", this->pb.val(reduced_output[j]).as_ulong());
++        }
++        printf("\n");
++    #endif
++    } else {
++        // Just perform SHA256 on the input.
++
++        std::vector<bool> input_iv;
++        std::vector<bool> input_digest;
++
++        for (size_t i = 0; i < 512; i++) {
++            input_digest.push_back(this->pb.val(new_block[i]) == FieldT::one());
++        }
++
++        for (size_t i = 0; i < 256; i++) {
++            input_iv.push_back(this->pb.lc_val(prev_output[i]) == FieldT::one());
++        }
++
++        CSHA256 hasher;
++        for (size_t i = 0; i < 8; i++) {
++            hasher.s[i] = 0;
++            for (size_t j = 0; j < 32; j++) {
++                hasher.s[i] |= (input_iv[(i * 32) + j] ? 0x00000001 : 0) << (31 - j);
++            }
++        }
++
++        std::vector<unsigned char> digest_v;
++        for (size_t i = 0; i < 64; i++) {
++            unsigned char b = 0;
++            for (size_t j = 0; j < 8; j++) {
++                b |= (input_digest[(i * 8) + j] ? 0x01 : 0) << (7 - j);
++            }
++            digest_v.push_back(b);
++        }
++        assert(digest_v.size() == 64);
++        hasher.Write(&digest_v[0], 64);
++
++        std::vector<unsigned char> final_digest(32, 0x00);
++        hasher.FinalizeNoPadding(&final_digest[0]);
++        assert(final_digest.size() == 32);
++
++        for (size_t i = 0; i < 32; i++) {
++            for (size_t j = 0; j < 8; j++) {
++                if (final_digest[i] & (0x01 << (7 - j))) {
++                    this->pb.val(internal_output->bits[(i * 8) + j]) = FieldT::one();
++                    this->pb.val(output.bits[(i * 8) + j]) = FieldT::one();
++                } else {
++                    this->pb.val(internal_output->bits[(i * 8) + j]) = FieldT::zero();
++                    this->pb.val(output.bits[(i * 8) + j]) = FieldT::zero();
++                }
++            }
++        }
+     }
+-    printf("\n");
+-#endif
+ }
+ 
+ template<typename FieldT>
+diff --git a/src/gadgetlib1/protoboard.hpp b/src/gadgetlib1/protoboard.hpp
+index a9c30b4..4548e70 100644
+--- a/src/gadgetlib1/protoboard.hpp
++++ b/src/gadgetlib1/protoboard.hpp
+@@ -37,6 +37,7 @@ private:
+ 
+ public:
+     protoboard();
++    bool unsafe_speedup;
+ 
+     void clear_values();
+ 
+diff --git a/src/gadgetlib1/protoboard.tcc b/src/gadgetlib1/protoboard.tcc
+index 61f50ad..b32b1da 100644
+--- a/src/gadgetlib1/protoboard.tcc
++++ b/src/gadgetlib1/protoboard.tcc
+@@ -15,7 +15,7 @@
+ namespace libsnark {
+ 
+ template<typename FieldT>
+-protoboard<FieldT>::protoboard()
++protoboard<FieldT>::protoboard() : unsafe_speedup(false)
+ {
+     constant_term = FieldT::one();
+ 

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -12,18 +12,18 @@
 class CSHA256
 {
 public:
+    uint32_t s[8];
     static const size_t OUTPUT_SIZE = 32;
 
     CSHA256();
     CSHA256& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     void FinalizeNoPadding(unsigned char hash[OUTPUT_SIZE]) {
-    	FinalizeNoPadding(hash, true);
+        FinalizeNoPadding(hash, true);
     };
     CSHA256& Reset();
 
 private:
-    uint32_t s[8];
     unsigned char buf[64];
     size_t bytes;
     void FinalizeNoPadding(unsigned char hash[OUTPUT_SIZE], bool enforce_compression);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -314,10 +314,11 @@ BOOST_AUTO_TEST_CASE(test_basic_pour_verification)
     static const unsigned int TEST_TREE_DEPTH = 3;
 
     // construct the r1cs keypair
-    auto keypair = ZerocashParams::GenerateNewKeyPair(TEST_TREE_DEPTH);
+    auto keypair = ZerocashParams::GenerateNewKeyPair(TEST_TREE_DEPTH, true);
     ZerocashParams p(
         TEST_TREE_DEPTH,
-        &keypair
+        &keypair,
+        true
     );
 
     // construct a merkle tree

--- a/src/zerocash/PourTransaction.cpp
+++ b/src/zerocash/PourTransaction.cpp
@@ -284,7 +284,8 @@ void PourTransaction::init(uint16_t version_num,
             val_old_pub_bv,
             val_new_pub_bv,
             { val_old_1_bv, val_old_2_bv },
-            h_S_bv);
+            h_S_bv,
+            params.unsafe_speedup);
 
         std::stringstream ss;
         ss << proofObj;

--- a/src/zerocash/ZerocashParams.cpp
+++ b/src/zerocash/ZerocashParams.cpp
@@ -31,14 +31,15 @@ int ZerocashParams::getTreeDepth()
     return treeDepth;
 }
 
-zerocash_pour_keypair<ZerocashParams::zerocash_pp> ZerocashParams::GenerateNewKeyPair(const unsigned int tree_depth)
+zerocash_pour_keypair<ZerocashParams::zerocash_pp> ZerocashParams::GenerateNewKeyPair(const unsigned int tree_depth, bool unsafe_speedup)
 {
     libzerocash::ZerocashParams::zerocash_pp::init_public_params();
     libzerocash::zerocash_pour_keypair<libzerocash::ZerocashParams::zerocash_pp> kp_v1 =
         libzerocash::zerocash_pour_ppzksnark_generator<libzerocash::ZerocashParams::zerocash_pp>(
             libzerocash::ZerocashParams::numPourInputs,
             libzerocash::ZerocashParams::numPourOutputs,
-            tree_depth
+            tree_depth,
+            unsafe_speedup
         );
     return kp_v1;
 }
@@ -119,9 +120,10 @@ zerocash_pour_verification_key<ZerocashParams::zerocash_pp> ZerocashParams::Load
 
 ZerocashParams::ZerocashParams(
     const unsigned int tree_depth,
-    zerocash_pour_keypair<ZerocashParams::zerocash_pp> *keypair
+    zerocash_pour_keypair<ZerocashParams::zerocash_pp> *keypair,
+    bool unsafe_speedup
 ) :
-    treeDepth(tree_depth)
+    treeDepth(tree_depth), unsafe_speedup(unsafe_speedup)
 {
     params_pk_v1 = new zerocash_pour_proving_key<ZerocashParams::zerocash_pp>(keypair->pk);
     params_vk_v1 = new zerocash_pour_verification_key<ZerocashParams::zerocash_pp>(keypair->vk);
@@ -132,7 +134,7 @@ ZerocashParams::ZerocashParams(
     std::string proving_key_path,
     zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1
 ) : 
-    treeDepth(tree_depth), provingKeyPath(proving_key_path)
+    treeDepth(tree_depth), provingKeyPath(proving_key_path), unsafe_speedup(false)
 {
     params_vk_v1 = new zerocash_pour_verification_key<ZerocashParams::zerocash_pp>(*p_vk_1);
     params_pk_v1 = NULL;
@@ -143,7 +145,7 @@ ZerocashParams::ZerocashParams(
     zerocash_pour_proving_key<ZerocashParams::zerocash_pp>* p_pk_1,
     zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1
 ) :
-    treeDepth(tree_depth)
+    treeDepth(tree_depth), unsafe_speedup(false)
 {
     assert(p_pk_1 != NULL || p_vk_1 != NULL);
 

--- a/src/zerocash/ZerocashParams.h
+++ b/src/zerocash/ZerocashParams.h
@@ -23,10 +23,12 @@ class ZerocashParams {
 
 public:
     typedef default_r1cs_ppzksnark_pp zerocash_pp;
+    bool unsafe_speedup;
 
     ZerocashParams(
         const unsigned int tree_depth,
-        zerocash_pour_keypair<ZerocashParams::zerocash_pp> *keypair
+        zerocash_pour_keypair<ZerocashParams::zerocash_pp> *keypair,
+        bool unsafe_speedup = false
     );
 
     ZerocashParams(
@@ -49,7 +51,7 @@ public:
     static const size_t numPourInputs = 2;
     static const size_t numPourOutputs = 2;
 
-    static zerocash_pour_keypair<ZerocashParams::zerocash_pp> GenerateNewKeyPair(const unsigned int tree_depth);
+    static zerocash_pour_keypair<ZerocashParams::zerocash_pp> GenerateNewKeyPair(const unsigned int tree_depth, bool unsafe_speedup = false);
 
     static void SaveProvingKeyToFile(const zerocash_pour_proving_key<ZerocashParams::zerocash_pp>* p_pk_1, std::string path);
     static void SaveVerificationKeyToFile(const zerocash_pour_verification_key<ZerocashParams::zerocash_pp>* p_vk_1, std::string path);

--- a/src/zerocash/tests/zerocashTest.cpp
+++ b/src/zerocash/tests/zerocashTest.cpp
@@ -32,7 +32,7 @@
 using namespace std;
 using namespace libsnark;
 
-#define TEST_TREE_DEPTH 4
+#define TEST_TREE_DEPTH 32
 
 BOOST_AUTO_TEST_CASE( SaveAndLoadKeysFromFiles ) {
     cout << "\nSaveAndLoadKeysFromFiles TEST\n" << endl;
@@ -40,10 +40,10 @@ BOOST_AUTO_TEST_CASE( SaveAndLoadKeysFromFiles ) {
     cout << "Creating Params...\n" << endl;
 
     libzerocash::timer_start("Param Generation");
-    auto keypair = libzerocash::ZerocashParams::GenerateNewKeyPair(TEST_TREE_DEPTH);
+    auto keypair = libzerocash::ZerocashParams::GenerateNewKeyPair(TEST_TREE_DEPTH, true);
     libzerocash::ZerocashParams p(
         TEST_TREE_DEPTH,
-        &keypair
+        &keypair, true
     );
     libzerocash::timer_stop("Param Generation");
     print_mem("after param generation");
@@ -250,10 +250,11 @@ void test_pour(libzerocash::ZerocashParams& p,
 }
 
 BOOST_AUTO_TEST_CASE( PourVpubInTest ) {
-    auto keypair = libzerocash::ZerocashParams::GenerateNewKeyPair(TEST_TREE_DEPTH);
+    auto keypair = libzerocash::ZerocashParams::GenerateNewKeyPair(TEST_TREE_DEPTH, true);
     libzerocash::ZerocashParams p(
         TEST_TREE_DEPTH,
-        &keypair
+        &keypair,
+        true
     );
 
     // Things that should work..
@@ -331,10 +332,11 @@ BOOST_AUTO_TEST_CASE( PourTxTest ) {
     cout << "Creating Params...\n" << endl;
 
     libzerocash::timer_start("Param Generation");
-    auto keypair = libzerocash::ZerocashParams::GenerateNewKeyPair(TEST_TREE_DEPTH);
+    auto keypair = libzerocash::ZerocashParams::GenerateNewKeyPair(TEST_TREE_DEPTH, true);
     libzerocash::ZerocashParams p(
         TEST_TREE_DEPTH,
-        &keypair
+        &keypair,
+        true
     );
     libzerocash::timer_stop("Param Generation");
     print_mem("after param generation");
@@ -539,10 +541,11 @@ BOOST_AUTO_TEST_CASE( SimpleTxTest ) {
     cout << "\nSIMPLE TRANSACTION TEST\n" << endl;
 
     libzerocash::timer_start("Param Generation");
-    auto keypair = libzerocash::ZerocashParams::GenerateNewKeyPair(TEST_TREE_DEPTH);
+    auto keypair = libzerocash::ZerocashParams::GenerateNewKeyPair(TEST_TREE_DEPTH, true);
     libzerocash::ZerocashParams p(
         TEST_TREE_DEPTH,
-        &keypair
+        &keypair,
+        true
     );
     libzerocash::timer_stop("Param Generation");
 

--- a/src/zerocash/zerocash_pour_ppzksnark.hpp
+++ b/src/zerocash/zerocash_pour_ppzksnark.hpp
@@ -187,7 +187,8 @@ using zerocash_pour_proof = r1cs_ppzksnark_proof<ppzksnark_ppT>;
 template<typename ppzksnark_ppT>
 zerocash_pour_keypair<ppzksnark_ppT> zerocash_pour_ppzksnark_generator(const size_t num_old_coins,
                                                                        const size_t num_new_coins,
-                                                                       const size_t tree_depth);
+                                                                       const size_t tree_depth,
+                                                                       bool unsafe_speedup = false);
 
 /**
  * A prover algorithm for the Pour ppzkSNARK.
@@ -209,7 +210,8 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                                                                   const bit_vector &public_old_value,
                                                                   const bit_vector &public_new_value,
                                                                   const std::vector<bit_vector> &old_coin_values,
-                                                                  const bit_vector &signature_public_key_hash);
+                                                                  const bit_vector &signature_public_key_hash,
+                                                                  bool unsafe_speedup = false);
 
 /**
  * A verifier algorithm for the Pour ppzkSNARK.

--- a/src/zerocash/zerocash_pour_ppzksnark.tcc
+++ b/src/zerocash/zerocash_pour_ppzksnark.tcc
@@ -111,12 +111,14 @@ std::istream& operator>>(std::istream &in, zerocash_pour_keypair<ppzksnark_ppT> 
 template<typename ppzksnark_ppT>
 zerocash_pour_keypair<ppzksnark_ppT> zerocash_pour_ppzksnark_generator(const size_t num_old_coins,
                                                                        const size_t num_new_coins,
-                                                                       const size_t tree_depth)
+                                                                       const size_t tree_depth,
+                                                                       bool unsafe_speedup)
 {
     typedef Fr<ppzksnark_ppT> FieldT;
     enter_block("Call to zerocash_pour_ppzksnark_generator");
 
     protoboard<FieldT> pb;
+    pb.unsafe_speedup = unsafe_speedup;
     zerocash_pour_gadget<FieldT> g(pb, num_old_coins, num_new_coins, tree_depth, "zerocash_pour");
     g.generate_r1cs_constraints();
     const r1cs_constraint_system<FieldT> constraint_system = pb.get_constraint_system();
@@ -143,13 +145,15 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                                                                   const bit_vector &public_old_value,
                                                                   const bit_vector &public_new_value,
                                                                   const std::vector<bit_vector> &old_coin_values,
-                                                                  const bit_vector &signature_public_key_hash)
+                                                                  const bit_vector &signature_public_key_hash,
+                                                                  bool unsafe_speedup)
 {
     typedef Fr<ppzksnark_ppT> FieldT;
 
     enter_block("Call to zerocash_pour_ppzksnark_prover");
 
     protoboard<FieldT> pb;
+    pb.unsafe_speedup = unsafe_speedup;
     zerocash_pour_gadget<FieldT > g(pb, pk.num_old_coins, pk.num_new_coins, pk.tree_depth, "zerocash_pour");
     g.generate_r1cs_constraints();
     g.generate_r1cs_witness(old_coin_authentication_paths,


### PR DESCRIPTION
This PR is meant to address #803 by bypassing SHA256's internal constraints and variables when a flag is explicitly set to the libsnark protoboard. Right now, I enable the flag for `zerocashTest` and `transaction_tests`, and I even increase the test tree-depth in `zerocashTest` to 32, and it runs quite a bit faster.

Many of the constructions we test, outside of the direct circuit tests, will use a fixed-depth tree, so the time for playing with various depths to avoid performance issues in tests needs to come to an end, whether we go with this PR or not.

I think eventually we'll want this to be a compiler flag of some kind, but since libsnark's headers leak everywhere in the project, it was simpler to make this an explicit runtime change in specific binaries and avoid changing the build system. (I want some tests and binaries to compile with the efficient circuit and the rest to be secure.)

I also originally meant to simply disable the constraints, but realized we also need to avoid allocating the variables. Thus, inside of the SHA256 compression function gadget I invoke SHA256 directly, however, I create an internal constraint to avoid the outside digest from being overwritten. (This *can* happen, but the constraint is there to prevent it just as if the hash evaluation were correctly constrained.)