### PR TITLE
Add Dockerfile with instructions from README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:latest
+MAINTAINER alexellis2@gmail.com
+
+RUN apt-get update -q && apt-get -qy install \
+      build-essential pkg-config libc6-dev m4 g++-multilib \
+            autoconf libtool ncurses-dev unzip git python \
+                  zlib1g-dev wget bsdmainutils automake
+
+WORKDIR /root/
+RUN git clone https://github.com/zcash/zcash.git
+WORKDIR /root/zcash/
+RUN git checkout v1.0.0-rc4
+RUN ./zcutil/fetch-params.sh
+
+RUN ./zcutil/build.sh -j$(nproc)


### PR DESCRIPTION
Adding Dockerfile to go with tutorial published and shared by Docker inc - already has 126 pulls.

http://blog.alexellis.io/mine-zcash-with-docker/

This makes building and running extremely easy whatever the platform and uses the official instructions. 