### PR TITLE
.clang-format: change standard to C++11

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -46,6 +46,6 @@ SpacesInAngles:  false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
-Standard:        Cpp03
+Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never


### PR DESCRIPTION
A nitpick for folks who want to test with clang.