### PR TITLE
Fix the SIGHASH_SINGLE bug by checking for `1` return value

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1125,6 +1125,7 @@ bool TransactionSignatureChecker::VerifySignature(const std::vector<unsigned cha
 
 bool TransactionSignatureChecker::CheckSig(const vector<unsigned char>& vchSigIn, const vector<unsigned char>& vchPubKey, const CScript& scriptCode) const
 {
+    static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
     CPubKey pubkey(vchPubKey);
     if (!pubkey.IsValid())
         return false;
@@ -1137,6 +1138,10 @@ bool TransactionSignatureChecker::CheckSig(const vector<unsigned char>& vchSigIn
     vchSig.pop_back();
 
     uint256 sighash = SignatureHash(scriptCode, *txTo, nIn, nHashType);
+
+    if (sighash == one) {
+        return false;
+    }
 
     if (!VerifySignature(vchSig, pubkey, sighash))
         return false;

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -21,13 +21,22 @@ TransactionSignatureCreator::TransactionSignatureCreator(const CKeyStore* keysto
 
 bool TransactionSignatureCreator::CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& address, const CScript& scriptCode) const
 {
+    static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
     CKey key;
-    if (!keystore->GetKey(address, key))
+    if (!keystore->GetKey(address, key)) {
         return false;
+    }
 
     uint256 hash = SignatureHash(scriptCode, *txTo, nIn, nHashType);
-    if (!key.Sign(hash, vchSig))
+
+    if (hash == one) {
         return false;
+    }
+
+    if (!key.Sign(hash, vchSig)) {
+        return false;
+    }
+
     vchSig.push_back((unsigned char)nHashType);
     return true;
 }


### PR DESCRIPTION
Competes with #1079. Closes #1078.