### PR TITLE
Fix inconsistent -O1/-O2, fix libzcash flags, add -fwrapv -fno-strict-aliasing

### DIFF
--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -1,7 +1,7 @@
 linux_CFLAGS=-pipe
 linux_CXXFLAGS=$(linux_CFLAGS)
 
-linux_release_CFLAGS=-O2
+linux_release_CFLAGS=-O1
 linux_release_CXXFLAGS=$(linux_release_CFLAGS)
 
 linux_debug_CFLAGS=-O1

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -415,7 +415,11 @@ libzcash_a_SOURCES = \
   zcash/prf.cpp \
   zcash/util.cpp
 
-libzcash_a_CPPFLAGS = -DMULTICORE -fopenmp -fPIC -DBINARY_OUTPUT -DCURVE_ALT_BN128 -DBOOST_SPIRIT_THREADSAFE -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS $(HARDENED_CPPFLAGS) $(HARDENED_CXXFLAGS) $(HARDENED_LDFLAGS) -pipe -O1 -g -Wstack-protector -fstack-protector-all -fPIE -fvisibility=hidden -DSTATIC $(BITCOIN_INCLUDES)
+libzcash_a_CPPFLAGS = -DMULTICORE -fopenmp -fPIC -DBINARY_OUTPUT -DCURVE_ALT_BN128 -DBOOST_SPIRIT_THREADSAFE -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS $(HARDENED_CPPFLAGS) -pipe -O1 -g -Wstack-protector -fstack-protector-all -fPIE -fvisibility=hidden -DSTATIC $(BITCOIN_INCLUDES)
+
+libzcash_a_CXXFLAGS = $(HARDENED_CXXFLAGS) -fwrapv -fno-strict-aliasing
+
+libzcash_a_LDFLAGS = $(HARDENED_LDFLAGS)
 
 # bitcoinconsensus library #
 if BUILD_BITCOIN_LIBS

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -37,5 +37,5 @@ PREFIX="$(pwd)/depends/x86_64-unknown-linux-gnu/"
 
 make "$@" -C ./depends/ V=1 NO_QT=1
 ./autogen.sh
-./configure --prefix="${PREFIX}" --with-gui=no "$HARDENING_ARG" "$LCOV_ARG" CXXFLAGS='-Wno-deprecated-declarations -Wno-placement-new -Wno-terminate -Werror -O1 -g'
+./configure --prefix="${PREFIX}" --with-gui=no "$HARDENING_ARG" "$LCOV_ARG" CXXFLAGS='-Wno-deprecated-declarations -Wno-placement-new -Wno-terminate -Werror -g'
 make "$@" V=1

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -37,5 +37,5 @@ PREFIX="$(pwd)/depends/x86_64-unknown-linux-gnu/"
 
 make "$@" -C ./depends/ V=1 NO_QT=1
 ./autogen.sh
-./configure --prefix="${PREFIX}" --with-gui=no "$HARDENING_ARG" "$LCOV_ARG" CXXFLAGS='-Wno-deprecated-declarations -Wno-placement-new -Wno-terminate -Werror -g'
+./configure --prefix="${PREFIX}" --with-gui=no "$HARDENING_ARG" "$LCOV_ARG" CXXFLAGS='-fwrapv -fno-strict-aliasing -Wno-deprecated-declarations -Wno-placement-new -Wno-terminate -Werror -g'
 make "$@" V=1


### PR DESCRIPTION
Closes #1168. In that ticket I decided the optimization flags for dependencies are out of scope, i.e. we go with whatever the upstream package maintainer chose.