### PR TITLE
Clear note witness caches on reindexing

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -532,6 +532,11 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
     RenameThread("bitcoin-loadblk");
     // -reindex
     if (fReindex) {
+#ifdef ENABLE_WALLET
+        if (pwalletMain) {
+            pwalletMain->ClearNoteWitnessCache();
+        }
+#endif
         CImportingNow imp;
         int nFile = 0;
         while (true) {

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -592,12 +592,12 @@ TEST(wallet_tests, UpdatedNoteData) {
 
     // The txs should initially be different
     EXPECT_NE(wtx.mapNoteData, wtx2.mapNoteData);
-    EXPECT_NE(wtx.mapNoteData[jsoutpt].witnesses, wtx2.mapNoteData[jsoutpt].witnesses);
+    EXPECT_EQ(1, wtx.mapNoteData[jsoutpt].witnesses.size());
 
     // After updating, they should be the same
-    EXPECT_TRUE(wallet.UpdatedNoteData(wtx, wtx2));
+    EXPECT_TRUE(wallet.UpdatedNoteData(wtx2, wtx));
     EXPECT_EQ(wtx.mapNoteData, wtx2.mapNoteData);
-    EXPECT_EQ(wtx.mapNoteData[jsoutpt].witnesses, wtx2.mapNoteData[jsoutpt].witnesses);
+    EXPECT_EQ(1, wtx.mapNoteData[jsoutpt].witnesses.size());
     // TODO: The new note should get witnessed (but maybe not here) (#1350)
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -592,6 +592,17 @@ void CWallet::AddToSpends(const uint256& wtxid)
     }
 }
 
+void CWallet::ClearNoteWitnessCache()
+{
+    LOCK(cs_wallet);
+    for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
+        for (mapNoteData_t::value_type& item : wtxItem.second.mapNoteData) {
+            CNoteData* nd = &(item.second);
+            nd->witnesses.clear();
+        }
+    }
+}
+
 void CWallet::IncrementNoteWitnesses(const CBlockIndex* pindex,
                                      const CBlock* pblockIn,
                                      ZCIncrementalMerkleTree tree)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -597,8 +597,7 @@ void CWallet::ClearNoteWitnessCache()
     LOCK(cs_wallet);
     for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
         for (mapNoteData_t::value_type& item : wtxItem.second.mapNoteData) {
-            CNoteData* nd = &(item.second);
-            nd->witnesses.clear();
+            item.second.witnesses.clear();
         }
     }
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -598,6 +598,8 @@ public:
      */
     int64_t nWitnessCacheSize;
 
+    void ClearNoteWitnessCache();
+
 protected:
     void IncrementNoteWitnesses(const CBlockIndex* pindex,
                                 const CBlock* pblock,


### PR DESCRIPTION
This PR also fixes a test that was passing arguments in the wrong order.

Closes #1394