### PR TITLE
Add a make command for checking expected failures

### DIFF
--- a/src/Makefile.gtest.include
+++ b/src/Makefile.gtest.include
@@ -36,3 +36,6 @@ zcash_gtest_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) -static
 
 zcash-gtest_check: zcash-gtest FORCE
 	./zcash-gtest
+
+zcash-gtest-expected-failures: zcash-gtest FORCE
+	./zcash-gtest --gtest_filter=*DISABLED_* --gtest_also_run_disabled_tests

--- a/src/gtest/test_tautology.cpp
+++ b/src/gtest/test_tautology.cpp
@@ -3,3 +3,8 @@
 TEST(tautologies, seven_eq_seven) {
     ASSERT_EQ(7, 7);
 }
+
+TEST(tautologies, DISABLED_ObviousFailure)
+{
+    FAIL() << "This is expected";
+}


### PR DESCRIPTION
With this merged, we can add gtests prefixed with `DISABLED_`, and then configure Buildbot to run those tests but not require they pass in order to merge.