### PR TITLE
Fix bug where performance-measurements.sh fails hards when given no args

### DIFF
--- a/qa/zcash/performance-measurements.sh
+++ b/qa/zcash/performance-measurements.sh
@@ -154,6 +154,13 @@ EOF
     xzcat block-107134.tar.xz | tar x -C "$DATADIR/regtest"
 }
 
+
+if [ $# -lt 2 ]
+then
+    echo "$0 : two arguments are required!"
+    exit 1
+fi
+
 # Precomputation
 case "$1" in
     *)


### PR DESCRIPTION
Better than "$1: unbound variable", we ran into this when testing this script in the Hush repo, so we are pushing this fix upstream.

