### PR TITLE
Process verification keys to perform online verification

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -984,12 +984,13 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         threadGroup.create_thread(&ThreadShowMetricsScreen);
     }
 
-    // Initialize Zcash circuit parameters
-    ZC_LoadParams();
     // These must be disabled for now, they are buggy and we probably don't
     // want any of libsnark's profiling in production anyway.
     libsnark::inhibit_profiling_info = true;
     libsnark::inhibit_profiling_counters = true;
+
+    // Initialize Zcash circuit parameters
+    ZC_LoadParams();
 
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections


### PR DESCRIPTION
Checking proofs involves some arithmetic with pairings using components of the proof and the verification key. If you already have some curve points, like those in the verification key, you can amortize the cost of some of the more expensive arithmetic.

This PR adopts libsnark's precomputation of G2 elements in the verification key.

We *currently* call `r1cs_ppzksnark_verifier_strong_IC`:

```c++
template<typename ppT>
bool r1cs_ppzksnark_verifier_strong_IC(const r1cs_ppzksnark_verification_key<ppT> &vk,
                                       const r1cs_ppzksnark_primary_input<ppT> &primary_input,
                                       const r1cs_ppzksnark_proof<ppT> &proof)
{
    enter_block("Call to r1cs_ppzksnark_verifier_strong_IC");
    r1cs_ppzksnark_processed_verification_key<ppT> pvk = r1cs_ppzksnark_verifier_process_vk<ppT>(vk);
    bool result = r1cs_ppzksnark_online_verifier_strong_IC<ppT>(pvk, primary_input, proof);
    leave_block("Call to r1cs_ppzksnark_verifier_strong_IC");
    return result;
}
```

Notice that this merely performs precomputation of the verification key, and then calls `r1cs_ppzksnark_online_verifier_strong_IC`. This PR merely performs the precomputation during verification key initialization, and calls that function directly.