### PR TITLE
CreateJoinSplit: add start_profiling() call

### DIFF
--- a/src/zcash/CreateJoinSplit.cpp
+++ b/src/zcash/CreateJoinSplit.cpp
@@ -5,11 +5,14 @@
 #include "../util.h"
 #include "primitives/transaction.h"
 #include "zcash/JoinSplit.hpp"
+#include "libsnark/common/profiling.hpp"
 
 using namespace libzcash;
 
 int main(int argc, char **argv)
 {
+    libsnark::start_profiling();
+
     auto p = ZCJoinSplit::Unopened();
     p->loadVerifyingKey((ZC_GetParamsDir() / "sprout-verifying.key").string());
     p->setProvingKeyPath((ZC_GetParamsDir() / "sprout-proving.key").string());


### PR DESCRIPTION
This solves the problem of profiling output from the CreteJoinSplit benchmarking binary displaying nonsensical large time values.