### PR TITLE
RPC calls to manage zkey creation, management and backup

### DIFF
--- a/src/Makefile.gtest.include
+++ b/src/Makefile.gtest.include
@@ -14,6 +14,7 @@ zcash_gtest_SOURCES = \
 	gtest/test_merkletree.cpp \
 	gtest/test_circuit.cpp \
 	gtest/test_txid.cpp \
+	gtest/test_wallet_zkeys.cpp \
 	gtest/test_libzcash_utils.cpp \
 	gtest/test_proofs.cpp
 

--- a/src/gtest/test_wallet_zkeys.cpp
+++ b/src/gtest/test_wallet_zkeys.cpp
@@ -1,0 +1,140 @@
+#include <gtest/gtest.h>
+
+#include "zcash/Address.hpp"
+#include "wallet/wallet.h"
+#include "wallet/walletdb.h"
+#include "util.h"
+
+#include <boost/filesystem.hpp>
+
+/**
+ * This test covers methods on CWallet
+ * GenerateNewZKey()
+ * AddZKey()
+ * LoadZKey()
+ * LoadZKeyMetadata()
+ */
+TEST(wallet_zkeys_tests, store_and_load_zkeys) {
+    SelectParams(CBaseChainParams::MAIN);
+
+    CWallet wallet;
+
+    // wallet should by empty
+    std::set<libzcash::PaymentAddress> addrs;
+    wallet.GetPaymentAddresses(addrs);
+    ASSERT_EQ(0, addrs.size());
+
+    // wallet should have one key
+    CZCPaymentAddress paymentAddress = wallet.GenerateNewZKey();
+    wallet.GetPaymentAddresses(addrs);
+    ASSERT_EQ(1, addrs.size());
+
+    // verify wallet has spending key for the address
+    auto addr = paymentAddress.Get();
+    ASSERT_TRUE(wallet.HaveSpendingKey(addr));
+
+    // manually add new spending key to wallet
+    auto sk = libzcash::SpendingKey::random();
+    ASSERT_TRUE(wallet.AddZKey(sk));
+
+    // verify wallet did add it
+    addr = sk.address();
+    ASSERT_TRUE(wallet.HaveSpendingKey(addr));
+
+    // verify spending key stored correctly
+    libzcash::SpendingKey keyOut;
+    wallet.GetSpendingKey(addr, keyOut);
+    ASSERT_EQ(sk, keyOut);
+
+    // verify there are two keys
+    wallet.GetPaymentAddresses(addrs);
+    ASSERT_EQ(2, addrs.size());
+    ASSERT_EQ(1, addrs.count(addr));
+
+    // Load a third key into the wallet
+    sk = libzcash::SpendingKey::random();
+    ASSERT_TRUE(wallet.LoadZKey(sk));
+
+    // attach metadata to this third key
+    addr = sk.address();
+    int64_t now = GetTime();
+    CKeyMetadata meta(now);
+    ASSERT_TRUE(wallet.LoadZKeyMetadata(addr, meta));
+
+    // check metadata is the same
+    CKeyMetadata m= wallet.mapZKeyMetadata[addr];
+    ASSERT_EQ(m.nCreateTime, now);
+}
+
+/**
+ * This test covers methods on CWalletDB
+ * WriteZKey()
+ */
+TEST(wallet_zkeys_tests, write_zkey_direct_to_db) {
+    SelectParams(CBaseChainParams::TESTNET);
+
+    // Get temporary and unique path for file.
+    // Note: / operator to append paths
+    boost::filesystem::path temp = boost::filesystem::temp_directory_path() /
+            boost::filesystem::unique_path();
+    const std::string path = temp.native();
+
+    bool fFirstRun;
+    CWallet wallet(path);
+    ASSERT_EQ(DB_LOAD_OK, wallet.LoadWallet(fFirstRun));
+
+    // No default CPubKey set
+    ASSERT_TRUE(fFirstRun);
+
+    // wallet should by empty
+    std::set<libzcash::PaymentAddress> addrs;
+    wallet.GetPaymentAddresses(addrs);
+    ASSERT_EQ(0, addrs.size());
+
+    // Add random key to the wallet
+    auto paymentAddress = wallet.GenerateNewZKey();
+
+    // wallet should have one key
+    wallet.GetPaymentAddresses(addrs);
+    ASSERT_EQ(1, addrs.size());
+
+    // create random key and add it to database directly, bypassing wallet
+    auto sk = libzcash::SpendingKey::random();
+    auto addr = sk.address();
+    int64_t now = GetTime();
+    CKeyMetadata meta(now);
+    CWalletDB db(path);
+    db.WriteZKey(addr, sk, meta);
+
+    // wallet should not be aware of key
+    ASSERT_FALSE(wallet.HaveSpendingKey(addr));
+
+    // wallet sees one key
+    wallet.GetPaymentAddresses(addrs);
+    ASSERT_EQ(1, addrs.size());
+
+    // wallet should have default metadata for addr with null createtime
+    CKeyMetadata m = wallet.mapZKeyMetadata[addr];
+    ASSERT_EQ(m.nCreateTime, 0);
+    ASSERT_NE(m.nCreateTime, now);
+
+    // load the wallet again
+    ASSERT_EQ(DB_LOAD_OK, wallet.LoadWallet(fFirstRun));
+
+    // wallet can now see the spending key
+    ASSERT_TRUE(wallet.HaveSpendingKey(addr));
+
+    // check key is the same
+    libzcash::SpendingKey keyOut;
+    wallet.GetSpendingKey(addr, keyOut);
+    ASSERT_EQ(sk, keyOut);
+
+    // wallet should have two keys
+    wallet.GetPaymentAddresses(addrs);
+    ASSERT_EQ(2, addrs.size());
+
+    // check metadata is now the same
+    m = wallet.mapZKeyMetadata[addr];
+    ASSERT_EQ(m.nCreateTime, now);
+}
+

--- a/src/gtest/test_wallet_zkeys.cpp
+++ b/src/gtest/test_wallet_zkeys.cpp
@@ -19,7 +19,7 @@ TEST(wallet_zkeys_tests, store_and_load_zkeys) {
 
     CWallet wallet;
 
-    // wallet should by empty
+    // wallet should be empty
     std::set<libzcash::PaymentAddress> addrs;
     wallet.GetPaymentAddresses(addrs);
     ASSERT_EQ(0, addrs.size());
@@ -86,7 +86,7 @@ TEST(wallet_zkeys_tests, write_zkey_direct_to_db) {
     // No default CPubKey set
     ASSERT_TRUE(fFirstRun);
 
-    // wallet should by empty
+    // wallet should be empty
     std::set<libzcash::PaymentAddress> addrs;
     wallet.GetPaymentAddresses(addrs);
     ASSERT_EQ(0, addrs.size());

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -97,7 +97,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "zcrawjoinsplit", 4 },
     { "zcbenchmark", 1 },
     { "zcbenchmark", 2 },
-    { "getblocksubsidy", 0}
+    { "getblocksubsidy", 0},
+    { "z_importkey", 1 }
 };
 
 class CRPCConvertTable

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -381,7 +381,10 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "zcrawkeygen",            &zc_raw_keygen,          true  },
     { "wallet",             "zcrawjoinsplit",         &zc_raw_joinsplit,       true  },
     { "wallet",             "zcrawreceive",           &zc_raw_receive,         true  },
-    { "wallet",             "zcsamplejoinsplit",      &zc_sample_joinsplit,    true  }
+    { "wallet",             "zcsamplejoinsplit",      &zc_sample_joinsplit,    true  },
+    { "wallet",             "z_getnewaddress",        &z_getnewaddress,        true  },
+    { "wallet",             "z_exportkey",            &z_exportkey,            true  },
+    { "wallet",             "z_importkey",            &z_importkey,            true  }
 #endif // ENABLE_WALLET
 };
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -383,6 +383,7 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "zcrawreceive",           &zc_raw_receive,         true  },
     { "wallet",             "zcsamplejoinsplit",      &zc_sample_joinsplit,    true  },
     { "wallet",             "z_getnewaddress",        &z_getnewaddress,        true  },
+    { "wallet",             "z_listaddresses",        &z_listaddresses,        true  },
     { "wallet",             "z_exportkey",            &z_exportkey,            true  },
     { "wallet",             "z_importkey",            &z_importkey,            true  },
     { "wallet",             "z_exportwallet",         &z_exportwallet,         true  },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -384,7 +384,9 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "zcsamplejoinsplit",      &zc_sample_joinsplit,    true  },
     { "wallet",             "z_getnewaddress",        &z_getnewaddress,        true  },
     { "wallet",             "z_exportkey",            &z_exportkey,            true  },
-    { "wallet",             "z_importkey",            &z_importkey,            true  }
+    { "wallet",             "z_importkey",            &z_importkey,            true  },
+    { "wallet",             "z_exportwallet",         &z_exportwallet,         true  },
+    { "wallet",             "z_importwallet",         &z_importwallet,         true  }
 #endif // ENABLE_WALLET
 };
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -246,6 +246,8 @@ extern json_spirit::Value getblocksubsidy(const json_spirit::Array& params, bool
 extern json_spirit::Value z_exportkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value z_importkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value z_getnewaddress(const json_spirit::Array& params, bool fHelp); // in rpcwallet.cpp
+extern json_spirit::Value z_exportwallet(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
+extern json_spirit::Value z_importwallet(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 
 // in rest.cpp
 extern bool HTTPReq_REST(AcceptedConnection *conn,

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -246,6 +246,7 @@ extern json_spirit::Value getblocksubsidy(const json_spirit::Array& params, bool
 extern json_spirit::Value z_exportkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value z_importkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value z_getnewaddress(const json_spirit::Array& params, bool fHelp); // in rpcwallet.cpp
+extern json_spirit::Value z_listaddresses(const json_spirit::Array& params, bool fHelp); // in rpcwallet.cpp
 extern json_spirit::Value z_exportwallet(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value z_importwallet(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -243,6 +243,10 @@ extern json_spirit::Value reconsiderblock(const json_spirit::Array& params, bool
 
 extern json_spirit::Value getblocksubsidy(const json_spirit::Array& params, bool fHelp);
 
+extern json_spirit::Value z_exportkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
+extern json_spirit::Value z_importkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
+extern json_spirit::Value z_getnewaddress(const json_spirit::Array& params, bool fHelp); // in rpcwallet.cpp
+
 // in rest.cpp
 extern bool HTTPReq_REST(AcceptedConnection *conn,
                   const std::string& strURI,

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -421,6 +421,13 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_importexport)
     // Verify the two sets of addresses are the same
     BOOST_CHECK(listaddrs.size() == numAddrs);
     BOOST_CHECK(myaddrs == listaddrs);
+
+    // Add one more address
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("z_getnewaddress"));
+    std::string newaddress = retValue.get_str();
+    CZCPaymentAddress pa(newaddress);
+    auto newAddr = pa.Get();
+    BOOST_CHECK(pwalletMain->HaveSpendingKey(newAddr));
 }
         
 

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -11,8 +11,14 @@
 
 #include "test/test_bitcoin.h"
 
+#include "zcash/Address.hpp"
+
+#include <fstream>
+#include <unordered_set>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
+#include <boost/format.hpp>
 
 using namespace std;
 using namespace json_spirit;
@@ -217,5 +223,205 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     BOOST_CHECK(arr.size() > 0);
     BOOST_CHECK(CBitcoinAddress(arr[0].get_str()).Get() == demoAddress.Get());
 }
+
+/*
+ * This test covers RPC command z_exportwallet
+ */
+BOOST_AUTO_TEST_CASE(rpc_wallet_z_exportwallet)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    
+    // wallet should by empty
+    std::set<libzcash::PaymentAddress> addrs;
+    pwalletMain->GetPaymentAddresses(addrs);
+    BOOST_CHECK(addrs.size()==0);
+
+    // wallet should have one key
+    CZCPaymentAddress paymentAddress = pwalletMain->GenerateNewZKey();
+    pwalletMain->GetPaymentAddresses(addrs);
+    BOOST_CHECK(addrs.size()==1);
+    
+    BOOST_CHECK_THROW(CallRPC("z_exportwallet"), runtime_error);
+    
+   
+    boost::filesystem::path temp = boost::filesystem::temp_directory_path() /
+            boost::filesystem::unique_path();
+    const std::string path = temp.native();
+
+    BOOST_CHECK_NO_THROW(CallRPC(string("z_exportwallet ") + path));
+
+    auto addr = paymentAddress.Get();
+    libzcash::SpendingKey key;
+    BOOST_CHECK(pwalletMain->GetSpendingKey(addr, key));
+
+    std::string s1 = paymentAddress.ToString();
+    std::string s2 = CZCSpendingKey(key).ToString();
+    
+    // There's no way to really delete a private key so we will read in the
+    // exported wallet file and search for the spending key and payment address.
+    
+    EnsureWalletIsUnlocked();
+
+    ifstream file;
+    file.open(path.c_str(), std::ios::in | std::ios::ate);
+    BOOST_CHECK(file.is_open());
+    bool fVerified = false;
+    int64_t nFilesize = std::max((int64_t)1, (int64_t)file.tellg());
+    file.seekg(0, file.beg);
+    while (file.good()) {
+        std::string line;
+        std::getline(file, line);
+        if (line.empty() || line[0] == '#')
+            continue;
+        if (line.find(s1) != std::string::npos && line.find(s2) != std::string::npos) {
+            fVerified = true;
+            break;
+        }
+    }
+    BOOST_CHECK(fVerified);
+}
+
+
+/*
+ * This test covers RPC command z_importwallet
+ */
+BOOST_AUTO_TEST_CASE(rpc_wallet_z_importwallet)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    
+    // error if no args
+    BOOST_CHECK_THROW(CallRPC("z_importwallet"), runtime_error);
+
+    // create a random key locally
+    auto testSpendingKey = libzcash::SpendingKey::random();
+    auto testPaymentAddress = testSpendingKey.address();
+    std::string testAddr = CZCPaymentAddress(testPaymentAddress).ToString();
+    std::string testKey = CZCSpendingKey(testSpendingKey).ToString();
+
+//    std::cout << "testAddr = " << testAddr << std::endl;
+//    std::cout << "testKey = " << testKey << std::endl;
+    
+    // create test data using the random key
+    std::string format_str = "# Wallet dump created by Zcash v0.11.2.0.z8-9155cc6-dirty (2016-08-11 11:37:00 -0700)\n"
+            "# * Created on 2016-08-12T21:55:36Z\n"
+            "# * Best block at time of backup was 0 (0de0a3851fef2d433b9b4f51d4342bdd24c5ddd793eb8fba57189f07e9235d52),\n"
+            "#   mined on 2009-01-03T18:15:05Z\n"
+            "\n"
+            "# Zkeys\n"
+            "\n"
+            "%s 2016-08-12T21:55:36Z # zaddr=%s\n"
+            "\n"
+            "\n# End of dump";
+    
+    boost::format formatobject(format_str);
+    std::string testWalletDump = (formatobject % testKey % testAddr).str();
+
+//    std::cout << "testWalletDump =\n" << testWalletDump << std::endl;
+    
+    // write test data to file
+    boost::filesystem::path temp = boost::filesystem::temp_directory_path() /
+            boost::filesystem::unique_path();
+    const std::string path = temp.native();
+    std::ofstream file(path);
+    file << testWalletDump;
+    file << std::flush;
+
+    // wallet should currently be empty
+    std::set<libzcash::PaymentAddress> addrs;
+    pwalletMain->GetPaymentAddresses(addrs);
+    BOOST_CHECK(addrs.size()==0);
+    
+    // import test data from file into wallet
+    BOOST_CHECK_NO_THROW(CallRPC(string("z_importwallet ") + path));
+        
+    // wallet should now have one zkey
+    pwalletMain->GetPaymentAddresses(addrs);
+    BOOST_CHECK(addrs.size()==1);
+    
+    // check that we have the spending key for the address
+    CZCPaymentAddress address(testAddr);
+    auto addr = address.Get();
+    BOOST_CHECK(pwalletMain->HaveSpendingKey(addr));
+    
+    // Verify the spending keys is the same as the test data
+    libzcash::SpendingKey k;
+    BOOST_CHECK(pwalletMain->GetSpendingKey(addr, k));
+    CZCSpendingKey spendingkey(k);
+    BOOST_CHECK_EQUAL(testKey, spendingkey.ToString());
+    
+//    std::cout << "address = " << address.ToString() << std::endl;
+//    std::cout << "spendingkey = " << spendingkey.ToString() << std::endl;
+}
+
+
+/*
+ * This test covers RPC command z_listaddresses, z_importkey, z_exportkey
+ */
+BOOST_AUTO_TEST_CASE(rpc_wallet_z_importexport)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    Value retValue;
+    int n1 = 1000; // number of times to import/export
+    int n2 = 1000; // number of addresses to create and list
+   
+    // error if no args
+    BOOST_CHECK_THROW(CallRPC("z_importkey"), runtime_error);   
+    BOOST_CHECK_THROW(CallRPC("z_exportkey"), runtime_error);   
+
+    // wallet should currently be empty
+    std::set<libzcash::PaymentAddress> addrs;
+    pwalletMain->GetPaymentAddresses(addrs);
+    BOOST_CHECK(addrs.size()==0);
+
+    // verify import and export key
+    for (int i = 0; i < n1; i++) {
+        // create a random key locally
+        auto testSpendingKey = libzcash::SpendingKey::random();
+        auto testPaymentAddress = testSpendingKey.address();
+        std::string testAddr = CZCPaymentAddress(testPaymentAddress).ToString();
+        std::string testKey = CZCSpendingKey(testSpendingKey).ToString();
+        BOOST_CHECK_NO_THROW(CallRPC(string("z_importkey ") + testKey));
+        BOOST_CHECK_NO_THROW(retValue = CallRPC(string("z_exportkey ") + testAddr));
+        BOOST_CHECK_EQUAL(retValue.get_str(), testKey);
+    }
+
+    // Verify we can list the keys imported
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("z_listaddresses"));
+    Array arr = retValue.get_array();
+    BOOST_CHECK(arr.size() == n1);
+
+    // Put addresses into a set
+    std::unordered_set<std::string> myaddrs;
+    for (Value element : arr) {
+        myaddrs.insert(element.get_str());
+    }
+    
+    // Make new addresses for the set
+    for (int i=0; i<n2; i++) {
+        myaddrs.insert((pwalletMain->GenerateNewZKey()).ToString());
+    }
+
+    // Verify number of addresses stored in wallet is n1+n2
+    int numAddrs = myaddrs.size();
+    BOOST_CHECK(numAddrs == n1+n2);
+    pwalletMain->GetPaymentAddresses(addrs);
+    BOOST_CHECK(addrs.size()==numAddrs);  
+    
+    // Ask wallet to list addresses
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("z_listaddresses"));
+    arr = retValue.get_array();
+    BOOST_CHECK(arr.size() == numAddrs);
+  
+    // Create a set form them
+    std::unordered_set<std::string> listaddrs;
+    for (Value element : arr) {
+        listaddrs.insert(element.get_str());
+    }
+    
+    // Verify the two sets of addresses are the same
+    BOOST_CHECK(listaddrs.size() == numAddrs);
+    BOOST_CHECK(myaddrs == listaddrs);
+}
+        
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_exportwallet)
 {
     LOCK2(cs_main, pwalletMain->cs_wallet);
     
-    // wallet should by empty
+    // wallet should be empty
     std::set<libzcash::PaymentAddress> addrs;
     pwalletMain->GetPaymentAddresses(addrs);
     BOOST_CHECK(addrs.size()==0);
@@ -297,9 +297,6 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_importwallet)
     auto testPaymentAddress = testSpendingKey.address();
     std::string testAddr = CZCPaymentAddress(testPaymentAddress).ToString();
     std::string testKey = CZCSpendingKey(testSpendingKey).ToString();
-
-//    std::cout << "testAddr = " << testAddr << std::endl;
-//    std::cout << "testKey = " << testKey << std::endl;
     
     // create test data using the random key
     std::string format_str = "# Wallet dump created by Zcash v0.11.2.0.z8-9155cc6-dirty (2016-08-11 11:37:00 -0700)\n"
@@ -315,8 +312,6 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_importwallet)
     
     boost::format formatobject(format_str);
     std::string testWalletDump = (formatobject % testKey % testAddr).str();
-
-//    std::cout << "testWalletDump =\n" << testWalletDump << std::endl;
     
     // write test data to file
     boost::filesystem::path temp = boost::filesystem::temp_directory_path() /
@@ -343,19 +338,16 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_importwallet)
     auto addr = address.Get();
     BOOST_CHECK(pwalletMain->HaveSpendingKey(addr));
     
-    // Verify the spending keys is the same as the test data
+    // Verify the spending key is the same as the test data
     libzcash::SpendingKey k;
     BOOST_CHECK(pwalletMain->GetSpendingKey(addr, k));
     CZCSpendingKey spendingkey(k);
     BOOST_CHECK_EQUAL(testKey, spendingkey.ToString());
-    
-//    std::cout << "address = " << address.ToString() << std::endl;
-//    std::cout << "spendingkey = " << spendingkey.ToString() << std::endl;
 }
 
 
 /*
- * This test covers RPC command z_listaddresses, z_importkey, z_exportkey
+ * This test covers RPC commands z_listaddresses, z_importkey, z_exportkey
  */
 BOOST_AUTO_TEST_CASE(rpc_wallet_z_importexport)
 {
@@ -412,7 +404,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_importexport)
     arr = retValue.get_array();
     BOOST_CHECK(arr.size() == numAddrs);
   
-    // Create a set form them
+    // Create a set from them
     std::unordered_set<std::string> listaddrs;
     for (Value element : arr) {
         listaddrs.insert(element.get_str());

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -565,11 +565,11 @@ Value z_importkey(const Array& params, bool fHelp)
     auto addr = key.address();
 
     {
-        pwalletMain->MarkDirty();
-
         // Don't throw error in case a key is already there
         if (pwalletMain->HaveSpendingKey(addr))
             return Value::null;
+
+        pwalletMain->MarkDirty();
 
         if (!pwalletMain-> AddZKey(key))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding spending key to wallet");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2769,3 +2769,29 @@ Value zc_raw_keygen(const json_spirit::Array& params, bool fHelp)
     result.push_back(Pair("zcviewingkey", viewing_hex));
     return result;
 }
+
+
+Value z_getnewaddress(const Array& params, bool fHelp)
+{
+    if (!EnsureWalletIsAvailable(fHelp))
+        return Value::null;
+
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "z_getnewaddress\n"
+            "\nReturns a new zaddr for receiving payments.\n"
+            "\nArguments:\n"
+            "\nResult:\n"
+            "\"zcashaddress\"    (string) The new zaddr\n"
+            "\nExamples:\n"
+            + HelpExampleCli("z_getnewaddress", "")
+            + HelpExampleRpc("z_getnewaddress", "")
+        );
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CZCPaymentAddress pubaddr = pwalletMain->GenerateNewZKey();
+    std::string result = pubaddr.ToString();
+    return result;
+}
+

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2795,3 +2795,35 @@ Value z_getnewaddress(const Array& params, bool fHelp)
     return result;
 }
 
+
+Value z_listaddresses(const Array& params, bool fHelp)
+{
+    if (!EnsureWalletIsAvailable(fHelp))
+        return Value::null;
+
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "z_listaddresses\n"
+            "\nReturns the list of zaddr belonging to the wallet.\n"
+            "\nArguments:\n"
+            "\nResult:\n"
+            "[                     (json array of string)\n"
+            "  \"zaddr\"           (string) a zaddr belonging to the wallet\n"
+            "  ,...\n"
+            "]\n"
+            "\nExamples:\n"
+            + HelpExampleCli("z_listaddresses", "")
+            + HelpExampleRpc("z_listaddresses", "")
+        );
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    Array ret;
+    std::set<libzcash::PaymentAddress> addresses;
+    pwalletMain->GetPaymentAddresses(addresses);
+    for (auto addr : addresses ) {
+        ret.push_back(CZCPaymentAddress(addr).ToString());
+    }
+    return ret;
+}
+

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -80,7 +80,7 @@ CZCPaymentAddress CWallet::GenerateNewZKey()
 
     // Check for collision, even though it is unlikely to ever occur
     if (CCryptoKeyStore::HaveSpendingKey(addr))
-        throw std::runtime_error("CWallet::GenerateNewSpendingKey(): Collision detected");
+        throw std::runtime_error("CWallet::GenerateNewZKey(): Collision detected");
 
     // Create new metadata
     int64_t nCreationTime = GetTime();
@@ -88,7 +88,7 @@ CZCPaymentAddress CWallet::GenerateNewZKey()
 
     CZCPaymentAddress pubaddr(addr);
     if (!AddZKey(k))
-        throw std::runtime_error("CWallet::GenerateNewSpendingKey(): AddZKey failed");
+        throw std::runtime_error("CWallet::GenerateNewZKey(): AddZKey failed");
     return pubaddr;
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -18,6 +18,8 @@
 #include "wallet/crypter.h"
 #include "wallet/wallet_ismine.h"
 #include "wallet/walletdb.h"
+#include "zcash/Address.hpp"
+#include "base58.h"
 
 #include <algorithm>
 #include <map>
@@ -486,6 +488,7 @@ public:
 
     std::set<int64_t> setKeyPool;
     std::map<CKeyID, CKeyMetadata> mapKeyMetadata;
+    std::map<libzcash::PaymentAddress, CKeyMetadata> mapZKeyMetadata;
 
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
     MasterKeyMap mapMasterKeys;
@@ -594,6 +597,19 @@ public:
     bool EncryptWallet(const SecureString& strWalletPassphrase);
 
     void GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const;
+
+    /**
+      * ZKeys
+      */
+    //! Generates a new zaddr
+    CZCPaymentAddress GenerateNewZKey();
+    //! Adds spending key to the store, and saves it to disk
+    bool AddZKey(const libzcash::SpendingKey &key);
+    //! Adds spending key to the store, without saving it to disk (used by LoadWallet)
+    bool LoadZKey(const libzcash::SpendingKey &key);
+    //! Load spending key metadata (used by LoadWallet)
+    bool LoadZKeyMetadata(const libzcash::PaymentAddress &addr, const CKeyMetadata &meta);
+
 
     /** 
      * Increment the next transaction order id

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -641,6 +641,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
 static bool IsKeyType(string strType)
 {
     return (strType== "key" || strType == "wkey" ||
+            strType == "zkey" ||
             strType == "mkey" || strType == "ckey");
 }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -110,6 +110,17 @@ bool CWalletDB::WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey)
     return Write(std::make_pair(std::string("mkey"), nID), kMasterKey, true);
 }
 
+bool CWalletDB::WriteZKey(const libzcash::PaymentAddress& addr, const libzcash::SpendingKey& key, const CKeyMetadata &keyMeta)
+{
+    nWalletDBUpdated++;
+
+    if (!Write(std::make_pair(std::string("zkeymeta"), addr), keyMeta))
+        return false;
+
+    // pair is: tuple_key("spendingkey", paymentaddress) --> secretkey
+    return Write(std::make_pair(std::string("zkey"), addr), key, false);
+}
+
 bool CWalletDB::WriteCScript(const uint160& hash, const CScript& redeemScript)
 {
     nWalletDBUpdated++;
@@ -330,13 +341,15 @@ public:
     unsigned int nKeys;
     unsigned int nCKeys;
     unsigned int nKeyMeta;
+    unsigned int nZKeys;
+    unsigned int nZKeyMeta;
     bool fIsEncrypted;
     bool fAnyUnordered;
     int nFileVersion;
     vector<uint256> vWalletUpgrade;
 
     CWalletScanState() {
-        nKeys = nCKeys = nKeyMeta = 0;
+        nKeys = nCKeys = nKeyMeta = nZKeys = nZKeyMeta = 0;
         fIsEncrypted = false;
         fAnyUnordered = false;
         nFileVersion = 0;
@@ -428,6 +441,23 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             // Watch-only addresses have no birthday information for now,
             // so set the wallet birthday to the beginning of time.
             pwallet->nTimeFirstKey = 1;
+        }
+        else if (strType == "zkey")
+        {
+            libzcash::PaymentAddress addr;
+            ssKey >> addr;
+            libzcash::SpendingKey key;
+            ssValue >> key;
+
+            if (!pwallet->LoadZKey(key))
+            {
+                strErr = "Error reading wallet database: LoadZKey failed";
+                return false;
+            }
+
+            wss.nZKeys++;
+
+            CZCPaymentAddress pubaddr(addr);
         }
         else if (strType == "key" || strType == "wkey")
         {
@@ -537,6 +567,18 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             if (!pwallet->nTimeFirstKey ||
                 (keyMeta.nCreateTime < pwallet->nTimeFirstKey))
                 pwallet->nTimeFirstKey = keyMeta.nCreateTime;
+        }
+        else if (strType == "zkeymeta")
+        {
+            libzcash::PaymentAddress addr;
+            ssKey >> addr;
+            CKeyMetadata keyMeta;
+            ssValue >> keyMeta;
+            wss.nZKeyMeta++;
+
+            pwallet->LoadZKeyMetadata(addr, keyMeta);
+
+            // ignore earliest key creation time as taddr will exist before any zaddr
         }
         else if (strType == "defaultkey")
         {
@@ -684,6 +726,10 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
 
     LogPrintf("Keys: %u plaintext, %u encrypted, %u w/ metadata, %u total\n",
            wss.nKeys, wss.nCKeys, wss.nKeyMeta, wss.nKeys + wss.nCKeys);
+
+    // TODO: Keep track of encrypted ZKeys
+    LogPrintf("ZKeys: %u plaintext, -- encrypted, %u w/metadata, %u total\n",
+           wss.nZKeys, wss.nZKeyMeta, wss.nZKeys + 0);
 
     // nTimeFirstKey is only reliable if all keys have metadata
     if ((wss.nKeys + wss.nCKeys) != wss.nKeyMeta)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -117,7 +117,7 @@ bool CWalletDB::WriteZKey(const libzcash::PaymentAddress& addr, const libzcash::
     if (!Write(std::make_pair(std::string("zkeymeta"), addr), keyMeta))
         return false;
 
-    // pair is: tuple_key("spendingkey", paymentaddress) --> secretkey
+    // pair is: tuple_key("zkey", paymentaddress) --> secretkey
     return Write(std::make_pair(std::string("zkey"), addr), key, false);
 }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -456,8 +456,6 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             }
 
             wss.nZKeys++;
-
-            CZCPaymentAddress pubaddr(addr);
         }
         else if (strType == "key" || strType == "wkey")
         {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -10,6 +10,7 @@
 #include "wallet/db.h"
 #include "key.h"
 #include "keystore.h"
+#include "zcash/Address.hpp"
 
 #include <list>
 #include <stdint.h>
@@ -129,6 +130,9 @@ public:
     DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
     static bool Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, const std::string& filename);
+
+    /// Write spending key to wallet database, where key is payment address and value is spending key.
+    bool WriteZKey(const libzcash::PaymentAddress& addr, const libzcash::SpendingKey& key, const CKeyMetadata &keyMeta);
 
 private:
     CWalletDB(const CWalletDB&);


### PR DESCRIPTION
Rebased on PR #1205 for keystore functionality.

For #1197, implements:
z_getnewaddress
z_importkey
z_exportkey

For #1198, spending key support added to:
z_exportwallet
z_importwallet

Example dump file containing zkeys:
https://gist.github.com/bitcartel/d7013b30b19419c6a550bc5d6ff6cc47

Also adds:
z_listaddresses

Tests in:
gtest/test_wallet_zkeys
test/rpc_wallet_tests