### PR TITLE
V1.0.0 rc1 gitian

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -8,7 +8,7 @@ NO_WALLET ?=
 NO_UPNP ?=
 FALLBACK_DOWNLOAD_PATH ?= https://z.cash/depends-sources
 
-BUILD = $(shell ./config.guess)
+BUILD ?= $(shell ./config.guess)
 HOST ?= $(BUILD)
 PATCHES_PATH = $(BASEDIR)/patches
 BASEDIR = $(CURDIR)

--- a/depends/packages/libgmp.mk
+++ b/depends/packages/libgmp.mk
@@ -7,7 +7,7 @@ $(package)_dependencies=
 $(package)_config_opts=--enable-cxx --disable-shared
 
 define $(package)_config_cmds
-  $($(package)_autoconf)
+  $($(package)_autoconf) --host=$(host) --build=$(build)
 endef
 
 define $(package)_build_cmds

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -35,7 +35,7 @@ fi
 # BUG: parameterize the platform/host directory:
 PREFIX="$(pwd)/depends/x86_64-unknown-linux-gnu/"
 
-make "$@" -C ./depends/ V=1 NO_QT=1
+HOST=x86_64-unknown-linux-gnu BUILD=x86_64-unknown-linux-gnu make "$@" -C ./depends/ V=1 NO_QT=1
 ./autogen.sh
 ./configure --prefix="${PREFIX}" --host=x86_64-unknown-linux-gnu --build=x86_64-unknown-linux-gnu --with-gui=no "$HARDENING_ARG" "$LCOV_ARG" CXXFLAGS='-fwrapv -fno-strict-aliasing -Werror -g'
 make "$@" V=1

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -37,5 +37,5 @@ PREFIX="$(pwd)/depends/x86_64-unknown-linux-gnu/"
 
 make "$@" -C ./depends/ V=1 NO_QT=1
 ./autogen.sh
-./configure --prefix="${PREFIX}" --with-gui=no "$HARDENING_ARG" "$LCOV_ARG" CXXFLAGS='-fwrapv -fno-strict-aliasing -Werror -g'
+./configure --prefix="${PREFIX}" --host=x86_64-unknown-linux-gnu --build=x86_64-unknown-linux-gnu --with-gui=no "$HARDENING_ARG" "$LCOV_ARG" CXXFLAGS='-fwrapv -fno-strict-aliasing -Werror -g'
 make "$@" V=1


### PR DESCRIPTION
Removes indeterminism from gitian builds: underlying processor instruction set variant of x86_64 was being detected by the libgmp autoconf process, which caused differences in libgmp and libsnark