### PR TITLE
Lock to prevent parallel execution of fetch-params.sh

### DIFF
--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -59,7 +59,7 @@ function main() {
     || exit_locked_error
 
     cat <<EOF
-zcash - fetch-params.sh
+Zcash - fetch-params.sh
 
 EOF
 
@@ -69,7 +69,7 @@ EOF
         mkdir -p "$PARAMS_DIR"
         README_PATH="$PARAMS_DIR/README"
         cat >> "$README_PATH" <<EOF
-This directory stores common zcash zkSNARK parameters. Note that is is
+This directory stores common Zcash zkSNARK parameters. Note that is is
 distinct from the daemon's -datadir argument because the parameters are
 large and may be shared across multiple distinct -datadir's such as when
 setting up test networks.
@@ -96,21 +96,26 @@ fi
     fetch_params "$REGTEST_PKEY_URL" "$REGTEST_DIR/$REGTEST_PKEY_NAME"
     fetch_params "$REGTEST_VKEY_URL" "$REGTEST_DIR/$REGTEST_VKEY_NAME"
 
-    echo 'Updating testnet3 symlinks to regtest parameters.'
-    mkdir -p "$TESTNET3_DIR"
-    ln -sf "../regtest/$REGTEST_PKEY_NAME" "$TESTNET3_DIR/$REGTEST_PKEY_NAME"
-    ln -sf "../regtest/$REGTEST_VKEY_NAME" "$TESTNET3_DIR/$REGTEST_VKEY_NAME"
-
     cd "$PARAMS_DIR"
 
     # Now verify their hashes:
     echo 'Verifying parameter file integrity via sha256sum...'
     shasum -a 256 --check <<EOF
 226913bbdc48b70834f8e044d194ddb61c8e15329f67cdc6014f4e5ac11a82ab  regtest/$REGTEST_PKEY_NAME
-226913bbdc48b70834f8e044d194ddb61c8e15329f67cdc6014f4e5ac11a82ab  testnet3/$REGTEST_PKEY_NAME
 4c151c562fce2cdee55ac0a0f8bd9454eb69e6a0db9a8443b58b770ec29b37f5  regtest/$REGTEST_VKEY_NAME
-4c151c562fce2cdee55ac0a0f8bd9454eb69e6a0db9a8443b58b770ec29b37f5  testnet3/$REGTEST_VKEY_NAME
 EOF
+
+    # Check the exit code of the shasum command:
+    CHECKSUM_RESULT=$?
+    if [ $CHECKSUM_RESULT -eq 0 ]; then
+        echo 'Updating testnet3 symlinks to regtest parameters.'
+        mkdir -p "$TESTNET3_DIR"
+        ln -sf "../regtest/$REGTEST_PKEY_NAME" "$TESTNET3_DIR/$REGTEST_PKEY_NAME"
+        ln -sf "../regtest/$REGTEST_VKEY_NAME" "$TESTNET3_DIR/$REGTEST_VKEY_NAME"
+    else
+       exit 1
+    fi
+
 }
 
 main

--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -13,7 +13,6 @@ REGTEST_DIR="$PARAMS_DIR/regtest"
 # This should have the same params as regtest. We use symlinks for now.
 TESTNET3_DIR="$PARAMS_DIR/testnet3"
 
-
 function fetch_params {
     local url="$1"
     local output="$2"
@@ -38,17 +37,38 @@ function fetch_params {
     fi
 }
 
-cat <<EOF
+# Use flock to prevent parallel execution.
+function lock() {
+    local lockfile=/tmp/fetch_params.lock
+    # create lock file
+    eval "exec 200>/$lockfile"
+    # acquire the lock
+    flock -n 200 \
+        && return 0 \
+        || return 1
+}
+
+function exit_locked_error {
+    echo "Only one instance of fetch-params.sh can be run at a time." >&2
+    exit 1
+}
+
+function main() {
+
+    lock fetch-params.sh \
+    || exit_locked_error
+
+    cat <<EOF
 zcash - fetch-params.sh
 
 EOF
 
-# Now create PARAMS_DIR and insert a README if necessary:
-if ! [ -d "$PARAMS_DIR" ]
-then
-    mkdir -p "$PARAMS_DIR"
-    README_PATH="$PARAMS_DIR/README"
-    cat >> "$README_PATH" <<EOF
+    # Now create PARAMS_DIR and insert a README if necessary:
+    if ! [ -d "$PARAMS_DIR" ]
+    then
+        mkdir -p "$PARAMS_DIR"
+        README_PATH="$PARAMS_DIR/README"
+        cat >> "$README_PATH" <<EOF
 This directory stores common zcash zkSNARK parameters. Note that is is
 distinct from the daemon's -datadir argument because the parameters are
 large and may be shared across multiple distinct -datadir's such as when
@@ -71,24 +91,27 @@ $README_PATH
 EOF
 fi
 
-mkdir -p "$REGTEST_DIR"
+    mkdir -p "$REGTEST_DIR"
 
-fetch_params "$REGTEST_PKEY_URL" "$REGTEST_DIR/$REGTEST_PKEY_NAME"
-fetch_params "$REGTEST_VKEY_URL" "$REGTEST_DIR/$REGTEST_VKEY_NAME"
+    fetch_params "$REGTEST_PKEY_URL" "$REGTEST_DIR/$REGTEST_PKEY_NAME"
+    fetch_params "$REGTEST_VKEY_URL" "$REGTEST_DIR/$REGTEST_VKEY_NAME"
 
-echo 'Updating testnet3 symlinks to regtest parameters.'
-mkdir -p "$TESTNET3_DIR"
-ln -sf "../regtest/$REGTEST_PKEY_NAME" "$TESTNET3_DIR/$REGTEST_PKEY_NAME"
-ln -sf "../regtest/$REGTEST_VKEY_NAME" "$TESTNET3_DIR/$REGTEST_VKEY_NAME"
+    echo 'Updating testnet3 symlinks to regtest parameters.'
+    mkdir -p "$TESTNET3_DIR"
+    ln -sf "../regtest/$REGTEST_PKEY_NAME" "$TESTNET3_DIR/$REGTEST_PKEY_NAME"
+    ln -sf "../regtest/$REGTEST_VKEY_NAME" "$TESTNET3_DIR/$REGTEST_VKEY_NAME"
 
-cd "$PARAMS_DIR"
+    cd "$PARAMS_DIR"
 
-# Now verify their hashes:
-echo 'Verifying parameter file integrity via sha256sum...'
-shasum -a 256 --check <<EOF
+    # Now verify their hashes:
+    echo 'Verifying parameter file integrity via sha256sum...'
+    shasum -a 256 --check <<EOF
 226913bbdc48b70834f8e044d194ddb61c8e15329f67cdc6014f4e5ac11a82ab  regtest/$REGTEST_PKEY_NAME
 226913bbdc48b70834f8e044d194ddb61c8e15329f67cdc6014f4e5ac11a82ab  testnet3/$REGTEST_PKEY_NAME
 4c151c562fce2cdee55ac0a0f8bd9454eb69e6a0db9a8443b58b770ec29b37f5  regtest/$REGTEST_VKEY_NAME
 4c151c562fce2cdee55ac0a0f8bd9454eb69e6a0db9a8443b58b770ec29b37f5  testnet3/$REGTEST_VKEY_NAME
 EOF
+}
 
+main
+exit 0


### PR DESCRIPTION
Two instances of the fetch-params.sh script running at once will result in corruption of the proving key and an error when the hashes are computed. 
```
Verifying parameter file integrity via sha256sum...
regtest/z9-proving.key: FAILED

testnet3/z9-proving.key: FAILED
regtest/z9-verifying.key: OK
testnet3/z9-verifying.key: OK
shasum: WARNING: 2 computed checksums did NOT match
```

This commit implements a lock within the script to stop such a scenario from occurring. It also encapsulates the script's logic in a main() function.

Fixes #1306.