### PR TITLE
Get rid of underscore prefixes for include guards.

### DIFF
--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef __UNIVALUE_H__
-#define __UNIVALUE_H__
+#ifndef UNIVALUE_H__
+#define UNIVALUE_H__
 
 #include <stdint.h>
 
@@ -293,4 +293,4 @@ extern const UniValue NullUniValue;
 
 const UniValue& find_value( const UniValue& obj, const std::string& name);
 
-#endif // __UNIVALUE_H__
+#endif // UNIVALUE_H__

--- a/src/zcash/Address.hpp
+++ b/src/zcash/Address.hpp
@@ -1,5 +1,5 @@
-#ifndef _ZCADDRESS_H_
-#define _ZCADDRESS_H_
+#ifndef ZC_ADDRESS_H_
+#define ZC_ADDRESS_H_
 
 #include "uint256.h"
 #include "uint252.h"
@@ -58,4 +58,4 @@ public:
 
 }
 
-#endif // _ZCADDRESS_H_
+#endif // ZC_ADDRESS_H_

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -1,5 +1,5 @@
-#ifndef ZCINCREMENTALMERKLETREE_H_
-#define ZCINCREMENTALMERKLETREE_H_
+#ifndef ZC_INCREMENTALMERKLETREE_H_
+#define ZC_INCREMENTALMERKLETREE_H_
 
 #include <deque>
 #include <boost/optional.hpp>
@@ -202,5 +202,4 @@ typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, l
 typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::SHA256Compress> ZCIncrementalWitness;
 typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::SHA256Compress> ZCTestingIncrementalWitness;
 
-#endif /* ZCINCREMENTALMERKLETREE_H_ */
-
+#endif /* ZC_INCREMENTALMERKLETREE_H_ */

--- a/src/zcash/JoinSplit.hpp
+++ b/src/zcash/JoinSplit.hpp
@@ -1,5 +1,5 @@
-#ifndef _ZCJOINSPLIT_H_
-#define _ZCJOINSPLIT_H_
+#ifndef ZC_JOINSPLIT_H_
+#define ZC_JOINSPLIT_H_
 
 #include "Zcash.h"
 #include "Proof.hpp"
@@ -102,4 +102,4 @@ protected:
 typedef libzcash::JoinSplit<ZC_NUM_JS_INPUTS,
                             ZC_NUM_JS_OUTPUTS> ZCJoinSplit;
 
-#endif // _ZCJOINSPLIT_H_
+#endif // ZC_JOINSPLIT_H_

--- a/src/zcash/Note.hpp
+++ b/src/zcash/Note.hpp
@@ -1,5 +1,5 @@
-#ifndef _ZCNOTE_H_
-#define _ZCNOTE_H_
+#ifndef ZC_NOTE_H_
+#define ZC_NOTE_H_
 
 #include "uint256.h"
 #include "Zcash.h"
@@ -68,4 +68,4 @@ public:
 
 }
 
-#endif // _ZCNOTE_H_
+#endif // ZC_NOTE_H_

--- a/src/zcash/Proof.hpp
+++ b/src/zcash/Proof.hpp
@@ -1,5 +1,5 @@
-#ifndef _ZCPROOF_H_
-#define _ZCPROOF_H_
+#ifndef ZC_PROOF_H_
+#define ZC_PROOF_H_
 
 #include "serialize.h"
 #include "uint256.h"
@@ -274,4 +274,4 @@ public:
 
 }
 
-#endif // _ZCPROOF_H_
+#endif // ZC_PROOF_H_

--- a/src/zcash/Zcash.h
+++ b/src/zcash/Zcash.h
@@ -1,5 +1,5 @@
-#ifndef _ZCCONSTANTS_H_
-#define _ZCCONSTANTS_H_
+#ifndef ZC_ZCASH_H_
+#define ZC_ZCASH_H_
 
 #define ZC_NUM_JS_INPUTS 2
 #define ZC_NUM_JS_OUTPUTS 2
@@ -14,4 +14,4 @@
 
 #define ZC_NOTEPLAINTEXT_SIZE (ZC_NOTEPLAINTEXT_LEADING + ZC_V_SIZE + ZC_RHO_SIZE + ZC_R_SIZE + ZC_MEMO_SIZE)
 
-#endif // _ZCCONSTANTS_H_
+#endif // ZC_ZCASH_H_

--- a/src/zcash/prf.h
+++ b/src/zcash/prf.h
@@ -3,8 +3,8 @@ Zcash uses SHA256Compress as a PRF for various components
 within the zkSNARK circuit.
 */
 
-#ifndef _PRF_H_
-#define _PRF_H_
+#ifndef ZC_PRF_H_
+#define ZC_PRF_H_
 
 #include "uint256.h"
 #include "uint252.h"
@@ -15,4 +15,4 @@ uint256 PRF_nf(const uint252& a_sk, const uint256& rho);
 uint256 PRF_pk(const uint252& a_sk, size_t i0, const uint256& h_sig);
 uint256 PRF_rho(const uint252& phi, size_t i0, const uint256& h_sig);
 
-#endif // _PRF_H_
+#endif // ZC_PRF_H_

--- a/src/zcash/util.h
+++ b/src/zcash/util.h
@@ -1,5 +1,5 @@
-#ifndef __ZCASH_UTIL_H
-#define __ZCASH_UTIL_H
+#ifndef ZC_UTIL_H_
+#define ZC_UTIL_H_
 
 #include <vector>
 #include <cstdint>
@@ -8,4 +8,4 @@ std::vector<unsigned char> convertIntToVectorLE(const uint64_t val_int);
 std::vector<bool> convertBytesVectorToVector(const std::vector<unsigned char>& bytes);
 uint64_t convertVectorToInt(const std::vector<bool>& v);
 
-#endif // __ZCASH_UTIL_H
+#endif // ZC_UTIL_H_


### PR DESCRIPTION
This is because they may conflict with reserved names. Also took
this opportunity to make the guards in the zcash subdir a bit
more uniform by having them all conform to ZC_<...>_H_

This closes #1272