### PR TITLE
Extend try catch block around call to libsnark verifier

### DIFF
--- a/src/zcash/JoinSplit.cpp
+++ b/src/zcash/JoinSplit.cpp
@@ -139,25 +139,25 @@ public:
             throw std::runtime_error("JoinSplit verifying key not loaded");
         }
 
-        r1cs_ppzksnark_proof<ppzksnark_ppT> r1cs_proof;
-        std::stringstream ss;
-        std::string proof_str(proof.begin(), proof.end());
-        ss.str(proof_str);
-        ss >> r1cs_proof;
-
-        uint256 h_sig = this->h_sig(randomSeed, nullifiers, pubKeyHash);
-
-        auto witness = joinsplit_gadget<FieldT, NumInputs, NumOutputs>::witness_map(
-            rt,
-            h_sig,
-            macs,
-            nullifiers,
-            commitments,
-            vpub_old,
-            vpub_new
-        );
-
         try {
+            r1cs_ppzksnark_proof<ppzksnark_ppT> r1cs_proof;
+            std::stringstream ss;
+            std::string proof_str(proof.begin(), proof.end());
+            ss.str(proof_str);
+            ss >> r1cs_proof;
+
+            uint256 h_sig = this->h_sig(randomSeed, nullifiers, pubKeyHash);
+
+            auto witness = joinsplit_gadget<FieldT, NumInputs, NumOutputs>::witness_map(
+                rt,
+                h_sig,
+                macs,
+                nullifiers,
+                commitments,
+                vpub_old,
+                vpub_new
+            );
+
             return r1cs_ppzksnark_verifier_strong_IC<ppzksnark_ppT>(*vk, witness, r1cs_proof);
         } catch (...) {
             return false;


### PR DESCRIPTION
As discussed in #1126.  

@daira Per your [comment](https://github.com/zcash/zcash/pull/1126#issuecomment-234714939):

> I would like assertion errors during tests to cause a test failure (unless the test explicitly expects them). Can we split this into verify and verify_internal, where the former does the try/catch around a call to verify_internal, and the latter is called by verification unit tests?

Did you mean move everything inside the extended try/catch to verify_internal, or just the call to r1cs_ppzksnark_verifier_strong_IC?