### PR TITLE
[macOS] system linker does not support “--version” option but only “-v”

### DIFF
--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -102,7 +102,7 @@ eval "$MAKE" --version
 eval "$CC" --version
 eval "$CXX" --version
 as --version
-ld --version
+ld -v
 
 HOST="$HOST" BUILD="$BUILD" NO_RUST="$RUST_ARG" NO_PROTON="$PROTON_ARG" "$MAKE" "$@" -C ./depends/ V=1
 ./autogen.sh


### PR DESCRIPTION
To build Zcash on macOS Sierra I use a self-built gcc-6.3/g++-6.3 but macOS linker (/usr/bin/ld). macOS linker does not support “--version” option but “-v” 

On Ubuntu 16.04
```
$ ld --version
GNU ld (GNU Binutils for Ubuntu) 2.26.1
Copyright (C) 2015 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) a later version.
This program has absolutely no warranty.
$ ld -v
GNU ld (GNU Binutils for Ubuntu) 2.26.1
```

On macOS Sierra
```
$ ld --version
ld: unknown option: --version
$ ld -v
@(#)PROGRAM:ld  PROJECT:ld64-278.4
configured to support archs: armv6 armv7 armv7s arm64 i386 x86_64 x86_64h armv6m armv7k armv7m armv7em (tvOS)
LTO support using: LLVM version 8.1.0, (clang-802.0.42)
TAPI support using: Apple TAPI version 1.33.11
```
