### PR TITLE
Print toolchain versions before making depends, autoconf, or main build.

### DIFF
--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -98,6 +98,12 @@ fi
 
 PREFIX="$(pwd)/depends/$BUILD/"
 
+eval "$MAKE" --version
+eval "$CC" --version
+eval "$CXX" --version
+as --version
+ld --version
+
 HOST="$HOST" BUILD="$BUILD" NO_RUST="$RUST_ARG" NO_PROTON="$PROTON_ARG" "$MAKE" "$@" -C ./depends/ V=1
 ./autogen.sh
 CC="$CC" CXX="$CXX" ./configure --prefix="${PREFIX}" --host="$HOST" --build="$BUILD" "$RUST_ARG" "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" "$PROTON_ARG" CXXFLAGS='-fwrapv -fno-strict-aliasing -Werror -g'


### PR DESCRIPTION
Closes #2218.

Note: I spent a half hour attempting to have make do this so that people not using `build.sh` would get the same output. There's no easy way I found to ensure that output occurs first and regardless of the result of other build rules.