### PR TITLE
Return JoinSplit and JoinSplitOutput indexes in z_listreceivedbyaddress

### DIFF
--- a/qa/rpc-tests/zkey_import_export.py
+++ b/qa/rpc-tests/zkey_import_export.py
@@ -89,6 +89,12 @@ class ZkeyImportExportTest (BitcoinTestFramework):
 
             try:
                 assert_equal(amts, [tx["amount"] for tx in txs])
+                for tx in txs:
+                    # make sure JoinSplit keys exist and have valid values
+                    assert_equal( "jsindex" in tx, True)
+                    assert_equal( "jsoutindex" in tx, True)
+                    assert_greater_than( tx["jsindex"], -1 )
+                    assert_greater_than( tx["jsoutindex"], -1 )
             except AssertionError:
                 logging.error(
                     'Expected amounts: %r; txs: %r',

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3111,6 +3111,9 @@ UniValue z_listreceivedbyaddress(const UniValue& params, bool fHelp)
         obj.push_back(Pair("amount", ValueFromAmount(CAmount(entry.plaintext.value))));
         std::string data(entry.plaintext.memo.begin(), entry.plaintext.memo.end());
         obj.push_back(Pair("memo", HexStr(data)));
+        // (txid, jsindex, jsoutindex) is needed to globally identify a note
+        obj.push_back(Pair("jsindex", entry.jsop.js));
+        obj.push_back(Pair("jsoutindex", entry.jsop.n));
         result.push_back(obj);
     }
     return result;


### PR DESCRIPTION
This implements a feature request by @nathan-at-least in https://github.com/zcash/zcash/issues/2932 and I wanted to ask for feedback about the exact form of the data returned before updating tests and docs.
