### PR TITLE
Improve speed and accuracy of zcbenchmark validatelargetx

### DIFF
--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -200,7 +200,7 @@ double benchmark_large_tx()
     timer_start();
     for (size_t i = 0; i < NUM_INPUTS; i++) {
         ScriptError serror = SCRIPT_ERR_OK;
-        assert(VerifyScript(spending_tx.vin[i].scriptSig,
+        assert(VerifyScript(final_spending_tx.vin[i].scriptSig,
                             prevPubKey,
                             STANDARD_SCRIPT_VERIFY_FLAGS,
                             TransactionSignatureChecker(&final_spending_tx, i),

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -193,6 +193,9 @@ double benchmark_large_tx()
         assert(ss.size() > MAX_BLOCK_SIZE - error);
     }
 
+    // Spending tx has all its inputs signed and does not need to be mutated anymore
+    CTransaction final_spending_tx(spending_tx);
+
     // Benchmark signature verification costs:
     timer_start();
     for (size_t i = 0; i < NUM_INPUTS; i++) {
@@ -200,7 +203,7 @@ double benchmark_large_tx()
         assert(VerifyScript(spending_tx.vin[i].scriptSig,
                             prevPubKey,
                             STANDARD_SCRIPT_VERIFY_FLAGS,
-                            MutableTransactionSignatureChecker(&spending_tx, i),
+                            TransactionSignatureChecker(&final_spending_tx, i),
                             &serror));
     }
     return timer_stop();


### PR DESCRIPTION
The verification test, in a loop, passes `spending_tx` (a `CMutableTransaction`) to the constructor of `MutableTransactionSignatureChecker`, which immediately uses it to create a non-mutable `CTransaction` object, which is used for the actual verification process.

Since `spending_tx` is not mutated during the verification loop & process, we can instead convert it to a `CTransaction` just once, and use it with `TransactionSignatureChecker`.

This removes the time to create `CTransaction` objects from the benchmark itself.

Results show an improvement in running time to complete the verification phase of the test and consistent times across z7 and z8 releases.

```
Benchmarks on i3 processor:
z7 old 228.67205900 --> z7 new 49.27225200
z7 old 229.90048900 --> z7 new 48.38650700
z8 old 295.77963800 --> z8 new 48.37695100
z8 old 294.32640100 --> z8 new 49.93216100
```