### PR TITLE
FIX #1631 - The epoch for std::chrono::system_clock is unspecified 

### DIFF
--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -13,9 +13,11 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
 
+
 using namespace std;
 
 static int64_t nMockTime = 0;  //! For unit testing
+const int64_t Epoch = std::chrono::system_clock::from_time_t(0); // Constant so that relying on defacto Standard is avoided
 
 int64_t GetTime()
 {
@@ -32,13 +34,13 @@ void SetMockTime(int64_t nMockTimeIn)
 int64_t GetTimeMillis()
 {
     return std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
+            std::chrono::system_clock::now().time_since_epoch() - Epoch).count();
 }
 
 int64_t GetTimeMicros()
 {
     return std::chrono::duration_cast<std::chrono::microseconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
+            std::chrono::system_clock::now().time_since_epoch() - Epoch).count();
 }
 
 void MilliSleep(int64_t n)


### PR DESCRIPTION
Using the idea from the Question : 
https://stackoverflow.com/questions/27365236/get-posix-epoch-as-system-clocktime-point

This is done so that relying on the de facto standard is avoided and we can just subtract from a constant .
