### PR TITLE
Fixes #1779 so that sending to multiple zaddrs no longer fails.

### DIFF
--- a/qa/rpc-tests/wallet_protectcoinbase.py
+++ b/qa/rpc-tests/wallet_protectcoinbase.py
@@ -148,5 +148,22 @@ class Wallet2Test (BitcoinTestFramework):
         # check balance
         assert_equal(self.nodes[2].getbalance(), 9)
 
+        # Check that chained joinsplits in a single tx are created successfully.
+        recipients = []
+        num_recipients = 3
+        amount_per_recipient = Decimal('0.002')
+        for i in xrange(0,num_recipients):
+            newzaddr = self.nodes[2].z_getnewaddress()
+            recipients.append({"address":newzaddr, "amount":amount_per_recipient})
+        myopid = self.nodes[0].z_sendmany(myzaddr, recipients)
+        self.wait_for_operationd_success(myopid)
+        self.sync_all()
+        self.nodes[1].generate(1)
+        self.sync_all()
+
+        # check balances
+        resp = self.nodes[2].z_gettotalbalance()
+        assert_equal(Decimal(resp["private"]), num_recipients * amount_per_recipient)
+
 if __name__ == '__main__':
     Wallet2Test ().main ()

--- a/src/gtest/test_random.cpp
+++ b/src/gtest/test_random.cpp
@@ -24,4 +24,12 @@ TEST(Random, MappedShuffle) {
     std::vector<int> em2 {0, 1, 2, 3, 4};
     EXPECT_EQ(ea2, a2);
     EXPECT_EQ(em2, m2);
+
+    auto a3 = a;
+    auto m3 = m;
+    MappedShuffle(a3.begin(), m3.begin(), a3.size(), GenIdentity);
+    std::vector<int> ea3 {8, 4, 6, 3, 5};
+    std::vector<int> em3 {0, 1, 2, 3, 4};
+    EXPECT_EQ(ea3, a3);
+    EXPECT_EQ(em3, m3);
 }

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -57,8 +57,10 @@ JSDescription JSDescription::Randomized(
     // Randomize the order of the inputs and outputs
     inputMap = {0, 1};
     outputMap = {0, 1};
-    MappedShuffle(inputs.begin(), inputMap.begin(), ZC_NUM_JS_INPUTS, gen);
-    MappedShuffle(outputs.begin(), outputMap.begin(), ZC_NUM_JS_OUTPUTS, gen);
+    if (gen) {
+        MappedShuffle(inputs.begin(), inputMap.begin(), ZC_NUM_JS_INPUTS, gen);
+        MappedShuffle(outputs.begin(), outputMap.begin(), ZC_NUM_JS_OUTPUTS, gen);
+    }
 
     return JSDescription(
         params, pubKeyHash, anchor, inputs, outputs,

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -57,10 +57,11 @@ JSDescription JSDescription::Randomized(
     // Randomize the order of the inputs and outputs
     inputMap = {0, 1};
     outputMap = {0, 1};
-    if (gen) {
-        MappedShuffle(inputs.begin(), inputMap.begin(), ZC_NUM_JS_INPUTS, gen);
-        MappedShuffle(outputs.begin(), outputMap.begin(), ZC_NUM_JS_OUTPUTS, gen);
-    }
+
+    assert(gen);
+
+    MappedShuffle(inputs.begin(), inputMap.begin(), ZC_NUM_JS_INPUTS, gen);
+    MappedShuffle(outputs.begin(), outputMap.begin(), ZC_NUM_JS_OUTPUTS, gen);
 
     return JSDescription(
         params, pubKeyHash, anchor, inputs, outputs,

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -137,3 +137,8 @@ void seed_insecure_rand(bool fDeterministic)
         insecure_rand_Rw = tmp;
     }
 }
+
+int GenIdentity(int n)
+{
+    return n-1;
+}

--- a/src/random.h
+++ b/src/random.h
@@ -26,6 +26,11 @@ int GetRandInt(int nMax);
 uint256 GetRandHash();
 
 /**
+ * Identity function for MappedShuffle, so that elements retain their original order.
+ */
+ int GenIdentity(int n);
+
+/**
  * Rearranges the elements in the range [first,first+len) randomly, assuming
  * that gen is a uniform random number generator. Follows the same algorithm as
  * std::shuffle in C++11 (a Durstenfeld shuffle).

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -875,6 +875,7 @@ Object AsyncRPCOperation_sendmany::perform_joinsplit(
             {info.vjsout[0], info.vjsout[1]};
     boost::array<size_t, ZC_NUM_JS_INPUTS> inputMap;
     boost::array<size_t, ZC_NUM_JS_OUTPUTS> outputMap;
+    std::function<int(int)> emptyFunc;
     JSDescription jsdesc = JSDescription::Randomized(
             *pzcashParams,
             joinSplitPubKey_,
@@ -885,7 +886,9 @@ Object AsyncRPCOperation_sendmany::perform_joinsplit(
             outputMap,
             info.vpub_old,
             info.vpub_new,
-            !this->testmode);
+            !this->testmode,
+            // Temporary fix for #1779 is to disable shuffling of inputs and outputs.
+            emptyFunc);
 
     if (!(jsdesc.Verify(*pzcashParams, joinSplitPubKey_))) {
         throw std::runtime_error("error verifying joinsplit");

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -875,7 +875,6 @@ Object AsyncRPCOperation_sendmany::perform_joinsplit(
             {info.vjsout[0], info.vjsout[1]};
     boost::array<size_t, ZC_NUM_JS_INPUTS> inputMap;
     boost::array<size_t, ZC_NUM_JS_OUTPUTS> outputMap;
-    std::function<int(int)> emptyFunc;
     JSDescription jsdesc = JSDescription::Randomized(
             *pzcashParams,
             joinSplitPubKey_,
@@ -888,7 +887,7 @@ Object AsyncRPCOperation_sendmany::perform_joinsplit(
             info.vpub_new,
             !this->testmode,
             // Temporary fix for #1779 is to disable shuffling of inputs and outputs.
-            emptyFunc);
+            GenIdentity);
 
     if (!(jsdesc.Verify(*pzcashParams, joinSplitPubKey_))) {
         throw std::runtime_error("error verifying joinsplit");


### PR DESCRIPTION
Closes #1779 

Commit 2eeb6b randomized the order of input and output notes,
but this is now known to prevent the chaining of multiple joinsplits
in a single transaction.  The root cause has yet to be determined.

This patch is a temporary fix and disables the shuffling of input
and output notes.  It also adds a chained joinsplit test to the
python qa test suite.