### PR TITLE
Fix issue where z_sendmany amount parameter is too strict

### DIFF
--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -240,7 +240,7 @@ class WalletTest (BitcoinTestFramework):
 
         # send node 2 taddr to zaddr
         recipients = []
-        recipients.append({"address":myzaddr, "amount":7.0})
+        recipients.append({"address":myzaddr, "amount":7})
         myopid = self.nodes[2].z_sendmany(mytaddr, recipients)
 
         opids = []
@@ -288,7 +288,7 @@ class WalletTest (BitcoinTestFramework):
         node2balance = self.nodes[2].getbalance() # 16.99790000
 
         recipients = []
-        recipients.append({"address":self.nodes[0].getnewaddress(), "amount":1.0})
+        recipients.append({"address":self.nodes[0].getnewaddress(), "amount":1})
         recipients.append({"address":self.nodes[2].getnewaddress(), "amount":1.0})
         myopid = self.nodes[2].z_sendmany(myzaddr, recipients)
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3222,8 +3222,6 @@ Value z_sendmany(const Array& params, bool fHelp)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected object");
         const Object& o = output.get_obj();
 
-        RPCTypeCheck(o, boost::assign::map_list_of("address", str_type)("amount", real_type));
-
         // sanity check, report error if unknown key-value pairs
         for (const Pair& p : o) {
             std::string s = p.name_;


### PR DESCRIPTION
Upstream treats an amount parameter of `1` the same as `1.0`.  Third-party would like this fixed.
