### PR TITLE
Verify TLS certificates w/ wget in fetch-params.sh

### DIFF
--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -21,13 +21,8 @@ function fetch_params {
     if ! [ -f "$output" ]
     then
         echo "Retrieving: $url"
-        # Note: --no-check-certificate should be ok, since we rely on
-        # sha256 for integrity, and there's no confidentiality requirement.
-        # Our website uses letsencrypt certificates which are not supported
-        # by some wget installations, so we expect some cert failures.
         wget \
             --progress=dot:giga \
-            --no-check-certificate \
             --output-document="$dlname" \
             --continue \
             "$url"


### PR DESCRIPTION
Per NCC-2016-017, wget was being run with `--no-check-certificate`, which means that the connection can be man-in-the-middled, even if we are verifying the integrity of the parameters later via hash sums.
The rationale cited in the Bash comments does not stand up to scrutiny. There's really no persuasive reason not to verify certificates.

Fixes #1346.