### PR TITLE
Add message directing users to security guide

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -65,8 +65,9 @@ static bool AppInitRPC(int argc, char* argv[])
     ParseParameters(argc, argv);
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help") || mapArgs.count("-version")) {
         std::string strUsage = _("Zcash RPC client version") + " " + FormatFullVersion() + "\n";
-        strUsage += "\n" + _("In order to ensure you are adequately protecting your privacy when using Zcash, please see https://z.cash/support/security/index.html") + "\n";
         if (!mapArgs.count("-version")) {
+            strUsage += "\n" + strprintf(_("In order to ensure you are adequately protecting your privacy when using Zcash, please see %s"), "https://z.cash/support/security/index.html") + "\n";
+
             strUsage += "\n" + _("Usage:") + "\n" +
                   "  zcash-cli [options] <command> [params]  " + _("Send command to Zcash") + "\n" +
                   "  zcash-cli [options] help                " + _("List commands") + "\n" +

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -64,10 +64,8 @@ static bool AppInitRPC(int argc, char* argv[])
     //
     ParseParameters(argc, argv);
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help") || mapArgs.count("-version")) {
-        std::string strUsage = _("Zcash RPC client version") + " " + FormatFullVersion() + "\n";
+        std::string strUsage = _("Zcash RPC client version") + " " + FormatFullVersion() + "\n" + PrivacyInfo();
         if (!mapArgs.count("-version")) {
-            strUsage += "\n" + strprintf(_("In order to ensure you are adequately protecting your privacy when using Zcash, please see %s"), "https://z.cash/support/security/index.html") + "\n";
-
             strUsage += "\n" + _("Usage:") + "\n" +
                   "  zcash-cli [options] <command> [params]  " + _("Send command to Zcash") + "\n" +
                   "  zcash-cli [options] help                " + _("List commands") + "\n" +

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -65,6 +65,7 @@ static bool AppInitRPC(int argc, char* argv[])
     ParseParameters(argc, argv);
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help") || mapArgs.count("-version")) {
         std::string strUsage = _("Zcash RPC client version") + " " + FormatFullVersion() + "\n";
+        strUsage += "\n" + _("In order to ensure you are adequately protecting your privacy when using Zcash, please see https://z.cash/support/security.html") + "\n";
         if (!mapArgs.count("-version")) {
             strUsage += "\n" + _("Usage:") + "\n" +
                   "  zcash-cli [options] <command> [params]  " + _("Send command to Zcash") + "\n" +

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -65,7 +65,7 @@ static bool AppInitRPC(int argc, char* argv[])
     ParseParameters(argc, argv);
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help") || mapArgs.count("-version")) {
         std::string strUsage = _("Zcash RPC client version") + " " + FormatFullVersion() + "\n";
-        strUsage += "\n" + _("In order to ensure you are adequately protecting your privacy when using Zcash, please see https://z.cash/support/security.html") + "\n";
+        strUsage += "\n" + _("In order to ensure you are adequately protecting your privacy when using Zcash, please see https://z.cash/support/security/index.html") + "\n";
         if (!mapArgs.count("-version")) {
             strUsage += "\n" + _("Usage:") + "\n" +
                   "  zcash-cli [options] <command> [params]  " + _("Send command to Zcash") + "\n" +

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -68,7 +68,7 @@ bool AppInit(int argc, char* argv[])
     // Process help and version before taking care about datadir
     if (mapArgs.count("-?") || mapArgs.count("-h") ||  mapArgs.count("-help") || mapArgs.count("-version"))
     {
-        std::string strUsage = _("Zcash Daemon") + " " + _("version") + " " + FormatFullVersion() + "\n";
+        std::string strUsage = _("Zcash Daemon") + " " + _("version") + " " + FormatFullVersion() + "\n" + PrivacyInfo();
 
         if (mapArgs.count("-version"))
         {

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -331,9 +331,8 @@ void ThreadShowMetricsScreen()
         std::cout << _("Thank you for running a Zcash node!") << std::endl;
         std::cout << _("You're helping to strengthen the network and contributing to a social good :)") << std::endl;
 
-        // Security warning text
-        std::cout << std::endl;
-        std::cout << strprintf(_("In order to ensure you are adequately protecting your privacy when using Zcash, please see %s"), "https://z.cash/support/security/index.html") << std::endl;
+        // Privacy notice text
+        std::cout << PrivacyInfo();
         std::cout << std::endl;
     }
 

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -330,6 +330,10 @@ void ThreadShowMetricsScreen()
         // Thank you text
         std::cout << _("Thank you for running a Zcash node!") << std::endl;
         std::cout << _("You're helping to strengthen the network and contributing to a social good :)") << std::endl;
+
+        // Security warning text
+        std::cout << std::endl;
+        std::cout << _("In order to ensure you are adequately protecting your privacy when using Zcash, please see https://z.cash/support/security/index.html") << std::endl;
         std::cout << std::endl;
     }
 

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -333,7 +333,7 @@ void ThreadShowMetricsScreen()
 
         // Security warning text
         std::cout << std::endl;
-        std::cout << _("In order to ensure you are adequately protecting your privacy when using Zcash, please see https://z.cash/support/security/index.html") << std::endl;
+        std::cout << strprintf(_("In order to ensure you are adequately protecting your privacy when using Zcash, please see %s"), "https://z.cash/support/security/index.html") << std::endl;
         std::cout << std::endl;
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -878,7 +878,8 @@ void SetThreadPriority(int nPriority)
 
 std::string LicenseInfo()
 {
-    return FormatParagraph(strprintf(_("Copyright (C) 2009-%i The Bitcoin Core Developers"), COPYRIGHT_YEAR)) + "\n" +
+    return "\n" + FormatParagraph(strprintf(_("In order to ensure you are adequately protecting your privacy when using Zcash, please see %s"), "https://z.cash/support/security/index.html")) + "\n" + "\n" +
+           FormatParagraph(strprintf(_("Copyright (C) 2009-%i The Bitcoin Core Developers"), COPYRIGHT_YEAR)) + "\n" +
            FormatParagraph(strprintf(_("Copyright (C) 2015-%i The Zcash Developers"), COPYRIGHT_YEAR)) + "\n" +
            "\n" +
            FormatParagraph(_("This is experimental software.")) + "\n" +

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -876,9 +876,16 @@ void SetThreadPriority(int nPriority)
 #endif // WIN32
 }
 
+std::string PrivacyInfo()
+{
+    return "\n" +
+           FormatParagraph(strprintf(_("In order to ensure you are adequately protecting your privacy when using Zcash, please see <%s>."),
+                                     "https://z.cash/support/security/index.html")) + "\n";
+}
+
 std::string LicenseInfo()
 {
-    return "\n" + FormatParagraph(strprintf(_("In order to ensure you are adequately protecting your privacy when using Zcash, please see %s"), "https://z.cash/support/security/index.html")) + "\n" + "\n" +
+    return "\n" +
            FormatParagraph(strprintf(_("Copyright (C) 2009-%i The Bitcoin Core Developers"), COPYRIGHT_YEAR)) + "\n" +
            FormatParagraph(strprintf(_("Copyright (C) 2015-%i The Zcash Developers"), COPYRIGHT_YEAR)) + "\n" +
            "\n" +

--- a/src/util.h
+++ b/src/util.h
@@ -141,6 +141,9 @@ void ShrinkDebugFile();
 void runCommand(const std::string& strCommand);
 const boost::filesystem::path GetExportDir();
 
+/** Returns privacy notice (for -version, -help and metrics screen) */
+std::string PrivacyInfo();
+
 /** Returns licensing information (for -version) */
 std::string LicenseInfo();
 


### PR DESCRIPTION
Addresses #2142, which was blocking on updates to zcash/support/security.html. That page has now been added, so this message directing users to the site can be included. 

It displays in the zcash-cli --help and --version message text, and on the zcashd metrics screen.