### PR TITLE
Flush to disk more consistently by accounting memory usage of serials/anchors in cache.

### DIFF
--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -136,7 +136,9 @@ public:
     void SelfTest() const
     {
         // Manually recompute the dynamic usage of the whole data, and compare it.
-        size_t ret = memusage::DynamicUsage(cacheCoins);
+        size_t ret = memusage::DynamicUsage(cacheCoins) +
+                     memusage::DynamicUsage(cacheAnchors) +
+                     memusage::DynamicUsage(cacheSerials);
         for (CCoinsMap::iterator it = cacheCoins.begin(); it != cacheCoins.end(); it++) {
             ret += memusage::DynamicUsage(it->second.coins);
         }

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -60,6 +60,12 @@ public:
 
     IncrementalMerkleTree() { }
 
+    size_t DynamicMemoryUsage() const {
+        return 32 + // left
+               32 + // right
+               parents.size() * 32; // parents
+    }
+
     void append(Hash obj);
     Hash root() const {
         return root(Depth, std::deque<Hash>());


### PR DESCRIPTION
Closes #626.

It's important that this at least *approximates* the memory usage, so that we flush the cache to disk as expected. It's okay that we overestimate. The serials are stored in keys in the `boost::unordered_map`, so we can simply use that map's `DynamicMemoryUsage`. The anchors are another story.