### PR TITLE
Fix libsnark test failure.

### DIFF
--- a/src/snark/src/algebra/fields/bigint.tcc
+++ b/src/snark/src/algebra/fields/bigint.tcc
@@ -201,7 +201,7 @@ inline bigint<m> bigint<n>::shorten(const bigint<m>& q, const char *msg) const
         }
     }
     bigint<m> res;
-    mpn_copyi(res.data, data, n);
+    mpn_copyi(res.data, data, m);
     res.limit(q, msg);
     return res;
 }


### PR DESCRIPTION
The shorten() method was copying too much into the destination
buffer, overflowing it and affecting neighboring data.