### PR TITLE
Separate concepts of block difficulty and network difficulty in RPC

### DIFF
--- a/src/gtest/test_rpc.cpp
+++ b/src/gtest/test_rpc.cpp
@@ -6,8 +6,36 @@
 #include "chainparams.h"
 #include "clientversion.h"
 #include "primitives/block.h"
+#include "rpcserver.h"
 #include "streams.h"
 #include "utilstrencodings.h"
+
+TEST(rpc, GetDifficultyTestnetRules) {
+    SelectParams(CBaseChainParams::TESTNET);
+
+    CBlockIndex prev;
+    prev.nTime = 1472700000;
+    prev.nBits = 0x201fffff;
+
+    CBlockIndex curr;
+    curr.pprev = &prev;
+    curr.nTime = 1472700300;
+    curr.nBits = 0x207fffff;
+
+    // Time interval is within 5 minutes, so the min-difficulty block should be
+    // interpreted as a valid network difficulty.
+    EXPECT_EQ(1, GetDifficulty(&curr));
+    EXPECT_EQ(1, GetNetworkDifficulty(&curr));
+
+    curr.nTime += 1;
+
+    // Time interval is over 5 minutes, so the min-difficulty block should be
+    // ignored for network difficulty determination.
+    EXPECT_EQ(1, GetDifficulty(&curr));
+    // We have to check this directly, because of some combination of rounding
+    // and truncation issues that result in Google Test displaying 4 != 4
+    EXPECT_EQ((double)0x7fffff/(double)0x1fffff, GetNetworkDifficulty(&curr));
+}
 
 extern json_spirit::Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false);
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -286,7 +286,7 @@ Value getmininginfo(const Array& params, bool fHelp)
     obj.push_back(Pair("blocks",           (int)chainActive.Height()));
     obj.push_back(Pair("currentblocksize", (uint64_t)nLastBlockSize));
     obj.push_back(Pair("currentblocktx",   (uint64_t)nLastBlockTx));
-    obj.push_back(Pair("difficulty",       (double)GetDifficulty()));
+    obj.push_back(Pair("difficulty",       (double)GetNetworkDifficulty()));
     obj.push_back(Pair("errors",           GetWarnings("statusbar")));
     obj.push_back(Pair("genproclimit",     (int)GetArg("-genproclimit", -1)));
     obj.push_back(Pair("networkhashps",    getnetworkhashps(params, false)));

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -140,6 +140,7 @@ extern int64_t nWalletUnlockTime;
 extern CAmount AmountFromValue(const json_spirit::Value& value);
 extern json_spirit::Value ValueFromAmount(const CAmount& amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
+extern double GetNetworkDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HelpRequiringPassphrase();
 extern std::string HelpExampleCli(std::string methodname, std::string args);
 extern std::string HelpExampleRpc(std::string methodname, std::string args);


### PR DESCRIPTION
"Block difficulty" is the difficulty listed in a block's header, which in the
testnet can sometimes be min-difficulty (if time-since-last-block is too large).

"Network difficulty" is the difficulty that the network was trying to satisfy
at a particular block height. In mainnet this is always equal to the difficulty
of the solved block for that height, but in testnet the network difficulty is
derived from the last non-min-difficulty block difficulty.

This commit fixes the RPC APIs that are intended to show network difficulty, so
that on testnet they don't sometimes drop to 1.0, confusing users.

Closes #1181