### PR TITLE
Use JoinSplitTestingSetup for Boost sighash tests

### DIFF
--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -152,7 +152,7 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
     }
 }
 
-BOOST_FIXTURE_TEST_SUITE(sighash_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(sighash_tests, JoinSplitTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sighash_test)
 {


### PR DESCRIPTION
Symptom: When running all tests, the test suite passed. But when running the
sighash tests on their own, the test suite segfaulted.

Cause: The sighash tests depend on the proving parameters being accessible, but
BasicTestingSetup doesn't load them.