### PR TITLE
Allow to configure the zk-SNARK parameters directory using `-paramsdir=`

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -335,6 +335,7 @@ std::string HelpMessage(HelpMessageMode mode)
 #endif
     }
     strUsage += HelpMessageOpt("-datadir=<dir>", _("Specify data directory"));
+    strUsage += HelpMessageOpt("-paramsdir=<dir>", _("Specify Zcash network parameters directory"));
     strUsage += HelpMessageOpt("-dbcache=<n>", strprintf(_("Set database cache size in megabytes (%d to %d, default: %d)"), nMinDbCache, nMaxDbCache, nDefaultDbCache));
     strUsage += HelpMessageOpt("-debuglogfile=<file>", strprintf(_("Specify location of debug log file: this can be an absolute path or a path relative to the data directory (default: %s)"), DEFAULT_DEBUGLOGFILE));
     strUsage += HelpMessageOpt("-exportdir=<dir>", _("Specify directory to be used when exporting data"));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -549,8 +549,7 @@ const boost::filesystem::path &ZC_GetParamsDir()
     if (mapArgs.count("-paramsdir")) {
         path = fs::system_complete(mapArgs["-paramsdir"]);
         if (!fs::is_directory(path)) {
-            path = "";
-            return path;
+            throw std::runtime_error(strprintf("The -paramsdir '%s' does not exist or is not a directory", path.string()));
         }
     } else {
         path = ZC_GetDefaultBaseParamsDir();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -502,7 +502,7 @@ static boost::filesystem::path pathCachedNetSpecific;
 static boost::filesystem::path zc_paramsPathCached;
 static CCriticalSection csPathCached;
 
-static boost::filesystem::path ZC_GetBaseParamsDir()
+static boost::filesystem::path ZC_GetDefaultBaseParamsDir()
 {
     // Copied from GetDefaultDataDir and adapter for zcash params.
 
@@ -546,7 +546,15 @@ const boost::filesystem::path &ZC_GetParamsDir()
     if (!path.empty())
         return path;
 
-    path = ZC_GetBaseParamsDir();
+    if (mapArgs.count("-paramsdir")) {
+        path = fs::system_complete(mapArgs["-paramsdir"]);
+        if (!fs::is_directory(path)) {
+            path = "";
+            return path;
+        }
+    } else {
+        path = ZC_GetDefaultBaseParamsDir();
+    }
 
     return path;
 }


### PR DESCRIPTION
same use as datadir=/foo/bar parameter
