### PR TITLE
Try FALLBACK_DOWNLOAD_PATH as fallback url for dependency builds

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -22,8 +22,8 @@ endef
 define fetch_file
 (test -f $$($(1)_source_dir)/$(4) || \
   ( mkdir -p $$($(1)_download_dir) && echo Fetching $(1)... && \
-  ( $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(FALLBACK_DOWNLOAD_PATH)/$(4)" || \
-    $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(2)/$(3)" ) && \
+  ( $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(2)/$(3)" || \
+    $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(FALLBACK_DOWNLOAD_PATH)/$(4)" ) && \
     echo "$(5)  $$($(1)_download_dir)/$(4).temp" > $$($(1)_download_dir)/.$(4).hash && \
     $(build_SHA256SUM) -c $$($(1)_download_dir)/.$(4).hash && \
     mv $$($(1)_download_dir)/$(4).temp $$($(1)_source_dir)/$(4) && \


### PR DESCRIPTION
Dependency builder first check FALLBACK_DOWNLOAD_PATH and if package is not present in z.cash/depends-sources it downloads a small file (web page) instead. This creates a sha256 verification failure (tested on macOS, rust-1.16.0-apple-darwin was the problematic package).

Please close if this is the intended behaviour.