### PR TITLE
Write note witness cache atomically to disk to avoid corruption

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -603,6 +603,7 @@ protected:
                                 const CBlock* pblock,
                                 ZCIncrementalMerkleTree tree);
     void DecrementNoteWitnesses();
+    void WriteWitnessCache();
 
 private:
     template <class T>


### PR DESCRIPTION
Closes #1378