### PR TITLE
Update boost package URL to match official download url on boost.org

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,6 +1,6 @@
 package=boost
 $(package)_version=1_66_0
-$(package)_download_path=http://sourceforge.net/projects/boost/files/boost/1.66.0
+$(package)_download_path=https://dl.bintray.com/boostorg/release/1.66.0/source
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9
 


### PR DESCRIPTION
Part of #3123.