### PR TITLE
Remove the constraint system from the alpha proving key.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -605,8 +605,8 @@ static void ZC_LoadParams()
     struct timeval tv_start, tv_end;
     float elapsed;
 
-    boost::filesystem::path pk_path = ZC_GetParamsDir() / "z5-proving.key";
-    boost::filesystem::path vk_path = ZC_GetParamsDir() / "z5-verifying.key";
+    boost::filesystem::path pk_path = ZC_GetParamsDir() / "z7-proving.key";
+    boost::filesystem::path vk_path = ZC_GetParamsDir() / "z7-verifying.key";
 
     pzcashParams = ZCJoinSplit::Unopened();
 

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -50,8 +50,8 @@ double benchmark_sleep()
 double benchmark_parameter_loading()
 {
     // FIXME: this is duplicated with the actual loading code
-    boost::filesystem::path pk_path = ZC_GetParamsDir() / "z5-proving.key";
-    boost::filesystem::path vk_path = ZC_GetParamsDir() / "z5-verifying.key";
+    boost::filesystem::path pk_path = ZC_GetParamsDir() / "z7-proving.key";
+    boost::filesystem::path vk_path = ZC_GetParamsDir() / "z7-verifying.key";
 
     timer_start();
 

--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -4,8 +4,8 @@ set -eu
 
 PARAMS_DIR="$HOME/.zcash-params"
 
-REGTEST_PKEY_NAME='z5-proving.key'
-REGTEST_VKEY_NAME='z5-verifying.key'
+REGTEST_PKEY_NAME='z7-proving.key'
+REGTEST_VKEY_NAME='z7-verifying.key'
 REGTEST_PKEY_URL="https://z.cash/downloads/$REGTEST_PKEY_NAME"
 REGTEST_VKEY_URL="https://z.cash/downloads/$REGTEST_VKEY_NAME"
 REGTEST_DIR="$PARAMS_DIR/regtest"
@@ -86,8 +86,8 @@ cd "$PARAMS_DIR"
 # Now verify their hashes:
 echo 'Verifying parameter file integrity via sha256sum...'
 shasum -a 256 --check <<EOF
-72bd11091a1747de09fcfcddabbb1b4b6146a68ae2025bf732c1bee160366b75  regtest/$REGTEST_PKEY_NAME
-72bd11091a1747de09fcfcddabbb1b4b6146a68ae2025bf732c1bee160366b75  testnet3/$REGTEST_PKEY_NAME
+18bf2599787a2ed6ee4218d433983d15195944f8a40e09ef9cb80c186c142bc3  regtest/$REGTEST_PKEY_NAME
+18bf2599787a2ed6ee4218d433983d15195944f8a40e09ef9cb80c186c142bc3  testnet3/$REGTEST_PKEY_NAME
 239ddba9249bdd1f4ba7654b17a960bd319c1cefcd3cd79883b422d0f4a806da  regtest/$REGTEST_VKEY_NAME
 239ddba9249bdd1f4ba7654b17a960bd319c1cefcd3cd79883b422d0f4a806da  testnet3/$REGTEST_VKEY_NAME
 EOF


### PR DESCRIPTION
This removes the constraint system from the `z5-proving.key`, shortening it by about 35%. It appeared at the end of the file, which is why we didn't need to change public parameters in #1104.