### PR TITLE
Manually backport upstream's NODE_BLOOM bit

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -42,6 +42,7 @@ testScriptsExt=(
     'hardforkdetection.py'
     'invalidateblock.py'
     'keypool.py'
+    'p2p-mempool.py'
     'receivedby.py'
     'reindex.py'
     'rpcbind_test.py'

--- a/qa/rpc-tests/p2p-mempool.py
+++ b/qa/rpc-tests/p2p-mempool.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import time
+
+class TestNode(NodeConnCB):
+    def __init__(self):
+        NodeConnCB.__init__(self)
+        self.connection = None
+        self.ping_counter = 1
+        self.last_pong = msg_pong()
+        self.block_receive_map = {}
+
+    def add_connection(self, conn):
+        self.connection = conn
+        self.peer_disconnected = False
+
+    def on_inv(self, conn, message):
+        pass
+
+    # Track the last getdata message we receive (used in the test)
+    def on_getdata(self, conn, message):
+        self.last_getdata = message
+
+    def on_block(self, conn, message):
+        message.block.calc_sha256()
+        try:
+            self.block_receive_map[message.block.sha256] += 1
+        except KeyError as e:
+            self.block_receive_map[message.block.sha256] = 1
+
+    # Spin until verack message is received from the node.
+    # We use this to signal that our test can begin. This
+    # is called from the testing thread, so it needs to acquire
+    # the global lock.
+    def wait_for_verack(self):
+        def veracked():
+            return self.verack_received
+        return wait_until(veracked, timeout=10)
+
+    def wait_for_disconnect(self):
+        def disconnected():
+            return self.peer_disconnected
+        return wait_until(disconnected, timeout=10)
+
+    # Wrapper for the NodeConn's send_message function
+    def send_message(self, message):
+        self.connection.send_message(message)
+
+    def on_pong(self, conn, message):
+        self.last_pong = message
+
+    def on_close(self, conn):
+        self.peer_disconnected = True
+
+    # Sync up with the node after delivery of a block
+    def sync_with_ping(self, timeout=30):
+        def received_pong():
+            return (self.last_pong.nonce == self.ping_counter)
+        self.connection.send_message(msg_ping(nonce=self.ping_counter))
+        success = wait_until(received_pong, timeout=timeout)
+        self.ping_counter += 1
+        return success
+
+    def send_mempool(self):
+        self.lastInv = []
+        self.send_message(msg_mempool())
+
+class P2PMempoolTests(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def setup_network(self):
+        # Start a node with maxuploadtarget of 200 MB (/24h)
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-peerbloomfilters=0"]))
+
+    def run_test(self):
+        #connect a mininode
+        aTestNode = TestNode()
+        node = NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], aTestNode)
+        aTestNode.add_connection(node)
+        NetworkThread().start()
+        aTestNode.wait_for_verack()
+
+        #request mempool
+        aTestNode.send_mempool()
+        aTestNode.wait_for_disconnect()
+
+        #mininode must be disconnected at this point
+        assert_equal(len(self.nodes[0].getpeerinfo()), 0)
+    
+if __name__ == '__main__':
+    P2PMempoolTests().main()

--- a/qa/rpc-tests/p2p-mempool.py
+++ b/qa/rpc-tests/p2p-mempool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 # Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -74,7 +74,7 @@ class TestNode(NodeConnCB):
 class P2PMempoolTests(BitcoinTestFramework):
 
     def __init__(self):
-        super().__init__()
+        super(P2PMempoolTests, self).__init__()
         self.setup_clean_chain = True
         self.num_nodes = 2
 

--- a/qa/rpc-tests/p2p-mempool.py
+++ b/qa/rpc-tests/p2p-mempool.py
@@ -6,6 +6,7 @@
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
+from test_framework.comptool import *
 import time
 
 class TestNode(NodeConnCB):

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -323,6 +323,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-onion=<ip:port>", strprintf(_("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)"), "-proxy"));
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), 1));
+    strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with bloom filters (default: %u)"), true));
     strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u or testnet: %u)"), 8233, 18233));
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
     strUsage += HelpMessageOpt("-proxyrandomize", strprintf(_("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)"), 1));
@@ -911,6 +912,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes);
 
     fAlerts = GetBoolArg("-alerts", DEFAULT_ALERTS);
+
+    if (GetBoolArg("-peerbloomfilters", true)) {
+        nLocalServices = nLocalServices | NODE_BLOOM;
+    }
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4272,7 +4272,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     }
 
 
-    if ((pfrom->nServices & NODE_BLOOM) &&
+    if (!(pfrom->nServices & NODE_BLOOM) &&
         (strCommand == "filterload" ||
          strCommand == "filteradd" ||
          strCommand == "filterclear"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4272,6 +4272,15 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     }
 
 
+    if ((pfrom->nServices & NODE_BLOOM) &&
+        (strCommand == "filterload" ||
+         strCommand == "filteradd" ||
+         strCommand == "filterclear"))
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return false;
+    }
 
 
     if (strCommand == "version")
@@ -4876,6 +4885,13 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
     else if (strCommand == "mempool")
     {
+        if (!(pfrom->nServices & NODE_BLOOM) && !pfrom->fWhitelisted)
+        {
+            LogPrint("net", "mempool request with bloom filters disabled, disconnect peer=%d\n", pfrom->GetId());
+            pfrom->fDisconnect = true;
+            return true;
+        }
+
         LOCK2(cs_main, pfrom->cs_filter);
 
         std::vector<uint256> vtxid;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -75,6 +75,11 @@ enum {
     // Bitcoin Core does not support this but a patch set called Bitcoin XT does.
     // See BIP 64 for details on how this is implemented.
     NODE_GETUTXO = (1 << 1),
+    // NODE_BLOOM means the node is capable and willing to handle bloom-filtered connections.
+    // Bitcoin Core nodes used to support this by default, without advertising this bit,
+    // but no longer do as of protocol version 70011 (= NO_BLOOM_VERSION). In Zcash, there
+    // is no NO_BLOOM_VERSION since the NODE_BLOOM bit was present at launch.
+    NODE_BLOOM = (1 << 2),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the


### PR DESCRIPTION
This manually backports upstream's https://github.com/bitcoin/bitcoin/pull/6579 and https://github.com/bitcoin/bitcoin/pull/8078. Instead of actually using those PRs I just copied everything relevant from the current Bitcoin master (https://github.com/bitcoin/bitcoin/).

I didn't copy over the whole `NO_BLOOM_VERSION` thing since if this is going into a backwards-compatibility-breaking release where the network magic numbers are changing (like the 1.0 launch is?) then that extra code shouldn't be necessary.

What this does is add a command-line option node operators can use to disable bloom filters if they find their node to be under attack. For Zcash, we should consider changing the default to false, so that bloom filters are disabled unless the operator opts-in or even disabling bloom filters altogether.

What's missing:
- [ ] An RPC test that tries to send one of the filter commands to a node with `-peerbloomfilters=0`. I couldn't find a test like this in upstream.
