### PR TITLE
Removed markdown from COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,5 @@
 Copyright (c) 2016-2017 The Zcash developers
-Copyright (c) 2009-2015 The Bitcoin Core developers
+Copyright (c) 2009-2017 The Bitcoin Core developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright (c) 2016 The Zcash developers
+Copyright (c) 2016-2017 The Zcash developers
 Copyright (c) 2009-2015 The Bitcoin Core developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -20,15 +20,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-The [MIT software license](http://www.opensource.org/licenses/mit-license.php)
+The MIT software license (http://www.opensource.org/licenses/mit-license.php)
 above applies to the code directly included in this source distribution.
 Dependencies downloaded as part of the build process may be covered by other
 open-source licenses. For further details see 'contrib/debian/copyright'.
 
 
 This product includes software developed by the OpenSSL Project for use in the
-[OpenSSL Toolkit](https://www.openssl.org/). This product includes cryptographic
-software written by Eric Young ([eay@cryptsoft.com](mailto:eay@cryptsoft.com)),
+OpenSSL Toolkit (https://www.openssl.org/). This product includes cryptographic
+software written by Eric Young (eay@cryptsoft.com),
 and UPnP software written by Thomas Bernard.
 
 


### PR DESCRIPTION
Updated the Copyright statement at the top of the file from "2016" to "2016-2017" and removed markdown markup from the main text.