### PR TITLE
Remove the override of nMaxTipAge that effectively disables it on testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -175,7 +175,6 @@ public:
         vAlertPubKey = ParseHex("044e7a1553392325c871c5ace5d6ad73501c66f4c185d6b0453cf45dec5a1322e705c672ac1a27ef7cdaf588c10effdf50ed5f95f85f2f54a5f6159fca394ed0c6");
         nDefaultPort = 18233;
         nMinerThreads = 0;
-        nMaxTipAge = 0x7fffffff;
         nPruneAfterHeight = 1000;
 
         //! Modify the testnet genesis block so the timestamp is valid for a later start.


### PR DESCRIPTION
This is relevant to #1609 because it hid the bug, but does not fix that
issue; the fix is to regenerate the genesis blocks.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>