### PR TITLE
Update GetDifficulty() to use consensus.powLimit 

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -33,9 +33,6 @@ double GetDifficulty(const CBlockIndex* blockindex)
             blockindex = chainActive.Tip();
     }
 
-    int nShift = (blockindex->nBits >> 24) & 0xff;
-
-
     bool fNegative;
     bool fOverflow;
     arith_uint256 bnDiff;
@@ -49,7 +46,7 @@ double GetDifficulty(const CBlockIndex* blockindex)
     if (fNegative || fOverflow)
         dDiff = 0.0;
 
-    bnDiff /= ArithToUint256(bnCurr);
+    bnDiff /= bnCurr;
 
     dDiff = bnDiff.getdouble();
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -35,21 +35,26 @@ double GetDifficulty(const CBlockIndex* blockindex)
 
     int nShift = (blockindex->nBits >> 24) & 0xff;
 
-    double dDiff =
-        (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
 
-    while (nShift < 29)
-    {
-        dDiff *= 256.0;
-        nShift++;
-    }
-    while (nShift > 29)
-    {
-        dDiff /= 256.0;
-        nShift--;
-    }
+    bool fNegative;
+    bool fOverflow;
+    arith_uint256 bnDiff;
+    arith_uint256 bnCurr;
+    double dDiff;
+
+    bnDiff = UintToArith256(uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+
+    bnCurr.SetCompact(blockindex->nBits, &fNegative, &fOverflow);
+
+    if (fNegative || fOverflow)
+        dDiff = 0.0;
+
+    bnDiff /= ArithToUint256(bnCurr);
+
+    dDiff = bnDiff.getdouble();
 
     return dDiff;
+
 }
 
 


### PR DESCRIPTION
Update GetDifficulty() to use consensus.powLimit from current parameters. Note that the consensus parameters are not passed to GetDifficulty(), so this uses a hardcoded consensus.powLimit. I believe this fixes #1032.