### PR TITLE
Closes #1315 - change to RPC getblocksubsidy

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -763,12 +763,12 @@ Value estimatepriority(const Array& params, bool fHelp)
 
 Value getblocksubsidy(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
+    if (fHelp || params.size() > 1)
         throw runtime_error(
             "getblocksubsidy height\n"
             "\nReturns block subsidy reward, taking into account the mining slow start and the founders reward, of block at index provided.\n"
             "\nArguments:\n"
-            "1. height        (numeric, required) The block height.\n"
+            "1. height         (numeric, optional) The block height.  If not provided, defaults to the current height of the chain.\n"
             "\nResult:\n"
             "{\n"
             "  \"miner\" : x.xxx           (numeric) The mining reward amount in ZEC.\n"
@@ -779,9 +779,9 @@ Value getblocksubsidy(const Array& params, bool fHelp)
             + HelpExampleRpc("getblockubsidy", "1000")
         );
 
-    int nHeight = params[0].get_int();
     LOCK(cs_main);
-    if (nHeight < 0 || nHeight > chainActive.Height())
+    int nHeight = (params.size()==1) ? params[0].get_int() : chainActive.Height();
+    if (nHeight < 0)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
 
     CAmount nReward = GetBlockSubsidy(nHeight, Params().GetConsensus());

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -222,6 +222,24 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     Array arr = retValue.get_array();
     BOOST_CHECK(arr.size() > 0);
     BOOST_CHECK(CBitcoinAddress(arr[0].get_str()).Get() == demoAddress.Get());
+
+    /*
+     * getblocksubsidy
+     */
+    BOOST_CHECK_THROW(CallRPC("getblocksubsidy too many args"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("getblocksubsidy -1"), runtime_error);
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 50000"));
+    Object obj = retValue.get_obj();
+    BOOST_CHECK(find_value(obj, "miner") == 10.0);
+    BOOST_CHECK(find_value(obj, "founders") == 2.5);
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 1000000"));
+    obj = retValue.get_obj();
+    BOOST_CHECK(find_value(obj, "miner") == 6.25);
+    BOOST_CHECK(find_value(obj, "founders") == 0.0);
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 2000000"));
+    obj = retValue.get_obj();
+    BOOST_CHECK(find_value(obj, "miner") == 3.125);
+    BOOST_CHECK(find_value(obj, "founders") == 0.0);
 }
 
 /*


### PR DESCRIPTION
For #1315 
RPC getblocksubsidy height parameter is now optional
Returns result for future block
Test has been added to verify parameter input and results
