### PR TITLE
Prevent RPC calls dumpwallet and z_exportwallet from overwriting an existing file

### DIFF
--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -34,6 +34,7 @@ and confirm again balances are correct.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, start_node, connect_nodes, stop_node, \
     sync_blocks, sync_mempools
@@ -140,6 +141,14 @@ class WalletBackupTest(BitcoinTestFramework):
         self.nodes[1].dumpwallet("walletdump")
         self.nodes[2].backupwallet("walletbak")
         self.nodes[2].dumpwallet("walletdump")
+
+        # Verify dumpwallet cannot overwrite an existing file
+        try:
+            self.nodes[2].dumpwallet("walletdump")
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            assert("Cannot overwrite existing file" in errorString)
 
         logging.info("More transactions")
         for i in range(5):

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -428,7 +428,7 @@ UniValue z_exportwallet(const UniValue& params, bool fHelp)
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "z_exportwallet \"filename\"\n"
-            "\nExports all wallet keys, for taddr and zaddr, in a human-readable format.\n"
+            "\nExports all wallet keys, for taddr and zaddr, in a human-readable format.  Overwriting an existing file is not permitted.\n"
             "\nArguments:\n"
             "1. \"filename\"    (string, required) The filename, saved in folder set by zcashd -exportdir option\n"
             "\nResult:\n"
@@ -449,7 +449,7 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "dumpwallet \"filename\"\n"
-            "\nDumps taddr wallet keys in a human-readable format.\n"
+            "\nDumps taddr wallet keys in a human-readable format.  Overwriting an existing file is not permitted.\n"
             "\nArguments:\n"
             "1. \"filename\"    (string, required) The filename, saved in folder set by zcashd -exportdir option\n"
             "\nResult:\n"
@@ -483,6 +483,10 @@ UniValue dumpwallet_impl(const UniValue& params, bool fHelp, bool fDumpZKeys)
         throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Filename is invalid as only alphanumeric characters are allowed.  Try '%s' instead.", clean));
     }
     boost::filesystem::path exportfilepath = exportdir / clean;
+
+    if (boost::filesystem::exists(exportfilepath)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot overwrite existing file " + exportfilepath.string());
+    }
 
     ofstream file;
     file.open(exportfilepath.string().c_str());


### PR DESCRIPTION
Closes #2740 