### PR TITLE
Apply MiniUPnP patches to enable compilation on Solaris 11

### DIFF
--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -3,6 +3,7 @@ $(package)_version=2.0
 $(package)_download_path=http://miniupnp.free.fr/files
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=d434ceb8986efbe199c5ca53f90ed53eab290b1e6d0530b717eb6fa49d61f93b
+$(package)_patches=fix-solaris-compilation.patch strlen-before-memcmp.patch
 
 define $(package)_set_vars
 $(package)_build_opts=CC="$($(package)_cc)"
@@ -14,7 +15,9 @@ endef
 define $(package)_preprocess_cmds
   mkdir dll && \
   sed -e 's|MINIUPNPC_VERSION_STRING \"version\"|MINIUPNPC_VERSION_STRING \"$($(package)_version)\"|' -e 's|OS/version|$(host)|' miniupnpcstrings.h.in > miniupnpcstrings.h && \
-  sed -i.old "s|miniupnpcstrings.h: miniupnpcstrings.h.in wingenminiupnpcstrings|miniupnpcstrings.h: miniupnpcstrings.h.in|" Makefile.mingw
+  sed -i.old "s|miniupnpcstrings.h: miniupnpcstrings.h.in wingenminiupnpcstrings|miniupnpcstrings.h: miniupnpcstrings.h.in|" Makefile.mingw && \
+  patch -p2 < $($(package)_patch_dir)/fix-solaris-compilation.patch && \
+  patch -p2 < $($(package)_patch_dir)/strlen-before-memcmp.patch
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -3,7 +3,7 @@ $(package)_version=2.0
 $(package)_download_path=http://miniupnp.free.fr/files
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=d434ceb8986efbe199c5ca53f90ed53eab290b1e6d0530b717eb6fa49d61f93b
-$(package)_patches=fix-solaris-compilation.patch strlen-before-memcmp.patch
+$(package)_patches=fix-solaris-compilation.patch strlen-before-memcmp.patch patch-strlen-patch.patch
 
 define $(package)_set_vars
 $(package)_build_opts=CC="$($(package)_cc)"
@@ -17,7 +17,8 @@ define $(package)_preprocess_cmds
   sed -e 's|MINIUPNPC_VERSION_STRING \"version\"|MINIUPNPC_VERSION_STRING \"$($(package)_version)\"|' -e 's|OS/version|$(host)|' miniupnpcstrings.h.in > miniupnpcstrings.h && \
   sed -i.old "s|miniupnpcstrings.h: miniupnpcstrings.h.in wingenminiupnpcstrings|miniupnpcstrings.h: miniupnpcstrings.h.in|" Makefile.mingw && \
   patch -p2 < $($(package)_patch_dir)/fix-solaris-compilation.patch && \
-  patch -p2 < $($(package)_patch_dir)/strlen-before-memcmp.patch
+  patch -p2 < $($(package)_patch_dir)/strlen-before-memcmp.patch && \
+  patch -p2 < $($(package)_patch_dir)/patch-strlen-patch.patch
 endef
 
 define $(package)_build_cmds

--- a/depends/patches/miniupnpc/fix-solaris-compilation.patch
+++ b/depends/patches/miniupnpc/fix-solaris-compilation.patch
@@ -1,0 +1,42 @@
+From 71ce1d6dfa5424f8fe8633e23494c7638ea2c79e Mon Sep 17 00:00:00 2001
+From: Thomas Bernard <miniupnp@free.fr>
+Date: Thu, 10 Nov 2016 21:55:33 +0100
+Subject: [PATCH] fix for Solaris 11 compilation
+
+see #216
+---
+ miniupnpc/Makefile    | 2 ++
+ miniupnpc/minissdpc.c | 3 +++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/miniupnpc/Makefile b/miniupnpc/Makefile
+index 5c23000..72cdc0f 100644
+--- a/miniupnpc/Makefile
++++ b/miniupnpc/Makefile
+@@ -43,10 +43,12 @@ CFLAGS += -D_NETBSD_SOURCE
+ endif
+ ifneq ($(OS), FreeBSD)
+ ifneq ($(OS), Darwin)
++ifneq ($(OS), SunOS)
+ #CFLAGS += -D_POSIX_C_SOURCE=200112L
+ CFLAGS += -D_XOPEN_SOURCE=600
+ endif
+ endif
++endif
+ #CFLAGS += -ansi
+ # -DNO_GETADDRINFO
+ INSTALL = install
+diff --git a/miniupnpc/minissdpc.c b/miniupnpc/minissdpc.c
+index f200f07..263160e 100644
+--- a/miniupnpc/minissdpc.c
++++ b/miniupnpc/minissdpc.c
+@@ -73,6 +73,9 @@ struct sockaddr_un {
+ 
+ #if !defined(HAS_IP_MREQN) && !defined(_WIN32)
+ #include <sys/ioctl.h>
++#if defined(__sun)
++#include <sys/sockio.h>
++#endif
+ #endif
+ 
+ #if defined(HAS_IP_MREQN) && defined(NEED_STRUCT_IP_MREQN)

--- a/depends/patches/miniupnpc/patch-strlen-patch.patch
+++ b/depends/patches/miniupnpc/patch-strlen-patch.patch
@@ -1,0 +1,22 @@
+From 0aa7c46227acd8ddb135c577674ad454bf2fba86 Mon Sep 17 00:00:00 2001
+From: Thomas Bernard <miniupnp@free.fr>
+Date: Fri, 11 Nov 2016 17:53:21 +0100
+Subject: [PATCH] remove unsigned/signed comparison
+
+---
+ miniupnpc/portlistingparse.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/miniupnpc/portlistingparse.c b/miniupnpc/portlistingparse.c
+index 1bed763..07f3f87 100644
+--- a/miniupnpc/portlistingparse.c
++++ b/miniupnpc/portlistingparse.c
+@@ -55,7 +55,7 @@ startelt(void * d, const char * name, int l)
+ 	pdata->curelt = PortMappingEltNone;
+ 	for(i = 0; elements[i].str; i++)
+ 	{
+-		if(strlen(elements[i].str) == l && memcmp(name, elements[i].str, l) == 0)
++		if(strlen(elements[i].str) == (size_t)l && memcmp(name, elements[i].str, l) == 0)
+ 		{
+ 			pdata->curelt = elements[i].code;
+ 			break;

--- a/depends/patches/miniupnpc/strlen-before-memcmp.patch
+++ b/depends/patches/miniupnpc/strlen-before-memcmp.patch
@@ -1,0 +1,23 @@
+From ec1c49bb0cd5e448e6f0adee7de3a831c4869bdd Mon Sep 17 00:00:00 2001
+From: Thomas Bernard <miniupnp@free.fr>
+Date: Fri, 11 Nov 2016 17:24:39 +0100
+Subject: [PATCH] check strlen before memcmp
+
+1st try to fix #220
+---
+ miniupnpc/portlistingparse.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/miniupnpc/portlistingparse.c b/miniupnpc/portlistingparse.c
+index 0e09278..1bed763 100644
+--- a/miniupnpc/portlistingparse.c
++++ b/miniupnpc/portlistingparse.c
+@@ -55,7 +55,7 @@ startelt(void * d, const char * name, int l)
+ 	pdata->curelt = PortMappingEltNone;
+ 	for(i = 0; elements[i].str; i++)
+ 	{
+-		if(memcmp(name, elements[i].str, l) == 0)
++		if(strlen(elements[i].str) == l && memcmp(name, elements[i].str, l) == 0)
+ 		{
+ 			pdata->curelt = elements[i].code;
+ 			break;


### PR DESCRIPTION
These can be removed after the next MiniUPnP release.

Closes #1835.