### PR TITLE
Additional well-formedness check for G2 elements

### DIFF
--- a/src/zcash/Proof.cpp
+++ b/src/zcash/Proof.cpp
@@ -163,6 +163,10 @@ curve_G2 CompressedG2::to_libsnark_g2() const
 
     assert(r.is_well_formed());
 
+    if (alt_bn128_modulus_r * r != curve_G2::zero()) {
+        throw std::runtime_error("point is not in G2");
+    }
+
     return r;
 }
 


### PR DESCRIPTION
libsnark currently checks that G<sub>1</sub> and G<sub>2</sub> elements are well-formed by ensuring that they satisfy their respective curve equations, and although this is enough for G<sub>1</sub> (which is instantiated as an order r curve E/F<sub>p</sub>: y^2 = x^3 + b), G<sub>2</sub> is the order r *subgroup* of the composite order r(2q-r) curve E'/Fp<sup>2</sup>: y^2 = x^3 + b/e constructed via a sextic twisting isomorphism. This means we need to ensure these points are order r as well.

None of the proofs on the Zcash blockchain violate this check, and it may not even be possible for them to violate this check (bilinearity is not preserved). Let's be cautious and do it anyway.