### PR TITLE
Add missing header

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -34,6 +34,8 @@
 #include "json/json_spirit_value.h"
 #include "asyncrpcqueue.h"
 
+#include <numeric>
+
 using namespace std;
 using namespace json_spirit;
 


### PR DESCRIPTION
Closes #2027 where gcc 6.2.0 identified that `rpcwallet.cpp` was missing a header file `<numeric>` which is required due to usage of `std::accumulate`.