### PR TITLE
Remove UTF-8 BOM 0xefbbbf from zcash.conf to avoid problems with command line tools

### DIFF
--- a/contrib/DEBIAN/examples/zcash.conf
+++ b/contrib/DEBIAN/examples/zcash.conf
@@ -1,4 +1,4 @@
-﻿##
+##
 ## zcash.conf configuration file. Lines beginning with # are comments.
 ##
 


### PR DESCRIPTION
Closes #2018 