### PR TITLE
[WIP] Point compressed proofs

### DIFF
--- a/depends/packages/libsnark.mk
+++ b/depends/packages/libsnark.mk
@@ -7,11 +7,12 @@ $(package)_sha256_hash=b5ec84a836d0d305407d5f39c8176bae2bb448abe802a8d11ba0f88f1
 $(package)_git_commit=69f312f149cc4bd8def8e2fed26a7941ff41251d
 
 $(package)_dependencies=libgmp
-$(package)_patches=1_fix_Wl_flag.patch 2_include_iota_header.patch
+$(package)_patches=1_fix_Wl_flag.patch 2_include_iota_header.patch 3_dynamic_point_compression.patch
 
 define $(package)_preprocess_cmds
     patch -p1 < $($(package)_patch_dir)/1_fix_Wl_flag.patch && \
-    patch -p1 < $($(package)_patch_dir)/2_include_iota_header.patch
+    patch -p1 < $($(package)_patch_dir)/2_include_iota_header.patch && \
+    patch -p1 < $($(package)_patch_dir)/3_dynamic_point_compression.patch
 endef
 
 define $(package)_build_cmds

--- a/depends/patches/libsnark/3_dynamic_point_compression.patch
+++ b/depends/patches/libsnark/3_dynamic_point_compression.patch
@@ -1,0 +1,214 @@
+diff --git a/src/algebra/curves/alt_bn128/alt_bn128_g1.cpp b/src/algebra/curves/alt_bn128/alt_bn128_g1.cpp
+index bf7f43d..381d357 100644
+--- a/src/algebra/curves/alt_bn128/alt_bn128_g1.cpp
++++ b/src/algebra/curves/alt_bn128/alt_bn128_g1.cpp
+@@ -19,6 +19,12 @@ std::vector<size_t> alt_bn128_G1::fixed_base_exp_window_table;
+ alt_bn128_G1 alt_bn128_G1::G1_zero;
+ alt_bn128_G1 alt_bn128_G1::G1_one;
+ 
++#ifdef NO_PT_COMPRESSION
++bool g1_enable_point_compression = false;
++#else
++bool g1_enable_point_compression = true;
++#endif
++
+ alt_bn128_G1::alt_bn128_G1()
+ {
+     this->X = G1_zero.X;
+@@ -407,12 +413,12 @@ std::ostream& operator<<(std::ostream &out, const alt_bn128_G1 &g)
+     copy.to_affine_coordinates();
+ 
+     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
+-#ifdef NO_PT_COMPRESSION
+-    out << copy.X << OUTPUT_SEPARATOR << copy.Y;
+-#else
+-    /* storing LSB of Y */
+-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
+-#endif
++    if(!g1_enable_point_compression) {
++        out << copy.X << OUTPUT_SEPARATOR << copy.Y;
++    } else {
++        /* storing LSB of Y */
++        out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
++    }
+ 
+     return out;
+ }
+@@ -422,33 +428,33 @@ std::istream& operator>>(std::istream &in, alt_bn128_G1 &g)
+     char is_zero;
+     alt_bn128_Fq tX, tY;
+ 
+-#ifdef NO_PT_COMPRESSION
+-    in >> is_zero >> tX >> tY;
+-    is_zero -= '0';
+-#else
+-    in.read((char*)&is_zero, 1); // this reads is_zero;
+-    is_zero -= '0';
+-    consume_OUTPUT_SEPARATOR(in);
+-
+-    unsigned char Y_lsb;
+-    in >> tX;
+-    consume_OUTPUT_SEPARATOR(in);
+-    in.read((char*)&Y_lsb, 1);
+-    Y_lsb -= '0';
+-
+-    // y = +/- sqrt(x^3 + b)
+-    if (!is_zero)
+-    {
+-        alt_bn128_Fq tX2 = tX.squared();
+-        alt_bn128_Fq tY2 = tX2*tX + alt_bn128_coeff_b;
+-        tY = tY2.sqrt();
+-
+-        if ((tY.as_bigint().data[0] & 1) != Y_lsb)
++    if (!g1_enable_point_compression) {
++        in >> is_zero >> tX >> tY;
++        is_zero -= '0';
++    } else {
++        in.read((char*)&is_zero, 1); // this reads is_zero;
++        is_zero -= '0';
++        consume_OUTPUT_SEPARATOR(in);
++
++        unsigned char Y_lsb;
++        in >> tX;
++        consume_OUTPUT_SEPARATOR(in);
++        in.read((char*)&Y_lsb, 1);
++        Y_lsb -= '0';
++
++        // y = +/- sqrt(x^3 + b)
++        if (!is_zero)
+         {
+-            tY = -tY;
++            alt_bn128_Fq tX2 = tX.squared();
++            alt_bn128_Fq tY2 = tX2*tX + alt_bn128_coeff_b;
++            tY = tY2.sqrt();
++
++            if ((tY.as_bigint().data[0] & 1) != Y_lsb)
++            {
++                tY = -tY;
++            }
+         }
+     }
+-#endif
+     // using Jacobian coordinates
+     if (!is_zero)
+     {
+diff --git a/src/algebra/curves/alt_bn128/alt_bn128_g1.hpp b/src/algebra/curves/alt_bn128/alt_bn128_g1.hpp
+index da11a2e..1cba511 100644
+--- a/src/algebra/curves/alt_bn128/alt_bn128_g1.hpp
++++ b/src/algebra/curves/alt_bn128/alt_bn128_g1.hpp
+@@ -13,6 +13,8 @@
+ 
+ namespace libsnark {
+ 
++extern bool g1_enable_point_compression;
++
+ class alt_bn128_G1;
+ std::ostream& operator<<(std::ostream &, const alt_bn128_G1&);
+ std::istream& operator>>(std::istream &, alt_bn128_G1&);
+diff --git a/src/algebra/curves/alt_bn128/alt_bn128_g2.cpp b/src/algebra/curves/alt_bn128/alt_bn128_g2.cpp
+index c4152e4..f3519f5 100644
+--- a/src/algebra/curves/alt_bn128/alt_bn128_g2.cpp
++++ b/src/algebra/curves/alt_bn128/alt_bn128_g2.cpp
+@@ -19,6 +19,12 @@ std::vector<size_t> alt_bn128_G2::fixed_base_exp_window_table;
+ alt_bn128_G2 alt_bn128_G2::G2_zero;
+ alt_bn128_G2 alt_bn128_G2::G2_one;
+ 
++#ifdef NO_PT_COMPRESSION
++bool g2_enable_point_compression = false;
++#else
++bool g2_enable_point_compression = true;
++#endif
++
+ alt_bn128_G2::alt_bn128_G2()
+ {
+     this->X = G2_zero.X;
+@@ -420,12 +426,12 @@ std::ostream& operator<<(std::ostream &out, const alt_bn128_G2 &g)
+     alt_bn128_G2 copy(g);
+     copy.to_affine_coordinates();
+     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
+-#ifdef NO_PT_COMPRESSION
+-    out << copy.X << OUTPUT_SEPARATOR << copy.Y;
+-#else
+-    /* storing LSB of Y */
+-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
+-#endif
++    if (!g2_enable_point_compression) {
++        out << copy.X << OUTPUT_SEPARATOR << copy.Y;
++    } else {
++        /* storing LSB of Y */
++        out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
++    }
+ 
+     return out;
+ }
+@@ -435,33 +441,33 @@ std::istream& operator>>(std::istream &in, alt_bn128_G2 &g)
+     char is_zero;
+     alt_bn128_Fq2 tX, tY;
+ 
+-#ifdef NO_PT_COMPRESSION
+-    in >> is_zero >> tX >> tY;
+-    is_zero -= '0';
+-#else
+-    in.read((char*)&is_zero, 1); // this reads is_zero;
+-    is_zero -= '0';
+-    consume_OUTPUT_SEPARATOR(in);
+-
+-    unsigned char Y_lsb;
+-    in >> tX;
+-    consume_OUTPUT_SEPARATOR(in);
+-    in.read((char*)&Y_lsb, 1);
+-    Y_lsb -= '0';
+-
+-    // y = +/- sqrt(x^3 + b)
+-    if (!is_zero)
+-    {
+-        alt_bn128_Fq2 tX2 = tX.squared();
+-        alt_bn128_Fq2 tY2 = tX2 * tX + alt_bn128_twist_coeff_b;
+-        tY = tY2.sqrt();
+-
+-        if ((tY.c0.as_bigint().data[0] & 1) != Y_lsb)
++    if (!g2_enable_point_compression) {
++        in >> is_zero >> tX >> tY;
++        is_zero -= '0';
++    } else {
++        in.read((char*)&is_zero, 1); // this reads is_zero;
++        is_zero -= '0';
++        consume_OUTPUT_SEPARATOR(in);
++
++        unsigned char Y_lsb;
++        in >> tX;
++        consume_OUTPUT_SEPARATOR(in);
++        in.read((char*)&Y_lsb, 1);
++        Y_lsb -= '0';
++
++        // y = +/- sqrt(x^3 + b)
++        if (!is_zero)
+         {
+-            tY = -tY;
++            alt_bn128_Fq2 tX2 = tX.squared();
++            alt_bn128_Fq2 tY2 = tX2 * tX + alt_bn128_twist_coeff_b;
++            tY = tY2.sqrt();
++
++            if ((tY.c0.as_bigint().data[0] & 1) != Y_lsb)
++            {
++                tY = -tY;
++            }
+         }
+     }
+-#endif
+     // using projective coordinates
+     if (!is_zero)
+     {
+diff --git a/src/algebra/curves/alt_bn128/alt_bn128_g2.hpp b/src/algebra/curves/alt_bn128/alt_bn128_g2.hpp
+index a996a2d..c2c58b5 100644
+--- a/src/algebra/curves/alt_bn128/alt_bn128_g2.hpp
++++ b/src/algebra/curves/alt_bn128/alt_bn128_g2.hpp
+@@ -13,6 +13,8 @@
+ 
+ namespace libsnark {
+ 
++extern bool g2_enable_point_compression;
++
+ class alt_bn128_G2;
+ std::ostream& operator<<(std::ostream &, const alt_bn128_G2&);
+ std::istream& operator>>(std::istream &, alt_bn128_G2&);

--- a/src/zcash/JoinSplit.cpp
+++ b/src/zcash/JoinSplit.cpp
@@ -24,6 +24,7 @@ namespace libzcash {
 
 #include "zcash/circuit/gadget.tcc"
 
+CCriticalSection cs_PointCompression;
 CCriticalSection cs_ParamsIO;
 CCriticalSection cs_InitializeParams;
 
@@ -141,10 +142,26 @@ public:
         }
 
         r1cs_ppzksnark_proof<ppzksnark_ppT> r1cs_proof;
-        std::stringstream ss;
-        std::string proof_str(proof.begin(), proof.end());
-        ss.str(proof_str);
-        ss >> r1cs_proof;
+        {
+            LOCK(cs_PointCompression);
+            libsnark::g1_enable_point_compression = true;
+            libsnark::g2_enable_point_compression = true;
+
+            try {
+                std::stringstream ss;
+                std::string proof_str(proof.begin(), proof.end());
+                ss.str(proof_str);
+                ss >> r1cs_proof;
+            } catch(...) {
+                libsnark::g1_enable_point_compression = false;
+                libsnark::g2_enable_point_compression = false;
+
+                throw std::ios_base::failure("failed to deserialize zkSNARK proof");
+            }
+
+            libsnark::g1_enable_point_compression = false;
+            libsnark::g2_enable_point_compression = false;
+        }
 
         uint256 h_sig = this->h_sig(randomSeed, nullifiers, pubKeyHash);
 
@@ -265,9 +282,20 @@ public:
             aux_input
         );
 
-        std::stringstream ss;
-        ss << proof;
-        std::string serialized_proof = ss.str();
+        std::string serialized_proof;
+
+        {
+            LOCK(cs_PointCompression);
+            libsnark::g1_enable_point_compression = true;
+            libsnark::g2_enable_point_compression = true;
+
+            std::stringstream ss;
+            ss << proof;
+            serialized_proof = ss.str();
+
+            libsnark::g1_enable_point_compression = false;
+            libsnark::g2_enable_point_compression = false;
+        }
 
         boost::array<unsigned char, ZKSNARK_PROOF_SIZE> result_proof;
         //std::cout << "proof size in bytes when serialized: " << serialized_proof.size() << std::endl;

--- a/src/zcash/Zcash.h
+++ b/src/zcash/Zcash.h
@@ -12,6 +12,6 @@
 #define ZC_R_SIZE 32
 #define ZC_MEMO_SIZE 128
 
-#define ZKSNARK_PROOF_SIZE 584
+#define ZKSNARK_PROOF_SIZE 304
 
 #endif // _ZCCONSTANTS_H_


### PR DESCRIPTION
Proof of concept for enabling it just to see the behavior.

The proofs end up being 304 bytes which is larger than they should be, see https://github.com/scipr-lab/libsnark/issues/38 and https://github.com/zcash/zips/issues/43.

Here's the final transaction:

```
0200000000000000000001000000000000000000000000000000000323f2850bf3444f4b4c5c09a6057ec7169190f45acb9e46984ab3dfcec4f06a022d8c738663ab3c5e60fc6c7f7a8e2caa4892dd64bcbfd948a0550e1163a69c5264da1ea2ab4b79fa3e744f4cf892f2ec41cd97da1d2181b2c28ead49effc407204a2f9676502e83f6210a231b493bc3b1c52e1c06d167d03b560a9bbed045d626826ec91641fe707ccd35ba2440e6dc5a6a41a21f1b8989ed83ec97bf530c4434b38adb52500fc0926f8944eef82f9949de155b80da1abfbe21adf123aa1715f54b8988348db7739cc526e14aec284bb5335951c7d710cd847b45f9acb3374d35a0f067ce9b4d375495c7b39b3fc4126cbf5476aef75e7105ee29040e8592cb76f8959ba36221fb6752687da7bce74c37a770ad51f87b76b64def5d02c03c950c3870acb9fa07115df5b8284c0a1d191a74fb698bf71f96e9fc42df1b8b7f5c8cacc278afcf49a4001551cc55d70df71eb0d0dae6dd51dd3e9f649ca0ff2524bb58f26b2fce17df8a463b5e2038994f464d67144b2c06560311db8f6fdf693f1c580d504c78e49dcc11ecccdb276f83c166f192c57513a5386c80bfc7615e31b267ccb3cc6bfef1adfd9b5305c732086d8b60c927e9a983acd83d1e38c91ee1a98fc435a76359c2213b77fd01dc3421d6ebceab181e20681a60b07f8084e2f61c33280a9f60ea7ad04f9525a3a04fbb21aedfeebf7b42e7f74f91f2aa39d0962cc2bc769f54211ea193ebd63b84005783e347804c6a5eeebffba8cc535863fedf0186b13d20e48e6f2c21283fccafa8a971d7da6a6695088d4d5ec3a1da66aee03da97af288462d045d50b17464d2da5127d47db5f229efc4dc8414ed011af2b00dc8d721a66cced019cc20bfd42bb5e0f209233aefe3608f834f3bc9975cd470a636b9c4d433b1bc1ce11826bf92f5a928f9c568b2c8e3453d650e6b9644c2368fe09a708ff8f64dba766191880c601486e0ba52a719349d9124c28c510833d6d9d4ba88e7b0b46a94019c798e687fd1630e3ae24492de027666d80192cba395212f989e273fb3d608e60c8b8e2f6a9dc2b30306794d0c5670bbaa8a5aa9d7b9ae54ecd6c61d56733bbc64860410123dbb7b50d3130b93643f6d3ef51880652743bc4bf22611c139491e75f48b84f696cbb045ae2078763bcaba3a1270748dee83fe81127a0da504b0dce8d18417bcd9a48e070c52d31307443e4e78487a4c610fc45ff8dee8e41ac205cf8f124804087eb7a88adebe9193130dc3ba3e8e0722892ac17a06b593fc452574aacb4c9cf6f2c8dd7718d3a13ec173130d2d1124897032d28d7c424946666f1f2674a16bba41f17cd723a00d0d9c1802e30307a3c752cdca81a7c1359841ac4bcce6d08eb558628d7d3fae41674e98e461a133130ccc91ebb60ce9ee9385a377d8cf1d6b877a942917c9d0c29e0f6bc63b32b29273182565b30ccbbc1a5f3ad1cd6713a9f2a0ce720a42770111114cf855f7541d69572c88d66d70992ae1d33b696ea3f1139df03ace1d712474a7a77293be9ded1f71ff1c59703d8eca3b9cb45344898d635d7a14ea760cb0af4f49be26bae138101
```

This means our transactions are roughly 1149 bytes best-case, with more optimized serialization they might be 1133.