### PR TITLE
Add security warnings doc with warning about side channels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,15 @@ proving scheme which preserves confidentiality of transaction metadata.
 
 Participation in the Zcash project is subject to a [Code of Conduct](code_of_conduct.md).
 
+Security Warnings
+-----------------
+
+See important security warnings in
+[doc/security-warnings.md](doc/security-warnings.md).
+
 License
 -------
 
 Zcash Core is released under the terms of the MIT license. See [COPYING](COPYING) for more
 information or see http://opensource.org/licenses/MIT.
+

--- a/doc/security-warnings.md
+++ b/doc/security-warnings.md
@@ -19,8 +19,9 @@ Side-Channel Attacks
 --------------------
 
 This implementation of Zcash is not resistant to side-channel attacks. You
-should assume other unprivileged users running on the same hardware as your
-`zcashd` process will be able to:
+should assume (even unprivileged) users who are running on the hardware, or who
+are physically near the hardware, that your `zcashd` process is running on will
+be able to:
 
 - Determine the values of your secret spending keys, as well as which notes you
   are spending, by observing cache side-channels as you perform a JoinSplit

--- a/doc/security-warnings.md
+++ b/doc/security-warnings.md
@@ -22,9 +22,10 @@ This implementation of Zcash is not resistant to side-channel attacks. You
 should assume other unprivileged users running on the same hardware as your
 `zcashd` process will be able to:
 
-- Determine which note your are spending by observing cache side-channels as you
-  perform a JoinSplit operation. This is due to probable side-channel leakage in
-  the libsnark proving machinery.
+- Determine the values of your secret spending keys, as well as which notes you
+  are spending, by observing cache side-channels as you perform a JoinSplit
+  operation. This is due to probable side-channel leakage in the libsnark
+  proving machinery.
 
 - Determine which notes you own by observing cache side-channel information
   leakage from the incremental witnesses as they are updated with new notes.

--- a/doc/security-warnings.md
+++ b/doc/security-warnings.md
@@ -29,6 +29,9 @@ should assume other unprivileged users running on the same hardware as your
 - Determine which notes you own by observing cache side-channel information
   leakage from the incremental witnesses as they are updated with new notes.
 
+- Determine which notes you own by observing the trial decryption process of
+  each note ciphertext on the blockchain.
+
 You should ensure no other users have the ability to execute code (even
 unprivileged) on the hardware your `zcashd` process runs on until these
 vulnerabilities are fully analyzed and fixed.

--- a/doc/security-warnings.md
+++ b/doc/security-warnings.md
@@ -7,6 +7,14 @@ Security Audit
 Zcash has not yet been subjected to a formal third-party security review. This
 section will be updated with links to security audit reports in the future.
 
+x86-64 Linux Only
+-----------------------
+
+There are [known bugs](https://github.com/scipr-lab/libsnark/issues/26) which
+make proving keys generated on 64-bit systems unusable on 32-bit and big-endian
+systems. It's unclear if a warning will be issued in this case, or if the
+proving system will be silently compromised.
+
 Side-Channel Attacks
 --------------------
 

--- a/doc/security-warnings.md
+++ b/doc/security-warnings.md
@@ -1,0 +1,26 @@
+Security Warnings
+====================
+
+Security Audit
+--------------
+
+Zcash has not yet been subjected to a formal third-party security review. This
+section will be updated with links to security audit reports in the future.
+
+Side-Channel Attacks
+--------------------
+
+This implementation of Zcash is not resistant to side-channel attacks. You
+should assume other unprivileged users running on the same hardware as your
+`zcashd` process will be able to:
+
+- Determine which note your are spending by observing cache side-channels as you
+  perform a JoinSplit operation. This is due to probable side-channel leakage in
+  the libsnark proving machinery.
+
+- Determine which notes you own by observing cache side-channel information
+  leakage from the incremental witnesses as they are updated with new notes.
+
+You should ensure no other users have the ability to execute code (even
+unprivileged) on the hardware your `zcashd` process runs on until these
+vulnerabilities are fully analyzed and fixed.


### PR DESCRIPTION
Closes #5. Closes #785. Closes #488. Closes #784.

Let's only merge this once we're sure the warning is at least as strong as it needs to be (and thus sufficient to close those tickets).