### PR TITLE
Add filename and SHA256 hash for Windows Rust package

### DIFF
--- a/depends/packages/rust.mk
+++ b/depends/packages/rust.mk
@@ -5,6 +5,9 @@ $(package)_file_name_linux=rust-$($(package)_version)-x86_64-unknown-linux-gnu.t
 $(package)_sha256_hash_linux=48621912c242753ba37cad5145df375eeba41c81079df46f93ffb4896542e8fd
 $(package)_file_name_darwin=rust-$($(package)_version)-x86_64-apple-darwin.tar.gz
 $(package)_sha256_hash_darwin=2d08259ee038d3a2c77a93f1a31fc59e7a1d6d1bbfcba3dba3c8213b2e5d1926
+$(package)_file_name_mingw32=rust-mingw-$($(package)_version)-x86_64-pc-windows-gnu.tar.gz
+$(package)_sha256_hash_mingw32=4975e1f8eade1afca5dd17e71659f665f3bcc645733a545179c887543da1e27c
+
 
 define $(package)_stage_cmds
   ./install.sh --destdir=$($(package)_staging_dir) --prefix=$(host_prefix)/native --disable-ldconfig


### PR DESCRIPTION
When running `make download` in the `depends` directory, the `download-win` target (which `download` depends on) generates an error when it runs the commands defined in `check_or_remove_sources`:

```Makefile
sha256sum: /home/vagrant/zcash/depends/work/download/rust-1.16.0/..hash: no properly formatted SHA256 checksum lines found
funcs.mk:242: recipe for target '/home/vagrant/gitian-builder/cache/common/download-stamps/.stamp_fetched-rust-.hash' failed
make[1]: *** [/home/vagrant/gitian-builder/cache/common/download-stamps/.stamp_fetched-rust-.hash] Error 1
make[1]: Leaving directory '/home/vagrant/zcash/depends'
Makefile:153: recipe for target 'download-win' failed
make: *** [download-win] Error 2
```

The reason for the error is that `depends/packages/rust.mk` defines `rust_file_name_linux` and `rust_file_name_darwin` but leaves `rust_file_name_mingw32` undefined.

A directory of available rust downloads is here: https://static.rust-lang.org/dist/index.html

The closest windows analog in that list (using the same version number as currently defined in `rust.mk`) appears to be `rust-mingw-1.16.0-x86_64-pc-windows-gnu.tar.gz`. A corresponding sha256 value is also given in `rust-mingw-1.16.0-x86_64-pc-windows-gnu.tar.gz.sha256`.

After adding these values to `rust.mk`, the rust-mingw tar package was downloaded along with the rest of the dependencies and the above error message went away.