### PR TITLE
Change Name to ZCRASH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-Zcash 1.0.0
+Zcrash 1.0.0
 ===========
 
-What is Zcash?
+What is Zcrash?
 --------------
 
-[Zcash](https://z.cash/) is an implementation of the "Zerocash" protocol.
+[Zcrash](https://z.cash/) is an implementation of the "Zerocash" protocol.
 Based on Bitcoin's code, it intends to offer a far higher standard of privacy
 and anonymity through a sophisticated zero-knowledge proving scheme that
 preserves confidentiality of transaction metadata. Technical details are
 available in our [Protocol Specification](https://github.com/zcash/zips/raw/master/protocol/protocol.pdf).
 
-This software is the Zcash client. It downloads and stores the entire history
-of Zcash transactions; depending on the speed of your computer and network
+This software is the Zcrash client. It downloads and stores the entire history
+of Zcrash transactions; depending on the speed of your computer and network
 connection, the synchronization process could take a day or more once the
 block chain has reached a significant size.
 
@@ -21,27 +21,27 @@ Security Warnings
 See important security warnings in
 [doc/security-warnings.md](doc/security-warnings.md).
 
-**Zcash is unfinished and highly experimental.** Use at your own risk.
+**Zcrash is unfinished and highly experimental.** Use at your own risk.
 
 Where do I begin?
 -----------------
 
 We have a guide for joining the public testnet:
-https://github.com/zcash/zcash/wiki/Beta-Guide
+https://github.com/zcrash/zcrash/wiki/Beta-Guide
 
 ### Need Help?
 
-* See the documentation at the [Zcash Wiki](https://github.com/zcash/zcash/wiki)
+* See the documentation at the [Zcrash Wiki](https://github.com/zcrash/zcrash/wiki)
   for help and more information.
-* Ask for help on the [Zcash](https://forum.z.cash/) forum.
+* Ask for help on the [Zcrash](https://forum.z.crash/) forum.
 
-Participation in the Zcash project is subject to a
+Participation in the Zcrash project is subject to a
 [Code of Conduct](code_of_conduct.md).
 
 Building
 --------
 
-Build Zcash along with most dependencies from source by running
+Build Zcrash along with most dependencies from source by running
 ./zcutil/build.sh. Currently only Linux is supported.
 
 License


### PR DESCRIPTION
In light of the excellent job you did hyping this thing to obnoxious valuations, creating a religion of bagholders to replace Ethereum for 2017, I request all instances of the name ZCASH be changed to ZCRASH. I feel that, in the branding world, it is important to communicate the value of your product as clearly as possible, and thus the new name is essential. I've taken the time to update this file, the rest is up to you!