### PR TITLE
read hashReserved from disk

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -304,6 +304,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->hashAnchor     = diskindex.hashAnchor;
                 pindexNew->nVersion       = diskindex.nVersion;
                 pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
+                pindexNew->hashReserved   = diskindex.hashReserved;
                 pindexNew->nTime          = diskindex.nTime;
                 pindexNew->nBits          = diskindex.nBits;
                 pindexNew->nNonce         = diskindex.nNonce;


### PR DESCRIPTION
This fixes a bug where the hashReserved field of the block header is not properly read back into CBlockIndex when loaded from disk. This happens to cause no issues currently because hashReserved has always been its default value (== 0), but if a block were ever mined where this was not the case, headers read back from disk would appear to have an invalid solution