### PR TITLE
Run all RPC tests, even when they fail.

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -e -o pipefail
 
 CURDIR=$(cd $(dirname "$0"); pwd)
 # Get BUILDDIR and REAL_BITCOIND
@@ -54,23 +54,53 @@ testScriptsExt=(
 extArg="-extended"
 passOn=${@#$extArg}
 
+successCount=0
+failCount=0
+
+function runTestScript
+{
+    local testName="$1"
+    shift
+
+    echo -e "=== Running testscript ${testName} ==="
+
+    if eval "$@" | sed 's/^/  /'
+    then
+        successCount=$(expr $successCount + 1)
+        echo "--- Success: ${testName} ---"
+    else
+        failCount=$(expr $failCount + 1)
+        echo "!!! FAIL: ${testName} !!!"
+    fi
+
+    echo
+}
+
 if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then
     for (( i = 0; i < ${#testScripts[@]}; i++ ))
     do
         if [ -z "$1" ] || [ "${1:0:1}" == "-" ] || [ "$1" == "${testScripts[$i]}" ] || [ "$1.py" == "${testScripts[$i]}" ]
         then
-            echo -e "Running testscript \033[1m${testScripts[$i]}...\033[0m"
-            ${BUILDDIR}/qa/rpc-tests/${testScripts[$i]} --srcdir "${BUILDDIR}/src" ${passOn}
+            runTestScript \
+                "${testScripts[$i]}" \
+                "${BUILDDIR}/qa/rpc-tests/${testScripts[$i]}" \
+                --srcdir "${BUILDDIR}/src" ${passOn}
         fi
     done
     for (( i = 0; i < ${#testScriptsExt[@]}; i++ ))
     do
         if [ "$1" == $extArg ] || [ "$1" == "${testScriptsExt[$i]}" ] || [ "$1.py" == "${testScriptsExt[$i]}" ]
         then
-            echo -e "Running \033[1m2nd level\033[0m testscript \033[1m${testScriptsExt[$i]}...\033[0m"
-            ${BUILDDIR}/qa/rpc-tests/${testScriptsExt[$i]} --srcdir "${BUILDDIR}/src" ${passOn}
+            runTestScript \
+                "${testScriptsExt[$i]}" \
+                "${BUILDDIR}/qa/rpc-tests/${testScriptsExt[$i]}" \
+                --srcdir "${BUILDDIR}/src" ${passOn}
         fi
     done
+
+    echo -e "\n\nTests completed: $(expr $successCount + $failCount)"
+    echo "successes $successCount; failures: $failCount"
+    exit $failCount
 else
   echo "No rpc tests to run. Wallet, utils, and bitcoind must all be enabled"
 fi


### PR DESCRIPTION
Other work has broken some RPC tests, but the upstream script dies on the first test failure. This updates that script to run all tests even when some fail in order to give more useful automated test logs.