### PR TITLE
Increase block size to 2MB and update performance test.

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -7,7 +7,7 @@
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
-static const unsigned int MAX_BLOCK_SIZE = 1000000;
+static const unsigned int MAX_BLOCK_SIZE = 2000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS = 20000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -135,7 +135,7 @@ double benchmark_verify_equihash()
 double benchmark_large_tx()
 {
     // Number of inputs in the spending transaction that we will simulate
-    const size_t NUM_INPUTS = 5550;
+    const size_t NUM_INPUTS = 11100;
 
     // Create priv/pub key
     CKey priv;


### PR DESCRIPTION
This increases the block size to 2MB, and we should see the worst-case verification costs reflected on speed.z.cash afterward.