### PR TITLE
Fix assert test to compare two Decimal objects

### DIFF
--- a/qa/rpc-tests/wallet_protectcoinbase.py
+++ b/qa/rpc-tests/wallet_protectcoinbase.py
@@ -120,7 +120,7 @@ class Wallet2Test (BitcoinTestFramework):
         self.sync_all()
 
         # check balance
-        assert_equal(self.nodes[2].getbalance(), Decimal('19'))
+        assert_equal(Decimal(self.nodes[2].getbalance()), Decimal('19'))
 
 if __name__ == '__main__':
     Wallet2Test ().main ()


### PR DESCRIPTION
This will fix a test which started to fail on builbot.
Maybe related to the version of Python installed on buildbot and its dependent libraries (if the server was updated recently)