### PR TITLE
[WIP] Add more commands to run unit tests under valgrind.

### DIFF
--- a/qa/zcash/performance-measurements.sh
+++ b/qa/zcash/performance-measurements.sh
@@ -153,6 +153,25 @@ case "$1" in
         zcashd_valgrind_stop
         rm -f valgrind.out
         ;;
+    valgrind-tests)
+        case "$2" in
+            gtest)
+                rm -f valgrind.out
+                valgrind --leak-check=yes -v --error-limit=no --log-file="valgrind.out" ./src/zcash-gtest
+                cat valgrind.out
+                rm -f valgrind.out
+                ;;
+            test_bitcoin)
+                rm -f valgrind.out
+                valgrind --leak-check=yes -v --error-limit=no --log-file="valgrind.out" ./src/test/test_bitcoin
+                cat valgrind.out
+                rm -f valgrind.out
+                ;;
+            *)
+                echo "Bad arguments."
+                exit 1
+        esac
+        ;;
     *)
         echo "Bad arguments."
         exit 1


### PR DESCRIPTION
This runs both zcash-gtest and test_bitcoin under valgrind. There's a corresponding PR to the buildbot config https://github.com/Electric-Coin-Company/bbotzc/pull/23. Closes #761.