### PR TITLE
[macOS] Fix test/gtest bugs caught by latest clang

### DIFF
--- a/src/gtest/test_deprecation.cpp
+++ b/src/gtest/test_deprecation.cpp
@@ -24,7 +24,7 @@ static bool ThreadSafeMessageBox(MockUIInterface *mock,
                                  const std::string& caption,
                                  unsigned int style)
 {
-    mock->ThreadSafeMessageBox(message, caption, style);
+    return mock->ThreadSafeMessageBox(message, caption, style);
 }
 
 class DeprecationTest : public ::testing::Test {

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -46,6 +46,13 @@ bool find_error(const UniValue& objError, const std::string& expected) {
     return find_value(objError, "message").get_str().find(expected) != string::npos;
 }
 
+static UniValue ValueFromString(const std::string &str)
+{
+    UniValue value;
+    BOOST_CHECK(value.setNumStr(str));
+    return value;
+}
+
 BOOST_FIXTURE_TEST_SUITE(rpc_wallet_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(rpc_addmultisig)
@@ -1061,14 +1068,14 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         CTransaction tx = proxy.getTx();
         BOOST_CHECK(tx.vout.size() == 0);
 
-        CAmount amount = 123.456;
+        CAmount amount = AmountFromValue(ValueFromString("123.456"));
         proxy.add_taddr_change_output_to_tx(amount);
         tx = proxy.getTx();
         BOOST_CHECK(tx.vout.size() == 1);
         CTxOut out = tx.vout[0];
         BOOST_CHECK_EQUAL(out.nValue, amount);
 
-        amount = 1.111;
+        amount = AmountFromValue(ValueFromString("1.111"));
         proxy.add_taddr_change_output_to_tx(amount);
         tx = proxy.getTx();
         BOOST_CHECK(tx.vout.size() == 2);


### PR DESCRIPTION
Tests fail with latest clang on macOS (clang-900.0.39.2)

```
test/rpc_wallet_tests.cpp:1064:26: error: implicit conversion from 'double' to 'CAmount' (aka 'long long') changes value from 123.456 to 123 [-Werror,-Wliteral-conversion]
test/rpc_wallet_tests.cpp:1071:18: error: implicit conversion from 'double' to 'CAmount' (aka 'long long') changes value from 1.111 to 1 [-Werror,-Wliteral-conversion]
gtest/test_deprecation.cpp:28:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
```

Part of #2246.