### PR TITLE
Fixes for gcc 7

### DIFF
--- a/src/leveldbwrapper.cpp
+++ b/src/leveldbwrapper.cpp
@@ -13,7 +13,7 @@
 #include <leveldb/filter_policy.h>
 #include <memenv.h>
 
-void HandleError(const leveldb::Status& status) throw(leveldb_error)
+void HandleError(const leveldb::Status& status)
 {
     if (status.ok())
         return;
@@ -81,7 +81,7 @@ CLevelDBWrapper::~CLevelDBWrapper()
     options.env = NULL;
 }
 
-bool CLevelDBWrapper::WriteBatch(CLevelDBBatch& batch, bool fSync) throw(leveldb_error)
+bool CLevelDBWrapper::WriteBatch(CLevelDBBatch& batch, bool fSync)
 {
     leveldb::Status status = pdb->Write(fSync ? syncoptions : writeoptions, &batch.batch);
     HandleError(status);

--- a/src/leveldbwrapper.h
+++ b/src/leveldbwrapper.h
@@ -22,7 +22,7 @@ public:
     leveldb_error(const std::string& msg) : std::runtime_error(msg) {}
 };
 
-void HandleError(const leveldb::Status& status) throw(leveldb_error);
+void HandleError(const leveldb::Status& status);
 
 /** Batch of changes queued to be written to a CLevelDBWrapper */
 class CLevelDBBatch
@@ -90,7 +90,7 @@ public:
     ~CLevelDBWrapper();
 
     template <typename K, typename V>
-    bool Read(const K& key, V& value) const throw(leveldb_error)
+    bool Read(const K& key, V& value) const
     {
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(ssKey.GetSerializeSize(key));
@@ -115,7 +115,7 @@ public:
     }
 
     template <typename K, typename V>
-    bool Write(const K& key, const V& value, bool fSync = false) throw(leveldb_error)
+    bool Write(const K& key, const V& value, bool fSync = false)
     {
         CLevelDBBatch batch;
         batch.Write(key, value);
@@ -123,7 +123,7 @@ public:
     }
 
     template <typename K>
-    bool Exists(const K& key) const throw(leveldb_error)
+    bool Exists(const K& key) const
     {
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(ssKey.GetSerializeSize(key));
@@ -142,14 +142,14 @@ public:
     }
 
     template <typename K>
-    bool Erase(const K& key, bool fSync = false) throw(leveldb_error)
+    bool Erase(const K& key, bool fSync = false)
     {
         CLevelDBBatch batch;
         batch.Erase(key);
         return WriteBatch(batch, fSync);
     }
 
-    bool WriteBatch(CLevelDBBatch& batch, bool fSync = false) throw(leveldb_error);
+    bool WriteBatch(CLevelDBBatch& batch, bool fSync = false);
 
     // not available for LevelDB; provide for compatibility with BDB
     bool Flush()
@@ -157,7 +157,7 @@ public:
         return true;
     }
 
-    bool Sync() throw(leveldb_error)
+    bool Sync()
     {
         CLevelDBBatch batch;
         return WriteBatch(batch, true);

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -117,5 +117,5 @@ ld -v
 
 HOST="$HOST" BUILD="$BUILD" NO_RUST="$RUST_ARG" NO_PROTON="$PROTON_ARG" "$MAKE" "$@" -C ./depends/ V=1
 ./autogen.sh
-CC="$CC" CXX="$CXX" ./configure --prefix="${PREFIX}" --host="$HOST" --build="$BUILD" "$RUST_ARG" "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" "$PROTON_ARG" "$LIBS_ARG" CXXFLAGS='-fwrapv -fno-strict-aliasing -Werror -g'
+CC="$CC" CXX="$CXX" ./configure --prefix="${PREFIX}" --host="$HOST" --build="$BUILD" "$RUST_ARG" "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" "$PROTON_ARG" "$LIBS_ARG" CXXFLAGS='-fwrapv -fno-strict-aliasing -Wno-builtin-declaration-mismatch -Werror -g'
 "$MAKE" "$@" V=1


### PR DESCRIPTION
This fixes a few issues when using a newer compiler (in my case gcc 7.1.1) available in for example Arch Linux.
Solves for example this issue: https://github.com/zcash/zcash/issues/2304

The first thing is an error when checking for boost_system and is solved by disabling that warning (wich is treated as an error and, hence, stops the build):

```
configure:22242: checking for exit in -lboost_system-mt
configure:22267: g++ -m64 -o conftest -std=c++11 -pipe -fPIC -O1 -fwrapv -fno-strict-aliasing -Werror -g  -Wformat -Wformat-security -Wstack-protector -fstack-protector-all -fPIE ..<snip>... /x86_64-unknown-linux-gnu/share/../lib conftest.cpp -lboost_system-mt  -lanl  >&5
conftest.cpp:70:6: error: declaration of 'char exit()' conflicts with built-in declaration 'void exit(int)' [-Werror=builtin-declaration-mismatch]
 char exit ();
      ^~~~
cc1plus: all warnings being treated as errors

```

The second thing was to clean some code that is deprecated in C++11 which also lead to a warning treated as error. It could also be fixed with `-Wno-deprecated` but better to fix the issue in my opinion.

