### PR TITLE
Fix CTransaction undefined behaviour by removing const specifiers and const_casts

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -121,9 +121,9 @@ uint256 CMutableTransaction::GetHash() const
     return SerializeHash(*this);
 }
 
-void CTransaction::UpdateHash() const
+void CTransaction::UpdateHash()
 {
-    *const_cast<uint256*>(&hash) = SerializeHash(*this);
+    hash = SerializeHash(*this);
 }
 
 CTransaction::CTransaction() : nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0), vpour(), joinSplitPubKey(), joinSplitSig() { }
@@ -135,14 +135,14 @@ CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion
 }
 
 CTransaction& CTransaction::operator=(const CTransaction &tx) {
-    *const_cast<int*>(&nVersion) = tx.nVersion;
-    *const_cast<std::vector<CTxIn>*>(&vin) = tx.vin;
-    *const_cast<std::vector<CTxOut>*>(&vout) = tx.vout;
-    *const_cast<unsigned int*>(&nLockTime) = tx.nLockTime;
-    *const_cast<std::vector<CPourTx>*>(&vpour) = tx.vpour;
-    *const_cast<uint256*>(&joinSplitPubKey) = tx.joinSplitPubKey;
-    *const_cast<joinsplit_sig_t*>(&joinSplitSig) = tx.joinSplitSig;
-    *const_cast<uint256*>(&hash) = tx.hash;
+    nVersion = tx.nVersion;
+    vin = tx.vin;
+    vout = tx.vout;
+    nLockTime = tx.nLockTime;
+    vpour = tx.vpour;
+    joinSplitPubKey = tx.joinSplitPubKey;
+    joinSplitSig = tx.joinSplitSig;
+    hash = tx.hash;
     return *this;
 }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -286,16 +286,16 @@ class CTransaction
 {
 private:
     /** Memory only. */
-    const uint256 hash;
-    void UpdateHash() const;
+    uint256 hash;
+    void UpdateHash();
 
 public:
     typedef boost::array<unsigned char, 64> joinsplit_sig_t;
 
     static const int32_t CURRENT_VERSION=1;
 
-    // The user of this class MUST NOT modify these variables. The cached
-    // hash value will not be updated if you do so.
+    // The user of this class MUST NOT directly modify these variables.
+    // The cached hash value will not be updated if you do so.
     int32_t nVersion;
     std::vector<CTxIn> vin;
     std::vector<CTxOut> vout;
@@ -316,16 +316,16 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(*const_cast<int32_t*>(&this->nVersion));
+        READWRITE(this->nVersion);
         nVersion = this->nVersion;
-        READWRITE(*const_cast<std::vector<CTxIn>*>(&vin));
-        READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
-        READWRITE(*const_cast<uint32_t*>(&nLockTime));
+        READWRITE(vin);
+        READWRITE(vout);
+        READWRITE(nLockTime);
         if (nVersion >= 2) {
-            READWRITE(*const_cast<std::vector<CPourTx>*>(&vpour));
+            READWRITE(vpour);
             if (vpour.size() > 0) {
-                READWRITE(*const_cast<uint256*>(&joinSplitPubKey));
-                READWRITE(*const_cast<joinsplit_sig_t*>(&joinSplitSig));
+                READWRITE(joinSplitPubKey);
+                READWRITE(joinSplitSig);
             }
         }
         if (ser_action.ForRead())
@@ -336,7 +336,7 @@ public:
         return vin.empty() && vout.empty();
     }
 
-    const uint256& GetHash() const {
+    uint256 GetHash() const {
         return hash;
     }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -294,18 +294,15 @@ public:
 
     static const int32_t CURRENT_VERSION=1;
 
-    // The local variables are made const to prevent unintended modification
-    // without updating the cached hash value. However, CTransaction is not
-    // actually immutable; deserialization and assignment are implemented,
-    // and bypass the constness. This is safe, as they update the entire
-    // structure, including the hash.
-    const int32_t nVersion;
-    const std::vector<CTxIn> vin;
-    const std::vector<CTxOut> vout;
-    const uint32_t nLockTime;
-    const std::vector<CPourTx> vpour;
-    const uint256 joinSplitPubKey;
-    const joinsplit_sig_t joinSplitSig;
+    // The user of this class MUST NOT modify these variables. The cached
+    // hash value will not be updated if you do so.
+    int32_t nVersion;
+    std::vector<CTxIn> vin;
+    std::vector<CTxOut> vout;
+    uint32_t nLockTime;
+    std::vector<CPourTx> vpour;
+    uint256 joinSplitPubKey;
+    joinsplit_sig_t joinSplitSig;
 
     /** Construct a CTransaction that qualifies as IsNull() */
     CTransaction();


### PR DESCRIPTION
Supercedes #981. Fixes #967.