### PR TITLE
Fix CheckTransaction bugs.

### DIFF
--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -171,12 +171,24 @@ TEST(checktransaction_tests, bad_txns_txouttotal_toolarge_outputs) {
 TEST(checktransaction_tests, bad_txns_txouttotal_toolarge_joinsplit) {
     CMutableTransaction mtx = GetValidTransaction();
     mtx.vout[0].nValue = 1;
-    mtx.vjoinsplit[0].vpub_new = MAX_MONEY;
+    mtx.vjoinsplit[0].vpub_old = MAX_MONEY;
 
     CTransaction tx(mtx);
 
     MockCValidationState state;
     EXPECT_CALL(state, DoS(100, false, REJECT_INVALID, "bad-txns-txouttotal-toolarge", false)).Times(1);
+    CheckTransactionWithoutProofVerification(tx, state);
+}
+
+TEST(checktransaction_tests, bad_txns_txintotal_toolarge_joinsplit) {
+    CMutableTransaction mtx = GetValidTransaction();
+    mtx.vjoinsplit[0].vpub_new = MAX_MONEY - 1;
+    mtx.vjoinsplit[1].vpub_new = MAX_MONEY - 1;
+
+    CTransaction tx(mtx);
+
+    MockCValidationState state;
+    EXPECT_CALL(state, DoS(100, false, REJECT_INVALID, "bad-txns-txintotal-toolarge", false)).Times(1);
     CheckTransactionWithoutProofVerification(tx, state);
 }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -451,7 +451,7 @@ BOOST_AUTO_TEST_CASE(test_simple_joinsplit_invalidity)
         jsdesc2->vpub_new = (MAX_MONEY / 2) + 10;
 
         BOOST_CHECK(!CheckTransaction(newTx, state));
-        BOOST_CHECK(state.GetRejectReason() == "bad-txns-txouttotal-toolarge");
+        BOOST_CHECK(state.GetRejectReason() == "bad-txns-txintotal-toolarge");
     }
     {
         // Ensure that nullifiers are never duplicated within a transaction.


### PR DESCRIPTION
Closes #1319.

Does not address the name of `vpub_old` or `vpub_new`.