### PR TITLE
Closes #1583 by setting up the datadir for the wallet gtest.

### DIFF
--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -11,6 +11,8 @@
 #include "zcash/Note.hpp"
 #include "zcash/NoteEncryption.hpp"
 
+#include <boost/filesystem.hpp>
+
 using ::testing::Return;
 
 ZCJoinSplit* params = ZCJoinSplit::Unopened();
@@ -176,6 +178,13 @@ CWalletTx GetValidSpend(const libzcash::SpendingKey& sk,
     CTransaction tx {mtx};
     CWalletTx wtx {NULL, tx};
     return wtx;
+}
+
+TEST(wallet_tests, setup_datadir_location_run_as_first_test) {
+    // Get temporary and unique path for file.
+    boost::filesystem::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+    boost::filesystem::create_directories(pathTemp);
+    mapArgs["-datadir"] = pathTemp.string();
 }
 
 TEST(wallet_tests, note_data_serialisation) {


### PR DESCRIPTION
Stops test writing to ~/.zcash/testnet3.
Also related to #1506 