### PR TITLE
Updates dns.testnet.z.cash -> dnsseed.testnet.z.cash

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -175,7 +175,7 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
-        vSeeds.push_back(CDNSSeedData("z.cash", "dns.testnet.z.cash")); // Zcash
+        vSeeds.push_back(CDNSSeedData("z.cash", "dnsseed.testnet.z.cash")); // Zcash
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);


### PR DESCRIPTION
People seem to agree that dnsseed.* is a more intuitive address.
The original address was committed to beta1 as a result of a misunderstanding.
The DNS seeder service will be updated to coincide with this change at beta2 release.