### PR TITLE
Turn on wallet DB mocking for all gtests

### DIFF
--- a/src/gtest/main.cpp
+++ b/src/gtest/main.cpp
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "crypto/common.h"
+#include "wallet/db.h"
 
 #include "libsnark/common/default_types/r1cs_ppzksnark_pp.hpp"
 #include "libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
@@ -9,6 +10,8 @@ int main(int argc, char **argv) {
   libsnark::default_r1cs_ppzksnark_pp::init_public_params();
   libsnark::inhibit_profiling_info = true;
   libsnark::inhibit_profiling_counters = true;
+
+  bitdb.MakeMock();
   
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
This prevents any wallet gtest from writing to the actual filesystem, which will
ensure that it cannot interfere with live user files.