### PR TITLE
Deallocate the public parameters during Shutdown.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -208,6 +208,8 @@ void Shutdown()
     delete pwalletMain;
     pwalletMain = NULL;
 #endif
+    delete pzcashParams;
+    pzcashParams = NULL;
     ECC_Stop();
     LogPrintf("%s: done\n", __func__);
 }

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -43,6 +43,7 @@ BasicTestingSetup::BasicTestingSetup()
 BasicTestingSetup::~BasicTestingSetup()
 {
         ECC_Stop();
+        delete pzcashParams;
 }
 
 TestingSetup::TestingSetup()

--- a/src/zcash/GenerateParams.cpp
+++ b/src/zcash/GenerateParams.cpp
@@ -22,5 +22,7 @@ int main(int argc, char **argv)
     p->saveProvingKey(pkFile);
     p->saveVerifyingKey(vkFile);
 
+    delete p;
+
     return 0;
 }

--- a/src/zcash/JoinSplit.cpp
+++ b/src/zcash/JoinSplit.cpp
@@ -72,6 +72,9 @@ public:
     boost::optional<r1cs_ppzksnark_verification_key<ppzksnark_ppT>> vk;
     boost::optional<std::string> pkPath;
 
+    JoinSplitCircuit() {}
+    ~JoinSplitCircuit() {}
+
     static void initialize() {
         LOCK(cs_InitializeParams);
 
@@ -121,8 +124,6 @@ public:
         pk = keypair.pk;
         vk = keypair.vk;
     }
-
-    JoinSplitCircuit() {}
 
     bool verify(
         const ZCProof& proof,

--- a/src/zcash/JoinSplit.hpp
+++ b/src/zcash/JoinSplit.hpp
@@ -45,6 +45,8 @@ public:
 template<size_t NumInputs, size_t NumOutputs>
 class JoinSplit {
 public:
+    virtual ~JoinSplit() {}
+
     static JoinSplit<NumInputs, NumOutputs>* Generate();
     static JoinSplit<NumInputs, NumOutputs>* Unopened();
     static uint256 h_sig(const uint256& randomSeed,


### PR DESCRIPTION
This also has it deallocated in `GenerateParams` and `test_bitcoin`. The virtual destructor probably isn't necessary but I added it just in case we need it some other time.