### PR TITLE
README.md: simplify the title, drop "Core"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Zcash Core integration/staging tree
-=====================================
+Zcash
+=====
 
 https://z.cash/
 
@@ -9,7 +9,7 @@ Where do I begin?
 We have a guide for joining the public testnet: https://github.com/zcash/zcash/wiki/Public-Alpha-Guide
 
 What is Zcash?
-----------------
+--------------
 
 Zcash is an implementation of the "Zerocash" protocol. Based on Bitcoin's code, it intends to
 offer a far higher standard of privacy and anonymity through a sophisticiated zero-knowledge
@@ -22,5 +22,5 @@ Participation in the Zcash project is subject to a [Code of Conduct](code_of_con
 License
 -------
 
-Zcash Core is released under the terms of the MIT license. See [COPYING](COPYING) for more
+Zcash is released under the terms of the MIT license. See [COPYING](COPYING) for more
 information or see http://opensource.org/licenses/MIT.


### PR DESCRIPTION
We only have one public tree.