### PR TITLE
Add googlemock 1.7.0 dependency.

### DIFF
--- a/depends/packages/googlemock.mk
+++ b/depends/packages/googlemock.mk
@@ -1,0 +1,20 @@
+# url=https://github.com/google/googlemock/archive/release-1.7.0.tar.gz
+
+package=googlemock
+$(package)_version=1.7.0
+$(package)_dependencies=googletest
+
+$(package)_download_path=https://github.com/google/$(package)/archive/
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_download_file=release-$($(package)_version).tar.gz
+$(package)_sha256_hash=3f20b6acb37e5a98e8c4518165711e3e35d47deb6cdb5a4dd4566563b5efd232
+
+define $(package)_build_cmds
+  $(MAKE) -C make GTEST_DIR='$(host_prefix)' CXXFLAGS='-fPIC' gmock-all.o
+endef
+
+
+define $(package)_stage_cmds
+  install -D ./make/gmock-all.o $($(package)_staging_dir)$(host_prefix)/lib/libgmock.a && \
+  cp -a ./include $($(package)_staging_dir)$(host_prefix)/include
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,5 +1,5 @@
 zerocash_packages := libsnark libgmp libsodium
-packages := boost openssl $(zerocash_packages) googletest
+packages := boost openssl $(zerocash_packages) googletest googlemock
 native_packages := native_ccache native_comparisontool
 
 qt_native_packages = native_protobuf


### PR DESCRIPTION
closes #891. supercedes #909 which had spurious debug makefile stuff accidentally included.