### PR TITLE
[EXPERIMENTAL] Fix CTransaction const undefined behavior

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -122,9 +122,9 @@ void CTransaction::UpdateHash() const
     *const_cast<uint256*>(&hash) = SerializeHash(*this);
 }
 
-CTransaction::CTransaction() : nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0), vpour() { }
+CTransaction::CTransaction() : _nVersion(CTransaction::CURRENT_VERSION), _vin(), _vout(), _nLockTime(0), _vpour() { }
 
-CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime), vpour(tx.vpour) {
+CTransaction::CTransaction(const CMutableTransaction &tx) : _nVersion(tx.nVersion), _vin(tx.vin), _vout(tx.vout), _nLockTime(tx.nLockTime), _vpour(tx.vpour) {
     UpdateHash();
 }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -289,6 +289,12 @@ private:
     const uint256 hash;
     void UpdateHash() const;
 
+    int32_t _nVersion;
+    std::vector<CTxIn> _vin;
+    std::vector<CTxOut> _vout;
+    uint32_t _nLockTime;
+    std::vector<CPourTx> _vpour;
+
 public:
     static const int32_t CURRENT_VERSION=1;
 
@@ -297,11 +303,11 @@ public:
     // actually immutable; deserialization and assignment are implemented,
     // and bypass the constness. This is safe, as they update the entire
     // structure, including the hash.
-    const int32_t nVersion;
-    const std::vector<CTxIn> vin;
-    const std::vector<CTxOut> vout;
-    const uint32_t nLockTime;
-    const std::vector<CPourTx> vpour;
+    const int32_t &nVersion = _nVersion;
+    const std::vector<CTxIn> &vin = _vin;
+    const std::vector<CTxOut> &vout = _vout;
+    const uint32_t &nLockTime = _nLockTime;
+    const std::vector<CPourTx> &vpour = _vpour;
 
     /** Construct a CTransaction that qualifies as IsNull() */
     CTransaction();
@@ -315,13 +321,13 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(*const_cast<int32_t*>(&this->nVersion));
-        nVersion = this->nVersion;
-        READWRITE(*const_cast<std::vector<CTxIn>*>(&vin));
-        READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
-        READWRITE(*const_cast<uint32_t*>(&nLockTime));
+        READWRITE(this->_nVersion);
+        nVersion = this->_nVersion;
+        READWRITE(_vin);
+        READWRITE(_vout);
+        READWRITE(_nLockTime);
         if (nVersion >= 2) {
-            READWRITE(*const_cast<std::vector<CPourTx>*>(&vpour));
+            READWRITE(_vpour);
         }
         if (ser_action.ForRead())
             UpdateHash();


### PR DESCRIPTION
I'm not sure if this removes the undefined behavior. @nathan-at-least mentioned it may still be undefined behavior to take a "reference to const" of anything which can be accessed through a non-const path. I couldn't find a reference to back up that assertion (nor its negation).

Closes #967.