### PR TITLE
Fixes #2480 where missing map entry would cause a segfault.

### DIFF
--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -589,6 +589,10 @@ bool AsyncRPCOperation_sendmany::main_impl() {
             {
                 LOCK2(cs_main, pwalletMain->cs_wallet);
                 const CWalletTx& wtx = pwalletMain->mapWallet[jso.hash];
+                // Zero confirmaton notes belong to transactions which have not yet been mined
+                if (mapBlockIndex.find(wtx.hashBlock) == mapBlockIndex.end()) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, strprintf("mapBlockIndex does not contain block hash %s", wtx.hashBlock.ToString()));
+                }
                 wtxHeight = mapBlockIndex[wtx.hashBlock]->nHeight;
                 wtxDepth = wtx.GetDepthInMainChain();
             }


### PR DESCRIPTION
`wtxHeight = mapBlockIndex[wtx.hashBlock]->nHeight;` results in undefined behaviour when the block hash is not present in the map, returning a null value which is dereferenced via `->nHeight`.  This error is triggered by a zero-conf wallet transaction which has not been mined yet.  As discussed in #2480, on some systems there is a segfault whilst on others there is a silent exit.  This makes it difficult to write a test, but the fix has been tested empirically to confirm an exception is thrown.  This PR fixes the segfault and complements #2525 which prevents a user from sending from a zaddr with minconf 0.