### PR TITLE
Revert "Revert "Remove an unneeded version workaround..."

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4384,8 +4384,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return false;
         }
 
-        if (pfrom->nVersion == 10300)
-            pfrom->nVersion = 300;
         if (!vRecv.empty())
             vRecv >> addrFrom >> nNonce;
         if (!vRecv.empty()) {


### PR DESCRIPTION
This reverts commit 9ad9a25eff871e8c8fdb2468558c1d8b4b0a0d8e which itself reverted commit 1e9db0b38a64e8df510294e44b5e6afb4b2dffc8.

The code should be removed as it is redundant.  Zcash has never
had any nodes on protocol version 10300 or 300.  The original commit
was made in 2010 for Bitcoin 0.3 rc4 and can be found here:
https://github.com/bitcoin/bitcoin/commit/f077bc0f48bf0853cbe5d01b0e10df93c04917ab#diff-118fcbaaba162ba17933c7893247df3aR1865