### PR TITLE
Avoid building bitcoin-tx rawtxn utility

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -66,7 +66,7 @@ if BUILD_BITCOIND
 endif
 
 if BUILD_BITCOIN_UTILS
-  bin_PROGRAMS += zcash-cli bitcoin-tx
+  bin_PROGRAMS += zcash-cli
 endif
 
 # TODO: rename to libzcash


### PR DESCRIPTION
The bitcoin-tx utility is for manipulating Bitcoin raw transactions. There's no compelling reason to include the build target for it in Zcash.