### PR TITLE
Rename bitcoin bash completion files so that they refer to zcash and not bitcoin.

### DIFF
--- a/contrib/zcash-cli.bash-completion
+++ b/contrib/zcash-cli.bash-completion
@@ -1,9 +1,9 @@
-# bash programmable completion for bitcoin-cli(1)
+# bash programmable completion for zcash-cli(1)
 # Copyright (c) 2012-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-# call $bitcoin-cli for RPC
+# call $zcash-cli for RPC
 _zcash_rpc() {
     # determine already specified args necessary for RPC
     local rpcargs=()
@@ -14,7 +14,7 @@ _zcash_rpc() {
                 ;;
         esac
     done
-    $bitcoin_cli "${rpcargs[@]}" "$@"
+    $zcash_cli "${rpcargs[@]}" "$@"
 }
 
 # Add wallet accounts to COMPREPLY
@@ -28,11 +28,11 @@ _zcash_accounts() {
 
 _zcash_cli() {
     local cur prev words=() cword
-    local bitcoin_cli
+    local zcash_cli
 
-    # save and use original argument to invoke bitcoin-cli for -help, help and RPC
-    # as bitcoin-cli might not be in $PATH
-    bitcoin_cli="$1"
+    # save and use original argument to invoke zcash-cli for -help, help and RPC
+    # as zcash-cli might not be in $PATH
+    zcash_cli="$1"
 
     COMPREPLY=()
     _get_comp_words_by_ref -n = cur prev words cword
@@ -127,7 +127,7 @@ _zcash_cli() {
 
             # only parse -help if senseful
             if [[ -z "$cur" || "$cur" =~ ^- ]]; then
-                helpopts=$($bitcoin_cli -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }' )
+                helpopts=$($zcash_cli -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }' )
             fi
 
             # only parse help if senseful

--- a/contrib/zcash-tx.bash-completion
+++ b/contrib/zcash-tx.bash-completion
@@ -1,15 +1,15 @@
-# bash programmable completion for bitcoin-tx(1)
+# bash programmable completion for zcash-tx(1)
 # Copyright (c) 2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-_bitcoin_tx() {
+_zcash_tx() {
     local cur prev words=() cword
-    local bitcoin_tx
+    local zcash_tx
 
-    # save and use original argument to invoke bitcoin-tx for -help
+    # save and use original argument to invoke zcash-tx for -help
     # it might not be in $PATH
-    bitcoin_tx="$1"
+    zcash_tx="$1"
 
     COMPREPLY=()
     _get_comp_words_by_ref -n =: cur prev words cword
@@ -27,15 +27,15 @@ _bitcoin_tx() {
 
     if [[ "$cword" == 1 || ( "$prev" != "-create" && "$prev" == -* ) ]]; then
         # only options (or an uncompletable hex-string) allowed
-        # parse bitcoin-tx -help for options
+        # parse zcash-tx -help for options
         local helpopts
-        helpopts=$($bitcoin_tx -help | sed -e '/^  -/ p' -e d )
+        helpopts=$($zcash_tx -help | sed -e '/^  -/ p' -e d )
         COMPREPLY=( $( compgen -W "$helpopts" -- "$cur" ) )
     else
         # only commands are allowed
         # parse -help for commands
         local helpcmds
-        helpcmds=$($bitcoin_tx -help | sed -e '1,/Commands:/d' -e 's/=.*/=/' -e '/^  [a-z]/ p' -e d )
+        helpcmds=$($zcash_tx -help | sed -e '1,/Commands:/d' -e 's/=.*/=/' -e '/^  [a-z]/ p' -e d )
         COMPREPLY=( $( compgen -W "$helpcmds" -- "$cur" ) )
     fi
 
@@ -46,7 +46,7 @@ _bitcoin_tx() {
 
     return 0
 } &&
-complete -F _bitcoin_tx zcash-tx
+complete -F _zcash_tx zcash-tx
 
 # Local variables:
 # mode: shell-script

--- a/contrib/zcashd.bash-completion
+++ b/contrib/zcashd.bash-completion
@@ -6,11 +6,11 @@
 
 _zcashd() {
     local cur prev words=() cword
-    local bitcoind
+    local zcashd
 
     # save and use original argument to invoke zcashd for -help
     # it might not be in $PATH
-    bitcoind="$1"
+    zcashd="$1"
 
     COMPREPLY=()
     _get_comp_words_by_ref -n = cur prev words cword
@@ -34,7 +34,7 @@ _zcashd() {
             # only parse -help if senseful
             if [[ -z "$cur" || "$cur" =~ ^- ]]; then
                 local helpopts
-                helpopts=$($bitcoind -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }' )
+                helpopts=$($zcashd -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }' )
                 COMPREPLY=( $( compgen -W "$helpopts" -- "$cur" ) )
             fi
 

--- a/zcutil/build-debian-package.sh
+++ b/zcutil/build-debian-package.sh
@@ -51,8 +51,8 @@ cp $SRC_DOC/man/zcashd.1 $DEB_MAN
 cp $SRC_DOC/man/zcash-cli.1 $DEB_MAN
 cp $SRC_DOC/man/zcash-fetch-params.1 $DEB_MAN
 # Copy bash completion files
-cp $SRC_PATH/contrib/bitcoind.bash-completion $DEB_CMP/zcashd
-cp $SRC_PATH/contrib/bitcoin-cli.bash-completion $DEB_CMP/zcash-cli
+cp $SRC_PATH/contrib/zcashd.bash-completion $DEB_CMP/zcashd
+cp $SRC_PATH/contrib/zcash-cli.bash-completion $DEB_CMP/zcash-cli
 # Gzip files
 gzip --best -n $DEB_DOC/changelog
 gzip --best -n $DEB_DOC/changelog.Debian


### PR DESCRIPTION
This closes #2167 