### PR TITLE
Partial revert to clean up PR #1859

### DIFF
--- a/doc/release-notes/release-notes-1.0.2.md
+++ b/doc/release-notes/release-notes-1.0.2.md
@@ -5,12 +5,12 @@ ITH4Coinomia (2):
 S. Matthew English (1):
       enforcing consistency 'tor' to 'Tor'
 
-Sean Bowe (2):
+Sean Bowe (1):
       Write R1CS output to file in GenerateParams.
-      1.0.2 release.
 
-Simon Liu (4):
+Simon (4):
       Fixes #1762 segfault when miner is interrupted.
       Fixes #1779 so that sending to multiple zaddrs no longer fails.
       Add GenIdentity, an identity function for MappedShuffle.
       Add transaction size and zaddr output limit checks to z_sendmany.
+


### PR DESCRIPTION
Some documentation files were updated when the PR should only have added the new tool `zcutil/release-notes.py` and `doc/authors.md`.  This PR reverts and cherry-picks the correct file to merge.