### PR TITLE
Fixing floating point exception in non-TTY environments

### DIFF
--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -13,6 +13,7 @@
 #include <boost/thread/synchronized_value.hpp>
 #include <string>
 #include <sys/ioctl.h>
+#include <unistd.h>
 
 AtomicCounter transactionsValidated;
 AtomicCounter ehSolverRuns;
@@ -196,11 +197,11 @@ void ThreadShowMetricsScreen()
 
         // Get current window size
         if (isatty(STDOUT_FILENO)) {
-          struct winsize w;
-          ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
-          if (w.ws_col) {
-            cols = w.ws_col;
-          }
+            struct winsize w;
+            w.ws_col = 0;
+            if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) != -1 && w.ws_col != 0) {
+                cols = w.ws_col;
+            }
         }
 
         // Erase below current position

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -192,16 +192,22 @@ void ThreadShowMetricsScreen()
     while (true) {
         // Number of lines that are always displayed
         int lines = 1;
+        int cols = 80;
 
         // Get current window size
-        struct winsize w;
-        ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+        if (isatty(STDOUT_FILENO)) {
+          struct winsize w;
+          ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+          if (w.ws_col) {
+            cols = w.ws_col;
+          }
+        }
 
         // Erase below current position
         std::cout << "\e[J";
 
-        lines += printMetrics(w.ws_col, nStart, mining);
-        lines += printMessageBox(w.ws_col);
+        lines += printMetrics(cols, nStart, mining);
+        lines += printMessageBox(cols);
         lines += printInitMessage();
 
         // Explain how to exit


### PR DESCRIPTION
As reported in #1612, a floating point exception occurs when zcashd is started with `showmetrics` enabled in environments without a TTY, such as when started as a service or piped to a file.

The root cause is that the metrics code attempts to get the screen width and uses this as a divisor in calculations. For non-TTY environments, this value is 0, leading to a division by zero error.

This PR adds a default screen width of 80 and uses the actual screen width only if the width can be fetched (and in a TTY environment).
