### PR TITLE
Closes #1097 so that zcash-cli displays license info like zcashd.

### DIFF
--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -301,7 +301,7 @@ class WalletTest (BitcoinTestFramework):
         opids = []
         opids.append(myopid)
 
-        timeout = 120
+        timeout = 300
         status = None
         for x in xrange(1, timeout):
             results = self.nodes[2].z_getoperationresult(opids)

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -71,6 +71,8 @@ static bool AppInitRPC(int argc, char* argv[])
                   "  zcash-cli [options] help <command>      " + _("Get help for a command") + "\n";
 
             strUsage += "\n" + HelpMessageCli();
+        } else {
+            strUsage += LicenseInfo();
         }
 
         fprintf(stdout, "%s", strUsage.c_str());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -460,19 +460,6 @@ std::string HelpMessage(HelpMessageMode mode)
     return strUsage;
 }
 
-std::string LicenseInfo()
-{
-    return FormatParagraph(strprintf(_("Copyright (C) 2009-%i The Bitcoin Core Developers"), COPYRIGHT_YEAR)) + "\n" +
-           FormatParagraph(strprintf(_("Copyright (C) 2015-%i The Zcash Developers"), COPYRIGHT_YEAR)) + "\n" +
-           "\n" +
-           FormatParagraph(_("This is experimental software.")) + "\n" +
-           "\n" +
-           FormatParagraph(_("Distributed under the MIT software license, see the accompanying file COPYING or <http://www.opensource.org/licenses/mit-license.php>.")) + "\n" +
-           "\n" +
-           FormatParagraph(_("This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit <https://www.openssl.org/> and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.")) +
-           "\n";
-}
-
 static void BlockNotifyCallback(const uint256& hashNewTip)
 {
     std::string strCmd = GetArg("-blocknotify", "");

--- a/src/init.h
+++ b/src/init.h
@@ -34,7 +34,5 @@ enum HelpMessageMode {
 
 /** Help for options shared between UI and daemon (for -help) */
 std::string HelpMessage(HelpMessageMode mode);
-/** Returns licensing information (for -version) */
-std::string LicenseInfo();
 
 #endif // BITCOIN_INIT_H

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -815,3 +815,16 @@ void SetThreadPriority(int nPriority)
 #endif // PRIO_THREAD
 #endif // WIN32
 }
+
+std::string LicenseInfo()
+{
+    return FormatParagraph(strprintf(_("Copyright (C) 2009-%i The Bitcoin Core Developers"), COPYRIGHT_YEAR)) + "\n" +
+           FormatParagraph(strprintf(_("Copyright (C) 2015-%i The Zcash Developers"), COPYRIGHT_YEAR)) + "\n" +
+           "\n" +
+           FormatParagraph(_("This is experimental software.")) + "\n" +
+           "\n" +
+           FormatParagraph(_("Distributed under the MIT software license, see the accompanying file COPYING or <http://www.opensource.org/licenses/mit-license.php>.")) + "\n" +
+           "\n" +
+           FormatParagraph(_("This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit <https://www.openssl.org/> and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.")) +
+           "\n";
+}

--- a/src/util.h
+++ b/src/util.h
@@ -135,6 +135,9 @@ boost::filesystem::path GetTempPath();
 void ShrinkDebugFile();
 void runCommand(std::string strCommand);
 
+/** Returns licensing information (for -version) */
+std::string LicenseInfo();
+
 inline bool IsSwitchChar(char c)
 {
 #ifdef WIN32


### PR DESCRIPTION
LicenseInfo is refactored from init.cpp to util.cpp so that the
bitcoin-cli makefile target does not need to be modified.