### PR TITLE
Add z_embedstring and z_readstring for storing strings in the blockchain

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -35,6 +35,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getnetworksolps", 1 },
     { "sendtoaddress", 1 },
     { "sendtoaddress", 4 },
+    { "z_embedstring", 1 },
     { "settxfee", 0 },
     { "getreceivedbyaddress", 1 },
     { "getreceivedbyaccount", 1 },


### PR DESCRIPTION
This adds an RPC that makes it easy to store and retrieve strings in the Zcash blockchain. I needed it for a time capsule thing I'm building; it might be useful for other purposes.

TODO:

- [ ] handle too-long strings more gracefully (it currently gives a misleading error message)
- [ ] add a mindepth argument to z_readstring to check that it's actually in a mined block of sufficient depth.
- [ ] RPC tests.
- [ ] Make it actually allow 0 burned value (currently I get "error code: -8 ... Invalid amount" when passing 0.000).
- [ ] Find out if we want to continue supporting this feature and if it needs a ZIP.
- [x] make it possible to burn 0 ZEC (will the consensus rules allow that?) except for the fee.
- [ ] ~~put the new code in the right files.~~
- [ ] ~~make it possible to pay the fee from a zaddr.~~