### PR TITLE
new templates for github issues, pull requests and ccoc

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer (see below). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.
+
+You may send reports to [our Conduct email](mailto:conduct@z.cash).
+
+If you wish to contact specific maintainers directly, the following have made
+themselves available for conduct issues:
+
+- Daira Hopwood (daira at leastauthority.com)
+- Sean Bowe (sean at z.cash)
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Problem
+Please describe your problem here and document the zcash version used.
+
+## What I do
+A step-by-step description or script to replicate the issue.
+
+## What I expect to see
+The expected result.
+
+## What I see instead
+The actual result.
+
+## Possibly related (but unsure)
+Note all related issues here, if any.
+
+## Details
+Here is the place to write with more details about the issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Status
+READY / IN DEVELOPMENT
+
+## Description
+A few sentences describing the overall goals of the pull request's commits.
+
+## Related PRs
+List related PRs against other branches:
+
+branch | PR
+------ | ------
+other_pr_production | [link]()
+other_pr_master | [link]()
+
+
+## Todos
+- [ ] Tests
+- [ ] Documentation
+
+
+## Deploy Notes
+Notes regarding deployment the contained body of work. 
+
+## Impacted Areas in Application
+List general components of the application that this PR will affect here.


### PR DESCRIPTION
This pull request contains templates for issues and pull requests that can be used by the project. Additionally, the Contributor Code of Conduct is shown when code is contributed (eg via pull request in github).

This is a github feature that is described here:
https://github.com/blog/2111-issue-and-pull-request-templates

You will want to tune these to your needs, i hope they are nevertheless useful for you.

