### PR TITLE
Release version handling

### DIFF
--- a/contrib/devtools/gen-manpages.sh
+++ b/contrib/devtools/gen-manpages.sh
@@ -11,7 +11,9 @@ ZCASHTX=${ZCASHTX:-$SRCDIR/zcash-tx}
 [ ! -x $ZCASHD ] && echo "$ZCASHD not found or not executable." && exit 1
 
 # The autodetected version git tag can screw up manpage output a little bit
-ZECVER=($($ZCASHCLI --version | head -n1 | awk -F'[ -]' '{ print $5, $6 }'))
+ZECVERSTR=$($ZCASHCLI --version | head -n1 | awk '{ print $NF }')
+ZECVER=$(echo $ZECVERSTR | awk -F- '{ OFS="-"; NF--; print $0; }')
+ZECCOMMIT=$(echo $ZECVERSTR | awk -F- '{ print $NF }')
 
 # Create a footer file with copyright content.
 # This gets autodetected fine for zcashd if --version-string is not set,
@@ -21,8 +23,8 @@ $ZCASHD --version | sed -n '1!p' >> footer.h2m
 
 for cmd in $ZCASHD $ZCASHCLI $ZCASHTX; do
   cmdname="${cmd##*/}"
-  help2man -N --version-string=${ZECVER[0]} --include=footer.h2m -o ${MANDIR}/${cmdname}.1 ${cmd}
-  sed -i "s/\\\-${ZECVER[1]}//g" ${MANDIR}/${cmdname}.1
+  help2man -N --version-string=$ZECVER --include=footer.h2m -o ${MANDIR}/${cmdname}.1 ${cmd}
+  sed -i "s/\\\-$ZECCOMMIT//g" ${MANDIR}/${cmdname}.1
 done
 
 rm -f footer.h2m

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -81,7 +81,7 @@ Add the newly created release notes to the Git repository:
 
 Update the Debian package changelog:
 
-    export DEBVERSION="${ZCASH_RELEASE}"
+    export DEBVERSION=$(echo $ZCASH_RELEASE | sed 's/-beta/~beta/' | sed 's/-rc/~rc/' | sed 's/-/+/')
     export DEBEMAIL="${DEBEMAIL:-team@z.cash}"
     export DEBFULLNAME="${DEBFULLNAME:-Zcash Company}"
 

--- a/zcutil/build-debian-package.sh
+++ b/zcutil/build-debian-package.sh
@@ -18,6 +18,7 @@ if [ ! -d $BUILD_PATH ]; then
 fi
 
 PACKAGE_VERSION=$($SRC_PATH/src/zcashd --version | grep version | cut -d' ' -f4 | tr -d v)
+DEBVERSION=$(echo $PACKAGE_VERSION | sed 's/-beta/~beta/' | sed 's/-rc/~rc/' | sed 's/-/+/')
 BUILD_DIR="$BUILD_PATH/$PACKAGE_NAME-$PACKAGE_VERSION-amd64"
 
 if [ -d $BUILD_DIR ]; then
@@ -63,7 +64,7 @@ cd $SRC_PATH/contrib
 
 # Create the control file
 dpkg-shlibdeps $DEB_BIN/zcashd $DEB_BIN/zcash-cli
-dpkg-gencontrol -P$BUILD_DIR
+dpkg-gencontrol -P$BUILD_DIR -v$DEBVERSION
 
 # Create the Debian package
 fakeroot dpkg-deb --build $BUILD_DIR


### PR DESCRIPTION
- Convert Zcash versions to Debian format for packaging
- [manpage] Handle build numbers in versions