### PR TITLE
Fix sha256sum on busybox

### DIFF
--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -28,7 +28,7 @@ function fetch_params {
             --retry-connrefused --waitretry=3 --timeout=30 \
             "$url"
 
-        "$SHA256CMD" $SHA256ARGS --check <<EOF
+        "$SHA256CMD" $SHA256ARGS -c <<EOF
 $expectedhash  $dlname
 EOF
 


### PR DESCRIPTION
Busybox's version of `sha256sum` doesn't support `--check` parameter

```
/usr/bin/sha256sum: unrecognized option: check
BusyBox v1.24.2 (2016-08-12 14:38:34 GMT) multi-call binary.

Usage: sha256sum [-c[sw]] [FILE]...

Print or check SHA256 checksums

	-c	Check sums against list in FILEs
	-s	Don't output anything, status code shows success
	-w	Warn about improperly formatted checksum lines
The command '/bin/sh -c ./zcutil/fetch-params.sh' returned a non-zero code: 1```