### PR TITLE
Anchors and nullifiers should always be inherited from the parent cache.

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -303,16 +303,12 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins,
             CAnchorsMap::iterator parent_it = cacheAnchors.find(child_it->first);
 
             if (parent_it == cacheAnchors.end()) {
-                if (child_it->second.entered) {
-                    // Parent doesn't have an entry, but child has a new commitment root.
+                CAnchorsCacheEntry& entry = cacheAnchors[child_it->first];
+                entry.entered = child_it->second.entered;
+                entry.tree = child_it->second.tree;
+                entry.flags = CAnchorsCacheEntry::DIRTY;
 
-                    CAnchorsCacheEntry& entry = cacheAnchors[child_it->first];
-                    entry.entered = true;
-                    entry.tree = child_it->second.tree;
-                    entry.flags = CAnchorsCacheEntry::DIRTY;
-
-                    cachedCoinsUsage += memusage::DynamicUsage(entry.tree);
-                }
+                cachedCoinsUsage += memusage::DynamicUsage(entry.tree);
             } else {
                 if (parent_it->second.entered != child_it->second.entered) {
                     // The parent may have removed the entry.
@@ -332,14 +328,9 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins,
             CNullifiersMap::iterator parent_it = cacheNullifiers.find(child_it->first);
 
             if (parent_it == cacheNullifiers.end()) {
-                if (child_it->second.entered) {
-                    // Parent doesn't have an entry, but child has a SPENT nullifier.
-                    // Move the spent nullifier up.
-
-                    CNullifiersCacheEntry& entry = cacheNullifiers[child_it->first];
-                    entry.entered = true;
-                    entry.flags = CNullifiersCacheEntry::DIRTY;
-                }
+                CNullifiersCacheEntry& entry = cacheNullifiers[child_it->first];
+                entry.entered = child_it->second.entered;
+                entry.flags = CNullifiersCacheEntry::DIRTY;
             } else {
                 if (parent_it->second.entered != child_it->second.entered) {
                     parent_it->second.entered = child_it->second.entered;

--- a/src/zcash/JoinSplit.cpp
+++ b/src/zcash/JoinSplit.cpp
@@ -5,6 +5,7 @@
 #include "zcash/util.h"
 
 #include <memory>
+#include <mutex>
 
 #include <boost/foreach.hpp>
 #include <boost/format.hpp>
@@ -24,8 +25,9 @@ namespace libzcash {
 
 #include "zcash/circuit/gadget.tcc"
 
+std::once_flag init_public_params_once_flag;
+
 CCriticalSection cs_ParamsIO;
-CCriticalSection cs_InitializeParams;
 CCriticalSection cs_LoadKeys;
 
 template<typename T>
@@ -79,9 +81,7 @@ public:
     ~JoinSplitCircuit() {}
 
     static void initialize() {
-        LOCK(cs_InitializeParams);
-
-        ppzksnark_ppT::init_public_params();
+        std::call_once (init_public_params_once_flag, ppzksnark_ppT::init_public_params);
     }
 
     void setProvingKeyPath(std::string path) {


### PR DESCRIPTION
The `CoinsCache` abstraction, during flushing to its base cache, did not remove nullifiers or anchors from the base cache that were not brought into the base cache from a backing store (the transaction database on disk).

Closes #1769.