### PR TITLE
Enable high-priority alerts to put the RPC into safe mode

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -41,7 +41,7 @@ void CUnsignedAlert::SetNull()
 
     strComment.clear();
     strStatusBar.clear();
-    strReserved.clear();
+    strRPCError.clear();
 }
 
 std::string CUnsignedAlert::ToString() const
@@ -66,6 +66,7 @@ std::string CUnsignedAlert::ToString() const
         "    nPriority    = %d\n"
         "    strComment   = \"%s\"\n"
         "    strStatusBar = \"%s\"\n"
+        "    strRPCError  = \"%s\"\n"
         ")\n",
         nVersion,
         nRelayUntil,
@@ -78,7 +79,8 @@ std::string CUnsignedAlert::ToString() const
         strSetSubVer,
         nPriority,
         strComment,
-        strStatusBar);
+        strStatusBar,
+        strRPCError);
 }
 
 void CAlert::SetNull()

--- a/src/alert.h
+++ b/src/alert.h
@@ -44,7 +44,7 @@ public:
     // Actions
     std::string strComment;
     std::string strStatusBar;
-    std::string strReserved;
+    std::string strRPCError;
 
     ADD_SERIALIZE_METHODS;
 
@@ -64,7 +64,7 @@ public:
 
         READWRITE(LIMITED_STRING(strComment, 65536));
         READWRITE(LIMITED_STRING(strStatusBar, 256));
-        READWRITE(LIMITED_STRING(strReserved, 256));
+        READWRITE(LIMITED_STRING(strRPCError, 256));
     }
 
     void SetNull();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4052,6 +4052,9 @@ string GetWarnings(string strFor)
             {
                 nPriority = alert.nPriority;
                 strStatusBar = alert.strStatusBar;
+                if (alert.nPriority >= ALERT_PRIORITY_SAFE_MODE) {
+                    strRPC = alert.strRPCError;
+                }
             }
         }
     }

--- a/src/main.h
+++ b/src/main.h
@@ -57,6 +57,8 @@ static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** Default for accepting alerts from the P2P network. */
 static const bool DEFAULT_ALERTS = true;
+/** Minimum alert priority for enabling safe mode. */
+static const int ALERT_PRIORITY_SAFE_MODE = 4000;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */

--- a/src/sendalert.cpp
+++ b/src/sendalert.cpp
@@ -85,9 +85,11 @@ void ThreadSendAlert()
     //  1000 for Misc warnings like out of disk space and clock is wrong
     //  2000 for longer invalid proof-of-work chain 
     //  Higher numbers mean higher priority
+    //  4000 or higher will put the RPC into safe mode
     alert.nPriority     = 5000;
     alert.strComment    = "";
     alert.strStatusBar  = "URGENT: Upgrade required: see https://z.cash";
+    alert.strRPCError   = "URGENT: Upgrade required: see https://z.cash";
 
     // Set specific client version/versions here. If setSubVer is empty, no filtering on subver is done:
     // alert.setSubVer.insert(std::string("/Satoshi:0.7.2/"));


### PR DESCRIPTION
This reverts the changes in 986b5e257e2bb9d7aaed5111ca335732f8808b2d and adds a
priority check.

Closes #1106