### PR TITLE
Remove unused NOBLKS_VERSION_{START,END} constants from version.h

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -24,10 +24,6 @@ static const int MIN_PEER_PROTO_VERSION = 170002;
 //! if possible, avoid requesting addresses nodes older than this
 static const int CADDR_TIME_VERSION = 31402;
 
-//! only request blocks from nodes outside this range of versions
-static const int NOBLKS_VERSION_START = 32000;
-static const int NOBLKS_VERSION_END = 32400;
-
 //! BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;
 


### PR DESCRIPTION
Closes #2901. Backport from upstream PR https://github.com/bitcoin/bitcoin/pull/7662.