### PR TITLE
Remove more from libsnark, and fix potential remote-DoS.

### DIFF
--- a/depends/packages/libsnark.mk
+++ b/depends/packages/libsnark.mk
@@ -3,8 +3,8 @@ $(package)_version=0.1
 $(package)_download_path=https://github.com/zcash/$(package)/archive/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=43b0c921e8a1d556e70cf5c63c921db54f151842eb3cada029e3b92095e7b6f9
-$(package)_git_commit=a7031481fd8d2360337321401fe8e24f0359317a
+$(package)_sha256_hash=369fe9f5a8018eb46cce3cf50bfbf21419d8e963b25067ffd00cb9ac5c39f649
+$(package)_git_commit=11242d8afe304c8bcc252baec483f04a110d1dd4
 
 $(package)_dependencies=libgmp libsodium
 

--- a/src/zcash/JoinSplit.cpp
+++ b/src/zcash/JoinSplit.cpp
@@ -157,7 +157,11 @@ public:
             vpub_new
         );
 
-        return r1cs_ppzksnark_verifier_strong_IC<ppzksnark_ppT>(*vk, witness, r1cs_proof);
+        try {
+            return r1cs_ppzksnark_verifier_strong_IC<ppzksnark_ppT>(*vk, witness, r1cs_proof);
+        } catch (...) {
+            return false;
+        }
     }
 
     boost::array<unsigned char, ZKSNARK_PROOF_SIZE> prove(


### PR DESCRIPTION
See https://github.com/zcash/libsnark/pull/1 as well.

[`59adbef`](https://github.com/zcash/libsnark/commit/59adbefcc870c1e807a0378403b6a4022da71d03) removes a remote-DoS that can occur if proofs are not well-formed.

[`e3779f9`](https://github.com/zcash/libsnark/commit/e3779f90490905e88c3a08c7194ee948dd8a0da5) removes more files that we do not need from libsnark.

[`11242d8`](https://github.com/zcash/libsnark/commit/11242d8afe304c8bcc252baec483f04a110d1dd4) replaces assertions that could be triggered by our verifier with exceptions.

Here in Zcash, we catch all exceptions from the verifier and return false.

Closes #459, Closes #69