### PR TITLE
Set wget retry options for fetching parameters

### DIFF
--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -22,7 +22,7 @@ function fetch_params {
             --progress=dot:giga \
             --output-document="$dlname" \
             --continue \
-            --retry-connrefused --waitretry=1 --timeout=10 --tries 0 \
+            --retry-connrefused --waitretry=3 --timeout=30 \
             "$url"
 
         shasum -a 256 --check <<EOF

--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -22,6 +22,7 @@ function fetch_params {
             --progress=dot:giga \
             --output-document="$dlname" \
             --continue \
+            --retry-connrefused --waitretry=1 --timeout=10 --tries 0 \
             "$url"
 
         shasum -a 256 --check <<EOF


### PR DESCRIPTION
This will retry upon refused connections and similar errors, wait 1 second before the next retry, time out after 10 seconds if no data is received or the connection times out, plus try an infinite number of times.

Resolves #1196.