### PR TITLE
Use block hash comparison for consistency check when loading block index

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -314,9 +314,11 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nTx            = diskindex.nTx;
                 pindexNew->nSproutValue   = diskindex.nSproutValue;
 
+                // Consistency checks
                 auto header = pindexNew->GetBlockHeader();
-                if (!CheckEquihashSolution(&header, Params()))
-                    return error("LoadBlockIndex(): CheckEquihashSolution failed: %s", pindexNew->ToString());
+                if (header.GetHash() != pindexNew->GetBlockHash())
+                    return error("LoadBlockIndex(): block header inconsistency detected: on-disk = %s, in-memory = %s",
+                       diskindex.ToString(),  pindexNew->ToString());
                 if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params().GetConsensus()))
                     return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());
 


### PR DESCRIPTION
The Equihash check caused block index loading to take around 38x longer.
However, we don't need to check it directly, as the only paths to writing a
block header to disk already go through a proof-of-work check (e.g. receiving a
block over the network). By forcing the block header inside the CBlockIndex to
be re-serialized, we retain the benefits of the consistency check without the
overhead at startup.