### PR TITLE
Add getblocksubsidy RPC command to return block reward taking into account mining slow start

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -95,7 +95,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "zcrawpour", 2 },
     { "zcrawpour", 3 },
     { "zcrawpour", 4 },
-    { "zcbenchmark", 1 }
+    { "zcbenchmark", 1 },
+    { "getblocksubsidy", 0}
 };
 
 class CRPCConvertTable

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -771,10 +771,10 @@ Value getblocksubsidy(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
         throw runtime_error(
-            "getblocksubsidy index\n"
+            "getblocksubsidy height\n"
             "\nReturns block subsidy reward, taking into account the mining slow start, of block at index provided.\n"
             "\nArguments:\n"
-            "1. index         (numeric, required) The block index\n"
+            "1. height        (numeric, required) The block height.\n"
             "\nResult:\n"
             "amount           (numeric) The block reward amount in ZEC.\n"
             "\nExamples:\n"

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -772,11 +772,14 @@ Value getblocksubsidy(const Array& params, bool fHelp)
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "getblocksubsidy height\n"
-            "\nReturns block subsidy reward, taking into account the mining slow start, of block at index provided.\n"
+            "\nReturns block subsidy reward, taking into account the mining slow start and the founders reward, of block at index provided.\n"
             "\nArguments:\n"
             "1. height        (numeric, required) The block height.\n"
             "\nResult:\n"
-            "amount           (numeric) The block reward amount in ZEC.\n"
+            "{\n"
+            "  \"miner\" : x.xxx           (numeric) The mining reward amount in ZEC.\n"
+            "  \"founders\" : x.xxx        (numeric) The founders reward amount in ZEC.\n"
+            "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getblocksubsidy", "1000")
             + HelpExampleRpc("getblockubsidy", "1000")
@@ -788,5 +791,13 @@ Value getblocksubsidy(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
 
     CAmount nReward = GetBlockSubsidy(nHeight, Params().GetConsensus());
-    return ValueFromAmount(nReward);
+    CAmount nFoundersReward = 0;
+    if ((nHeight > 0) && (nHeight < Params().GetConsensus().nSubsidyHalvingInterval)) {
+        nFoundersReward = nReward/5;
+        nReward -= nFoundersReward;
+    }
+    Object result;
+    result.push_back(Pair("miner", ValueFromAmount(nReward)));
+    result.push_back(Pair("founders", ValueFromAmount(nFoundersReward)));
+    return result;
 }

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -782,8 +782,8 @@ Value getblocksubsidy(const Array& params, bool fHelp)
             + HelpExampleRpc("getblockubsidy", "1000")
         );
 
-    LOCK(cs_main);
     int nHeight = params[0].get_int();
+    LOCK(cs_main);
     if (nHeight < 0 || nHeight > chainActive.Height())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -766,3 +766,27 @@ Value estimatepriority(const Array& params, bool fHelp)
 
     return mempool.estimatePriority(nBlocks);
 }
+
+Value getblocksubsidy(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "getblocksubsidy index\n"
+            "\nReturns block subsidy reward, taking into account the mining slow start, of block at index provided.\n"
+            "\nArguments:\n"
+            "1. index         (numeric, required) The block index\n"
+            "\nResult:\n"
+            "amount           (numeric) The block reward amount in ZEC.\n"
+            "\nExamples:\n"
+            + HelpExampleCli("getblocksubsidy", "1000")
+            + HelpExampleRpc("getblockubsidy", "1000")
+        );
+
+    LOCK(cs_main);
+    int nHeight = params[0].get_int();
+    if (nHeight < 0 || nHeight > chainActive.Height())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
+
+    CAmount nReward = GetBlockSubsidy(nHeight, Params().GetConsensus());
+    return ValueFromAmount(nReward);
+}

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -304,6 +304,7 @@ static const CRPCCommand vRPCCommands[] =
     { "mining",             "getnetworkhashps",       &getnetworkhashps,       true  },
     { "mining",             "prioritisetransaction",  &prioritisetransaction,  true  },
     { "mining",             "submitblock",            &submitblock,            true  },
+    { "mining",             "getblocksubsidy",        &getblocksubsidy,        true  },
 
 #ifdef ENABLE_WALLET
     /* Coin generation */

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -240,6 +240,8 @@ extern json_spirit::Value getchaintips(const json_spirit::Array& params, bool fH
 extern json_spirit::Value invalidateblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value reconsiderblock(const json_spirit::Array& params, bool fHelp);
 
+extern json_spirit::Value getblocksubsidy(const json_spirit::Array& params, bool fHelp);
+
 // in rest.cpp
 extern bool HTTPReq_REST(AcceptedConnection *conn,
                   const std::string& strURI,


### PR DESCRIPTION
This PR adds a new RPC command to return the block reward as defined by function `GetBlockSubsidy`.

Usage:
`zcash-cli getblocksubsidy blockheight
`

The basis for this PR is that some users have been unaware of the mining slow start and they subsequently sought help to clarify if they were mining blocks correctly or if there was a bug in the reward schedule.

