### PR TITLE
support per platform filename and hash setting for dependencies

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -43,6 +43,10 @@ $(eval $(1)_build_id_long:=$(1)-$($(1)_version)-$($(1)_recipe_hash)-$(release_ty
 $(eval $(1)_build_id:=$(shell echo -n "$($(1)_build_id_long)" | $(build_SHA256SUM) | cut -c-$(HASH_LENGTH)))
 final_build_id_long+=$($(package)_build_id_long)
 
+#override platform specific files and hashes
+$(eval $(1)_file_name=$(if $($(1)_file_name_$(host_os)),$($(1)_file_name_$(host_os)),$($(1)_file_name)))
+$(eval $(1)_sha256_hash=$(if $($(1)_sha256_hash_$(host_os)),$($(1)_sha256_hash_$(host_os)),$($(1)_sha256_hash)))
+
 #compute package-specific paths
 $(1)_build_subdir?=.
 $(1)_download_file?=$($(1)_file_name)

--- a/depends/packages/rust.mk
+++ b/depends/packages/rust.mk
@@ -1,8 +1,10 @@
 package=rust
 $(package)_version=1.16.0
 $(package)_download_path=https://static.rust-lang.org/dist
-$(package)_file_name=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
-$(package)_sha256_hash=48621912c242753ba37cad5145df375eeba41c81079df46f93ffb4896542e8fd
+$(package)_file_name_linux=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
+$(package)_sha256_hash_linux=48621912c242753ba37cad5145df375eeba41c81079df46f93ffb4896542e8fd
+$(package)_file_name_darwin=rust-$($(package)_version)-x86_64-apple-darwin.tar.gz
+$(package)_sha256_hash_darwin=2d08259ee038d3a2c77a93f1a31fc59e7a1d6d1bbfcba3dba3c8213b2e5d1926
 
 define $(package)_stage_cmds
   ./install.sh --destdir=$($(package)_staging_dir) --prefix=$(host_prefix)/native --disable-ldconfig


### PR DESCRIPTION
added to support per-platform Rust packages, tested on macOS Sierra 10.12.5 and Ubuntu 16.04 LTS (issue #2431)