### PR TITLE
Updated Tromp's equihash solver to his latest version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -150,6 +150,12 @@ AC_ARG_ENABLE([glibc-back-compat],
   [use_glibc_compat=$enableval],
   [use_glibc_compat=no])
 
+AC_ARG_ENABLE([tromp-avx2],
+  [AS_HELP_STRING([--enable-tromp-avx2],
+  [enable AVX2 blake2 optimizaion in Tromp equihash solver])],
+  [tromp_avx2=$enableval],
+  [tromp_avx2=no])
+
 AC_ARG_WITH([protoc-bindir],[AS_HELP_STRING([--with-protoc-bindir=BIN_DIR],[specify protoc bin path])], [protoc_bin_path=$withval], [])
 
 # Enable debug 
@@ -889,6 +895,7 @@ AM_CONDITIONAL([USE_LCOV],[test x$use_lcov = xyes])
 AM_CONDITIONAL([USE_COMPARISON_TOOL],[test x$use_comparison_tool != xno])
 AM_CONDITIONAL([USE_COMPARISON_TOOL_REORG_TESTS],[test x$use_comparison_tool_reorg_test != xno])
 AM_CONDITIONAL([GLIBC_BACK_COMPAT],[test x$use_glibc_compat = xyes])
+AM_CONDITIONAL([USE_TROMP_AVX2], [test x$tromp_avx2 = xyes])
 AM_CONDITIONAL([HARDEN],[test x$use_hardening = xyes])
 
 AC_DEFINE(CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MAJOR, [Major version])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -250,8 +250,14 @@ EQUIHASH_TROMP_SOURCES = \
   pow/tromp/equi.h \
   pow/tromp/osx_barrier.h
 
+EQUIHASH_TROMP_AVX2_SOURCES = \
+  pow/tromp/blake2-avx2/blake2b-common.h \
+  pow/tromp/blake2-avx2/blake2b-load-avx2-simple.h \
+  pow/tromp/blake2-avx2/blake2bip.c \
+  pow/tromp/blake2-avx2/blake2bip.h
+
 # crypto primitives library
-crypto_libbitcoin_crypto_a_CPPFLAGS = $(BITCOIN_CONFIG_INCLUDES) -DEQUIHASH_TROMP_ATOMIC
+crypto_libbitcoin_crypto_a_CPPFLAGS = $(BITCOIN_CONFIG_INCLUDES) -DEQUIHASH_TROMP_UNROLL
 crypto_libbitcoin_crypto_a_SOURCES = \
   crypto/common.h \
   crypto/equihash.cpp \
@@ -270,6 +276,13 @@ crypto_libbitcoin_crypto_a_SOURCES = \
   crypto/sha512.cpp \
   crypto/sha512.h \
   ${EQUIHASH_TROMP_SOURCES}
+
+if USE_TROMP_AVX2
+crypto_libbitcoin_crypto_a_CPPFLAGS += -mavx2
+crypto_libbitcoin_crypto_a_SOURCES += ${EQUIHASH_TROMP_AVX2_SOURCES}
+else
+crypto_libbitcoin_crypto_a_CPPFLAGS += -DEQUIHASH_TROMP_ATOMIC
+endif
 
 # univalue JSON library
 univalue_libbitcoin_univalue_a_SOURCES = \

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -473,6 +473,9 @@ void static BitcoinMiner(CWallet *pwallet)
     );
 
     try {
+        unique_ptr<equi> peq;
+        if (solver == "tromp")
+            peq.reset(new equi(1));
         while (true) {
             if (chainparams.MiningRequiresPeers()) {
                 // Busy-wait for the network to come online so we don't waste time mining
@@ -576,17 +579,17 @@ void static BitcoinMiner(CWallet *pwallet)
 
                 // TODO: factor this out into a function with the same API for each solver.
                 if (solver == "tromp") {
-                    // Create solver and initialize it.
-                    equi eq(1);
+                    equi& eq = *peq;
+                    // initialize solver
                     eq.setstate(&curr_state);
 
                     // Intialization done, start algo driver.
                     eq.digit0(0);
-                    eq.xfull = eq.bfull = eq.hfull = 0;
+                    eq.bfull = eq.hfull = 0;
                     eq.showbsizes(0);
                     for (u32 r = 1; r < WK; r++) {
                         (r&1) ? eq.digitodd(r, 0) : eq.digiteven(r, 0);
-                        eq.xfull = eq.bfull = eq.hfull = 0;
+                        eq.bfull = eq.hfull = 0;
                         eq.showbsizes(r);
                     }
                     eq.digitK(0);

--- a/src/pow/tromp/blake2-avx2/LICENSE
+++ b/src/pow/tromp/blake2-avx2/LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/src/pow/tromp/blake2-avx2/README.md
+++ b/src/pow/tromp/blake2-avx2/README.md
@@ -1,0 +1,9 @@
+# BLAKE2 AVX2 implementations
+
+This is **experimental** code implementing [BLAKE2](https://blake2.net/) using the AVX2 instruction set present in the Intel [Haswell](https://en.wikipedia.org/wiki/Haswell_%28microarchitecture%29) and later microarchitectures.
+
+It currently implements BLAKE2b, BLAKE2bp, and BLAKE2sp using 3 similar but slightly different approaches: one lets the compiler choose how to permute the message, another one does it manually, and the final one uses the gather instructions introduced with AVX2. Current recorded speeds for long messages are:
+
+ - 3.19 cycles per byte on Haswell for BLAKE2b;
+ - 1.45 cycles per byte on Haswell for BLAKE2bp;
+ - 1.56 cycles per byte on Haswell for BLAKE2sp.

--- a/src/pow/tromp/blake2-avx2/blake2.h
+++ b/src/pow/tromp/blake2-avx2/blake2.h
@@ -1,0 +1,158 @@
+/*
+   BLAKE2 reference source code package - optimized C implementations
+
+   Written in 2012 by Samuel Neves <sneves@dei.uc.pt>
+
+   To the extent possible under law, the author(s) have dedicated all copyright
+   and related and neighboring rights to this software to the public domain
+   worldwide. This software is distributed without any warranty.
+
+   You should have received a copy of the CC0 Public Domain Dedication along with
+   this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+*/
+#pragma once
+#ifndef __BLAKE2_H__
+#define __BLAKE2_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(_MSC_VER)
+#define ALIGN(x) __declspec(align(x))
+#else
+#define ALIGN(x) __attribute__ ((__aligned__(x)))
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+  enum blake2s_constant
+  {
+    BLAKE2S_BLOCKBYTES = 64,
+    BLAKE2S_OUTBYTES   = 32,
+    BLAKE2S_KEYBYTES   = 32,
+    BLAKE2S_SALTBYTES  = 8,
+    BLAKE2S_PERSONALBYTES = 8
+  };
+
+  enum blake2b_constant
+  {
+    BLAKE2B_BLOCKBYTES = 128,
+    BLAKE2B_OUTBYTES   = 64,
+    BLAKE2B_KEYBYTES   = 64,
+    BLAKE2B_SALTBYTES  = 16,
+    BLAKE2B_PERSONALBYTES = 16
+  };
+
+#pragma pack(push, 1)
+  typedef struct __blake2s_param
+  {
+    uint8_t  digest_length; // 1
+    uint8_t  key_length;    // 2
+    uint8_t  fanout;        // 3
+    uint8_t  depth;         // 4
+    uint32_t leaf_length;   // 8
+    uint8_t  node_offset[6];// 14
+    uint8_t  node_depth;    // 15
+    uint8_t  inner_length;  // 16
+    // uint8_t  reserved[0];
+    uint8_t  salt[BLAKE2S_SALTBYTES]; // 24
+    uint8_t  personal[BLAKE2S_PERSONALBYTES];  // 32
+  } blake2s_param;
+
+  ALIGN( 64 ) typedef struct __blake2s_state
+  {
+    uint32_t h[8];
+    uint32_t t[2];
+    uint32_t f[2];
+    uint8_t  buf[2 * BLAKE2S_BLOCKBYTES];
+    size_t   buflen;
+    uint8_t  last_node;
+  } blake2s_state;
+
+  typedef struct __blake2b_param
+  {
+    uint8_t  digest_length; // 1
+    uint8_t  key_length;    // 2
+    uint8_t  fanout;        // 3
+    uint8_t  depth;         // 4
+    uint32_t leaf_length;   // 8
+    uint64_t node_offset;   // 16
+    uint8_t  node_depth;    // 17
+    uint8_t  inner_length;  // 18
+    uint8_t  reserved[14];  // 32
+    uint8_t  salt[BLAKE2B_SALTBYTES]; // 48
+    uint8_t  personal[BLAKE2B_PERSONALBYTES];  // 64
+  } blake2b_param;
+/*
+  ALIGN( 64 ) typedef struct __blake2b_state
+  {
+    uint64_t h[8];
+    uint8_t  buf[BLAKE2B_BLOCKBYTES];
+    uint16_t counter;
+    uint8_t  buflen;
+    uint8_t  lastblock;
+  } blake2b_state;
+*/
+  typedef crypto_generichash_blake2b_state blake2b_state;
+
+  ALIGN( 64 ) typedef struct __blake2sp_state
+  {
+    blake2s_state S[8][1];
+    blake2s_state R[1];
+    uint8_t buf[8 * BLAKE2S_BLOCKBYTES];
+    size_t  buflen;
+  } blake2sp_state;
+
+  ALIGN( 64 ) typedef struct __blake2bp_state
+  {
+    blake2b_state S[4][1];
+    blake2b_state R[1];
+    uint8_t buf[4 * BLAKE2B_BLOCKBYTES];
+    size_t  buflen;
+  } blake2bp_state;
+#pragma pack(pop)
+
+  // Streaming API
+  int blake2s_init( blake2s_state *S, const uint8_t outlen );
+  int blake2s_init_key( blake2s_state *S, const uint8_t outlen, const void *key, const uint8_t keylen );
+  int blake2s_init_param( blake2s_state *S, const blake2s_param *P );
+  int blake2s_update( blake2s_state *S, const uint8_t *in, uint64_t inlen );
+  int blake2s_final( blake2s_state *S, uint8_t *out, uint8_t outlen );
+
+  int blake2b_init( blake2b_state *S, const uint8_t outlen );
+  int blake2b_init_key( blake2b_state *S, const uint8_t outlen, const void *key, const uint8_t keylen );
+  int blake2b_init_param( blake2b_state *S, const blake2b_param *P );
+  int blake2b_update( blake2b_state *S, const uint8_t *in, uint64_t inlen );
+  int blake2b_final( blake2b_state *S, uint8_t *out, uint8_t outlen );
+
+  int blake2sp_init( blake2sp_state *S, const uint8_t outlen );
+  int blake2sp_init_key( blake2sp_state *S, const uint8_t outlen, const void *key, const uint8_t keylen );
+  int blake2sp_update( blake2sp_state *S, const uint8_t *in, uint64_t inlen );
+  int blake2sp_final( blake2sp_state *S, uint8_t *out, uint8_t outlen );
+
+  int blake2bp_init( blake2bp_state *S, const uint8_t outlen );
+  int blake2bp_init_key( blake2bp_state *S, const uint8_t outlen, const void *key, const uint8_t keylen );
+  int blake2bp_update( blake2bp_state *S, const uint8_t *in, uint64_t inlen );
+  int blake2bp_final( blake2bp_state *S, uint8_t *out, uint8_t outlen );
+
+  // Simple API
+  int blake2s( uint8_t *out, const void *in, const void *key, const uint8_t outlen, const uint64_t inlen, uint8_t keylen );
+  int blake2b( uint8_t *out, const void *in, const void *key, const uint8_t outlen, const uint64_t inlen, uint8_t keylen );
+  int blake2b_long(uint8_t *out, const void *in, const uint32_t outlen, const uint64_t inlen);
+
+  int blake2sp( uint8_t *out, const void *in, const void *key, const uint8_t outlen, const uint64_t inlen, uint8_t keylen );
+  int blake2bp( uint8_t *out, const void *in, const void *key, const uint8_t outlen, const uint64_t inlen, uint8_t keylen );
+
+  static inline int blake2( uint8_t *out, const void *in, const void *key, const uint8_t outlen, const uint64_t inlen, uint8_t keylen )
+  {
+    return blake2b( out, in, key, outlen, inlen, keylen );
+  }
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+

--- a/src/pow/tromp/blake2-avx2/blake2b-common.h
+++ b/src/pow/tromp/blake2-avx2/blake2b-common.h
@@ -1,0 +1,61 @@
+#ifndef BLAKE2_AVX2_BLAKE2B_COMMON_H
+#define BLAKE2_AVX2_BLAKE2B_COMMON_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <immintrin.h>
+
+//#include "blake2.h"
+#include "sodium.h"
+
+#define LOAD128(p)  _mm_load_si128( (__m128i *)(p) )
+#define STORE128(p,r) _mm_store_si128((__m128i *)(p), r)
+
+#define LOADU128(p)  _mm_loadu_si128( (__m128i *)(p) )
+#define STOREU128(p,r) _mm_storeu_si128((__m128i *)(p), r)
+
+#define LOAD(p)  _mm256_load_si256( (__m256i *)(p) )
+#define STORE(p,r) _mm256_store_si256((__m256i *)(p), r)
+
+#define LOADU(p)  _mm256_loadu_si256( (__m256i *)(p) )
+#define STOREU(p,r) _mm256_storeu_si256((__m256i *)(p), r)
+
+#if !defined(__cplusplus) && (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L)
+  #if   defined(_MSC_VER)
+    #define INLINE __inline
+ #elif defined(__GNUC__)
+    #define INLINE __inline__
+  #else
+    #define INLINE
+  #endif
+#else
+  #define INLINE inline
+#endif
+
+static INLINE uint64_t LOADU64(void const * p) {
+  uint64_t v;
+  memcpy(&v, p, sizeof v);
+  return v;
+}
+
+#define ROTATE16 _mm256_setr_epi8( 2, 3, 4, 5, 6, 7, 0, 1, 10, 11, 12, 13, 14, 15, 8, 9, \
+                                   2, 3, 4, 5, 6, 7, 0, 1, 10, 11, 12, 13, 14, 15, 8, 9 )
+
+#define ROTATE24 _mm256_setr_epi8( 3, 4, 5, 6, 7, 0, 1, 2, 11, 12, 13, 14, 15, 8, 9, 10, \
+                                   3, 4, 5, 6, 7, 0, 1, 2, 11, 12, 13, 14, 15, 8, 9, 10 )
+
+#define ADD(a, b) _mm256_add_epi64(a, b)
+#define SUB(a, b) _mm256_sub_epi64(a, b)
+
+#define XOR(a, b) _mm256_xor_si256(a, b)
+#define AND(a, b) _mm256_and_si256(a, b)
+#define  OR(a, b) _mm256_or_si256(a, b)
+
+#define ROT32(x) _mm256_shuffle_epi32((x), _MM_SHUFFLE(2, 3, 0, 1))
+#define ROT24(x) _mm256_shuffle_epi8((x), ROTATE24)
+#define ROT16(x) _mm256_shuffle_epi8((x), ROTATE16)
+#define ROT63(x) _mm256_or_si256(_mm256_srli_epi64((x), 63), ADD((x), (x)))
+
+#endif

--- a/src/pow/tromp/blake2-avx2/blake2b-load-avx2-simple.h
+++ b/src/pow/tromp/blake2-avx2/blake2b-load-avx2-simple.h
@@ -1,0 +1,54 @@
+#ifndef BLAKE2_AVX2_BLAKE2B_LOAD_AVX2_SIMPLE_H
+#define BLAKE2_AVX2_BLAKE2B_LOAD_AVX2_SIMPLE_H
+
+#define BLAKE2B_LOAD_MSG_0_1(b0) b0 = _mm256_set_epi64x(m6, m4, m2, m0);
+#define BLAKE2B_LOAD_MSG_0_2(b0) b0 = _mm256_set_epi64x(m7, m5, m3, m1);
+#define BLAKE2B_LOAD_MSG_0_3(b0) b0 = _mm256_set_epi64x(m14, m12, m10, m8);
+#define BLAKE2B_LOAD_MSG_0_4(b0) b0 = _mm256_set_epi64x(m15, m13, m11, m9);
+#define BLAKE2B_LOAD_MSG_1_1(b0) b0 = _mm256_set_epi64x(m13, m9, m4, m14);
+#define BLAKE2B_LOAD_MSG_1_2(b0) b0 = _mm256_set_epi64x(m6, m15, m8, m10);
+#define BLAKE2B_LOAD_MSG_1_3(b0) b0 = _mm256_set_epi64x(m5, m11, m0, m1);
+#define BLAKE2B_LOAD_MSG_1_4(b0) b0 = _mm256_set_epi64x(m3, m7, m2, m12);
+#define BLAKE2B_LOAD_MSG_2_1(b0) b0 = _mm256_set_epi64x(m15, m5, m12, m11);
+#define BLAKE2B_LOAD_MSG_2_2(b0) b0 = _mm256_set_epi64x(m13, m2, m0, m8);
+#define BLAKE2B_LOAD_MSG_2_3(b0) b0 = _mm256_set_epi64x(m9, m7, m3, m10);
+#define BLAKE2B_LOAD_MSG_2_4(b0) b0 = _mm256_set_epi64x(m4, m1, m6, m14);
+#define BLAKE2B_LOAD_MSG_3_1(b0) b0 = _mm256_set_epi64x(m11, m13, m3, m7);
+#define BLAKE2B_LOAD_MSG_3_2(b0) b0 = _mm256_set_epi64x(m14, m12, m1, m9);
+#define BLAKE2B_LOAD_MSG_3_3(b0) b0 = _mm256_set_epi64x(m15, m4, m5, m2);
+#define BLAKE2B_LOAD_MSG_3_4(b0) b0 = _mm256_set_epi64x(m8, m0, m10, m6);
+#define BLAKE2B_LOAD_MSG_4_1(b0) b0 = _mm256_set_epi64x(m10, m2, m5, m9);
+#define BLAKE2B_LOAD_MSG_4_2(b0) b0 = _mm256_set_epi64x(m15, m4, m7, m0);
+#define BLAKE2B_LOAD_MSG_4_3(b0) b0 = _mm256_set_epi64x(m3, m6, m11, m14);
+#define BLAKE2B_LOAD_MSG_4_4(b0) b0 = _mm256_set_epi64x(m13, m8, m12, m1);
+#define BLAKE2B_LOAD_MSG_5_1(b0) b0 = _mm256_set_epi64x(m8, m0, m6, m2);
+#define BLAKE2B_LOAD_MSG_5_2(b0) b0 = _mm256_set_epi64x(m3, m11, m10, m12);
+#define BLAKE2B_LOAD_MSG_5_3(b0) b0 = _mm256_set_epi64x(m1, m15, m7, m4);
+#define BLAKE2B_LOAD_MSG_5_4(b0) b0 = _mm256_set_epi64x(m9, m14, m5, m13);
+#define BLAKE2B_LOAD_MSG_6_1(b0) b0 = _mm256_set_epi64x(m4, m14, m1, m12);
+#define BLAKE2B_LOAD_MSG_6_2(b0) b0 = _mm256_set_epi64x(m10, m13, m15, m5);
+#define BLAKE2B_LOAD_MSG_6_3(b0) b0 = _mm256_set_epi64x(m8, m9, m6, m0);
+#define BLAKE2B_LOAD_MSG_6_4(b0) b0 = _mm256_set_epi64x(m11, m2, m3, m7);
+#define BLAKE2B_LOAD_MSG_7_1(b0) b0 = _mm256_set_epi64x(m3, m12, m7, m13);
+#define BLAKE2B_LOAD_MSG_7_2(b0) b0 = _mm256_set_epi64x(m9, m1, m14, m11);
+#define BLAKE2B_LOAD_MSG_7_3(b0) b0 = _mm256_set_epi64x(m2, m8, m15, m5);
+#define BLAKE2B_LOAD_MSG_7_4(b0) b0 = _mm256_set_epi64x(m10, m6, m4, m0);
+#define BLAKE2B_LOAD_MSG_8_1(b0) b0 = _mm256_set_epi64x(m0, m11, m14, m6);
+#define BLAKE2B_LOAD_MSG_8_2(b0) b0 = _mm256_set_epi64x(m8, m3, m9, m15);
+#define BLAKE2B_LOAD_MSG_8_3(b0) b0 = _mm256_set_epi64x(m10, m1, m13, m12);
+#define BLAKE2B_LOAD_MSG_8_4(b0) b0 = _mm256_set_epi64x(m5, m4, m7, m2);
+#define BLAKE2B_LOAD_MSG_9_1(b0) b0 = _mm256_set_epi64x(m1, m7, m8, m10);
+#define BLAKE2B_LOAD_MSG_9_2(b0) b0 = _mm256_set_epi64x(m5, m6, m4, m2);
+#define BLAKE2B_LOAD_MSG_9_3(b0) b0 = _mm256_set_epi64x(m13, m3, m9, m15);
+#define BLAKE2B_LOAD_MSG_9_4(b0) b0 = _mm256_set_epi64x(m0, m12, m14, m11);
+#define BLAKE2B_LOAD_MSG_10_1(b0) b0 = _mm256_set_epi64x(m6, m4, m2, m0);
+#define BLAKE2B_LOAD_MSG_10_2(b0) b0 = _mm256_set_epi64x(m7, m5, m3, m1);
+#define BLAKE2B_LOAD_MSG_10_3(b0) b0 = _mm256_set_epi64x(m14, m12, m10, m8);
+#define BLAKE2B_LOAD_MSG_10_4(b0) b0 = _mm256_set_epi64x(m15, m13, m11, m9);
+#define BLAKE2B_LOAD_MSG_11_1(b0) b0 = _mm256_set_epi64x(m13, m9, m4, m14);
+#define BLAKE2B_LOAD_MSG_11_2(b0) b0 = _mm256_set_epi64x(m6, m15, m8, m10);
+#define BLAKE2B_LOAD_MSG_11_3(b0) b0 = _mm256_set_epi64x(m5, m11, m0, m1);
+#define BLAKE2B_LOAD_MSG_11_4(b0) b0 = _mm256_set_epi64x(m3, m7, m2, m12);
+
+#endif
+

--- a/src/pow/tromp/blake2-avx2/blake2bip.c
+++ b/src/pow/tromp/blake2-avx2/blake2bip.c
@@ -1,0 +1,348 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sodium.h"
+#include "blake2.h"
+#include "blake2b-common.h"
+#include "blake2bip.h"
+
+#ifdef __APPLE__
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#endif
+
+ALIGN(64) static const uint64_t blake2b_IV[8] = {
+  UINT64_C(0x6A09E667F3BCC908), UINT64_C(0xBB67AE8584CAA73B),
+  UINT64_C(0x3C6EF372FE94F82B), UINT64_C(0xA54FF53A5F1D36F1),
+  UINT64_C(0x510E527FADE682D1), UINT64_C(0x9B05688C2B3E6C1F),
+  UINT64_C(0x1F83D9ABFB41BD6B), UINT64_C(0x5BE0CD19137E2179),
+};
+
+ALIGN(64) static const uint32_t blake2b_sigma[12][16] = {
+  {  0,  32,  64,  96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, 480},
+  {448, 320, 128, 256, 288, 480, 416, 192,  32, 384,   0,  64, 352, 224, 160,  96},
+  {352, 256, 384,   0, 160,  64, 480, 416, 320, 448,  96, 192, 224,  32, 288, 128},
+  {224, 288,  96,  32, 416, 384, 352, 448,  64, 192, 160, 320, 128,   0, 480, 256},
+  {288,   0, 160, 224,  64, 128, 320, 480, 448,  32, 352, 384, 192, 256,  96, 416},
+  { 64, 384, 192, 320,   0, 352, 256,  96, 128, 416, 224, 160, 480, 448,  32, 288},
+  {384, 160,  32, 480, 448, 416, 128, 320,   0, 224, 192,  96, 288,  64, 256, 352},
+  {416, 352, 224, 448, 384,  32,  96, 288, 160,   0, 480, 128, 256, 192,  64, 320},
+  {192, 480, 448, 288, 352,  96,   0, 256, 384,  64, 416, 224,  32, 128, 320, 160},
+  {320,  64, 256, 128, 224, 192,  32, 160, 480, 352, 288, 448,  96, 384, 416,   0},
+  {  0,  32,  64,  96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, 480},
+  {448, 320, 128, 256, 288, 480, 416, 192,  32, 384,   0,  64, 352, 224, 160,  96},
+};
+
+#define BLAKE2B_G1_V1(a, b, c, d, m) do {     \
+  a = ADD(a, m);                              \
+  a = ADD(a, b); d = XOR(d, a); d = ROT32(d); \
+  c = ADD(c, d); b = XOR(b, c); b = ROT24(b); \
+} while(0)
+
+#define BLAKE2B_G2_V1(a, b, c, d, m) do {     \
+  a = ADD(a, m);                              \
+  a = ADD(a, b); d = XOR(d, a); d = ROT16(d); \
+  c = ADD(c, d); b = XOR(b, c); b = ROT63(b); \
+} while(0)
+
+#define BLAKE2B_DIAG_V1(a, b, c, d) do {                 \
+  d = _mm256_permute4x64_epi64(d, _MM_SHUFFLE(2,1,0,3)); \
+  c = _mm256_permute4x64_epi64(c, _MM_SHUFFLE(1,0,3,2)); \
+  b = _mm256_permute4x64_epi64(b, _MM_SHUFFLE(0,3,2,1)); \
+} while(0)
+
+#define BLAKE2B_UNDIAG_V1(a, b, c, d) do {               \
+  d = _mm256_permute4x64_epi64(d, _MM_SHUFFLE(0,3,2,1)); \
+  c = _mm256_permute4x64_epi64(c, _MM_SHUFFLE(1,0,3,2)); \
+  b = _mm256_permute4x64_epi64(b, _MM_SHUFFLE(2,1,0,3)); \
+} while(0)
+
+#if defined(PERMUTE_WITH_SHUFFLES)
+  #include "blake2b-load-avx2.h"
+#elif defined(PERMUTE_WITH_GATHER)
+#else
+  #include "blake2b-load-avx2-simple.h"
+#endif
+
+#if defined(PERMUTE_WITH_GATHER)
+ALIGN(64) static const uint32_t indices[12][16] = {
+  { 0,  2,  4,  6, 1,  3,  5,  7, 8, 10, 12, 14, 9, 11, 13, 15},
+  {14,  4,  9, 13,10,  8, 15,  6, 1,  0, 11,  5,12,  2,  7,  3},
+  {11, 12,  5, 15, 8,  0,  2, 13,10,  3,  7,  9,14,  6,  1,  4},
+  { 7,  3, 13, 11, 9,  1, 12, 14, 2,  5,  4, 15, 6, 10,  0,  8},
+  { 9,  5,  2, 10, 0,  7,  4, 15,14, 11,  6,  3, 1, 12,  8, 13},
+  { 2,  6,  0,  8,12, 10, 11,  3, 4,  7, 15,  1,13,  5, 14,  9},
+  {12,  1, 14,  4, 5, 15, 13, 10, 0,  6,  9,  8, 7,  3,  2, 11},
+  {13,  7, 12,  3,11, 14,  1,  9, 5, 15,  8,  2, 0,  4,  6, 10},
+  { 6, 14, 11,  0,15,  9,  3,  8,12, 13,  1, 10, 2,  7,  4,  5},
+  {10,  8,  7,  1, 2,  4,  6,  5,15,  9,  3, 13,11, 14, 12,  0},
+  { 0,  2,  4,  6, 1,  3,  5,  7, 8, 10, 12, 14, 9, 11, 13, 15},
+  {14,  4,  9, 13,10,  8, 15,  6, 1,  0, 11,  5,12,  2,  7,  3},
+};
+
+#define BLAKE2B_ROUND_V1(a, b, c, d, r, m) do {                              \
+  __m256i b0;                                                                \
+  b0 = _mm256_i32gather_epi64((void *)(m), LOAD128(&indices[r][ 0]), 8);     \
+  BLAKE2B_G1_V1(a, b, c, d, b0);                                             \
+  b0 = _mm256_i32gather_epi64((void *)(m), LOAD128(&indices[r][ 4]), 8);     \
+  BLAKE2B_G2_V1(a, b, c, d, b0);                                             \
+  BLAKE2B_DIAG_V1(a, b, c, d);                                               \
+  b0 = _mm256_i32gather_epi64((void *)(m), LOAD128(&indices[r][ 8]), 8);     \
+  BLAKE2B_G1_V1(a, b, c, d, b0);                                             \
+  b0 = _mm256_i32gather_epi64((void *)(m), LOAD128(&indices[r][12]), 8);     \
+  BLAKE2B_G2_V1(a, b, c, d, b0);                                             \
+  BLAKE2B_UNDIAG_V1(a, b, c, d);                                             \
+} while(0)
+
+#define BLAKE2B_ROUNDS_V1(a, b, c, d, m) do { \
+  int i;                                      \
+  for(i = 0; i < 12; ++i) {                   \
+    BLAKE2B_ROUND_V1(a, b, c, d, i, m);       \
+  }                                           \
+} while(0)
+#else /* !PERMUTE_WITH_GATHER */
+#define BLAKE2B_ROUND_V1(a, b, c, d, r, m) do { \
+  __m256i b0;                                   \
+  BLAKE2B_LOAD_MSG_ ##r ##_1(b0);               \
+  BLAKE2B_G1_V1(a, b, c, d, b0);                \
+  BLAKE2B_LOAD_MSG_ ##r ##_2(b0);               \
+  BLAKE2B_G2_V1(a, b, c, d, b0);                \
+  BLAKE2B_DIAG_V1(a, b, c, d);                  \
+  BLAKE2B_LOAD_MSG_ ##r ##_3(b0);               \
+  BLAKE2B_G1_V1(a, b, c, d, b0);                \
+  BLAKE2B_LOAD_MSG_ ##r ##_4(b0);               \
+  BLAKE2B_G2_V1(a, b, c, d, b0);                \
+  BLAKE2B_UNDIAG_V1(a, b, c, d);                \
+} while(0)
+
+#define BLAKE2B_ROUNDS_V1(a, b, c, d, m) do {   \
+  BLAKE2B_ROUND_V1(a, b, c, d,  0, (m));        \
+  BLAKE2B_ROUND_V1(a, b, c, d,  1, (m));        \
+  BLAKE2B_ROUND_V1(a, b, c, d,  2, (m));        \
+  BLAKE2B_ROUND_V1(a, b, c, d,  3, (m));        \
+  BLAKE2B_ROUND_V1(a, b, c, d,  4, (m));        \
+  BLAKE2B_ROUND_V1(a, b, c, d,  5, (m));        \
+  BLAKE2B_ROUND_V1(a, b, c, d,  6, (m));        \
+  BLAKE2B_ROUND_V1(a, b, c, d,  7, (m));        \
+  BLAKE2B_ROUND_V1(a, b, c, d,  8, (m));        \
+  BLAKE2B_ROUND_V1(a, b, c, d,  9, (m));        \
+  BLAKE2B_ROUND_V1(a, b, c, d, 10, (m));        \
+  BLAKE2B_ROUND_V1(a, b, c, d, 11, (m));        \
+} while(0)
+#endif
+
+#if defined(PERMUTE_WITH_GATHER)
+#define DECLARE_MESSAGE_WORDS(m)
+#elif defined(PERMUTE_WITH_SHUFFLES)
+#define DECLARE_MESSAGE_WORDS(m)                                       \
+  const __m256i m0 = _mm256_broadcastsi128_si256(LOADU128((m) +   0)); \
+  const __m256i m1 = _mm256_broadcastsi128_si256(LOADU128((m) +  16)); \
+  const __m256i m2 = _mm256_broadcastsi128_si256(LOADU128((m) +  32)); \
+  const __m256i m3 = _mm256_broadcastsi128_si256(LOADU128((m) +  48)); \
+  const __m256i m4 = _mm256_broadcastsi128_si256(LOADU128((m) +  64)); \
+  const __m256i m5 = _mm256_broadcastsi128_si256(LOADU128((m) +  80)); \
+  const __m256i m6 = _mm256_broadcastsi128_si256(LOADU128((m) +  96)); \
+  const __m256i m7 = _mm256_broadcastsi128_si256(LOADU128((m) + 112)); \
+  __m256i t0, t1;
+#else
+#define DECLARE_MESSAGE_WORDS(m)           \
+  const uint64_t  m0 = LOADU64((m) +   0); \
+  const uint64_t  m1 = LOADU64((m) +   8); \
+  const uint64_t  m2 = LOADU64((m) +  16); \
+  const uint64_t  m3 = LOADU64((m) +  24); \
+  const uint64_t  m4 = LOADU64((m) +  32); \
+  const uint64_t  m5 = LOADU64((m) +  40); \
+  const uint64_t  m6 = LOADU64((m) +  48); \
+  const uint64_t  m7 = LOADU64((m) +  56); \
+  const uint64_t  m8 = LOADU64((m) +  64); \
+  const uint64_t  m9 = LOADU64((m) +  72); \
+  const uint64_t m10 = LOADU64((m) +  80); \
+  const uint64_t m11 = LOADU64((m) +  88); \
+  const uint64_t m12 = LOADU64((m) +  96); \
+  const uint64_t m13 = LOADU64((m) + 104); \
+  const uint64_t m14 = LOADU64((m) + 112); \
+  const uint64_t m15 = LOADU64((m) + 120);
+#endif
+
+#define BLAKE2B_COMPRESS_V1(a, b, m, t0, t1, f0, f1) do { \
+  DECLARE_MESSAGE_WORDS(m)                                \
+  const __m256i iv0 = a;                                  \
+  const __m256i iv1 = b;                                  \
+  __m256i c = LOAD(&blake2b_IV[0]);                       \
+  __m256i d = XOR(                                        \
+    LOAD(&blake2b_IV[4]),                                 \
+    _mm256_set_epi64x(f1, f0, t1, t0)                     \
+  );                                                      \
+  BLAKE2B_ROUNDS_V1(a, b, c, d, m);                       \
+  a = XOR(a, c);                                          \
+  b = XOR(b, d);                                          \
+  a = XOR(a, iv0);                                        \
+  b = XOR(b, iv1);                                        \
+} while(0)
+
+#define BLAKE2B_G_V4(m, r, i, a, b, c, d) do {                       \
+  a = ADD(a, LOAD((uint8_t const *)(m) + blake2b_sigma[r][2*i+0]));  \
+  a = ADD(a, b); d = XOR(d, a); d = ROT32(d);                        \
+  c = ADD(c, d); b = XOR(b, c); b = ROT24(b);                        \
+  a = ADD(a, LOAD((uint8_t const *)(m) + blake2b_sigma[r][2*i+1]));  \
+  a = ADD(a, b); d = XOR(d, a); d = ROT16(d);                        \
+  c = ADD(c, d); b = XOR(b, c); b = ROT63(b);                        \
+} while(0)
+
+#define BLAKE2B_ROUND_V4(v, m, r) do {                \
+  BLAKE2B_G_V4(m, r, 0, v[ 0], v[ 4], v[ 8], v[12]);  \
+  BLAKE2B_G_V4(m, r, 1, v[ 1], v[ 5], v[ 9], v[13]);  \
+  BLAKE2B_G_V4(m, r, 2, v[ 2], v[ 6], v[10], v[14]);  \
+  BLAKE2B_G_V4(m, r, 3, v[ 3], v[ 7], v[11], v[15]);  \
+  BLAKE2B_G_V4(m, r, 4, v[ 0], v[ 5], v[10], v[15]);  \
+  BLAKE2B_G_V4(m, r, 5, v[ 1], v[ 6], v[11], v[12]);  \
+  BLAKE2B_G_V4(m, r, 6, v[ 2], v[ 7], v[ 8], v[13]);  \
+  BLAKE2B_G_V4(m, r, 7, v[ 3], v[ 4], v[ 9], v[14]);  \
+} while(0)
+
+#if defined(PERMUTE_WITH_GATHER)
+#define BLAKE2B_LOADMSG_V4(w, m) do {             \
+  int i;                                          \
+  for(i = 0; i < 16; ++i) {                       \
+    w[i] = _mm256_i32gather_epi64(                \
+      (const void *)((m) + i * sizeof(uint64_t)), \
+      _mm_set_epi32(48, 32, 16, 0),               \
+      sizeof(uint64_t)                            \
+    );                                            \
+  }                                               \
+} while(0)
+#else
+#define BLAKE2B_PACK_MSG_V4(w, m) do {              \
+  __m256i t0, t1, t2, t3;                           \
+  t0 = _mm256_unpacklo_epi64(m[ 0], m[ 4]);         \
+  t1 = _mm256_unpackhi_epi64(m[ 0], m[ 4]);         \
+  t2 = _mm256_unpacklo_epi64(m[ 8], m[12]);         \
+  t3 = _mm256_unpackhi_epi64(m[ 8], m[12]);         \
+  w[ 0] = _mm256_permute2x128_si256(t0, t2, 0x20);  \
+  w[ 2] = _mm256_permute2x128_si256(t0, t2, 0x31);  \
+  w[ 1] = _mm256_permute2x128_si256(t1, t3, 0x20);  \
+  w[ 3] = _mm256_permute2x128_si256(t1, t3, 0x31);  \
+  t0 = _mm256_unpacklo_epi64(m[ 1], m[ 5]);         \
+  t1 = _mm256_unpackhi_epi64(m[ 1], m[ 5]);         \
+  t2 = _mm256_unpacklo_epi64(m[ 9], m[13]);         \
+  t3 = _mm256_unpackhi_epi64(m[ 9], m[13]);         \
+  w[ 4] = _mm256_permute2x128_si256(t0, t2, 0x20);  \
+  w[ 6] = _mm256_permute2x128_si256(t0, t2, 0x31);  \
+  w[ 5] = _mm256_permute2x128_si256(t1, t3, 0x20);  \
+  w[ 7] = _mm256_permute2x128_si256(t1, t3, 0x31);  \
+  t0 = _mm256_unpacklo_epi64(m[ 2], m[ 6]);         \
+  t1 = _mm256_unpackhi_epi64(m[ 2], m[ 6]);         \
+  t2 = _mm256_unpacklo_epi64(m[10], m[14]);         \
+  t3 = _mm256_unpackhi_epi64(m[10], m[14]);         \
+  w[ 8] = _mm256_permute2x128_si256(t0, t2, 0x20);  \
+  w[10] = _mm256_permute2x128_si256(t0, t2, 0x31);  \
+  w[ 9] = _mm256_permute2x128_si256(t1, t3, 0x20);  \
+  w[11] = _mm256_permute2x128_si256(t1, t3, 0x31);  \
+  t0 = _mm256_unpacklo_epi64(m[ 3], m[ 7]);         \
+  t1 = _mm256_unpackhi_epi64(m[ 3], m[ 7]);         \
+  t2 = _mm256_unpacklo_epi64(m[11], m[15]);         \
+  t3 = _mm256_unpackhi_epi64(m[11], m[15]);         \
+  w[12] = _mm256_permute2x128_si256(t0, t2, 0x20);  \
+  w[14] = _mm256_permute2x128_si256(t0, t2, 0x31);  \
+  w[13] = _mm256_permute2x128_si256(t1, t3, 0x20);  \
+  w[15] = _mm256_permute2x128_si256(t1, t3, 0x31);  \
+} while(0)
+
+#define BLAKE2B_LOADMSG_V4(w, m) do { \
+  __m256i t[16];                      \
+  int i;                              \
+  for(i = 0; i < 16; ++i) {           \
+    t[i] = LOADU((m) + i * 32);       \
+  }                                   \
+  BLAKE2B_PACK_MSG_V4(w, t);          \
+} while(0)
+#endif
+
+#define BLAKE2B_UNPACK_STATE_V4(u, v) do {         \
+  __m256i t0, t1, t2, t3;                          \
+  t0 = _mm256_unpacklo_epi64(v[0], v[1]);          \
+  t1 = _mm256_unpackhi_epi64(v[0], v[1]);          \
+  t2 = _mm256_unpacklo_epi64(v[2], v[3]);          \
+  t3 = _mm256_unpackhi_epi64(v[2], v[3]);          \
+  u[0] = _mm256_permute2x128_si256(t0, t2, 0x20);  \
+  u[2] = _mm256_permute2x128_si256(t1, t3, 0x20);  \
+  u[4] = _mm256_permute2x128_si256(t0, t2, 0x31);  \
+  u[6] = _mm256_permute2x128_si256(t1, t3, 0x31);  \
+  t0 = _mm256_unpacklo_epi64(v[4], v[5]);          \
+  t1 = _mm256_unpackhi_epi64(v[4], v[5]);          \
+  t2 = _mm256_unpacklo_epi64(v[6], v[7]);          \
+  t3 = _mm256_unpackhi_epi64(v[6], v[7]);          \
+  u[1] = _mm256_permute2x128_si256(t0, t2, 0x20);  \
+  u[3] = _mm256_permute2x128_si256(t1, t3, 0x20);  \
+  u[5] = _mm256_permute2x128_si256(t0, t2, 0x31);  \
+  u[7] = _mm256_permute2x128_si256(t1, t3, 0x31);  \
+} while(0)
+
+#define BLAKE2B_COMPRESS_V4(v, m, counter, flag) do {                   \
+  __m256i iv[8], w[16];                                                 \
+  int i, r;                                                             \
+  for(i = 0; i < 8; ++i) {                                              \
+    iv[i] = v[i];                                                       \
+  }                                                                     \
+  v[ 8] = _mm256_set1_epi64x(blake2b_IV[0]);                            \
+  v[ 9] = _mm256_set1_epi64x(blake2b_IV[1]);                            \
+  v[10] = _mm256_set1_epi64x(blake2b_IV[2]);                            \
+  v[11] = _mm256_set1_epi64x(blake2b_IV[3]);                            \
+  v[12] = XOR(_mm256_set1_epi64x(blake2b_IV[4]), counter);              \
+  v[13] = _mm256_set1_epi64x(blake2b_IV[5]);                            \
+  v[14] = XOR(_mm256_set1_epi64x(blake2b_IV[6]), flag);                 \
+  v[15] = XOR(_mm256_set1_epi64x(blake2b_IV[7]), flag);                 \
+  BLAKE2B_LOADMSG_V4(w, m);                                             \
+  for(r = 0; r < 12; ++r) {                                             \
+    BLAKE2B_ROUND_V4(v, w, r);                                          \
+  }                                                                     \
+  for(i = 0; i < 8; ++i) {                                              \
+    v[i] = XOR(XOR(v[i], v[i+8]), iv[i]);                               \
+  }                                                                     \
+} while(0)
+
+void blake2bip_final(const crypto_generichash_blake2b_state *S, uchar *out, u32 blockidx) {
+  __m256i v[16], s[8], iv[8], w[16], counter, flag;
+  uint32_t b, i, r;
+
+  ALIGN(64) uint8_t buffer[4 * BLAKE2B_BLOCKBYTES]; // 4 * 128
+  memset(buffer, 0, 4 * BLAKE2B_BLOCKBYTES);
+  for (i = 0; i < 4; i++) {
+    memcpy(buffer+128*i, S->buf, S->buflen);
+    b = htole32(4 * blockidx + i);
+    memcpy(buffer+128*i + S->buflen, &b, 4);
+  }
+
+  for(i = 0; i < 8; ++i) {
+    v[i] = _mm256_set1_epi64x(S->h[i]);
+  }
+
+  counter = _mm256_set1_epi64x(128 + S->buflen + 4);
+  flag    = _mm256_set1_epi64x(~0);
+
+  for(i = 0; i < 8; ++i) {
+    iv[i] = v[i];
+  }
+  v[ 8] = _mm256_set1_epi64x(blake2b_IV[0]);
+  v[ 9] = _mm256_set1_epi64x(blake2b_IV[1]);
+  v[10] = _mm256_set1_epi64x(blake2b_IV[2]);
+  v[11] = _mm256_set1_epi64x(blake2b_IV[3]);
+  v[12] = XOR(_mm256_set1_epi64x(blake2b_IV[4]), counter);
+  v[13] = _mm256_set1_epi64x(blake2b_IV[5]);
+  v[14] = XOR(_mm256_set1_epi64x(blake2b_IV[6]), flag);
+  v[15] = _mm256_set1_epi64x(blake2b_IV[7]);
+  BLAKE2B_LOADMSG_V4(w, buffer);
+  for(r = 0; r < 12; ++r) {
+    BLAKE2B_ROUND_V4(v, w, r);
+  }
+  for(i = 0; i < 8; ++i) {
+    v[i] = XOR(XOR(v[i], v[i+8]), iv[i]);
+  }
+
+  BLAKE2B_UNPACK_STATE_V4(s, v);
+
+  memcpy(out, s, 256);
+}

--- a/src/pow/tromp/blake2-avx2/blake2bip.h
+++ b/src/pow/tromp/blake2-avx2/blake2bip.h
@@ -1,0 +1,11 @@
+#ifndef BLAKE2_AVX2_BLAKE2BIP_H
+#define BLAKE2_AVX2_BLAKE2BIP_H
+
+#include <stddef.h>
+
+typedef uint32_t u32;
+typedef unsigned char uchar;
+
+void blake2bip_final(const crypto_generichash_blake2b_state *midstate, uchar *hashout, u32 blockidx);
+
+#endif

--- a/src/pow/tromp/equi.h
+++ b/src/pow/tromp/equi.h
@@ -4,6 +4,7 @@
 #include "sodium.h"
 #ifdef __APPLE__
 #include "pow/tromp/osx_barrier.h"
+#define htole32(x) OSSwapHostToLittleInt32(x)
 #endif
 #include "compat/endian.h"
 
@@ -14,7 +15,7 @@
 typedef uint32_t u32;
 typedef unsigned char uchar;
 
-// algorithm parameters, prefixed with W to reduce include file conflicts
+// algorithm parameters, prefixed with W (for Wagner) to reduce include file conflicts
 
 #ifndef WN
 #define WN	200
@@ -34,7 +35,6 @@ static const u32 HASHESPERBLAKE = 512/WN;
 static const u32 HASHOUT = HASHESPERBLAKE*WN/8;
 
 typedef u32 proof[PROOFSIZE];
-
 
 enum verify_code { POW_OK, POW_DUPLICATE, POW_OUT_OF_ORDER, POW_NONZERO_XOR };
 const char *errstr[] = { "OK", "duplicate index", "indices out of order", "nonzero xor" };
@@ -65,7 +65,7 @@ int verifyrec(const crypto_generichash_blake2b_state *ctx, u32 *indices, uchar *
     return vrf1;
   for (int i=0; i < WN/8; i++)
     hash[i] = hash0[i] ^ hash1[i];
-  int i, b = r * DIGITBITS;
+  int i, b = r < WK ? r * DIGITBITS : WN;
   for (i = 0; i < b/8; i++)
     if (hash[i])
       return POW_NONZERO_XOR;

--- a/src/pow/tromp/equi_miner.h
+++ b/src/pow/tromp/equi_miner.h
@@ -1,32 +1,58 @@
 // Equihash solver
 // Copyright (c) 2016 John Tromp, The Zcash developers
 
-// Fix N, K, such that n = N/(k+1) is integer
-// Fix M = 2^{n+1} hashes each of length N bits,
-// H_0, ... , H_{M-1}, generated fom (n+1)-bit indices.
-// Problem: find binary tree on 2^K distinct indices,
-// for which the exclusive-or of leaf hashes is all 0s.
+// Equihash presents the following problem
+//
+// Fix N, K, such that N is a multiple of K+1
+// Let integer n = N/(K+1), and view N-bit words
+// as having K+1 "digits" of n bits each
+// Fix M = 2^{n+1} N-bit hashes H_0, ... , H_{M-1}
+// as outputs of a hash function applied to an (n+1)-bit index
+//
+// Problem: find a binary tree on 2^K distinct indices,
+// for which the exclusive-or of leaf hashes is all 0s
 // Additionally, it should satisfy the Wagner conditions:
-// for each height i subtree, the exclusive-or
-// of its 2^i corresponding hashes starts with i*n 0 bits,
-// and for i>0 the leftmost leaf of its left subtree
-// is less than the leftmost leaf of its right subtree
+// 1) for each height i subtree, the exclusive-or
+// of its 2^i leaf hashes starts with i*n 0 bits,
+// 2) the leftmost leaf of any left subtree is less
+// than the leftmost leaf of the corresponding right subtree
+//
+// The algorithm below solves this by storing trees
+// as a directed acyclic graph of K layers
+// The n digit bits are split into
+// n-RESTBITS bucket bits and RESTBITS leftover bits
+// Each layer i, consisting of height i subtrees
+// whose xor starts with i*n 0s, is partitioned into
+// 2^{n-RESTBITS} buckets according to the next n-RESTBITS
+// in the xor
+// Within each bucket, trees whose xor match in the
+// next RESTBITS bits are combined to produce trees
+// in the next layer
+// To eliminate trees with duplicated indices,
+// we simply test if the last 32 bits of the xor are 0,
+// and if so, assume that this is due to index duplication
+// In practice this works very well to avoid bucket overflow
+// and produces negligible false positives
 
-// The algorithm below solves this by maintaining the trees
-// in a graph of K layers, each split into buckets
-// with buckets indexed by the first n-RESTBITS bits following
-// the i*n 0s, each bucket having 4 * 2^RESTBITS slots,
-// twice the number of subtrees expected to land there.
+#if defined(__GNUC__) && !defined(__ICC)
+#pragma GCC push_options
+#pragma GCC optimize ("O2")
+#pragma GCC optimize ("omit-frame-pointer")
+#endif
 
 #include "pow/tromp/equi.h"
 #include <stdio.h>
-#include <stdlib.h>
 #include <pthread.h>
 #include <assert.h>
+
+#ifdef USE_TROMP_AVX2
+#include "pow/tromp/blake2-avx2/blake2bip.h"
+#endif
 
 typedef uint16_t u16;
 typedef uint64_t u64;
 
+// required for avoiding multio-threading race conflicts
 #ifdef EQUIHASH_TROMP_ATOMIC
 #include <atomic>
 typedef std::atomic<u32> au32;
@@ -41,45 +67,50 @@ typedef u32 au32;
 // 2_log of number of buckets
 #define BUCKBITS (DIGITBITS-RESTBITS)
 
+// by default buckets have a capacity of twice their expected size
+// but this factor reduced it accordingly
 #ifndef SAVEMEM
 #if RESTBITS == 4
 // can't save memory in such small buckets
 #define SAVEMEM 1
 #elif RESTBITS >= 8
-// take advantage of law of large numbers (sum of 2^8 random numbers)
-// this reduces (200,9) memory to under 144MB, with negligible discarding
+// an expected size of at least 512 has such relatively small
+// standard deviation that we can reduce capacity with negligible discarding
+// this value reduces (200,9) memory to under 144MB
 #define SAVEMEM 9/14
 #endif
 #endif
 
-// number of buckets
-static const u32 NBUCKETS = 1<<BUCKBITS;
-// 2_log of number of slots per bucket
-static const u32 SLOTBITS = RESTBITS+1+1;
-static const u32 SLOTRANGE = 1<<SLOTBITS;
-static const u32 SLOTMSB = 1<<(SLOTBITS-1);
-// number of slots per bucket
-static const u32 NSLOTS = SLOTRANGE * SAVEMEM;
-// number of per-xhash slots
-static const u32 XFULL = 16;
-// SLOTBITS mask
-static const u32 SLOTMASK = SLOTRANGE-1;
-// number of possible values of xhash (rest of n) bits
-static const u32 NRESTS = 1<<RESTBITS;
-// number of blocks of hashes extracted from single 512 bit blake2b output
-static const u32 NBLOCKS = (NHASHES+HASHESPERBLAKE-1)/HASHESPERBLAKE;
-// nothing larger found in 100000 runs
-static const u32 MAXSOLS = 8;
+static const u32 NBUCKETS = 1<<BUCKBITS;    // number of buckets
+static const u32 BUCKMASK = NBUCKETS-1;     // corresponding bucket mask
+static const u32 SLOTBITS = RESTBITS+1+1;   // 2_log of number of slots per bucket
+static const u32 SLOTRANGE = 1<<SLOTBITS;   // default bucket capacity
+static const u32 SLOTMASK = SLOTRANGE-1;    // corresponding SLOTBITS mask
+static const u32 SLOTMSB = 1<<(SLOTBITS-1); // most significat bit in SLOTMASK
+static const u32 NSLOTS = SLOTRANGE * SAVEMEM; // number of slots per bucket
+static const u32 NRESTS = 1<<RESTBITS;      // number of possible values of RESTBITS bits
+static const u32 MAXSOLS = 8;               // more than 8 solutions are rare
 
 // tree node identifying its children as two different slots in
-// a bucket on previous layer with the same rest bits (x-tra hash)
+// a bucket on previous layer with matching rest bits (x-tra hash)
 struct tree {
-  u32 bid_s0_s1; // manual bitfields
+  // formerly i had these bitfields
+  // unsigned bucketid : BUCKBITS;
+  // unsigned slotid0  : SLOTBITS;
+  // unsigned slotid1 : SLOTBITS;
+  // but these were poorly optimized by the compiler
+  // so now we do things "manually"
+  u32 bid_s0_s1;
 
+  // constructor for height 0 trees stores index instead
   tree(const u32 idx) {
     bid_s0_s1 = idx;
   }
   tree(const u32 bid, const u32 s0, const u32 s1) {
+// SLOTDIFF saves 1 bit by encoding the distance between
+// the two slots modulo SLOTRANGE instead, and picking
+// slotid0 such that this distance is at most SLOTRANGE/2
+// the extra branching involved gives noticeable slowdown
 #ifdef SLOTDIFF
     u32 ds10 = (s1 - s0) & SLOTMASK;
     if (ds10 & SLOTMSB) {
@@ -91,9 +122,11 @@ struct tree {
     bid_s0_s1 = (((bid << SLOTBITS) | s0) << SLOTBITS) | s1;
 #endif
   }
+  // retrieve hash index from tree(const u32 idx) constructor
   u32 getindex() const {
     return bid_s0_s1;
   }
+  // retrieve bucket index
   u32 bucketid() const {
 #ifdef SLOTDIFF
     return bid_s0_s1 >> (2 * SLOTBITS - 1);
@@ -101,6 +134,7 @@ struct tree {
     return bid_s0_s1 >> (2 * SLOTBITS);
 #endif
   }
+  // retrieve first slot index
   u32 slotid0() const {
 #ifdef SLOTDIFF
     return (bid_s0_s1 >> (SLOTBITS-1)) & SLOTMASK;
@@ -108,6 +142,7 @@ struct tree {
     return (bid_s0_s1 >> SLOTBITS) & SLOTMASK;
 #endif
   }
+  // retrieve second slot index
   u32 slotid1() const {
 #ifdef SLOTDIFF
     return (slotid0() + 1 + (bid_s0_s1 & (SLOTMASK>>1))) & SLOTMASK;
@@ -117,7 +152,14 @@ struct tree {
   }
 };
 
-union hashunit {
+// each bucket slot occupies a variable number of hash/tree units,
+// all but the last of which hold the xor over all leaf hashes,
+// or what's left of it after stripping the initial i*n 0s
+// the last unit holds the tree node itself
+// the hash is sometimes accessed 32 bits at a time (word)
+// and sometimes 8 bits at a time (bytes)
+union htunit {
+  tree tag;
   u32 word;
   uchar bytes[sizeof(u32)];
 };
@@ -126,15 +168,9 @@ union hashunit {
 #define HASHWORDS0 WORDS(WN - DIGITBITS + RESTBITS)
 #define HASHWORDS1 WORDS(WN - 2*DIGITBITS + RESTBITS)
 
-struct slot0 {
-  tree attr;
-  hashunit hash[HASHWORDS0];
-};
-
-struct slot1 {
-  tree attr;
-  hashunit hash[HASHWORDS1];
-};
+// A slot is up to HASHWORDS0 hash units followed by a tag
+typedef htunit slot0[HASHWORDS0+1];
+typedef htunit slot1[HASHWORDS1+1];
 
 // a bucket is NSLOTS treenodes
 typedef slot0 bucket0[NSLOTS];
@@ -143,6 +179,48 @@ typedef slot1 bucket1[NSLOTS];
 // each of which corresponds to a layer of NBUCKETS buckets
 typedef bucket0 digit0[NBUCKETS];
 typedef bucket1 digit1[NBUCKETS];
+typedef au32 bsizes[NBUCKETS];
+
+// The algorithm proceeds in K+1 rounds, one for each digit
+// All data is stored in two heaps,
+// heap0 of type digit0, and heap1 of type digit1
+// The following table shows the layout of these heaps
+// in each round, which is an optimized version
+// of xenoncat's fixed memory layout, avoiding any waste
+// Each line shows only a single slot, which is actually
+// replicated NSLOTS * NBUCKETS times
+//
+//             heap0         heap1
+// round  hashes   tree   hashes tree
+// 0      A A A A A A 0   . . . . . .
+// 1      A A A A A A 0   B B B B B 1
+// 2      C C C C C 2 0   B B B B B 1
+// 3      C C C C C 2 0   D D D D 3 1
+// 4      E E E E 4 2 0   D D D D 3 1
+// 5      E E E E 4 2 0   F F F 5 3 1
+// 6      G G 6 . 4 2 0   F F F 5 3 1
+// 7      G G 6 . 4 2 0   H H 7 5 3 1
+// 8      I 8 6 . 4 2 0   H H 7 5 3 1
+//
+// Round 0 generates hashes and stores them in the buckets
+// of heap0 according to the initial n-RESTBITS bits
+// These hashes are denoted A above and followed by the
+// tree tag denoted 0
+// In round 1 we combine each pair of slots in the same bucket
+// with matching RESTBITS of digit 0 and store the resulting
+// 1-tree in heap1 with its xor hash denoted B
+// Upon finishing round 1, the A space is no longer needed,
+// and is re-used in round 2 to store both the shorter C hashes,
+// and their tree tags denoted 2
+// Continuing in this manner, each round reads buckets from one
+// heap, and writes buckets in the other heap.
+// In the final round K, all pairs leading to 0 xors are identified
+// and their leafs recovered through the DAG of tree nodes
+
+// convenience function
+u32 min(const u32 a, const u32 b) {
+  return a < b ? a : b;
+}
 
 // size (in bytes) of hash in round 0 <= r < WK
 u32 hashsize(const u32 r) {
@@ -150,40 +228,23 @@ u32 hashsize(const u32 r) {
   return (hashbits + 7) / 8;
 }
 
+// convert bytes into words,rounding up
 u32 hashwords(u32 bytes) {
   return (bytes + 3) / 4;
 }
 
 // manages hash and tree data
 struct htalloc {
-  u32 *heap0;
-  u32 *heap1;
-  bucket0 *trees0[(WK+1)/2];
-  bucket1 *trees1[WK/2];
+  bucket0 *heap0;
+  bucket1 *heap1;
   u32 alloced;
   htalloc() {
     alloced = 0;
   }
   void alloctrees() {
-// optimize xenoncat's fixed memory layout, avoiding any waste
-// digit  trees  hashes  trees hashes
-// 0      0 A A A A A A   . . . . . .
-// 1      0 A A A A A A   1 B B B B B
-// 2      0 2 C C C C C   1 B B B B B
-// 3      0 2 C C C C C   1 3 D D D D
-// 4      0 2 4 E E E E   1 3 D D D D
-// 5      0 2 4 E E E E   1 3 5 F F F
-// 6      0 2 4 6 . G G   1 3 5 F F F
-// 7      0 2 4 6 . G G   1 3 5 7 H H
-// 8      0 2 4 6 8 . I   1 3 5 7 H H
     assert(DIGITBITS >= 16); // ensures hashes shorten by 1 unit every 2 digits
-    heap0 = (u32 *)alloc(1, sizeof(digit0));
-    heap1 = (u32 *)alloc(1, sizeof(digit1));
-    for (int r=0; r<WK; r++)
-      if ((r&1) == 0)
-        trees0[r/2]  = (bucket0 *)(heap0 + r/2);
-      else
-        trees1[r/2]  = (bucket1 *)(heap1 + r/2);
+    heap0 = (bucket0 *)alloc(NBUCKETS, sizeof(bucket0));
+    heap1 = (bucket1 *)alloc(NBUCKETS, sizeof(bucket1));
   }
   void dealloctrees() {
     free(heap0);
@@ -197,25 +258,20 @@ struct htalloc {
   }
 };
 
-typedef au32 bsizes[NBUCKETS];
-
-u32 min(const u32 a, const u32 b) {
-  return a < b ? a : b;
-}
-
+// main solver object, shared between all threads
 struct equi {
-  crypto_generichash_blake2b_state blake_ctx;
-  htalloc hta;
-  bsizes *nslots; // PUT IN BUCKET STRUCT
-  proof *sols;
-  au32 nsols;
+  crypto_generichash_blake2b_state blake_ctx; // holds blake2b midstate after call to setheadernounce
+  htalloc hta;             // holds allocated heaps
+  bsizes *nslots;          // counts number of slots used in buckets
+  proof *sols;             // store found solutions here (only first MAXSOLS)
+  au32 nsols;              // number of solutions found
   u32 nthreads;
-  u32 xfull;
-  u32 hfull;
-  u32 bfull;
-  pthread_barrier_t barry;
+  u32 bfull;               // count number of times bucket can't fit new item
+  u32 hfull;               // count number of xor-ed hash with last 32 bits zero
+  pthread_barrier_t barry; // used to sync threads
   equi(const u32 n_threads) {
-    assert(sizeof(hashunit) == 4);
+    assert(sizeof(htunit) == 4);
+    assert(WK&1); // assumed in candidate() calling indices1()
     nthreads = n_threads;
     const int err = pthread_barrier_init(&barry, NULL, nthreads);
     assert(!err);
@@ -231,22 +287,55 @@ struct equi {
   void setstate(const crypto_generichash_blake2b_state *ctx) {
     blake_ctx = *ctx;
     memset(nslots, 0, NBUCKETS * sizeof(au32)); // only nslots[0] needs zeroing
-    nsols = 0;
+    nsols = bfull = hfull = 0;
   }
-  u32 getslot(const u32 r, const u32 bucketi) {
+  // get heap0 bucket size in threadsafe manner
+  u32 getslot0(const u32 bucketi) {
 #ifdef EQUIHASH_TROMP_ATOMIC
-    return std::atomic_fetch_add_explicit(&nslots[r&1][bucketi], 1U, std::memory_order_relaxed);
+    return std::atomic_fetch_add_explicit(&nslots[0][bucketi], 1U, std::memory_order_relaxed);
 #else
-    return nslots[r&1][bucketi]++;
+    return nslots[0][bucketi]++;
 #endif
   }
-  u32 getnslots(const u32 r, const u32 bid) { // SHOULD BE METHOD IN BUCKET STRUCT
-    au32 &nslot = nslots[r&1][bid];
+  // get heap1 bucket size in threadsafe manner
+  u32 getslot1(const u32 bucketi) {
+#ifdef EQUIHASH_TROMP_ATOMIC
+    return std::atomic_fetch_add_explicit(&nslots[1][bucketi], 1U, std::memory_order_relaxed);
+#else
+    return nslots[1][bucketi]++;
+#endif
+  }
+  // get old heap0 bucket size and clear it for next round
+  u32 getnslots0(const u32 bid) {
+    au32 &nslot = nslots[0][bid];
     const u32 n = min(nslot, NSLOTS);
     nslot = 0;
     return n;
   }
-  void orderindices(u32 *indices, u32 size) {
+  // get old heap1 bucket size and clear it for next round
+  u32 getnslots1(const u32 bid) {
+    au32 &nslot = nslots[1][bid];
+    const u32 n = min(nslot, NSLOTS);
+    nslot = 0;
+    return n;
+  }
+// this was an experiment that turned out to be a slowdown
+// one can integrate a merge sort into the index recovery
+// but due to the memcpy's it's slower at recognizing dupes
+#ifdef MERGESORT
+  // if merged != 0, mergesort indices and return true if dupe found
+  // if merged == 0, order indices as in Wagner condition
+  bool orderindices(u32 *indices, u32 size, u32 *merged) {
+    if (merged) {
+      u32 i = 0, j = 0, k;
+      for (k = 0; i<size && j<size; k++) {
+        if (indices[i] == indices[size+j]) return true;
+        merged[k] = indices[i] < indices[size+j] ? indices[i++] : indices[size+j++];
+      }
+      memcpy(merged+k, indices+i, (size-i) * sizeof(u32));
+      memcpy(indices,  merged,    (size+j) * sizeof(u32));
+      return false;
+    } else {
     if (indices[0] > indices[size]) {
       for (u32 i=0; i < size; i++) {
         const u32 tmp = indices[i];
@@ -254,44 +343,113 @@ struct equi {
         indices[size+i] = tmp;
       }
     }
+      return false;
   }
-  void listindices0(u32 r, const tree t, u32 *indices) {
+  }
+  // return true if dupe found
+  bool listindices0(u32 r, const tree t, u32 *indices, u32 *merged) {
     if (r == 0) {
       *indices = t.getindex();
-      return;
+      return false;
     }
-    const bucket1 &buck = hta.trees1[--r/2][t.bucketid()];
-    const u32 size = 1 << r;
+    const slot1 *buck = hta.heap1[t.bucketid()];
+    const u32 size = 1 << --r;
     u32 *indices1 = indices + size;
-    listindices1(r, buck[t.slotid0()].attr, indices);
-    listindices1(r, buck[t.slotid1()].attr, indices1);
-    orderindices(indices, size);
+    u32 tagi = hashwords(hashsize(r));
+    return listindices1(r, buck[t.slotid0()][tagi].tag, indices,  merged)
+        || listindices1(r, buck[t.slotid1()][tagi].tag, indices1, merged)
+        || orderindices(indices, size, merged);
   }
-  void listindices1(u32 r, const tree t, u32 *indices) {
-    const bucket0 &buck = hta.trees0[--r/2][t.bucketid()];
-    const u32 size = 1 << r;
+  bool listindices1(u32 r, const tree t, u32 *indices, u32 *merged) {
+    const slot0 *buck = hta.heap0[t.bucketid()];
+    const u32 size = 1 << --r;
     u32 *indices1 = indices + size;
-    listindices0(r, buck[t.slotid0()].attr, indices);
-    listindices0(r, buck[t.slotid1()].attr, indices1);
-    orderindices(indices, size);
+    u32 tagi = hashwords(hashsize(r));
+    return listindices0(r, buck[t.slotid0()][tagi].tag, indices,  merged)
+        || listindices0(r, buck[t.slotid1()][tagi].tag, indices1, merged)
+        || orderindices(indices, size, merged);
   }
   void candidate(const tree t) {
-    proof prf;
-    listindices1(WK, t, prf); // assume WK odd
-    qsort(prf, PROOFSIZE, sizeof(u32), &compu32);
-    for (u32 i=1; i<PROOFSIZE; i++)
-      if (prf[i] <= prf[i-1])
-        return;
+    proof prf, merged;
+    if (listindices1(WK, t, prf, merged)) return;
 #ifdef EQUIHASH_TROMP_ATOMIC
     u32 soli = std::atomic_fetch_add_explicit(&nsols, 1U, std::memory_order_relaxed);
 #else
     u32 soli = nsols++;
 #endif
-    if (soli < MAXSOLS)
-      listindices1(WK, t, sols[soli]); // assume WK odd
+    if (soli < MAXSOLS) listindices1(WK, t, sols[soli], 0);
   }
+#else
+  // this is a differrent way to recognize most (but not all) dupes
+  // unlike MERGESORT it doesn't end up sorting the indices,
+  // but the few remaining candidates can easily
+  // affort to have a qsort applied to them in order to find remaining dupes
+  bool orderindices(u32 *indices, u32 size) {
+    if (indices[0] > indices[size]) {
+      for (u32 i=0; i < size; i++) {
+        const u32 tmp = indices[i];
+        indices[i] = indices[size+i];
+        indices[size+i] = tmp;
+      }
+    }
+    return false;
+  }
+  // if dupes != 0, list indices in arbitrary order and return true if dupe found
+  // if dupes == 0, order indices as in Wagner condition
+  bool listindices0(u32 r, const tree t, u32 *indices, u32 *dupes) {
+    if (r == 0) {
+      u32 idx = t.getindex();
+      if (dupes) {
+      // recognize most dupes by storing last seen index
+      // with same K least significant bits in array dupes
+        u32 bin = idx & (PROOFSIZE-1);
+        if (idx == dupes[bin]) return true;
+        dupes[bin] = idx;
+      }
+      *indices = idx;
+      return false;
+    }
+    const slot1 *buck = hta.heap1[t.bucketid()];
+    const u32 size = 1 << --r;
+    u32 tagi = hashwords(hashsize(r));
+    return listindices1(r, buck[t.slotid0()][tagi].tag, indices,      dupes)
+        || listindices1(r, buck[t.slotid1()][tagi].tag, indices+size, dupes)
+        || (!dupes && orderindices(indices, size));
+  }
+  // need separate instance for accessing (differently typed) heap1
+  bool listindices1(u32 r, const tree t, u32 *indices, u32 *dupes) {
+    const slot0 *buck = hta.heap0[t.bucketid()];
+    const u32 size = 1 << --r;
+    u32 tagi = hashwords(hashsize(r));
+    return listindices0(r, buck[t.slotid0()][tagi].tag, indices,      dupes)
+        || listindices0(r, buck[t.slotid1()][tagi].tag, indices+size, dupes)
+        || (!dupes && orderindices(indices, size));
+  }
+  // check a candidate that resulted in 0 xor
+  // add as solution, with proper subtree ordering, if it has unique indices
+  void candidate(const tree t) {
+    proof prf, dupes;
+    memset(dupes, 0xffff, sizeof(proof));
+    if (listindices1(WK, t, prf, dupes)) return; // assume WK odd
+    // it survived the probable dupe test, now check fully
+    qsort(prf, PROOFSIZE, sizeof(u32), &compu32);
+    for (u32 i=1; i<PROOFSIZE; i++) if (prf[i] <= prf[i-1]) return;
+    // and now we have ourselves a genuine solution, not yet properly ordered
+#ifdef EQUIHASH_TROMP_ATOMIC
+    u32 soli = std::atomic_fetch_add_explicit(&nsols, 1U, std::memory_order_relaxed);
+#else
+    u32 soli = nsols++;
+#endif
+    // retrieve solution indices in correct order
+    if (soli < MAXSOLS) listindices1(WK, t, sols[soli], 0); // assume WK odd
+  }
+#endif
+  // show bucket stats and, if desired, size distribution
   void showbsizes(u32 r) {
+//    printf(" b%d h%d\n", bfull, hfull);
+    bfull = hfull = 0;
 #if defined(HIST) || defined(SPARK) || defined(LOGSPARK)
+    // group bucket sizes in 64 bins, from empty to full (ignoring SAVEMEM)
     u32 binsizes[65];
     memset(binsizes, 0, 65 * sizeof(u32));
     for (u32 bucketid = 0; bucketid < NBUCKETS; bucketid++) {
@@ -299,10 +457,10 @@ struct equi {
       binsizes[bsize]++;
     }
     for (u32 i=0; i < 65; i++) {
-#ifdef HIST
+#ifdef HIST  // exact counts are useful for debugging
 //      printf(" %d:%d", i, binsizes[i]);
 #else
-#ifdef SPARK
+#ifdef SPARK // everybody loves sparklines
       u32 sparks = binsizes[i] / SPARKSCALE;
 #else
       u32 sparks = 0;
@@ -314,60 +472,66 @@ struct equi {
     }
 //    printf("\n");
 #endif
+//    printf("Digit %d", r+1);
   }
 
+  // thread-local object that precomputes various slot metrics for each round
+  // facilitating access to various bits in the variable size slots
   struct htlayout {
     htalloc hta;
-    u32 prevhashunits;
-    u32 nexthashunits;
+    u32 prevhtunits;
+    u32 nexthtunits;
     u32 dunits;
     u32 prevbo;
-    u32 nextbo;
-  
-    htlayout(equi *eq, u32 r): hta(eq->hta), prevhashunits(0), dunits(0) {
-      u32 nexthashbytes = hashsize(r);
-      nexthashunits = hashwords(nexthashbytes);
-      prevbo = 0;
-      nextbo = nexthashunits * sizeof(hashunit) - nexthashbytes; // 0-3
-      if (r) {
+
+    htlayout(equi *eq, u32 r): hta(eq->hta), prevhtunits(0), dunits(0) {
+      u32 nexthashbytes = hashsize(r);        // number of bytes occupied by round r hash
+      nexthtunits = hashwords(nexthashbytes); // number of 32bit words taken up by those bytes
+      prevbo = 0;                  // byte offset for accessing hash form previous round
+      if (r) {     // similar measure for previous round
         u32 prevhashbytes = hashsize(r-1);
-        prevhashunits = hashwords(prevhashbytes);
-        prevbo = prevhashunits * sizeof(hashunit) - prevhashbytes; // 0-3
-        dunits = prevhashunits - nexthashunits;
+        prevhtunits = hashwords(prevhashbytes);
+        prevbo = prevhtunits * sizeof(htunit) - prevhashbytes; // 0-3
+        dunits = prevhtunits - nexthtunits; // number of words by which hash shrinks
       }
     }
-    u32 getxhash0(const slot0* pslot) const {
+    // extract remaining bits in digit slots in same bucket still need to collide on
+    u32 getxhash0(const htunit* slot) const {
 #if WN == 200 && RESTBITS == 4
-      return pslot->hash->bytes[prevbo] >> 4;
+      return slot->bytes[prevbo] >> 4;
 #elif WN == 200 && RESTBITS == 8
-      return (pslot->hash->bytes[prevbo] & 0xf) << 4 | pslot->hash->bytes[prevbo+1] >> 4;
-#elif WN == 200 && RESTBITS == 9
-      return (pslot->hash->bytes[prevbo] & 0x1f) << 4 | pslot->hash->bytes[prevbo+1] >> 4;
+      return (slot->bytes[prevbo] & 0xf) << 4 | slot->bytes[prevbo+1] >> 4;
 #elif WN == 144 && RESTBITS == 4
-      return pslot->hash->bytes[prevbo] & 0xf;
+      return slot->bytes[prevbo] & 0xf;
 #else
 #error non implemented
 #endif
     }
-    u32 getxhash1(const slot1* pslot) const {
+    // similar but accounting for possible change in hashsize modulo 4 bits
+    u32 getxhash1(const htunit* slot) const {
 #if WN == 200 && RESTBITS == 4
-      return pslot->hash->bytes[prevbo] & 0xf;
+      return slot->bytes[prevbo] & 0xf;
 #elif WN == 200 && RESTBITS == 8
-      return pslot->hash->bytes[prevbo];
-#elif WN == 200 && RESTBITS == 9
-      return (pslot->hash->bytes[prevbo]&1) << 8 | pslot->hash->bytes[prevbo+1];
+      return slot->bytes[prevbo];
 #elif WN == 144 && RESTBITS == 4
-      return pslot->hash->bytes[prevbo] & 0xf;
+      return slot->bytes[prevbo] & 0xf;
 #else
 #error non implemented
 #endif
     }
-    bool equal(const hashunit *hash0, const hashunit *hash1) const {
-      return hash0[prevhashunits-1].word == hash1[prevhashunits-1].word;
+    // test whether two hashes match in last 32 bits
+    bool equal(const htunit *hash0, const htunit *hash1) const {
+      return hash0[prevhtunits-1].word == hash1[prevhtunits-1].word;
     }
   };
 
+  // this thread-local object performs in-bucket collisions
+  // by linking together slots that have identical rest bits
+  // (which is in essense a 2nd stage bucket sort)
   struct collisiondata {
+    // the bitmap is an early experiment in a bitmap encoding
+    // that works only for at most 64 slots
+    // it might as well be obsoleted as it performs worse even in that case
 #ifdef XBITMAP
 #if NSLOTS > 64
 #error cant use XBITMAP with more than 64 slots
@@ -375,16 +539,19 @@ struct equi {
     u64 xhashmap[NRESTS];
     u64 xmap;
 #else
+    // This maintains NRESTS = 2^RESTBITS lists whose starting slot
+    // are in xhashslots[] and where subsequent (next-lower-numbered)
+    // slots in each list are found through nextxhashslot[]
+    // since 0 is already a valid slot number, use ~0 as nil value
 #if RESTBITS <= 6
     typedef uchar xslot;
 #else
     typedef u16 xslot;
 #endif
-    xslot nxhashslots[NRESTS];
-    xslot xhashslots[NRESTS][XFULL];
-    xslot *xx;
-    u32 n0;
-    u32 n1;
+    static const xslot xnil = ~0;
+    xslot xhashslots[NRESTS];
+    xslot nextxhashslot[NSLOTS];
+    xslot nextslot;
 #endif
     u32 s0;
 
@@ -392,109 +559,115 @@ struct equi {
 #ifdef XBITMAP
       memset(xhashmap, 0, NRESTS * sizeof(u64));
 #else
-      memset(nxhashslots, 0, NRESTS * sizeof(xslot));
+      memset(xhashslots, xnil, NRESTS * sizeof(xslot));
+      memset(nextxhashslot, xnil, NSLOTS * sizeof(xslot));
 #endif
     }
-    bool addslot(u32 s1, u32 xh) {
+    void addslot(u32 s1, u32 xh) {
 #ifdef XBITMAP
       xmap = xhashmap[xh];
       xhashmap[xh] |= (u64)1 << s1;
       s0 = -1;
-      return true;
 #else
-      n1 = (u32)nxhashslots[xh]++;
-      if (n1 >= XFULL)
-        return false;
-      xx = xhashslots[xh];
-      xx[n1] = s1;
-      n0 = 0;
-      return true;
+      nextslot = xhashslots[xh];
+      nextxhashslot[s1] = nextslot;
+      xhashslots[xh] = s1;
 #endif
     }
     bool nextcollision() const {
 #ifdef XBITMAP
       return xmap != 0;
 #else
-      return n0 < n1;
+      return nextslot != xnil;
 #endif
     }
     u32 slot() {
 #ifdef XBITMAP
       const u32 ffs = __builtin_ffsll(xmap);
       s0 += ffs; xmap >>= ffs;
-      return s0;
 #else
-      return (u32)xx[n0++];
+      nextslot = nextxhashslot[s0 = nextslot];
 #endif
+      return s0;
     }
   };
 
+#ifdef USE_TROMP_AVX2
+static const u32 BLAKESINPARALLEL = 4;
+#else
+static const u32 BLAKESINPARALLEL = 1;
+#endif
+// number of hashes extracted from BLAKESINPARALLEL blake2b outputs
+static const u32 HASHESPERBLOCK = BLAKESINPARALLEL*HASHESPERBLAKE;
+// number of blocks of parallel blake2b calls
+static const u32 NBLOCKS = (NHASHES+HASHESPERBLOCK-1)/HASHESPERBLOCK;
   void digit0(const u32 id) {
-    uchar hash[HASHOUT];
-    crypto_generichash_blake2b_state state;
     htlayout htl(this, 0);
     const u32 hashbytes = hashsize(0);
+    uchar hashes[BLAKESINPARALLEL * 64];
+    crypto_generichash_blake2b_state state0 = blake_ctx;  // local copy on stack can be copied faster
     for (u32 block = id; block < NBLOCKS; block += nthreads) {
-      state = blake_ctx;
+#ifdef USE_TROMP_AVX2
+      blake2bip_final(&state0, hashes, block);
+#else
+      crypto_generichash_blake2b_state state = state0;  // make another copy since blake2b_final modifies it
       u32 leb = htole32(block);
       crypto_generichash_blake2b_update(&state, (uchar *)&leb, sizeof(u32));
-      crypto_generichash_blake2b_final(&state, hash, HASHOUT);
-      for (u32 i = 0; i<HASHESPERBLAKE; i++) {
-        const uchar *ph = hash + i * WN/8;
-#if BUCKBITS == 16 && RESTBITS == 4
+      crypto_generichash_blake2b_final(&state, hashes, HASHOUT);
+#endif
+      for (u32 i = 0; i<BLAKESINPARALLEL; i++) {
+        for (u32 j = 0; j<HASHESPERBLAKE; j++) {
+          const uchar *ph = hashes + i * 64 + j * WN/8;
+          // figure out bucket for this hash by extracting leading BUCKBITS bits
+#if BUCKBITS == 12 && RESTBITS == 8
+          const u32 bucketid = ((u32)ph[0] << 4) | ph[1] >> 4;
+#elif BUCKBITS == 16 && RESTBITS == 4
         const u32 bucketid = ((u32)ph[0] << 8) | ph[1];
-#elif BUCKBITS == 12 && RESTBITS == 8
-        const u32 bucketid = ((u32)ph[0] << 4) | ph[1] >> 4;
-#elif BUCKBITS == 11 && RESTBITS == 9
-        const u32 bucketid = ((u32)ph[0] << 3) | ph[1] >> 5;
 #elif BUCKBITS == 20 && RESTBITS == 4
         const u32 bucketid = ((((u32)ph[0] << 8) | ph[1]) << 4) | ph[2] >> 4;
-#elif BUCKBITS == 12 && RESTBITS == 4
-        const u32 bucketid = ((u32)ph[0] << 4) | ph[1] >> 4;
-        const u32 xhash = ph[1] & 0xf;
 #else
 #error not implemented
 #endif
-        const u32 slot = getslot(0, bucketid);
+          // grab next available slot in that bucket
+          const u32 slot = getslot0(bucketid);
         if (slot >= NSLOTS) {
-          bfull++;
+            bfull++; // this actually never seems to happen in round 0 due to uniformity
           continue;
         }
-        slot0 &s = hta.trees0[0][bucketid][slot];
-        s.attr = tree(block * HASHESPERBLAKE + i);
-        memcpy(s.hash->bytes+htl.nextbo, ph+WN/8-hashbytes, hashbytes);
+          // location for slot's tag
+          htunit *s = hta.heap0[bucketid][slot] + htl.nexthtunits;
+          // hash should end right before tag
+          memcpy(s->bytes-hashbytes, ph+WN/8-hashbytes, hashbytes);
+          // round 0 tags store hash-generating index
+          s->tag = tree((block * BLAKESINPARALLEL + i) * HASHESPERBLAKE + j);
+        }
       }
     }
   }
-  
+
   void digitodd(const u32 r, const u32 id) {
     htlayout htl(this, r);
     collisiondata cd;
+    // threads process buckets in round-robin fashion
     for (u32 bucketid=id; bucketid < NBUCKETS; bucketid += nthreads) {
-      cd.clear();
-      slot0 *buck = htl.hta.trees0[(r-1)/2][bucketid]; // optimize by updating previous buck?!
-      u32 bsize = getnslots(r-1, bucketid);       // optimize by putting bucketsize with block?!
-      for (u32 s1 = 0; s1 < bsize; s1++) {
-        const slot0 *pslot1 = buck + s1;          // optimize by updating previous pslot1?!
-        if (!cd.addslot(s1, htl.getxhash0(pslot1))) {
-          xfull++;
-          continue;
-        }
+      cd.clear(); // could have made this the constructor, and declare here
+      slot0 *buck = htl.hta.heap0[bucketid]; // point to first slot of this bucket
+      u32 bsize   = getnslots0(bucketid);    // grab and reset bucket size
+      for (u32 s1 = 0; s1 < bsize; s1++) {   // loop over slots
+        const htunit *slot1 = buck[s1];
+        cd.addslot(s1, htl.getxhash0(slot1));// identify list of previous colliding slots 
         for (; cd.nextcollision(); ) {
           const u32 s0 = cd.slot();
-          const slot0 *pslot0 = buck + s0;
-          if (htl.equal(pslot0->hash, pslot1->hash)) {
-            hfull++;
+          const htunit *slot0 = buck[s0];
+          if (htl.equal(slot0, slot1)) {     // expect difference in last 32 bits unless duped
+            hfull++;                         // record discarding
             continue;
           }
-          u32 xorbucketid;
-          const uchar *bytes0 = pslot0->hash->bytes, *bytes1 = pslot1->hash->bytes;
+          u32 xorbucketid;                   // determine bucket for s0 xor s1
+          const uchar *bytes0 = slot0->bytes, *bytes1 = slot1->bytes;
 #if WN == 200 && BUCKBITS == 12 && RESTBITS == 8
           xorbucketid = (((u32)(bytes0[htl.prevbo+1] ^ bytes1[htl.prevbo+1]) & 0xf) << 8)
                              | (bytes0[htl.prevbo+2] ^ bytes1[htl.prevbo+2]);
-#elif WN == 200 && BUCKBITS == 11 && RESTBITS == 9
-          xorbucketid = (((u32)(bytes0[htl.prevbo+1] ^ bytes1[htl.prevbo+1]) & 0xf) << 7)
-                             | (bytes0[htl.prevbo+2] ^ bytes1[htl.prevbo+2]) >> 1;
 #elif WN == 144 && BUCKBITS == 20 && RESTBITS == 4
           xorbucketid = ((((u32)(bytes0[htl.prevbo+1] ^ bytes1[htl.prevbo+1]) << 8)
                               | (bytes0[htl.prevbo+2] ^ bytes1[htl.prevbo+2])) << 4)
@@ -505,48 +678,46 @@ struct equi {
 #else
 #error not implemented
 #endif
-          const u32 xorslot = getslot(r, xorbucketid);
+          // grab next available slot in that bucket
+          const u32 xorslot = getslot1(xorbucketid);
           if (xorslot >= NSLOTS) {
-            bfull++;
+            bfull++;    // SAVEMEM determines how often this happens
             continue;
           }
-          slot1 &xs = htl.hta.trees1[r/2][xorbucketid][xorslot];
-          xs.attr = tree(bucketid, s0, s1);
-          for (u32 i=htl.dunits; i < htl.prevhashunits; i++)
-            xs.hash[i-htl.dunits].word = pslot0->hash[i].word ^ pslot1->hash[i].word;
+          // start of slot for s0 ^ s1
+          htunit *xs = htl.hta.heap1[xorbucketid][xorslot];
+          // store xor of hashes possibly minus initial 0 word due to collision
+          for (u32 i=htl.dunits; i < htl.prevhtunits; i++)
+            xs++->word = slot0[i].word ^ slot1[i].word;
+          // store tree node right after hash
+          xs->tag = tree(bucketid, s0, s1);
         }
       }
     }
   }
-  
+
   void digiteven(const u32 r, const u32 id) {
     htlayout htl(this, r);
     collisiondata cd;
     for (u32 bucketid=id; bucketid < NBUCKETS; bucketid += nthreads) {
       cd.clear();
-      slot1 *buck = htl.hta.trees1[(r-1)/2][bucketid]; // OPTIMIZE BY UPDATING PREVIOUS
-      u32 bsize = getnslots(r-1, bucketid);
+      slot1 *buck = htl.hta.heap1[bucketid];
+      u32 bsize   = getnslots1(bucketid);
       for (u32 s1 = 0; s1 < bsize; s1++) {
-        const slot1 *pslot1 = buck + s1;          // OPTIMIZE BY UPDATING PREVIOUS
-        if (!cd.addslot(s1, htl.getxhash1(pslot1))) {
-          xfull++;
-          continue;
-        }
+        const htunit *slot1 = buck[s1];
+        cd.addslot(s1, htl.getxhash1(slot1));
         for (; cd.nextcollision(); ) {
           const u32 s0 = cd.slot();
-          const slot1 *pslot0 = buck + s0;
-          if (htl.equal(pslot0->hash, pslot1->hash)) {
+          const htunit *slot0 = buck[s0];
+          if (htl.equal(slot0, slot1)) {
             hfull++;
             continue;
           }
           u32 xorbucketid;
-          const uchar *bytes0 = pslot0->hash->bytes, *bytes1 = pslot1->hash->bytes;
+          const uchar *bytes0 = slot0->bytes, *bytes1 = slot1->bytes;
 #if WN == 200 && BUCKBITS == 12 && RESTBITS == 8
           xorbucketid = ((u32)(bytes0[htl.prevbo+1] ^ bytes1[htl.prevbo+1]) << 4)
                             | (bytes0[htl.prevbo+2] ^ bytes1[htl.prevbo+2]) >> 4;
-#elif WN == 200 && BUCKBITS == 11 && RESTBITS == 9
-          xorbucketid = ((u32)(bytes0[htl.prevbo+2] ^ bytes1[htl.prevbo+2]) << 3)
-                            | (bytes0[htl.prevbo+3] ^ bytes1[htl.prevbo+3]) >> 5;
 #elif WN == 144 && BUCKBITS == 20 && RESTBITS == 4
           xorbucketid = ((((u32)(bytes0[htl.prevbo+1] ^ bytes1[htl.prevbo+1]) << 8)
                               | (bytes0[htl.prevbo+2] ^ bytes1[htl.prevbo+2])) << 4)
@@ -557,40 +728,305 @@ struct equi {
 #else
 #error not implemented
 #endif
-          const u32 xorslot = getslot(r, xorbucketid);
+          const u32 xorslot = getslot0(xorbucketid);
           if (xorslot >= NSLOTS) {
             bfull++;
             continue;
           }
-          slot0 &xs = htl.hta.trees0[r/2][xorbucketid][xorslot];
-          xs.attr = tree(bucketid, s0, s1);
-          for (u32 i=htl.dunits; i < htl.prevhashunits; i++)
-            xs.hash[i-htl.dunits].word = pslot0->hash[i].word ^ pslot1->hash[i].word;
+          htunit *xs = htl.hta.heap0[xorbucketid][xorslot];
+          for (u32 i=htl.dunits; i < htl.prevhtunits; i++)
+            xs++->word = slot0[i].word ^ slot1[i].word;
+          xs->tag = tree(bucketid, s0, s1);
         }
       }
     }
   }
-  
+
+  // functions digit1 through digit9 are unrolled versions specific to the
+  // (N=200,K=9) parameters with 8 RESTBITS
+  // and will be used with compile option -DEQUIHASH_TROMP_UNROLL
+  void digit1(const u32 id) {
+    htalloc heaps = hta;
+    collisiondata cd;
+    for (u32 bucketid=id; bucketid < NBUCKETS; bucketid += nthreads) {
+      cd.clear();
+      slot0 *buck = heaps.heap0[bucketid];
+      u32 bsize   = getnslots0(bucketid);
+      for (u32 s1 = 0; s1 < bsize; s1++) {
+        const htunit *slot1 = buck[s1];
+        cd.addslot(s1, htobe32(slot1->word) >> 20 & 0xff);
+        for (; cd.nextcollision(); ) {
+          const u32 s0 = cd.slot();
+          const htunit *slot0 = buck[s0];
+          if (slot0[5].word == slot1[5].word) {
+            hfull++;
+            continue;
+          }
+          u32 xorbucketid = htobe32(slot0->word ^ slot1->word) >> 8 & BUCKMASK;
+          const u32 xorslot = getslot1(xorbucketid);
+          if (xorslot >= NSLOTS) {
+            bfull++;
+            continue;
+          }
+          u64 *x  = (u64 *)heaps.heap1[xorbucketid][xorslot];
+          u64 *x0 = (u64 *)slot0, *x1 = (u64 *)slot1;
+          *x++ = x0[0] ^ x1[0];
+          *x++ = x0[1] ^ x1[1];
+          *x++ = x0[2] ^ x1[2];
+          ((htunit *)x)->tag = tree(bucketid, s0, s1);
+        }
+      }
+    }
+  }
+  void digit2(const u32 id) {
+    htalloc heaps = hta;
+    collisiondata cd;
+    for (u32 bucketid=id; bucketid < NBUCKETS; bucketid += nthreads) {
+      cd.clear();
+      slot1 *buck = heaps.heap1[bucketid];
+      u32 bsize   = getnslots1(bucketid);
+      for (u32 s1 = 0; s1 < bsize; s1++) {
+        const htunit *slot1 = buck[s1];
+        cd.addslot(s1, slot1->bytes[3]);
+        for (; cd.nextcollision(); ) {
+          const u32 s0 = cd.slot();
+          const htunit *slot0 = buck[s0];
+          if (slot0[5].word == slot1[5].word) {
+            hfull++;
+            continue;
+          }
+          u32 xorbucketid = htobe32(slot0[1].word ^ slot1[1].word) >> 20;
+          const u32 xorslot = getslot0(xorbucketid);
+          if (xorslot >= NSLOTS) {
+            bfull++;
+            continue;
+          }
+          htunit *xs = heaps.heap0[xorbucketid][xorslot];
+          xs++->word = slot0[1].word ^ slot1[1].word;
+          u64 *x = (u64 *)xs, *x0 = (u64 *)slot0, *x1 = (u64 *)slot1;
+          *x++ = x0[1] ^ x1[1];
+          *x++ = x0[2] ^ x1[2];
+          ((htunit *)x)->tag = tree(bucketid, s0, s1);
+        }
+      }
+    }
+  }
+  void digit3(const u32 id) {
+    htalloc heaps = hta;
+    collisiondata cd;
+    for (u32 bucketid=id; bucketid < NBUCKETS; bucketid += nthreads) {
+      cd.clear();
+      slot0 *buck = heaps.heap0[bucketid];
+      u32 bsize   = getnslots0(bucketid);
+      for (u32 s1 = 0; s1 < bsize; s1++) {
+        const htunit *slot1 = buck[s1];
+        cd.addslot(s1, htobe32(slot1->word) >> 12 & 0xff);
+        for (; cd.nextcollision(); ) {
+          const u32 s0 = cd.slot();
+          const htunit *slot0 = buck[s0];
+          if (slot0[4].word == slot1[4].word) {
+            hfull++;
+            continue;
+          }
+          u32 xorbucketid = htobe32(slot0[0].word ^ slot1[0].word) & BUCKMASK;
+          const u32 xorslot = getslot1(xorbucketid);
+          if (xorslot >= NSLOTS) {
+            bfull++;
+            continue;
+          }
+          u64 *x  = (u64 *)heaps.heap1[xorbucketid][xorslot];
+          u64 *x0 = (u64 *)(slot0+1), *x1 = (u64 *)(slot1+1);
+          *x++ = x0[0] ^ x1[0];
+          *x++ = x0[1] ^ x1[1];
+          ((htunit *)x)->tag = tree(bucketid, s0, s1);
+        }
+      }
+    }
+  }
+  void digit4(const u32 id) {
+    htalloc heaps = hta;
+    collisiondata cd;
+    for (u32 bucketid=id; bucketid < NBUCKETS; bucketid += nthreads) {
+      cd.clear();
+      slot1 *buck = heaps.heap1[bucketid];
+      u32 bsize   = getnslots1(bucketid);
+      for (u32 s1 = 0; s1 < bsize; s1++) {
+        const htunit *slot1 = buck[s1];
+        cd.addslot(s1, slot1->bytes[0]);
+        for (; cd.nextcollision(); ) {
+          const u32 s0 = cd.slot();
+          const htunit *slot0 = buck[s0];
+          if (slot0[3].word == slot1[3].word) {
+            hfull++;
+            continue;
+          }
+          u32 xorbucketid = htobe32(slot0[0].word ^ slot1[0].word) >> 12 & BUCKMASK;
+          const u32 xorslot = getslot0(xorbucketid);
+          if (xorslot >= NSLOTS) {
+            bfull++;
+            continue;
+          }
+          u64 *x  = (u64 *)heaps.heap0[xorbucketid][xorslot];
+          u64 *x0 = (u64 *)slot0, *x1 = (u64 *)slot1;
+          *x++ = x0[0] ^ x1[0];
+          *x++ = x0[1] ^ x1[1];
+          ((htunit *)x)->tag = tree(bucketid, s0, s1);
+        }
+      }
+    }
+  }
+  void digit5(const u32 id) {
+    htalloc heaps = hta;
+    collisiondata cd;
+    for (u32 bucketid=id; bucketid < NBUCKETS; bucketid += nthreads) {
+      cd.clear();
+      slot0 *buck = heaps.heap0[bucketid];
+      u32 bsize   = getnslots0(bucketid);
+      for (u32 s1 = 0; s1 < bsize; s1++) {
+        const htunit *slot1 = buck[s1];
+        cd.addslot(s1, htobe32(slot1->word) >> 4 & 0xff);
+        for (; cd.nextcollision(); ) {
+          const u32 s0 = cd.slot();
+          const htunit *slot0 = buck[s0];
+          if (slot0[3].word == slot1[3].word) {
+            hfull++;
+            continue;
+          }
+          u32 xor1 = slot0[1].word ^ slot1[1].word;
+          u32 xorbucketid = (((u32)(slot0->bytes[3] ^ slot1->bytes[3]) & 0xf)
+                               << 8) | (xor1 & 0xff);
+          const u32 xorslot = getslot1(xorbucketid);
+          if (xorslot >= NSLOTS) {
+            bfull++;
+            continue;
+          }
+          htunit *xs = heaps.heap1[xorbucketid][xorslot];
+          xs++->word = xor1;
+          u64 *x = (u64 *)xs, *x0 = (u64 *)slot0, *x1 = (u64 *)slot1;
+          *x++ = x0[1] ^ x1[1];
+          ((htunit *)x)->tag = tree(bucketid, s0, s1);
+        }
+      }
+    }
+  }
+  void digit6(const u32 id) {
+    htalloc heaps = hta;
+    collisiondata cd;
+    for (u32 bucketid=id; bucketid < NBUCKETS; bucketid += nthreads) {
+      cd.clear();
+      slot1 *buck = heaps.heap1[bucketid];
+      u32 bsize   = getnslots1(bucketid);
+      for (u32 s1 = 0; s1 < bsize; s1++) {
+        const htunit *slot1 = buck[s1];
+        cd.addslot(s1, slot1->bytes[1]);
+        for (; cd.nextcollision(); ) {
+          const u32 s0 = cd.slot();
+          const htunit *slot0 = buck[s0];
+          if (slot0[2].word == slot1[2].word) {
+            hfull++;
+            continue;
+          }
+          u32 xorbucketid = htobe32(slot0[0].word ^ slot1[0].word) >> 4 & BUCKMASK;
+          const u32 xorslot = getslot0(xorbucketid);
+          if (xorslot >= NSLOTS) {
+            bfull++;
+            continue;
+          }
+          htunit *xs = heaps.heap0[xorbucketid][xorslot];
+          xs++->word = slot0[0].word ^ slot1[0].word;
+          u64 *x = (u64 *)xs, *x0 = (u64 *)(slot0+1), *x1 = (u64 *)(slot1+1);
+          *x++ = x0[0] ^ x1[0];
+          ((htunit *)x)->tag = tree(bucketid, s0, s1);
+        }
+      }
+    }
+  }
+  void digit7(const u32 id) {
+    htalloc heaps = hta;
+    collisiondata cd;
+    for (u32 bucketid=id; bucketid < NBUCKETS; bucketid += nthreads) {
+      cd.clear();
+      slot0 *buck = heaps.heap0[bucketid];
+      u32 bsize   = getnslots0(bucketid);
+      for (u32 s1 = 0; s1 < bsize; s1++) {
+        const htunit *slot1 = buck[s1];
+        cd.addslot(s1, (slot1->bytes[3] & 0xf) << 4 | slot1->bytes[4] >> 4);
+        for (; cd.nextcollision(); ) {
+          const u32 s0 = cd.slot();
+          const htunit *slot0 = buck[s0];
+          if (slot0[2].word == slot1[2].word) {
+            hfull++;
+            continue;
+          }
+          u32 xorbucketid = htobe32(slot0[1].word ^ slot1[1].word) >> 16 & BUCKMASK;
+          const u32 xorslot = getslot1(xorbucketid);
+          if (xorslot >= NSLOTS) {
+            bfull++;
+            continue;
+          }
+          u64 *x  = (u64 *)heaps.heap1[xorbucketid][xorslot];
+          u64 *x0 = (u64 *)(slot0+1), *x1 = (u64 *)(slot1+1);
+          *x++ = x0[0] ^ x1[0];
+          ((htunit *)x)->tag = tree(bucketid, s0, s1);
+        }
+      }
+    }
+  }
+  void digit8(const u32 id) {
+    htalloc heaps = hta;
+    collisiondata cd;
+    for (u32 bucketid=id; bucketid < NBUCKETS; bucketid += nthreads) {
+      cd.clear();
+      slot1 *buck = heaps.heap1[bucketid];
+      u32 bsize   = getnslots1(bucketid);
+      for (u32 s1 = 0; s1 < bsize; s1++) {
+        const htunit *slot1 = buck[s1];
+        cd.addslot(s1, slot1->bytes[2]);
+        for (; cd.nextcollision(); ) {
+          const u32 s0 = cd.slot();
+          const htunit *slot0 = buck[s0];
+          u32 xor1 = slot0[1].word ^ slot1[1].word;
+          if (!xor1) {
+            hfull++;
+            continue;
+          }
+          u32 xorbucketid = ((u32)(slot0->bytes[3] ^ slot1->bytes[3]) << 4)
+                          | (xor1 >> 4 & 0xf);
+          const u32 xorslot = getslot0(xorbucketid);
+          if (xorslot >= NSLOTS) {
+            bfull++;
+            continue;
+          }
+          htunit *xs = heaps.heap0[xorbucketid][xorslot];
+          xs++->word = xor1;
+          xs->tag = tree(bucketid, s0, s1);
+        }
+      }
+    }
+  }
+
+  // final round looks simpler
   void digitK(const u32 id) {
     collisiondata cd;
     htlayout htl(this, WK);
 u32 nc = 0;
     for (u32 bucketid = id; bucketid < NBUCKETS; bucketid += nthreads) {
       cd.clear();
-      slot0 *buck = htl.hta.trees0[(WK-1)/2][bucketid];
-      u32 bsize = getnslots(WK-1, bucketid);
+      slot0 *buck = htl.hta.heap0[bucketid];
+      u32 bsize   = getnslots0(bucketid);
       for (u32 s1 = 0; s1 < bsize; s1++) {
-        const slot0 *pslot1 = buck + s1;
-        if (!cd.addslot(s1, htl.getxhash0(pslot1))) // assume WK odd
-          continue;
+        const htunit *slot1 = buck[s1];
+        cd.addslot(s1, htl.getxhash0(slot1)); // assume WK odd
         for (; cd.nextcollision(); ) {
           const u32 s0 = cd.slot();
-          if (htl.equal(buck[s0].hash, pslot1->hash))
-nc++,       candidate(tree(bucketid, s0, s1));
+          if (htl.equal(buck[s0], slot1)) {    // there is only 1 word of hash left
+            candidate(tree(bucketid, s0, s1)); // so a match gives a solution candidate
+            nc++;
         }
       }
     }
-//printf(" %d candidates ", nc);
+    }
+//    printf(" %d candidates ", nc);  // this gets uncommented a lot for debugging
   }
 };
 
@@ -608,37 +1044,63 @@ void barrier(pthread_barrier_t *barry) {
   }
 }
 
+// do all rounds for each thread
 void *worker(void *vp) {
   thread_ctx *tp = (thread_ctx *)vp;
   equi *eq = tp->eq;
 
-  if (tp->id == 0)
-//    printf("Digit 0\n");
-  barrier(&eq->barry);
+//  if (tp->id == 0) printf("Digit 0");
   eq->digit0(tp->id);
   barrier(&eq->barry);
-  if (tp->id == 0) {
-    eq->xfull = eq->bfull = eq->hfull = 0;
-    eq->showbsizes(0);
-  }
+  if (tp->id == 0) eq->showbsizes(0);
   barrier(&eq->barry);
+#if WN == 200 && WK == 9 && RESTBITS == 8 && defined EQUIHASH_TROMP_UNROLL
+  eq->digit1(tp->id);
+  barrier(&eq->barry);
+  if (tp->id == 0) eq->showbsizes(1);
+  barrier(&eq->barry);
+  eq->digit2(tp->id);
+  barrier(&eq->barry);
+  if (tp->id == 0) eq->showbsizes(2);
+  barrier(&eq->barry);
+  eq->digit3(tp->id);
+  barrier(&eq->barry);
+  if (tp->id == 0) eq->showbsizes(3);
+  barrier(&eq->barry);
+  eq->digit4(tp->id);
+  barrier(&eq->barry);
+  if (tp->id == 0) eq->showbsizes(4);
+  barrier(&eq->barry);
+  eq->digit5(tp->id);
+  barrier(&eq->barry);
+  if (tp->id == 0) eq->showbsizes(5);
+  barrier(&eq->barry);
+  eq->digit6(tp->id);
+  barrier(&eq->barry);
+  if (tp->id == 0) eq->showbsizes(6);
+  barrier(&eq->barry);
+  eq->digit7(tp->id);
+  barrier(&eq->barry);
+  if (tp->id == 0) eq->showbsizes(7);
+  barrier(&eq->barry);
+  eq->digit8(tp->id);
+  barrier(&eq->barry);
+  if (tp->id == 0) eq->showbsizes(8);
+  barrier(&eq->barry);
+#else
   for (u32 r = 1; r < WK; r++) {
-    if (tp->id == 0)
-//      printf("Digit %d", r);
-    barrier(&eq->barry);
     r&1 ? eq->digitodd(r, tp->id) : eq->digiteven(r, tp->id);
     barrier(&eq->barry);
-    if (tp->id == 0) {
-//      printf(" x%d b%d h%d\n", eq->xfull, eq->bfull, eq->hfull);
-      eq->xfull = eq->bfull = eq->hfull = 0;
-      eq->showbsizes(r);
-    }
+    if (tp->id == 0) eq->showbsizes(r);
     barrier(&eq->barry);
   }
-  if (tp->id == 0)
-//    printf("Digit %d\n", WK);
+#endif
   eq->digitK(tp->id);
-  barrier(&eq->barry);
   pthread_exit(NULL);
   return 0;
 }
+
+#if defined(__GNUC__) && !defined(__ICC)
+#pragma GCC pop_options
+#endif
+


### PR DESCRIPTION
This is the update to zcash's current Tromp's equihash solver updated to Tromp's current version from https://github.com/tromp/equihash.
It already contains Tomp's AVX2 blake2 optimization. In order to test/run/use the AVX2 optimization too, the easiest way to patch zcutil/build.sh with:
```
diff --git a/zcutil/build.sh b/zcutil/build.sh
index 0000c62..f8ddd57 100755
--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -37,5 +37,5 @@ PREFIX="$(pwd)/depends/x86_64-unknown-linux-gnu/"
 
 HOST=x86_64-unknown-linux-gnu BUILD=x86_64-unknown-linux-gnu make "$@" -C ./depends/ V=1 NO_QT=1
 ./autogen.sh
-./configure --prefix="${PREFIX}" --host=x86_64-unknown-linux-gnu --build=x86_64-unknown-linux-gnu --with-gui=no "$HARDENING_ARG" "$LCOV_ARG" CXXFLAGS='-fwrapv -fno-strict-aliasing -Werror -g'
+./configure --prefix="${PREFIX}" --host=x86_64-unknown-linux-gnu --build=x86_64-unknown-linux-gnu --with-gui=no "$HARDENING_ARG" "$LCOV_ARG" CXXFLAGS='-fwrapv -fno-strict-aliasing -Werror -g' --enable-tromp-avx2=yes
 make "$@" V=1
```

The original PR has many problem (wrong branch and accidentally merged and reverted checkis etc), but this was the original PR:
https://github.com/zcash/zcash/pull/1788
for the reference with discussions.