### PR TITLE
Introduce `zcsamplejoinsplit` for creating a raw joinsplit description

### DIFF
--- a/qa/zcash/performance-measurements.sh
+++ b/qa/zcash/performance-measurements.sh
@@ -52,6 +52,17 @@ function zcashd_valgrind_stop {
     cat valgrind.out
 }
 
+# Precomputation
+case "$1" in
+    *)
+        case "$2" in
+            verifyjoinsplit)
+                zcashd_start
+                RAWJOINSPLIT=$(zcash_rpc zcsamplejoinsplit)
+                zcashd_stop
+        esac
+esac
+
 case "$1" in
     time)
         zcashd_start
@@ -66,7 +77,7 @@ case "$1" in
                 zcash_rpc zcbenchmark createjoinsplit 10
                 ;;
             verifyjoinsplit)
-                zcash_rpc zcbenchmark verifyjoinsplit 1000
+                zcash_rpc zcbenchmark verifyjoinsplit 1000 "$RAWJOINSPLIT"
                 ;;
             solveequihash)
                 zcash_rpc zcbenchmark solveequihash 10
@@ -97,7 +108,7 @@ case "$1" in
                 zcash_rpc zcbenchmark createjoinsplit 1
                 ;;
             verifyjoinsplit)
-                zcash_rpc zcbenchmark verifyjoinsplit 1
+                zcash_rpc zcbenchmark verifyjoinsplit 1 "$RAWJOINSPLIT"
                 ;;
             solveequihash)
                 zcash_rpc zcbenchmark solveequihash 1
@@ -126,7 +137,7 @@ case "$1" in
                 zcash_rpc zcbenchmark createjoinsplit 1
                 ;;
             verifyjoinsplit)
-                zcash_rpc zcbenchmark verifyjoinsplit 1
+                zcash_rpc zcbenchmark verifyjoinsplit 1 "$RAWJOINSPLIT"
                 ;;
             solveequihash)
                 zcash_rpc zcbenchmark solveequihash 1

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -380,7 +380,8 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "zcbenchmark",            &zc_benchmark,           true  },
     { "wallet",             "zcrawkeygen",            &zc_raw_keygen,          true  },
     { "wallet",             "zcrawjoinsplit",         &zc_raw_joinsplit,       true  },
-    { "wallet",             "zcrawreceive",           &zc_raw_receive,         true  }
+    { "wallet",             "zcrawreceive",           &zc_raw_receive,         true  },
+    { "wallet",             "zcsamplejoinsplit",      &zc_sample_joinsplit,    true  }
 #endif // ENABLE_WALLET
 };
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -212,6 +212,7 @@ extern json_spirit::Value zc_benchmark(const json_spirit::Array& params, bool fH
 extern json_spirit::Value zc_raw_keygen(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value zc_raw_joinsplit(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value zc_raw_receive(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value zc_sample_joinsplit(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
We need this to generate joinsplits for use in the performance measurements. The current measurements for *memory usage* of verification are wrong now that we're computing the joinsplit before verifying: https://speed.z.cash/timeline/?exe=1&base=1%2B9&ben=memory+verifyjoinsplit&env=1&revs=50&equid=off&quarts=on&extr=on

This PR fixes that.