### PR TITLE
[mining] let "getblocktemplate" work when disable wallet

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -293,9 +293,7 @@ static const CRPCCommand vRPCCommands[] =
     { "blockchain",         "verifychain",            &verifychain,            true  },
 
     /* Mining */
-#ifdef ENABLE_WALLET
     { "mining",             "getblocktemplate",       &getblocktemplate,       true  },
-#endif
     { "mining",             "getmininginfo",          &getmininginfo,          true  },
     { "mining",             "getlocalsolps",          &getlocalsolps,          true  },
     { "mining",             "getnetworksolps",        &getnetworksolps,        true  },


### PR DESCRIPTION
we already support GetBlockTemplate without build wallet, see: 

https://github.com/zcash/zcash/blob/master/src/rpcmining.cpp

```
    // Wallet or miner address is required because we support coinbasetxn
    if (GetArg("-mineraddress", "").empty()) {
#ifdef ENABLE_WALLET
        if (!pwalletMain) {
            throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Wallet disabled and -mineraddress not set");
        }
#else
        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "zcashd compiled without wallet and -mineraddress not set");
#endif
    }
```

so the macro should be removed from `src/rpcserver.cpp`, otherwise you can't call `getblocktemplate` when you disable wallet.