### PR TITLE
Benchmark 50 iterations of solveequihash

### DIFF
--- a/qa/zcash/performance-measurements.sh
+++ b/qa/zcash/performance-measurements.sh
@@ -80,7 +80,7 @@ case "$1" in
                 zcash_rpc zcbenchmark verifyjoinsplit 1000 "\"$RAWJOINSPLIT\""
                 ;;
             solveequihash)
-                zcash_rpc zcbenchmark solveequihash 10 "${@:3}"
+                zcash_rpc zcbenchmark solveequihash 50 "${@:3}"
                 ;;
             verifyequihash)
                 zcash_rpc zcbenchmark verifyequihash 1000


### PR DESCRIPTION
Since the parameters changed in z8, the benchmark on speed.z.cash is showing misleading results due to variability. (The quartile and extrema bars will still show the variability with 50 runs, they just won't jump around as much between benchmark data points.)