### PR TITLE
Split declaration and definition of SPROUT_BRANCH_ID constant

### DIFF
--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -26,6 +26,8 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
     }
 };
 
+const uint32_t SPROUT_BRANCH_ID = NetworkUpgradeInfo[Consensus::BASE_SPROUT].nBranchId;
+
 UpgradeState NetworkUpgradeState(
     int nHeight,
     const Consensus::Params& params,

--- a/src/consensus/upgrades.h
+++ b/src/consensus/upgrades.h
@@ -27,7 +27,7 @@ struct NUInfo {
 extern const struct NUInfo NetworkUpgradeInfo[];
 
 // Consensus branch id to identify pre-overwinter (Sprout) consensus rules.
-static const uint32_t SPROUT_BRANCH_ID = NetworkUpgradeInfo[Consensus::BASE_SPROUT].nBranchId;
+extern const uint32_t SPROUT_BRANCH_ID;
 
 /**
  * Checks the state of a given network upgrade based on block height.


### PR DESCRIPTION
Fixes an initialization-order-fiasco error detected by ASan:
https://ci.z.cash/#/builders/7/builds/149