### PR TITLE
Update GetDifficulty() to use consensus.powLimit from consensus parameters.

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -34,16 +34,20 @@ double GetDifficulty(const CBlockIndex* blockindex)
     }
 
     int nShift = (blockindex->nBits >> 24) & 0xff;
+    uint32_t powLimit =
+        UintToArith256(Params().GetConsensus().powLimit).GetCompact();;
+    int nShiftAmount = (powLimit >> 24) & 0xff;
 
     double dDiff =
-        (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
+        (double)(powLimit & 0x00ffffff) / 
+        (double)(blockindex->nBits & 0x00ffffff);
 
-    while (nShift < 29)
+    while (nShift < nShiftAmount)
     {
         dDiff *= 256.0;
         nShift++;
     }
-    while (nShift > 29)
+    while (nShift > nShiftAmount)
     {
         dDiff /= 256.0;
         nShift--;


### PR DESCRIPTION
Fixes #1032.