### PR TITLE
ALTERNATE SOLN TO PR 1790: Fixes #1779 so that sending to multiple zaddrs no longer fails.

### DIFF
--- a/qa/rpc-tests/wallet_protectcoinbase.py
+++ b/qa/rpc-tests/wallet_protectcoinbase.py
@@ -148,5 +148,22 @@ class Wallet2Test (BitcoinTestFramework):
         # check balance
         assert_equal(self.nodes[2].getbalance(), 9)
 
+        # Check that chained joinsplits in a single tx are created successfully.
+        recipients = []
+        num_recipients = 3
+        amount_per_recipient = Decimal('0.002')
+        for i in xrange(0,num_recipients):
+            newzaddr = self.nodes[2].z_getnewaddress()
+            recipients.append({"address":newzaddr, "amount":amount_per_recipient})
+        myopid = self.nodes[0].z_sendmany(myzaddr, recipients)
+        self.wait_for_operationd_success(myopid)
+        self.sync_all()
+        self.nodes[1].generate(1)
+        self.sync_all()
+
+        # check balances
+        resp = self.nodes[2].z_gettotalbalance()
+        assert_equal(Decimal(resp["private"]), num_recipients * amount_per_recipient)
+
 if __name__ == '__main__':
     Wallet2Test ().main ()

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -29,22 +29,6 @@
 
 using namespace libzcash;
 
-int find_output(Object obj, int n) {
-    Value outputMapValue = find_value(obj, "outputmap");
-    if (outputMapValue.type() != array_type) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Missing outputmap for JoinSplit operation");
-    }
-
-    Array outputMap = outputMapValue.get_array();
-    for (size_t i = 0; i < outputMap.size(); i++) {
-        if (outputMap[i] == n) {
-            return i;
-        }
-    }
-
-    return -1;
-}
-
 AsyncRPCOperation_sendmany::AsyncRPCOperation_sendmany(
         std::string fromAddress,
         std::vector<SendManyRecipient> tOutputs,
@@ -380,7 +364,6 @@ bool AsyncRPCOperation_sendmany::main_impl() {
      */
     Object obj;
     CAmount jsChange = 0;   // this is updated after each joinsplit
-    int changeOutputIndex = -1; // this is updated after each joinsplit if jsChange > 0
     bool minersFeeProcessed = false;
 
     if (t_outputs_total > 0) {
@@ -438,10 +421,6 @@ bool AsyncRPCOperation_sendmany::main_impl() {
             }
 
             obj = perform_joinsplit(info, outPoints);
-
-            if (jsChange > 0) {
-                changeOutputIndex = find_output(obj, 1);
-            }
         }
     }
 
@@ -455,6 +434,9 @@ bool AsyncRPCOperation_sendmany::main_impl() {
         // Keep track of treestate within this transaction 
         boost::unordered_map<uint256, ZCIncrementalMerkleTree, CCoinsKeyHasher> intermediates;
         std::vector<uint256> previousCommitments;
+
+        // NOTE: Randomization of input and output order could break this in future
+        const int changeOutputIndex = 1;
         
         while (zOutputsDeque.size() > 0) {
             AsyncJoinSplitInfo info;
@@ -655,10 +637,6 @@ bool AsyncRPCOperation_sendmany::main_impl() {
             }
 
             obj = perform_joinsplit(info, witnesses, jsAnchor);
-
-            if (jsChange > 0) {
-                changeOutputIndex = find_output(obj, 1);
-            }
         }
     }
 
@@ -869,20 +847,11 @@ Object AsyncRPCOperation_sendmany::perform_joinsplit(
             );
 
     // Generate the proof, this can take over a minute.
-    boost::array<libzcash::JSInput, ZC_NUM_JS_INPUTS> inputs
-            {info.vjsin[0], info.vjsin[1]};
-    boost::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS> outputs
-            {info.vjsout[0], info.vjsout[1]};
-    boost::array<size_t, ZC_NUM_JS_INPUTS> inputMap;
-    boost::array<size_t, ZC_NUM_JS_OUTPUTS> outputMap;
-    JSDescription jsdesc = JSDescription::Randomized(
-            *pzcashParams,
+    JSDescription jsdesc(*pzcashParams,
             joinSplitPubKey_,
             anchor,
-            inputs,
-            outputs,
-            inputMap,
-            outputMap,
+            {info.vjsin[0], info.vjsin[1]},
+            {info.vjsout[0], info.vjsout[1]},
             info.vpub_old,
             info.vpub_new,
             !this->testmode);
@@ -943,21 +912,10 @@ Object AsyncRPCOperation_sendmany::perform_joinsplit(
         encryptedNote2 = HexStr(ss2.begin(), ss2.end());
     }
 
-    Array arrInputMap;
-    Array arrOutputMap;
-    for (size_t i = 0; i < ZC_NUM_JS_INPUTS; i++) {
-        arrInputMap.push_back(inputMap[i]);
-    }
-    for (size_t i = 0; i < ZC_NUM_JS_OUTPUTS; i++) {
-        arrOutputMap.push_back(outputMap[i]);
-    }
-
     Object obj;
     obj.push_back(Pair("encryptednote1", encryptedNote1));
     obj.push_back(Pair("encryptednote2", encryptedNote2));
     obj.push_back(Pair("rawtxn", HexStr(ss.begin(), ss.end())));
-    obj.push_back(Pair("inputmap", arrInputMap));
-    obj.push_back(Pair("outputmap", arrOutputMap));
     return obj;
 }
 

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -493,6 +493,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
                     throw JSONRPCError(RPC_WALLET_ERROR, "Could not find previous JoinSplit anchor");
                 }
                 
+                // NOTE: We assume the last commitment, output 1, is the change we want
                 for (const uint256& commitment : prevJoinSplit.commitments) {
                     tree.append(commitment);
                     previousCommitments.push_back(commitment);                   

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -36,14 +36,13 @@ int find_output(Object obj, int n) {
     }
 
     Array outputMap = outputMapValue.get_array();
-    assert(outputMap.size() == ZC_NUM_JS_OUTPUTS);
     for (size_t i = 0; i < outputMap.size(); i++) {
         if (outputMap[i] == n) {
             return i;
         }
     }
 
-    throw std::logic_error("n is not present in outputmap");
+    return -1;
 }
 
 AsyncRPCOperation_sendmany::AsyncRPCOperation_sendmany(


### PR DESCRIPTION
This is an alternate solution to PR #1790 which fixes #1779.

**Do not merge this if #1790 is being merged.**

This solution differs from #1790 in that it rolls back changes made to z_sendmany related to note randomization, instead of disabling note randomization.

This solution is the same as #1790 by also adding a test for chained join splits.