### PR TITLE
Drop note witness caches on reindexing

### DIFF
--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -592,12 +592,12 @@ TEST(wallet_tests, UpdatedNoteData) {
 
     // The txs should initially be different
     EXPECT_NE(wtx.mapNoteData, wtx2.mapNoteData);
-    EXPECT_NE(wtx.mapNoteData[jsoutpt].witnesses, wtx2.mapNoteData[jsoutpt].witnesses);
+    EXPECT_EQ(1, wtx.mapNoteData[jsoutpt].witnesses.size());
 
     // After updating, they should be the same
-    EXPECT_TRUE(wallet.UpdatedNoteData(wtx, wtx2));
+    EXPECT_TRUE(wallet.UpdatedNoteData(wtx2, wtx));
     EXPECT_EQ(wtx.mapNoteData, wtx2.mapNoteData);
-    EXPECT_EQ(wtx.mapNoteData[jsoutpt].witnesses, wtx2.mapNoteData[jsoutpt].witnesses);
+    EXPECT_EQ(1, wtx.mapNoteData[jsoutpt].witnesses.size());
     // TODO: The new note should get witnessed (but maybe not here) (#1350)
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -964,15 +964,30 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
 
 bool CWallet::UpdatedNoteData(const CWalletTx& wtxIn, CWalletTx& wtx)
 {
+    // On reindex, IncrementNoteWitnesses() is called for every block again. So
+    // we drop the cached witnesses for any transactions we already know about.
+    bool dropCache = GetBoolArg("-reindex", false);
+
     if (wtxIn.mapNoteData.empty() || wtxIn.mapNoteData == wtx.mapNoteData) {
-        return false;
+        // No change in note data; check for cache invalidation
+        if (dropCache) {
+            for (std::pair<JSOutPoint, CNoteData> nd : wtx.mapNoteData) {
+                wtx.mapNoteData.at(nd.first).witnesses.clear();
+            }
+            return true;
+        } else {
+            return false;
+        }
     }
+
     auto tmp = wtxIn.mapNoteData;
-    // Ensure we keep any cached witnesses we may already have
-    for (const std::pair<JSOutPoint, CNoteData> nd : wtx.mapNoteData) {
-        if (tmp.count(nd.first) && nd.second.witnesses.size() > 0) {
-            tmp.at(nd.first).witnesses.assign(
-                nd.second.witnesses.cbegin(), nd.second.witnesses.cend());
+    if (!dropCache) {
+        // Ensure we keep any cached witnesses we may already have
+        for (const std::pair<JSOutPoint, CNoteData> nd : wtx.mapNoteData) {
+            if (tmp.count(nd.first) && nd.second.witnesses.size() > 0) {
+                tmp.at(nd.first).witnesses.assign(
+                    nd.second.witnesses.cbegin(), nd.second.witnesses.cend());
+            }
         }
     }
     // Now copy over the updated note data


### PR DESCRIPTION
This PR also fixes a test that was passing arguments in the wrong order.

Closes #1394