### PR TITLE
Annotations

### DIFF
--- a/src/gtest/test_circuit.cpp
+++ b/src/gtest/test_circuit.cpp
@@ -97,8 +97,8 @@ bool test_merkle_gadget(
     pb_variable<FieldT> commitment2_read;
     commitment2_read.allocate(pb);
 
-    merkle_tree_gadget<FieldT> mgadget1(pb, commitment1, root, commitment1_read);
-    merkle_tree_gadget<FieldT> mgadget2(pb, commitment2, root, commitment2_read);
+    merkle_tree_gadget<FieldT> mgadget1(pb, commitment1, root, commitment1_read, "mgadget_1");
+    merkle_tree_gadget<FieldT> mgadget2(pb, commitment2, root, commitment2_read, "mgadget_2");
 
     commitment1.generate_r1cs_constraints();
     commitment2.generate_r1cs_constraints();

--- a/src/snark/src/gadgetlib1/gadgets/hashes/sha256/sha256_components.tcc
+++ b/src/snark/src/gadgetlib1/gadgets/hashes/sha256/sha256_components.tcc
@@ -88,7 +88,7 @@ sha256_message_schedule_gadget<FieldT>::sha256_message_schedule_gadget(protoboar
         compute_sigma1[i].reset(new small_sigma_gadget<FieldT>(pb, W_bits[i-2], sigma1[i], 17, 19, 10, FMT(this->annotation_prefix, " compute_sigma1_%zu", i)));
 
         /* unreduced_W = sigma0(W_{i-15}) + sigma1(W_{i-2}) + W_{i-7} + W_{i-16} before modulo 2^32 */
-        unreduced_W[i].allocate(pb, FMT(this->annotation_prefix, "unreduced_W_%zu", i));
+        unreduced_W[i].allocate(pb, FMT(this->annotation_prefix, " unreduced_W_%zu", i));
 
         /* allocate the bit representation of packed_W[i] */
         W_bits[i].allocate(pb, 32, FMT(this->annotation_prefix, " W_bits_%zu", i));

--- a/src/zcash/circuit/gadget.tcc
+++ b/src/zcash/circuit/gadget.tcc
@@ -177,7 +177,7 @@ public:
                 generate_boolean_r1cs_constraint<FieldT>(
                     this->pb,
                     zk_total_uint64[i],
-                    FMT(this->annotation_prefix, " ensure_left_is_64")
+                    FMT(this->annotation_prefix, " ensure_left_is_64[%d]", i)
                 );
             }
 

--- a/src/zcash/circuit/merkle.tcc
+++ b/src/zcash/circuit/merkle.tcc
@@ -12,12 +12,12 @@ public:
         protoboard<FieldT>& pb,
         digest_variable<FieldT> leaf,
         digest_variable<FieldT> root,
-        pb_variable<FieldT>& enforce
-    ) : gadget<FieldT>(pb) {
-        positions.allocate(pb, INCREMENTAL_MERKLE_TREE_DEPTH);
+        pb_variable<FieldT>& enforce,
+	const std::string &annotation_prefix
+		       ) : gadget<FieldT>(pb, FMT(annotation_prefix, " merkle_tree_gadget")) {
+	positions.allocate(pb, INCREMENTAL_MERKLE_TREE_DEPTH, FMT(this->annotation_prefix, " positions"));
         authvars.reset(new merkle_authentication_path_variable<FieldT, sha256_gadget>(
-            pb, INCREMENTAL_MERKLE_TREE_DEPTH, "auth"
-        ));
+										      pb, INCREMENTAL_MERKLE_TREE_DEPTH, FMT(this->annotation_prefix, " auth")));
         auth.reset(new merkle_tree_check_read_gadget<FieldT, sha256_gadget>(
             pb,
             INCREMENTAL_MERKLE_TREE_DEPTH,
@@ -26,7 +26,7 @@ public:
             root,
             *authvars,
             enforce,
-            ""
+            FMT(this->annotation_prefix, " check")
         ));
     }
 
@@ -39,7 +39,7 @@ public:
             generate_boolean_r1cs_constraint<FieldT>(
                 this->pb,
                 positions[i],
-                "boolean_positions"
+                FMT(this->annotation_prefix, " boolean_positions")
             );
         }
 

--- a/src/zcash/circuit/merkle.tcc
+++ b/src/zcash/circuit/merkle.tcc
@@ -39,7 +39,7 @@ public:
             generate_boolean_r1cs_constraint<FieldT>(
                 this->pb,
                 positions[i],
-                FMT(this->annotation_prefix, " boolean_positions")
+                FMT(this->annotation_prefix, " boolean_positions[%d]", i)
             );
         }
 

--- a/src/zcash/circuit/note.tcc
+++ b/src/zcash/circuit/note.tcc
@@ -14,7 +14,7 @@ public:
             generate_boolean_r1cs_constraint<FieldT>(
                 this->pb,
                 value[i],
-                FMT(this->annotation_prefix, " boolean_value")
+                FMT(this->annotation_prefix, " boolean_value[%d]", i)
             );
         }
 

--- a/src/zcash/circuit/prfs.tcc
+++ b/src/zcash/circuit/prfs.tcc
@@ -15,8 +15,9 @@ public:
         bool d,
         pb_variable_array<FieldT> x,
         pb_variable_array<FieldT> y,
-        std::shared_ptr<digest_variable<FieldT>> result
-    ) : gadget<FieldT>(pb), result(result) {
+        std::shared_ptr<digest_variable<FieldT>> result,
+	const std::string &annotation_prefix
+	       ) : gadget<FieldT>(pb, FMT(annotation_prefix, " PRF_gadget")), result(result) {
 
         pb_linear_combination_array<FieldT> IV = SHA256_default_IV(pb);
 
@@ -30,14 +31,14 @@ public:
             discriminants,
             x,
             y
-        }, "PRF_block"));
+	      }, FMT(this->annotation_prefix, " block")));
 
         hasher.reset(new sha256_compression_function_gadget<FieldT>(
             pb,
             IV,
             block->bits,
             *result,
-        "PRF_hasher"));
+	    FMT(this->annotation_prefix, " hasher")));
     }
 
     void generate_r1cs_constraints() {
@@ -66,8 +67,9 @@ public:
         protoboard<FieldT>& pb,
         pb_variable<FieldT>& ZERO,
         pb_variable_array<FieldT>& a_sk,
-        std::shared_ptr<digest_variable<FieldT>> result
-    ) : PRF_gadget<FieldT>(pb, ZERO, 1, 1, 0, 0, a_sk, gen256zeroes(ZERO), result) {}
+        std::shared_ptr<digest_variable<FieldT>> result,
+	const std::string &annotation_prefix
+			 ) : PRF_gadget<FieldT>(pb, ZERO, 1, 1, 0, 0, a_sk, gen256zeroes(ZERO), result, annotation_prefix) {}
 };
 
 template<typename FieldT>
@@ -78,8 +80,9 @@ public:
         pb_variable<FieldT>& ZERO,
         pb_variable_array<FieldT>& a_sk,
         pb_variable_array<FieldT>& rho,
-        std::shared_ptr<digest_variable<FieldT>> result
-    ) : PRF_gadget<FieldT>(pb, ZERO, 1, 1, 1, 0, a_sk, rho, result) {}
+        std::shared_ptr<digest_variable<FieldT>> result,
+	const std::string &annotation_prefix
+		  ) : PRF_gadget<FieldT>(pb, ZERO, 1, 1, 1, 0, a_sk, rho, result, annotation_prefix) {}
 };
 
 template<typename FieldT>
@@ -91,8 +94,9 @@ public:
         pb_variable_array<FieldT>& a_sk,
         pb_variable_array<FieldT>& h_sig,
         bool nonce,
-        std::shared_ptr<digest_variable<FieldT>> result
-    ) : PRF_gadget<FieldT>(pb, ZERO, 0, nonce, 0, 0, a_sk, h_sig, result) {}
+        std::shared_ptr<digest_variable<FieldT>> result,
+	const std::string &annotation_prefix
+		  ) : PRF_gadget<FieldT>(pb, ZERO, 0, nonce, 0, 0, a_sk, h_sig, result, annotation_prefix) {}
 };
 
 template<typename FieldT>
@@ -104,6 +108,7 @@ public:
         pb_variable_array<FieldT>& phi,
         pb_variable_array<FieldT>& h_sig,
         bool nonce,
-        std::shared_ptr<digest_variable<FieldT>> result
-    ) : PRF_gadget<FieldT>(pb, ZERO, 0, nonce, 1, 0, phi, h_sig, result) {}
+        std::shared_ptr<digest_variable<FieldT>> result,
+	const std::string &annotation_prefix
+    ) : PRF_gadget<FieldT>(pb, ZERO, 0, nonce, 1, 0, phi, h_sig, result, annotation_prefix) {}
 };


### PR DESCRIPTION
This pull request adds debugging "annotations" to the zcash snark circuit gadgets. 

The `gadgetlib1` examples in libsnark have such annotations (see the [SHA256 gadget](https://github.com/scipr-lab/libsnark/blob/master/libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.tcc) for example), but the Zcash gadgets don't use them. They only have an effect when `DEBUG` is defined anyway. For an example of how they can be used, see https://github.com/amiller/zcash/blob/circuit-annotations/README.md

There's not much direct benefit to having them in this code repository, except that it may make it easier for developers of other Zcash-compatible libraries to have a canonical name for each variable and constraint.