### PR TITLE
Undo debugging change from 5be6abbf84c46e8fc4c8ef9be987a44de22d0d05

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -96,10 +96,6 @@ unsigned int CalculateNextWorkRequired(uint32_t nBits, int64_t nLastBlockTime, i
 
 bool CheckEquihashSolution(const CBlockHeader *pblock, const CChainParams& params)
 {
-    // Don't validate genesis
-    if (pblock->hashPrevBlock.IsNull())
-        return true;
-
     unsigned int n = params.EquihashN();
     unsigned int k = params.EquihashK();
 


### PR DESCRIPTION
This was unintentionally committed, and caused Equihash verification of blocks
without parents to be skipped. This only affects the genesis block on the test
network, but also causes the "time verifyequihash" benchmark to incorrectly
appear instantaneous.