### PR TITLE
zcash-addrgen, a small tool to generate a shielded address

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,7 +75,7 @@ if BUILD_BITCOIND
 endif
 
 if BUILD_BITCOIN_UTILS
-  bin_PROGRAMS += zcash-cli zcash-tx
+  bin_PROGRAMS += zcash-cli zcash-tx zcash-addrgen
 endif
 
 LIBZCASH_H = \
@@ -463,6 +463,23 @@ zcash_tx_LDADD = \
   $(LIBZCASH_LIBS)
 
 zcash_tx_LDADD += $(BOOST_LIBS) $(CRYPTO_LIBS)
+#
+
+# zcash-addrgen (just copy&pasted from zcash-tx)
+zcash_addrgen_SOURCES = zcash-addrgen.cc
+zcash_addrgen_CPPFLAGS = $(BITCOIN_INCLUDES)
+zcash_addrgen_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+
+zcash_addrgen_LDADD = \
+  $(LIBUNIVALUE) \
+  $(LIBBITCOIN_COMMON) \
+  $(LIBBITCOIN_UTIL) \
+  $(LIBSECP256K1) \
+  $(LIBZCASH) \
+  $(LIBBITCOIN_CRYPTO) \
+  $(LIBZCASH_LIBS)
+
+zcash_addrgen_LDADD += $(BOOST_LIBS) $(CRYPTO_LIBS)
 #
 
 # zcash protocol primitives #

--- a/src/zcash-addrgen.cc
+++ b/src/zcash-addrgen.cc
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <vector>
+
+#include "config/bitcoin-config.h"
+#include "chainparams.h"
+#include "base58.h"
+
+int main(int argc, char **argv)
+{
+	if(argc != 2) {
+		fprintf(stderr, "need seed as an argument\n");
+		return 1;
+	}
+	if(strlen(argv[1]) == 64) {
+		fprintf(stderr, "WARNING: seed should be 63, not 64 characters. Ignoring the first.\n");
+		argv[1]++;
+	}
+	if(strlen(argv[1]) != 63) {
+		fprintf(stderr, "seed must be exactly 63 characters\n");
+		return 1;
+	}
+
+	std::vector<unsigned char> vec;
+	char digit[3];
+	digit[2] = '\x0';
+	for(int i=0; i<32; i++) {
+		if(i == 0) {
+			digit[0] = argv[1][0];
+			digit[1] = '\x0';
+		} else {
+			digit[0] = argv[1][i*2-1];
+			digit[1] = argv[1][i*2];
+		}
+		long int n = strtol(digit, NULL, 16);
+		unsigned char chr = n;
+		vec.push_back(chr);
+	}
+	uint256 uv(vec);
+	uint252 uv2(uv);
+
+	SelectParams(CBaseChainParams::MAIN);
+	libzcash::SpendingKey k(uv2);
+	CZCSpendingKey ck(k);
+	printf("sk: %s\n", ck.ToString().c_str());
+	CZCPaymentAddress pa = k.address();
+	printf("pa: %s\n", pa.ToString().c_str());
+
+	return 0;
+}

--- a/zcutil/build-debian-package.sh
+++ b/zcutil/build-debian-package.sh
@@ -40,6 +40,8 @@ chmod 0755 -R $BUILD_DIR/*
 # Copy binaries
 cp $SRC_PATH/src/zcashd $DEB_BIN
 cp $SRC_PATH/src/zcash-cli $DEB_BIN
+cp $SRC_PATH/src/zcash-tx $DEB_BIN
+cp $SRC_PATH/src/zcash-addrgen $DEB_BIN
 cp $SRC_PATH/zcutil/fetch-params.sh $DEB_BIN/zcash-fetch-params
 # Copy docs
 cp $SRC_PATH/doc/release-notes/release-notes-1.0.0.md $DEB_DOC/changelog
@@ -63,7 +65,8 @@ gzip --best -n $DEB_MAN/zcash-fetch-params.1
 cd $SRC_PATH/contrib
 
 # Create the control file
-dpkg-shlibdeps $DEB_BIN/zcashd $DEB_BIN/zcash-cli
+strip $DEB_BIN/zcashd $DEB_BIN/zcash-cli $DEB_BIN/zcash-tx $DEB_BIN/zcash-addrgen
+dpkg-shlibdeps $DEB_BIN/zcashd $DEB_BIN/zcash-cli $DEB_BIN/zcash-tx $DEB_BIN/zcash-addrgen
 dpkg-gencontrol -P$BUILD_DIR -v$DEBVERSION
 
 # Create the Debian package


### PR DESCRIPTION
Hello all,

I've written a tiny tool to convert a random seed (which can come from a mnemonic) into a Spending Key and a Payment Address. This will be a part of my cold storage solution - I'll put it on a Live CD later. It's meant for quick and easy address generation, without having to download all the network params (without which a zcash node doesn't like to start up).

This is probably too early a stage to warrant merging into the official zcash tree, but please let me know if you like it. I'll be happy to polish it up a bit if you're interested in merging it later. Or if you think it sucks feel free to close this PR.