### PR TITLE
point "where do i begin?" readme link to 1.0 guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ See important security warnings in
 
 Where do I begin?
 -----------------
-
-We have a guide for joining the public testnet:
-https://github.com/zcash/zcash/wiki/Beta-Guide
+We have a guide for joining the main Zcash network:
+https://github.com/zcash/zcash/wiki/1.0-User-Guide
 
 ### Need Help?
 


### PR DESCRIPTION
The existing link points to the beta guide; seems preferable to link straight to 1.0.
