### PR TITLE
Remove mempool transactions which commit to an unmineable branch ID

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -29,6 +29,7 @@ testScripts=(
     'mempool_spendcoinbase.py'
     'mempool_coinbase_spends.py'
     'mempool_tx_input_limit.py'
+    'mempool_nu_activation.py'
     'httpbasics.py'
     'zapwallettxes.py'
     'proxy_test.py'

--- a/qa/rpc-tests/mempool_nu_activation.py
+++ b/qa/rpc-tests/mempool_nu_activation.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python2
+# Copyright (c) 2018 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import assert_equal, initialize_chain_clean, \
+    start_node, connect_nodes
+
+import time
+from decimal import Decimal
+
+# Test mempool behaviour around network upgrade activation
+class MempoolUpgradeActivationTest(BitcoinTestFramework):
+
+    alert_filename = None  # Set by setup_network
+
+    def setup_network(self):
+        args = ["-checkmempool", "-debug=mempool", "-blockmaxsize=1000", "-nuparams=5ba81b19:200"]
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, args))
+        self.nodes.append(start_node(1, self.options.tmpdir, args))
+        connect_nodes(self.nodes[1], 0)
+        self.is_network_split = False
+        self.sync_all
+
+    def setup_chain(self):
+        print "Initializing test directory "+self.options.tmpdir
+        initialize_chain_clean(self.options.tmpdir, 2)
+
+    def run_test(self):
+        self.nodes[1].generate(100)
+        self.sync_all()
+
+        # Mine 98 blocks. After this, nodes[1] blocks
+        # 1 to 98 are spend-able, and the mempool expects
+        # block 199, which is a Sprout block.
+        self.nodes[0].generate(98)
+        self.sync_all()
+
+        # Mempool should be empty.
+        assert_equal(set(self.nodes[0].getrawmempool()), set())
+
+        # Fill the mempool with twice as many transactions as can fit into blocks
+        node0_taddr = self.nodes[0].getnewaddress()
+        sprout_txids = []
+        while self.nodes[1].getmempoolinfo()['bytes'] < 2 * 1000:
+            sprout_txids.append(self.nodes[1].sendtoaddress(node0_taddr, Decimal('0.001')))
+        self.sync_all()
+
+        # Spends should be in the mempool
+        sprout_mempool = set(self.nodes[0].getrawmempool())
+        assert_equal(sprout_mempool, set(sprout_txids))
+
+        # Generate block 199. After this, the mempool expects
+        # block 200, which is the first Overwinter block.
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # mempool should be empty.
+        assert_equal(set(self.nodes[0].getrawmempool()), set())
+
+        # Block 199 should contain a subset of the original mempool
+        # (with all other transactions having been dropped)
+        block_txids = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['tx']
+        assert(len(block_txids) < len(sprout_txids))
+        for txid in block_txids[1:]: # Exclude coinbase
+            assert(txid in sprout_txids)
+
+        # Create some Overwinter transactions
+        overwinter_txids = [self.nodes[1].sendtoaddress(node0_taddr, Decimal('0.001')) for i in range(10)]
+        self.sync_all()
+
+        # Spends should be in the mempool
+        assert_equal(set(self.nodes[0].getrawmempool()), set(overwinter_txids))
+
+        # Invalidate block 199.
+        self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
+
+        # mempool should now only contain the transactions that were
+        # in block 199, the Overwinter transactions having been dropped.
+        assert_equal(set(self.nodes[0].getrawmempool()), set(block_txids[1:]))
+
+if __name__ == '__main__':
+    MempoolUpgradeActivationTest().main()

--- a/src/gtest/test_mempool.cpp
+++ b/src/gtest/test_mempool.cpp
@@ -83,7 +83,8 @@ TEST(Mempool, PriorityStatsDoNotCrash) {
     unsigned int nHeight = 92045;
     double dPriority = view.GetPriority(tx, nHeight);
 
-    CTxMemPoolEntry entry(tx, nFees, nTime, dPriority, nHeight, true);
+    // TODO: SPROUT_BRANCH_ID
+    CTxMemPoolEntry entry(tx, nFees, nTime, dPriority, nHeight, true, 0);
 
     // Check it does not crash (ie. the death test fails)
     EXPECT_NONFATAL_FAILURE(EXPECT_DEATH(testPool.addUnchecked(tx.GetHash(), entry), ""), "");

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "consensus/upgrades.h"
 #include "main.h"
 #include "txmempool.h"
 #include "util.h"
@@ -99,6 +100,58 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     BOOST_CHECK_EQUAL(removed.size(), 6);
     BOOST_CHECK_EQUAL(testPool.size(), 0);
     removed.clear();
+}
+
+BOOST_AUTO_TEST_CASE(RemoveWithoutBranchId) {
+    CTxMemPool pool(CFeeRate(0));
+
+    // Add some Sprout transactions
+    for (auto i = 1; i < 11; i++) {
+        CMutableTransaction tx = CMutableTransaction();
+        tx.vout.resize(1);
+        tx.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+        tx.vout[0].nValue = i * COIN;
+        pool.addUnchecked(tx.GetHash(), CTxMemPoolEntry(tx, 0, 0, 0.0, 1, true, NetworkUpgradeInfo[Consensus::BASE_SPROUT].nBranchId));
+    }
+    BOOST_CHECK_EQUAL(pool.size(), 10);
+
+    // Check the pool only contains Sprout transactions
+    for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = pool.mapTx.begin(); it != pool.mapTx.end(); it++) {
+        BOOST_CHECK_EQUAL(it->second.GetBranchId(), NetworkUpgradeInfo[Consensus::BASE_SPROUT].nBranchId);
+    }
+
+    // Add some dummy transactions
+    for (auto i = 1; i < 11; i++) {
+        CMutableTransaction tx = CMutableTransaction();
+        tx.vout.resize(1);
+        tx.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+        tx.vout[0].nValue = i * COIN + 100;
+        pool.addUnchecked(tx.GetHash(), CTxMemPoolEntry(tx, 0, 0, 0.0, 1, true, NetworkUpgradeInfo[Consensus::UPGRADE_TESTDUMMY].nBranchId));
+    }
+    BOOST_CHECK_EQUAL(pool.size(), 20);
+
+    // Add some Overwinter transactions
+    for (auto i = 1; i < 11; i++) {
+        CMutableTransaction tx = CMutableTransaction();
+        tx.vout.resize(1);
+        tx.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+        tx.vout[0].nValue = i * COIN + 200;
+        pool.addUnchecked(tx.GetHash(), CTxMemPoolEntry(tx, 0, 0, 0.0, 1, true, NetworkUpgradeInfo[Consensus::UPGRADE_OVERWINTER].nBranchId));
+    }
+    BOOST_CHECK_EQUAL(pool.size(), 30);
+
+    // Remove transactions that are not for Overwinter
+    pool.removeWithoutBranchId(NetworkUpgradeInfo[Consensus::UPGRADE_OVERWINTER].nBranchId);
+    BOOST_CHECK_EQUAL(pool.size(), 10);
+
+    // Check the pool only contains Overwinter transactions
+    for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = pool.mapTx.begin(); it != pool.mapTx.end(); it++) {
+        BOOST_CHECK_EQUAL(it->second.GetBranchId(), NetworkUpgradeInfo[Consensus::UPGRADE_OVERWINTER].nBranchId);
+    }
+
+    // Roll back to Sprout
+    pool.removeWithoutBranchId(NetworkUpgradeInfo[Consensus::BASE_SPROUT].nBranchId);
+    BOOST_CHECK_EQUAL(pool.size(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -25,9 +25,9 @@ CTxMemPoolEntry::CTxMemPoolEntry():
 
 CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, const CAmount& _nFee,
                                  int64_t _nTime, double _dPriority,
-                                 unsigned int _nHeight, bool poolHasNoInputsOf):
+                                 unsigned int _nHeight, bool poolHasNoInputsOf, uint32_t _nBranchId):
     tx(_tx), nFee(_nFee), nTime(_nTime), dPriority(_dPriority), nHeight(_nHeight),
-    hadNoDependencies(poolHasNoInputsOf)
+    hadNoDependencies(poolHasNoInputsOf), nBranchId(_nBranchId)
 {
     nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
     nModSize = tx.CalculateModifiedSize(nTxSize);
@@ -270,6 +270,28 @@ void CTxMemPool::removeForBlock(const std::vector<CTransaction>& vtx, unsigned i
     }
     // After the txs in the new block have been removed from the mempool, update policy estimates
     minerPolicyEstimator->processBlock(nBlockHeight, entries, fCurrentEstimate);
+}
+
+/**
+ * Called whenever the tip changes. Removes transactions which don't commit to
+ * the given branch ID from the mempool.
+ */
+void CTxMemPool::removeWithoutBranchId(uint32_t nMemPoolBranchId)
+{
+    LOCK(cs);
+    std::list<CTransaction> transactionsToRemove;
+
+    for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
+        const CTransaction& tx = it->second.GetTx();
+        if (it->second.GetBranchId() != nMemPoolBranchId) {
+            transactionsToRemove.push_back(tx);
+        }
+    }
+
+    for (const CTransaction& tx : transactionsToRemove) {
+        std::list<CTransaction> removed;
+        remove(tx, removed, true);
+    }
 }
 
 void CTxMemPool::clear()

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -45,10 +45,11 @@ private:
     double dPriority; //! Priority when entering the mempool
     unsigned int nHeight; //! Chain height when entering the mempool
     bool hadNoDependencies; //! Not dependent on any other txs when it entered the mempool
+    uint32_t nBranchId; //! Branch ID this transaction commits to
 
 public:
     CTxMemPoolEntry(const CTransaction& _tx, const CAmount& _nFee,
-                    int64_t _nTime, double _dPriority, unsigned int _nHeight, bool poolHasNoInputsOf = false);
+                    int64_t _nTime, double _dPriority, unsigned int _nHeight, bool poolHasNoInputsOf = false, uint32_t nBranchId = 0); // TODO: SPROUT_BRANCH_ID
     CTxMemPoolEntry();
     CTxMemPoolEntry(const CTxMemPoolEntry& other);
 
@@ -60,6 +61,8 @@ public:
     unsigned int GetHeight() const { return nHeight; }
     bool WasClearAtEntry() const { return hadNoDependencies; }
     size_t DynamicMemoryUsage() const { return nUsageSize; }
+
+    uint32_t GetBranchId() const { return nBranchId; }
 };
 
 class CBlockPolicyEstimator;
@@ -124,6 +127,7 @@ public:
     void removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed);
     void removeForBlock(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight,
                         std::list<CTransaction>& conflicts, bool fCurrentEstimate = true);
+    void removeWithoutBranchId(uint32_t nMemPoolBranchId);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
     void pruneSpent(const uint256& hash, CCoins &coins);


### PR DESCRIPTION
Whenever the local chain tip is updated, transactions in the mempool which commit to an
unmineable branch ID (for example, just before a network upgrade activates, where the
next block will have a different branch ID) will be removed.