### PR TITLE
Revert "Avoid boost::posix_time functions that have potential out-of-bounds read bugs. ref #1459"

### DIFF
--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -9,7 +9,6 @@
 
 #include "utiltime.h"
 
-#include <chrono>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
 
@@ -31,14 +30,14 @@ void SetMockTime(int64_t nMockTimeIn)
 
 int64_t GetTimeMillis()
 {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
+    return (boost::posix_time::microsec_clock::universal_time() -
+            boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_milliseconds();
 }
 
 int64_t GetTimeMicros()
 {
-    return std::chrono::duration_cast<std::chrono::microseconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
+    return (boost::posix_time::microsec_clock::universal_time() -
+            boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_microseconds();
 }
 
 void MilliSleep(int64_t n)


### PR DESCRIPTION
This reverts commit a652e4183ec8e0a8041a7f29c85e36557acac327, which we suspect of causing subsequent nondeterministic test failures in qa/rpc-tests/test_framework/test_framework.py.