### PR TITLE
Add getdeprecationinfo RPC method to return deprecation block height

### DIFF
--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -401,10 +401,11 @@ static UniValue GetNetworksInfo()
 
 UniValue getdeprecationinfo(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
+    const CChainParams& chainparams = Params();
+    if (fHelp || params.size() != 0 || chainparams.NetworkIDString() != "main")
         throw runtime_error(
             "getdeprecationinfo\n"
-            "Returns an object containing current version and deprecation block height.\n"
+            "Returns an object containing current version and deprecation block height. Applicable only on mainnet.\n"
             "\nResult:\n"
             "{\n"
             "  \"version\": xxxxx,                      (numeric) the server version\n"
@@ -416,9 +417,8 @@ UniValue getdeprecationinfo(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getdeprecationinfo", "")
         );
 
-
     UniValue obj(UniValue::VOBJ);
-    obj.push_back(Pair("version",       CLIENT_VERSION));
+    obj.push_back(Pair("version", CLIENT_VERSION));
     obj.push_back(Pair("subversion",
         FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>())));
     obj.push_back(Pair("deprecationheight", DEPRECATION_HEIGHT));

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -13,6 +13,7 @@
 #include "timedata.h"
 #include "util.h"
 #include "version.h"
+#include "deprecation.h"
 
 #include <boost/foreach.hpp>
 
@@ -396,6 +397,33 @@ static UniValue GetNetworksInfo()
         networks.push_back(obj);
     }
     return networks;
+}
+
+UniValue getdeprecationinfo(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getdeprecationinfo\n"
+            "Returns an object containing current version and deprecation block height.\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"version\": xxxxx,                      (numeric) the server version\n"
+            "  \"subversion\": \"/MagicBean:x.y.z[-v]/\",     (string) the server subversion string\n"
+            "  \"deprecationheight\": xxxxx,            (numeric) the block height at which this version will deprecate and shut down (unless -disabledeprecation is set)\n"
+            "}\n"
+            "\nExamples:\n"
+            + HelpExampleCli("getdeprecationinfo", "")
+            + HelpExampleRpc("getdeprecationinfo", "")
+        );
+
+
+    UniValue obj(UniValue::VOBJ);
+    obj.push_back(Pair("version",       CLIENT_VERSION));
+    obj.push_back(Pair("subversion",
+        FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>())));
+    obj.push_back(Pair("deprecationheight", DEPRECATION_HEIGHT));
+
+    return obj;
 }
 
 UniValue getnetworkinfo(const UniValue& params, bool fHelp)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -265,6 +265,7 @@ static const CRPCCommand vRPCCommands[] =
 
     /* P2P networking */
     { "network",            "getnetworkinfo",         &getnetworkinfo,         true  },
+    { "network",            "getdeprecationinfo",     &getdeprecationinfo,     true  },
     { "network",            "addnode",                &addnode,                true  },
     { "network",            "disconnectnode",         &disconnectnode,         true  },
     { "network",            "getaddednodeinfo",       &getaddednodeinfo,       true  },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -238,6 +238,7 @@ extern UniValue getinfo(const UniValue& params, bool fHelp);
 extern UniValue getwalletinfo(const UniValue& params, bool fHelp);
 extern UniValue getblockchaininfo(const UniValue& params, bool fHelp);
 extern UniValue getnetworkinfo(const UniValue& params, bool fHelp);
+extern UniValue getdeprecationinfo(const UniValue& params, bool fHelp);
 extern UniValue setmocktime(const UniValue& params, bool fHelp);
 extern UniValue resendwallettransactions(const UniValue& params, bool fHelp);
 extern UniValue zc_benchmark(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Closes #2828 

Returns:
```
{
  "version": xxxxx,                      (numeric) the server version
  "subversion": "/MagicBean:x.y.z[-v]/",     (string) the server subversion string
  "deprecationheight": xxxxx,            (numeric) the deprecation block height
}
```