### PR TITLE
Update libsnark again.

### DIFF
--- a/depends/packages/libsnark.mk
+++ b/depends/packages/libsnark.mk
@@ -3,8 +3,8 @@ $(package)_version=0.1
 $(package)_download_path=https://github.com/zcash/$(package)/archive/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=cf002c50711654f0a4abb76b63f5b7d3679403822025772acc334bc7992e9494
-$(package)_git_commit=d65904ac6f1c0f7676035e62f84d6352b386ba45
+$(package)_sha256_hash=378cf10b1eb603780718edb2b64ff7e1e90a63309a40b48c1aefc4f4ebaba326
+$(package)_git_commit=4d23a06660aa74a3f5be1bf4739bee0a37e05387
 
 $(package)_dependencies=libgmp libsodium
 

--- a/src/gtest/test_proofs.cpp
+++ b/src/gtest/test_proofs.cpp
@@ -22,6 +22,12 @@ typedef libsnark::default_r1cs_ppzksnark_pp::Fqe_type curve_Fq2;
 #include "version.h"
 #include "utilstrencodings.h"
 
+TEST(proofs, sqrt_zero)
+{
+    ASSERT_TRUE(curve_Fq::zero() == curve_Fq::zero().sqrt());
+    ASSERT_TRUE(curve_Fq2::zero() == curve_Fq2::zero().sqrt());
+}
+
 TEST(proofs, sqrt_fq)
 {
     // Poor man's PRNG


### PR DESCRIPTION
Closes #1320.

See https://github.com/zcash/libsnark/pull/6 for the accompanying changes in libsnark.