### PR TITLE
Remove redundant service flag NODE_GETUTXO meant for Bitcoin XT.

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -71,10 +71,6 @@ enum {
     // set by all Bitcoin Core nodes, and is unset by SPV clients or other peers that just want
     // network services but don't provide them.
     NODE_NETWORK = (1 << 0),
-    // NODE_GETUTXO means the node is capable of responding to the getutxo protocol request.
-    // Bitcoin Core does not support this but a patch set called Bitcoin XT does.
-    // See BIP 64 for details on how this is implemented.
-    NODE_GETUTXO = (1 << 1),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the


### PR DESCRIPTION
For #2885. This frees up a service bit.  Zcash has never used this flag
and upstream Bitcoin Core does not support this flag, although
it did reserve it for compatibility with Bitcoin XT.
