### PR TITLE
Edit for grammar: "block chain"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ in our [Protocol Specification](https://github.com/zcash/zips/raw/master/protoco
 This software is the Zcash client. It downloads and stores the entire history
 of Zcash transactions; depending on the speed of your computer and network
 connection, the synchronization process could take a day or more once the
-block chain has reached a significant size.
+blockchain has reached a significant size.
 
 Security Warnings
 -----------------


### PR DESCRIPTION
At this point, I believe it is universally accepted that "blockchain" is one word, and should not be separated into two.