### PR TITLE
Make some globals static that can be

### DIFF
--- a/src/asyncrpcoperation.cpp
+++ b/src/asyncrpcoperation.cpp
@@ -16,7 +16,7 @@ using namespace std;
 
 static boost::uuids::random_generator uuidgen;
 
-std::map<OperationStatus, std::string> OperationStatusMap = {
+static std::map<OperationStatus, std::string> OperationStatusMap = {
     {OperationStatus::READY, "queued"},
     {OperationStatus::EXECUTING, "executing"},
     {OperationStatus::CANCELLED, "cancelled"},

--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -26,7 +26,7 @@
 
 #include <boost/optional.hpp>
 
-EhSolverCancelledException solver_cancelled;
+static EhSolverCancelledException solver_cancelled;
 
 template<unsigned int N, unsigned int K>
 int Equihash<N,K>::InitialiseState(eh_HashState& base_state)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ CCriticalSection cs_main;
 BlockMap mapBlockIndex;
 CChain chainActive;
 CBlockIndex *pindexBestHeader = NULL;
-int64_t nTimeBestReceived = 0;
+static int64_t nTimeBestReceived = 0;
 CWaitableCriticalSection csBestBlock;
 CConditionVariable cvBlockChange;
 int nScriptCheckThreads = 0;
@@ -1436,9 +1436,10 @@ bool IsInitialBlockDownload()
     return state;
 }
 
-bool fLargeWorkForkFound = false;
-bool fLargeWorkInvalidChainFound = false;
-CBlockIndex *pindexBestForkTip = NULL, *pindexBestForkBase = NULL;
+static bool fLargeWorkForkFound = false;
+static bool fLargeWorkInvalidChainFound = false;
+static CBlockIndex *pindexBestForkTip = NULL;
+static CBlockIndex *pindexBestForkBase = NULL;
 
 void CheckForkWarningConditions()
 {
@@ -5578,7 +5579,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
 
 
 
-class CMainCleanup
+static class CMainCleanup
 {
 public:
     CMainCleanup() {}

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -64,21 +64,21 @@ double AtomicTimer::rate(const AtomicCounter& count)
     return duration > 0 ? (double)count.get() / duration : 0;
 }
 
-CCriticalSection cs_metrics;
+static CCriticalSection cs_metrics;
 
-boost::synchronized_value<int64_t> nNodeStartTime;
-boost::synchronized_value<int64_t> nNextRefresh;
+static boost::synchronized_value<int64_t> nNodeStartTime;
+static boost::synchronized_value<int64_t> nNextRefresh;
 AtomicCounter transactionsValidated;
 AtomicCounter ehSolverRuns;
 AtomicCounter solutionTargetChecks;
-AtomicCounter minedBlocks;
+static AtomicCounter minedBlocks;
 AtomicTimer miningTimer;
 
-boost::synchronized_value<std::list<uint256>> trackedBlocks;
+static boost::synchronized_value<std::list<uint256>> trackedBlocks;
 
-boost::synchronized_value<std::list<std::string>> messageBox;
-boost::synchronized_value<std::string> initMessage;
-bool loaded = false;
+static boost::synchronized_value<std::list<std::string>> messageBox;
+static boost::synchronized_value<std::string> initMessage;
+static bool loaded = false;
 
 extern int64_t GetNetworkHashPS(int lookup, int height);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -81,10 +81,10 @@ CCriticalSection cs_mapRelay;
 limitedmap<CInv, int64_t> mapAlreadyAskedFor(MAX_INV_SZ);
 
 static deque<string> vOneShots;
-CCriticalSection cs_vOneShots;
+static CCriticalSection cs_vOneShots;
 
-set<CNetAddr> setservAddNodeAddresses;
-CCriticalSection cs_setservAddNodeAddresses;
+static set<CNetAddr> setservAddNodeAddresses;
+static CCriticalSection cs_setservAddNodeAddresses;
 
 vector<std::string> vAddedNodes;
 CCriticalSection cs_vAddedNodes;
@@ -93,7 +93,7 @@ NodeId nLastNodeId = 0;
 CCriticalSection cs_nLastNodeId;
 
 static CSemaphore *semOutbound = NULL;
-boost::condition_variable messageHandlerCondition;
+static boost::condition_variable messageHandlerCondition;
 
 // Signals for message handling
 static CNodeSignals g_signals;
@@ -1779,7 +1779,7 @@ bool StopNode()
     return true;
 }
 
-class CNetCleanup
+static class CNetCleanup
 {
 public:
     CNetCleanup() {}

--- a/src/snark/libsnark/common/profiling.cpp
+++ b/src/snark/libsnark/common/profiling.cpp
@@ -45,8 +45,10 @@ long long get_nsec_cpu_time()
     return ts.tv_sec * 1000000000ll + ts.tv_nsec;
 }
 
-long long start_time, last_time;
-long long start_cpu_time, last_cpu_time;
+static long long start_time;
+static long long last_time;
+static long long start_cpu_time;
+static long long last_cpu_time;
 
 void start_profiling()
 {
@@ -57,20 +59,20 @@ void start_profiling()
 }
 
 std::map<std::string, size_t> invocation_counts;
-std::map<std::string, long long> enter_times;
+static std::map<std::string, long long> enter_times;
 std::map<std::string, long long> last_times;
 std::map<std::string, long long> cumulative_times;
 //TODO: Instead of analogous maps for time and cpu_time, use a single struct-valued map
-std::map<std::string, long long> enter_cpu_times;
-std::map<std::string, long long> last_cpu_times;
-std::map<std::pair<std::string, std::string>, long long> op_counts;
-std::map<std::pair<std::string, std::string>, long long> cumulative_op_counts; // ((msg, data_point), value)
+static std::map<std::string, long long> enter_cpu_times;
+static std::map<std::string, long long> last_cpu_times;
+static std::map<std::pair<std::string, std::string>, long long> op_counts;
+static std::map<std::pair<std::string, std::string>, long long> cumulative_op_counts; // ((msg, data_point), value)
     // TODO: Convert op_counts and cumulative_op_counts from pair to structs
-size_t indentation = 0;
+static size_t indentation = 0;
 
-std::vector<std::string> block_names;
+static std::vector<std::string> block_names;
 
-std::list<std::pair<std::string, long long*> > op_data_points = {
+static std::list<std::pair<std::string, long long*> > op_data_points = {
 #ifdef PROFILE_OP_COUNTS
     std::make_pair("Fradd", &Fr<default_ec_pp>::add_cnt),
     std::make_pair("Frsub", &Fr<default_ec_pp>::sub_cnt),

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -124,7 +124,7 @@ void locking_callback(int mode, int i, const char* file, int line) NO_THREAD_SAF
 }
 
 // Init
-class CInit
+static class CInit
 {
 public:
     CInit()

--- a/src/zcash/JoinSplit.cpp
+++ b/src/zcash/JoinSplit.cpp
@@ -24,8 +24,7 @@ namespace libzcash {
 
 #include "zcash/circuit/gadget.tcc"
 
-CCriticalSection cs_ParamsIO;
-CCriticalSection cs_LoadKeys;
+static CCriticalSection cs_ParamsIO;
 
 template<typename T>
 void saveToFile(const std::string path, T& obj) {

--- a/src/zcash/Proof.cpp
+++ b/src/zcash/Proof.cpp
@@ -216,7 +216,7 @@ ZCProof ZCProof::random_invalid()
     return p;
 }
 
-std::once_flag init_public_params_once_flag;
+static std::once_flag init_public_params_once_flag;
 
 void initialize_curve_params()
 {


### PR DESCRIPTION
I wrote this patch as part of making a Bazel build system but it really is independent from that so I'm putting this as a separate PR.

External linkage does not help and just encourages sloppy dependencies (ie using symbols only declared in a cpp file in some other cpp file) and can lead to weird issues when there are name collisions.