### PR TITLE
Fix Equihash state initialisation in miner

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -486,19 +486,19 @@ void static BitcoinMiner(CWallet *pwallet)
             int64_t nStart = GetTime();
             arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
 
-            // Hash state
-            crypto_generichash_blake2b_state state;
-            eh.InitialiseState(state);
-
-            // I = the block header minus nonce and solution.
-            CEquihashInput I{*pblock};
-            CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-            ss << I;
-
-            // H(I||...
-            crypto_generichash_blake2b_update(&state, (unsigned char*)&ss[0], ss.size());
-
             while (true) {
+                // Hash state
+                crypto_generichash_blake2b_state state;
+                eh.InitialiseState(state);
+
+                // I = the block header minus nonce and solution.
+                CEquihashInput I{*pblock};
+                CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+                ss << I;
+
+                // H(I||...
+                crypto_generichash_blake2b_update(&state, (unsigned char*)&ss[0], ss.size());
+
                 // Find valid nonce
                 while (true)
                 {


### PR DESCRIPTION
After a new block is found or after a few nonces have been tried (currently
after every nonce), the miner checks for global changes. If any of these are
triggered, a new block is built from scratch, which re-initialises the Equihash
input. But if none of the checks are triggered, the miner just updates nTime and
continues mining - without updating the Equihash input to account for the new
block header. This bugfix corrects the behaviour by regenerating the Equihash
input in both situations.