### PR TITLE
Closes #2969. Overwinter protocol version bump.

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 170002;
+static const int PROTOCOL_VERSION = 170003;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
When a testnet activation height has been set in the code, bump the protocol version.