### PR TITLE
Track the correct change witness across chained joinsplits when notes are shuffled

### DIFF
--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -500,15 +500,23 @@ bool AsyncRPCOperation_sendmany::main_impl() {
                     throw JSONRPCError(RPC_WALLET_ERROR, "Could not find previous JoinSplit anchor");
                 }
                 
+                assert(changeOutputIndex != -1);
+                boost::optional<ZCIncrementalWitness> changeWitness;
+                int n = 0;
                 for (const uint256& commitment : prevJoinSplit.commitments) {
                     tree.append(commitment);
-                    previousCommitments.push_back(commitment);                   
+                    previousCommitments.push_back(commitment);
+                    if (!changeWitness && changeOutputIndex == n++) {
+                        changeWitness = tree.witness();
+                    } else if (changeWitness) {
+                        changeWitness.get().append(commitment);
+                    }
                 }
-                ZCIncrementalWitness changeWitness = tree.witness();
-                jsAnchor = changeWitness.root();
-                uint256 changeCommitment = prevJoinSplit.commitments[changeOutputIndex];
-                intermediates.insert(std::make_pair(tree.root(), tree));
-                witnesses.push_back(changeWitness);
+                if (changeWitness) {
+                        witnesses.push_back(changeWitness);
+                }
+                jsAnchor = tree.root();
+                intermediates.insert(std::make_pair(tree.root(), tree));    // chained js are interstitial (found in between block boundaries)
 
                 // Decrypt the change note's ciphertext to retrieve some data we need
                 ZCNoteDecryption decryptor(spendingkey_.viewing_key());
@@ -891,9 +899,7 @@ Object AsyncRPCOperation_sendmany::perform_joinsplit(
             outputMap,
             info.vpub_old,
             info.vpub_new,
-            !this->testmode,
-            // Temporary fix for #1779 is to disable shuffling of inputs and outputs.
-            GenIdentity);
+            !this->testmode);
 
     if (!(jsdesc.Verify(*pzcashParams, joinSplitPubKey_))) {
         throw std::runtime_error("error verifying joinsplit");


### PR DESCRIPTION
https://github.com/zcash/zcash/pull/1797#issuecomment-258912128
