### PR TITLE
Cross-platform build.sh

### DIFF
--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -2,6 +2,21 @@
 
 set -eu -o pipefail
 
+function cmd_pref() {
+    if type -p "$2" > /dev/null; then
+        eval "$1=$2"
+    else
+        eval "$1=$3"
+    fi
+}
+
+# If a g-prefixed version of the command exists, use it preferentially.
+function gprefix() {
+    cmd_pref "$1" "g$2" "$2"
+}
+
+gprefix READLINK readlink
+
 # Allow user overrides to $MAKE. Typical usage for users who need it:
 #   MAKE=gmake ./zcutil/build.sh -j$(nproc)
 if [[ -z "${MAKE-}" ]]; then
@@ -58,7 +73,7 @@ EOF
 fi
 
 set -x
-cd "$(dirname "$(readlink -f "$0")")/.."
+cd "$(dirname "$("$READLINK" -f "$0")")/.."
 
 # If --enable-lcov is the first argument, enable lcov coverage support:
 LCOV_ARG=''

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -16,6 +16,7 @@ function gprefix() {
 }
 
 gprefix READLINK readlink
+cd "$(dirname "$("$READLINK" -f "$0")")/.."
 
 # Allow user overrides to $MAKE. Typical usage for users who need it:
 #   MAKE=gmake ./zcutil/build.sh -j$(nproc)
@@ -26,10 +27,10 @@ fi
 # Allow overrides to $BUILD and $HOST for porters. Most users will not need it.
 #   BUILD=i686-pc-linux-gnu ./zcutil/build.sh
 if [[ -z "${BUILD-}" ]]; then
-    BUILD=x86_64-unknown-linux-gnu
+    BUILD="$(./depends/config.guess)"
 fi
 if [[ -z "${HOST-}" ]]; then
-    HOST=x86_64-unknown-linux-gnu
+    HOST="$BUILD"
 fi
 
 # Allow override to $CC and $CXX for porters. Most users will not need it.
@@ -73,7 +74,6 @@ EOF
 fi
 
 set -x
-cd "$(dirname "$("$READLINK" -f "$0")")/.."
 
 # If --enable-lcov is the first argument, enable lcov coverage support:
 LCOV_ARG=''


### PR DESCRIPTION
This enables `zcutil/build.sh` to be used on MacOS, and likely other non-Linux platforms.