### PR TITLE
Speed up coin selection by pre-selecting only as many UTXOs as we need

### DIFF
--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -79,7 +79,8 @@ class WalletTest (BitcoinTestFramework):
 
         # Check 'generated' field of listunspent
         # Node 0: has one coinbase utxo and two regular utxos
-        assert_equal(sum(int(uxto["generated"] is True) for uxto in node0utxos), 1)
+        # PATCH: Causes node 0 to have two coinbase utxos instead of one.
+        assert_equal(sum(int(uxto["generated"] is True) for uxto in node0utxos), 2)
         # Node 1: has 101 coinbase utxos and no regular utxos
         node1utxos = self.nodes[1].listunspent(1)
         assert_equal(len(node1utxos), 101)

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -23,6 +23,23 @@ ACTION(ThrowLogicError) {
     throw std::logic_error("Boom");
 }
 
+class FakeChainWalletTests : public ::testing::Test {
+protected:
+    std::vector<uint256> blockHashes;
+
+    FakeChainWalletTests() {
+        ECC_Start();
+    }
+
+    ~FakeChainWalletTests() {
+        chainActive.SetTip(NULL);
+        for (auto blockHash : blockHashes) {
+            mapBlockIndex.erase(blockHash);
+        }
+        ECC_Stop();
+    }
+};
+
 class MockWalletDB {
 public:
     MOCK_METHOD0(TxnBegin, bool());
@@ -80,6 +97,19 @@ libzcash::Note GetNote(const libzcash::SpendingKey& sk,
 CWalletTx GetValidSpend(const libzcash::SpendingKey& sk,
                         const libzcash::Note& note, CAmount value) {
     return GetValidSpend(*params, sk, note, value);
+}
+
+CWalletTx GetValidCoinReceive(CWallet* wallet, const CAmount& nValue)
+{
+    static int nextLockTime = 0;
+    CPubKey key = wallet->GenerateNewKey();
+    CMutableTransaction tx;
+    tx.nLockTime = nextLockTime++;        // so all transactions get different hashes
+    tx.vout.resize(1);
+    tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetID());
+    tx.vout[0].nValue = nValue;
+    CWalletTx wtx(wallet, tx);
+    return wtx;
 }
 
 JSOutPoint CreateValidBlock(TestWallet& wallet,
@@ -1045,4 +1075,77 @@ TEST(wallet_tests, MarkAffectedTransactionsDirty) {
     wallet.AddToWallet(wtx2, true, NULL);
     wallet.MarkAffectedTransactionsDirty(wtx2);
     EXPECT_FALSE(wallet.mapWallet[hash].fDebitCached);
+}
+
+TEST_F(FakeChainWalletTests, AvailableCoinsShortcut) {
+    TestWallet wallet;
+    size_t NUM_COINS = 10;
+
+    // Create fake available coins
+    std::vector<CWalletTx> transactions;
+    CBlock block;
+    for (auto i = 0; i < NUM_COINS; i++) {
+        auto wtx = GetValidCoinReceive(&wallet, i + 1);
+        transactions.push_back(wtx);
+        block.vtx.push_back(wtx);
+    }
+
+    // Fake-mine the transactions
+    EXPECT_EQ(-1, chainActive.Height());
+    block.hashMerkleRoot = block.BuildMerkleTree();
+    auto blockHash = block.GetHash();
+    blockHashes.push_back(blockHash);
+    CBlockIndex fakeIndex {block};
+    mapBlockIndex.insert(std::make_pair(blockHash, &fakeIndex));
+    chainActive.SetTip(&fakeIndex);
+    EXPECT_TRUE(chainActive.Contains(&fakeIndex));
+    EXPECT_EQ(0, chainActive.Height());
+
+    // Now add the fake coins to the wallet
+    for (auto wtx : transactions) {
+        wtx.SetMerkleBranch(block);
+        wallet.AddToWallet(wtx, true, NULL);
+    }
+
+    // If we don't constrain the result, we should get all coins
+    std::vector<COutput> vAllCoins;
+    wallet.AvailableCoins(vAllCoins, false, nullptr, false, true);
+    ASSERT_EQ(vAllCoins.size(), NUM_COINS);
+
+    std::vector<COutput> vCoins;
+    wallet.AvailableCoins(vCoins, false, nullptr, false, true, 0);
+    // We always fetch more value than we need, to try and give room for fees.
+    // But if you get "Insufficient funds", use the "receiver pays fee" mode in
+    // the RPC calls.
+    ASSERT_EQ(vCoins.size(), 1);
+    // We can't predict the order in which the coins will be returned, but we
+    // know that it will be deterministic.
+    EXPECT_EQ(vCoins[0], vAllCoins[0]);
+
+    vCoins.clear();
+    wallet.AvailableCoins(vCoins, false, nullptr, false, true, 5);
+    EXPECT_GT(vCoins.size(), 0);
+    EXPECT_LT(vCoins.size(), NUM_COINS);
+    for (auto i = 0; i < vCoins.size(); i++) {
+        EXPECT_EQ(vCoins[i], vAllCoins[i]);
+    }
+
+    vCoins.clear();
+    wallet.AvailableCoins(vCoins, false, nullptr, false, true, 6);
+    EXPECT_GT(vCoins.size(), 0);
+    EXPECT_LT(vCoins.size(), NUM_COINS);
+    for (auto i = 0; i < vCoins.size(); i++) {
+        EXPECT_EQ(vCoins[i], vAllCoins[i]);
+    }
+
+    // If we request as many coins as we have, we should get all of them.
+    vCoins.clear();
+    CAmount total = (NUM_COINS * (NUM_COINS + 1)) / 2;
+    wallet.AvailableCoins(vCoins, false, nullptr, false, true, total);
+    EXPECT_EQ(vCoins, vAllCoins);
+
+    // If we request more coins than we have, we should get all of them.
+    vCoins.clear();
+    wallet.AvailableCoins(vCoins, false, nullptr, false, true, total + 1);
+    EXPECT_EQ(vCoins, vAllCoins);
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2188,12 +2188,13 @@ CAmount CWallet::GetImmatureWatchOnlyBalance() const
 /**
  * populate vCoins with vector of available COutputs.
  */
-void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const CCoinControl *coinControl, bool fIncludeZeroValue, bool fIncludeCoinBase) const
+void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const CCoinControl *coinControl, bool fIncludeZeroValue, bool fIncludeCoinBase, boost::optional<CAmount> amount) const
 {
     vCoins.clear();
 
     {
         LOCK2(cs_main, cs_wallet);
+        CAmount currentAmount = 0;
         for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const uint256& wtxid = it->first;
@@ -2220,7 +2221,13 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
                 if (!(IsSpent(wtxid, i)) && mine != ISMINE_NO &&
                     !IsLockedCoin((*it).first, i) && (pcoin->vout[i].nValue > 0 || fIncludeZeroValue) &&
                     (!coinControl || !coinControl->HasSelected() || coinControl->fAllowOtherInputs || coinControl->IsSelected((*it).first, i)))
+                {
                         vCoins.push_back(COutput(pcoin, i, nDepth, (mine & ISMINE_SPENDABLE) != ISMINE_NO));
+                        if (vCoins.back().fSpendable)
+                            currentAmount += pcoin->vout[i].nValue;
+                        if (amount && currentAmount > *amount)
+                            return;
+                }
             }
         }
     }
@@ -2377,8 +2384,8 @@ bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletTx*
 {
     // Output parameter fOnlyCoinbaseCoinsRet is set to true when the only available coins are coinbase utxos.
     vector<COutput> vCoinsNoCoinbase, vCoinsWithCoinbase;
-    AvailableCoins(vCoinsNoCoinbase, true, coinControl, false, false);
-    AvailableCoins(vCoinsWithCoinbase, true, coinControl, false, true);
+    AvailableCoins(vCoinsNoCoinbase, true, coinControl, false, false, nTargetValue);
+    AvailableCoins(vCoinsWithCoinbase, true, coinControl, false, true, nTargetValue);
     fOnlyCoinbaseCoinsRet = vCoinsNoCoinbase.size() == 0 && vCoinsWithCoinbase.size() > 0;
 
     // If coinbase utxos can only be sent to zaddrs, exclude any coinbase utxos from coin selection.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -539,6 +539,10 @@ public:
     }
 
     std::string ToString() const;
+
+    bool operator==(const COutput& rhs) const {
+        return tx == rhs.tx && i == rhs.i && nDepth == rhs.nDepth && fSpendable == rhs.fSpendable;
+    }
 };
 
 
@@ -805,7 +809,7 @@ public:
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
 
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL, bool fIncludeZeroValue=false, bool fIncludeCoinBase=true) const;
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL, bool fIncludeZeroValue=false, bool fIncludeCoinBase=true, boost::optional<CAmount> amount = boost::none) const;
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;


### PR DESCRIPTION
This effectively converts the coin selection algorithm into "oldest first" (or
whatever sorting is applied to the UTXOs in-memory), but is not exactly that, as
the selected UTXOs are then passed into the existing knapsack algorithm from
Bitcoin. The speedup comes from that algorithm having many fewer UTXOs to
consider (in the case where the number of UTXOs in the wallet is orders of
magnitude greater than the number required).