### PR TITLE
Metrics - Don't exclaim unless > 1

### DIFF
--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -94,7 +94,6 @@ int printMetrics(size_t cols, int64_t nStart, bool mining)
     int hours = (uptime - (days * 24 * 60 * 60)) / (60 * 60);
     int minutes = (uptime - (((days * 24) + hours) * 60 * 60)) / 60;
     int seconds = uptime - (((((days * 24) + hours) * 60) + minutes) * 60);
-    int validatedCount = 0;
 
     // Display uptime
     std::string duration;
@@ -111,13 +110,13 @@ int printMetrics(size_t cols, int64_t nStart, bool mining)
     std::cout << strDuration << std::endl;
     lines += (strDuration.size() / cols);
 
-    validatedCount = transactionsValidated.get();
+    int validatedCount = transactionsValidated.get();
     if (validatedCount > 1) {
       std::cout << "- " << strprintf(_("You have validated %d transactions!"), validatedCount) << std::endl;
     } else if (validatedCount == 1) {
-      std::cout << "- " << strprintf(_("You have validated %d transaction."), validatedCount) << std::endl;
+      std::cout << "- " << _("You have validated a transaction!") << std::endl;
     } else {
-      std::cout << "- " << strprintf(_("You have validated %d transactions."), validatedCount) << std::endl;
+      std::cout << "- " << _("You have validated no transactions.") << std::endl;
     }
 
     if (mining) {

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -94,6 +94,7 @@ int printMetrics(size_t cols, int64_t nStart, bool mining)
     int hours = (uptime - (days * 24 * 60 * 60)) / (60 * 60);
     int minutes = (uptime - (((days * 24) + hours) * 60 * 60)) / 60;
     int seconds = uptime - (((((days * 24) + hours) * 60) + minutes) * 60);
+    int validatedCount = 0;
 
     // Display uptime
     std::string duration;
@@ -110,7 +111,14 @@ int printMetrics(size_t cols, int64_t nStart, bool mining)
     std::cout << strDuration << std::endl;
     lines += (strDuration.size() / cols);
 
-    std::cout << "- " << strprintf(_("You have validated %d transactions!"), transactionsValidated.get()) << std::endl;
+    validatedCount = transactionsValidated.get();
+    if (validatedCount > 1) {
+      std::cout << "- " << strprintf(_("You have validated %d transactions!"), validatedCount) << std::endl;
+    } else if (validatedCount == 1) {
+      std::cout << "- " << strprintf(_("You have validated %d transaction."), validatedCount) << std::endl;
+    } else {
+      std::cout << "- " << strprintf(_("You have validated %d transactions."), validatedCount) << std::endl;
+    }
 
     if (mining) {
         double solps = uptime > 0 ? (double)solutionTargetChecks.get() / uptime : 0;


### PR DESCRIPTION
"You have validated 0 transactions!" sounds a little less enthusiastic that intended. This uses a period instead.

After patch, it also says "a transaction".
