### PR TITLE
Update to beta2 public parameters

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -613,8 +613,8 @@ static void ZC_LoadParams()
     struct timeval tv_start, tv_end;
     float elapsed;
 
-    boost::filesystem::path pk_path = ZC_GetParamsDir() / "z9-proving.key";
-    boost::filesystem::path vk_path = ZC_GetParamsDir() / "z9-verifying.key";
+    boost::filesystem::path pk_path = ZC_GetParamsDir() / "beta2-proving.key";
+    boost::filesystem::path vk_path = ZC_GetParamsDir() / "beta2-verifying.key";
 
     pzcashParams = ZCJoinSplit::Unopened();
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -478,7 +478,6 @@ const boost::filesystem::path &ZC_GetParamsDir()
         return path;
 
     path = ZC_GetBaseParamsDir();
-    path /= BaseParams().DataDir();
 
     return path;
 }

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -52,8 +52,8 @@ double benchmark_sleep()
 double benchmark_parameter_loading()
 {
     // FIXME: this is duplicated with the actual loading code
-    boost::filesystem::path pk_path = ZC_GetParamsDir() / "z9-proving.key";
-    boost::filesystem::path vk_path = ZC_GetParamsDir() / "z9-verifying.key";
+    boost::filesystem::path pk_path = ZC_GetParamsDir() / "beta2-proving.key";
+    boost::filesystem::path vk_path = ZC_GetParamsDir() / "beta2-verifying.key";
 
     struct timeval tv_start;
     timer_start(tv_start);


### PR DESCRIPTION
Also gets rid of the `testnet3`/`regtest` subdirectories/symlinks and other such things.