### PR TITLE
Initialize libsodium in the gtest suite.

### DIFF
--- a/src/gtest/main.cpp
+++ b/src/gtest/main.cpp
@@ -1,6 +1,8 @@
 #include "gtest/gtest.h"
+#include "sodium.h"
 
 int main(int argc, char **argv) {
+  assert(sodium_init() != -1);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
We left behind this initialization routine when we switched to gtest. I would rather we had moved those tests over in a separate PR instead of changing existing PRs at the last second -- we would have paid more attention to the consequences.