### PR TITLE
Properly account for JoinSplit value when deciding if a transaction should be placed in a mined block.

### DIFF
--- a/qa/rpc-tests/zcjoinsplit.py
+++ b/qa/rpc-tests/zcjoinsplit.py
@@ -36,6 +36,14 @@ class JoinSplitTest(BitcoinTestFramework):
         receive_result = self.nodes[0].zcrawreceive(zcsecretkey, joinsplit_result["encryptednote1"])
         assert_equal(receive_result["exists"], True)
 
+        # The pure joinsplit we create should be mined in the next block
+        # despite other transactions being in the mempool.
+        addrtest = self.nodes[0].getnewaddress()
+        for xx in range(0,10):
+            self.nodes[0].generate(1)
+            for x in range(0,50):
+                self.nodes[0].sendtoaddress(addrtest, 0.01);
+
         joinsplit_tx = self.nodes[0].createrawtransaction([], {})
         joinsplit_result = self.nodes[0].zcrawjoinsplit(joinsplit_tx, {receive_result["note"] : zcsecretkey}, {zcaddress: 39.8}, 0, 0.1)
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -207,6 +207,8 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
 
                 dPriority += (double)nValueIn * nConf;
             }
+            nTotalIn += tx.GetJoinSplitValueIn();
+
             if (fMissingInputs) continue;
 
             // Priority is sum(valuein * age) / modified_txsize


### PR DESCRIPTION
Closes #1705.

The transaction selection logic in miner.cpp was not updated to account for JoinSplit value. This caused issues that include, but are not limited to, miners not including pure JoinSplit transactions in their blocks.
