### PR TITLE
Only increment new notes on reindex

### DIFF
--- a/doc/payment-api.md
+++ b/doc/payment-api.md
@@ -151,7 +151,7 @@ RPC_WALLET_ERROR (-4) | _Unspecified problem with wallet_
 ----------------------| -------------------------------------
 "Could not find previous JoinSplit anchor" | Try restarting node with `-reindex`.
 "Error decrypting output note of previous JoinSplit: __"  |
-"Could not find witness for note commitment" | Try restarting node with `-reindex`.
+"Could not find witness for note commitment" | Try restarting node with `-rescan`.
 "Witness for note commitment is null" | Missing witness for note commitement.
 "Witness for spendable note does not have same anchor as change input" | Invalid anchor for spendable note witness.
 "Not enough funds to pay miners fee" | Retry with sufficient funds.

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -51,7 +51,7 @@ public:
 
     void IncrementNoteWitnesses(const CBlockIndex* pindex,
                                 const CBlock* pblock,
-                                ZCIncrementalMerkleTree tree) {
+                                ZCIncrementalMerkleTree& tree) {
         CWallet::IncrementNoteWitnesses(pindex, pblock, tree);
     }
     void DecrementNoteWitnesses(const CBlockIndex* pindex) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -704,7 +704,8 @@ void CWallet::IncrementNoteWitnesses(const CBlockIndex* pindex,
                     // If this is our note, witness it
                     if (txIsOurs) {
                         JSOutPoint jsoutpt {hash, i, j};
-                        if (mapWallet[hash].mapNoteData.count(jsoutpt)) {
+                        if (mapWallet[hash].mapNoteData.count(jsoutpt) &&
+                                mapWallet[hash].mapNoteData[jsoutpt].witnessHeight < pindex->nHeight) {
                             CNoteData* nd = &(mapWallet[hash].mapNoteData[jsoutpt]);
                             if (nd->witnesses.size() > 0) {
                                 // We think this can happen because we write out the


### PR DESCRIPTION
Addresses another issue in #1904.

When an existing one of our notes was found again, its cache was reset and it was re-witnessed. This would cause encountered notes to get out-of-sync with the otherwise-ignored newer notes, which could be a problem if the wallet data happens to be written out during a reindex.