### PR TITLE
Make `validatelargetx` test more accurate, reduce block size limit

### DIFF
--- a/qa/zcash/performance-measurements.sh
+++ b/qa/zcash/performance-measurements.sh
@@ -32,19 +32,6 @@ function zcashd_massif_start {
     ZCASHD_PID=$!
 }
 
-function zcashd_massif_start_chain {
-    rm -rf "$DATADIR"
-    mkdir -p "$DATADIR"
-    rm -f massif.out
-    ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 &
-    ZCASHD_PID=$!
-    zcashd_generate
-    zcash_rpc stop > /dev/null
-    wait $ZCASHD_PID
-    valgrind --tool=massif --time-unit=ms --massif-out-file=massif.out ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 &
-    ZCASHD_PID=$!
-}
-
 function zcashd_massif_stop {
     zcash_rpc stop > /dev/null
     wait $ZCASHD_PID
@@ -55,19 +42,6 @@ function zcashd_valgrind_start {
     rm -rf "$DATADIR"
     mkdir -p "$DATADIR"
     rm -f valgrind.out
-    valgrind --leak-check=yes -v --error-limit=no --log-file="valgrind.out" ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 &
-    ZCASHD_PID=$!
-}
-
-function zcashd_valgrind_start_chain {
-    rm -rf "$DATADIR"
-    mkdir -p "$DATADIR"
-    rm -f valgrind.out
-    ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 &
-    ZCASHD_PID=$!
-    zcashd_generate
-    zcash_rpc stop > /dev/null
-    wait $ZCASHD_PID
     valgrind --leak-check=yes -v --error-limit=no --log-file="valgrind.out" ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 &
     ZCASHD_PID=$!
 }
@@ -102,13 +76,8 @@ case "$1" in
             verifyequihash)
                 zcash_rpc zcbenchmark verifyequihash 1000
                 ;;
-            createlargetx)
-                zcashd_generate
-                zcash_rpc zcbenchmark createlargetx 10
-                ;;
             validatelargetx)
-                zcashd_generate
-                zcash_rpc zcbenchmark validatelargetx 2
+                zcash_rpc zcbenchmark validatelargetx 5
                 ;;
             *)
                 zcashd_stop
@@ -118,13 +87,7 @@ case "$1" in
         zcashd_stop
         ;;
     memory)
-        case "$2" in
-            createlargetx|validatelargetx)
-                zcashd_massif_start_chain
-                ;;
-            *)
-                zcashd_massif_start
-        esac
+        zcashd_massif_start
         case "$2" in
             sleep)
                 zcash_rpc zcbenchmark sleep 1
@@ -143,12 +106,6 @@ case "$1" in
                 ;;
             verifyequihash)
                 zcash_rpc zcbenchmark verifyequihash 1
-                ;;
-            createlargetx)
-                zcash_rpc zcbenchmark validatelargetx 1
-                ;;
-            validatelargetx)
-                zcash_rpc zcbenchmark validatelargetx 1
                 ;;
             *)
                 zcashd_massif_stop
@@ -159,13 +116,7 @@ case "$1" in
         rm -f massif.out
         ;;
     valgrind)
-        case "$2" in
-            createlargetx|validatelargetx)
-                zcashd_valgrind_start_chain
-                ;;
-            *)
-                zcashd_valgrind_start
-        esac
+        zcashd_valgrind_start
         case "$2" in
             sleep)
                 zcash_rpc zcbenchmark sleep 1
@@ -184,12 +135,6 @@ case "$1" in
                 ;;
             verifyequihash)
                 zcash_rpc zcbenchmark verifyequihash 1
-                ;;
-            createlargetx)
-                zcash_rpc zcbenchmark validatelargetx 1
-                ;;
-            validatelargetx)
-                zcash_rpc zcbenchmark validatelargetx 1
                 ;;
             *)
                 zcashd_valgrind_stop

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -7,7 +7,7 @@
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
-static const unsigned int MAX_BLOCK_SIZE = 2000000;
+static const unsigned int MAX_BLOCK_SIZE = 1000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS = 20000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2419,10 +2419,8 @@ Value zc_benchmark(const json_spirit::Array& params, bool fHelp)
             sample_times.push_back(benchmark_solve_equihash());
         } else if (benchmarktype == "verifyequihash") {
             sample_times.push_back(benchmark_verify_equihash());
-        } else if (benchmarktype == "createlargetx") {
-            sample_times.push_back(benchmark_large_tx(false));
         } else if (benchmarktype == "validatelargetx") {
-            sample_times.push_back(benchmark_large_tx(true));
+            sample_times.push_back(benchmark_large_tx());
         } else {
             throw JSONRPCError(RPC_TYPE_ERROR, "Invalid benchmarktype");
         }

--- a/src/zcbenchmarks.h
+++ b/src/zcbenchmarks.h
@@ -10,6 +10,6 @@ extern double benchmark_create_joinsplit();
 extern double benchmark_solve_equihash();
 extern double benchmark_verify_joinsplit(const CPourTx &joinsplit);
 extern double benchmark_verify_equihash();
-extern double benchmark_large_tx(bool testValidate);
+extern double benchmark_large_tx();
 
 #endif


### PR DESCRIPTION
This temporarily reduces the block size limit to 1MB and makes the performance measurement test more accurate by bypassing Bitcoin's API (which performs signature verification caching) and verifying that the size of the transaction approximates the block size limit.