### PR TITLE
[macOS] curl fail on HTTP errors without downloading any data

### DIFF
--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -7,7 +7,7 @@ build_darwin_OTOOL: = $(shell xcrun -f otool)
 build_darwin_NM: = $(shell xcrun -f nm)
 build_darwin_INSTALL_NAME_TOOL:=$(shell xcrun -f install_name_tool)
 build_darwin_SHA256SUM = shasum -a 256
-build_darwin_DOWNLOAD = curl --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -L -o
+build_darwin_DOWNLOAD = curl --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --fail --retry $(DOWNLOAD_RETRIES) -L -o
 
 #darwin host on darwin builder. overrides darwin host preferences.
 darwin_CC=$(shell xcrun -f clang) -mmacosx-version-min=$(OSX_MIN_VERSION)


### PR DESCRIPTION
tested on macOS Sierra 10.12.5 (issue #2431)

```
mkdir -p /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/sources/download-stamps /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/sources
rm -f /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/sources/download-stamps/.stamp_fetched-rust-rust-1.16.0-x86_64-apple-darwin.tar.gz.hash
touch /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/sources/download-stamps/.stamp_fetched-rust-rust-1.16.0-x86_64-apple-darwin.tar.gz.hash
cd /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/sources/download-stamps; (test -f /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/sources/rust-1.16.0-x86_64-apple-darwin.tar.gz || ( mkdir -p /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/work/download/rust-1.16.0 && echo Fetching rust... && ( curl --connect-timeout 10 --fail --retry 3 -L -o "/Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/work/download/rust-1.16.0/rust-1.16.0-x86_64-apple-darwin.tar.gz.temp" "https://z.cash/depends-sources/rust-1.16.0-x86_64-apple-darwin.tar.gz" || curl --connect-timeout 10 --fail --retry 3 -L -o "/Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/work/download/rust-1.16.0/rust-1.16.0-x86_64-apple-darwin.tar.gz.temp" "https://static.rust-lang.org/dist/rust-1.16.0-x86_64-apple-darwin.tar.gz" ) && echo "2d08259ee038d3a2c77a93f1a31fc59e7a1d6d1bbfcba3dba3c8213b2e5d1926  /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/work/download/rust-1.16.0/rust-1.16.0-x86_64-apple-darwin.tar.gz.temp" > /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/work/download/rust-1.16.0/.rust-1.16.0-x86_64-apple-darwin.tar.gz.hash && shasum -a 256 -c /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/work/download/rust-1.16.0/.rust-1.16.0-x86_64-apple-darwin.tar.gz.hash && mv /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/work/download/rust-1.16.0/rust-1.16.0-x86_64-apple-darwin.tar.gz.temp /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/sources/rust-1.16.0-x86_64-apple-darwin.tar.gz && rm -rf /Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/work/download/rust-1.16.0 ))
Fetching rust...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 85.7M  100 85.7M    0     0  1444k      0  0:01:00  0:01:00 --:--:-- 2248k
/Users/loki/Desktop/devel/zcash-apple/zcash/zcash_v1.0.9/depends/work/download/rust-1.16.0/rust-1.16.0-x86_64-apple-darwin.tar.gz.temp: OK
```