### PR TITLE
[macOS] fix -Wreturn-type error in CurrentEpoch (clang-902.0.39.1)

### DIFF
--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -69,6 +69,7 @@ int CurrentEpoch(int nHeight, const Consensus::Params& params) {
             return idxInt;
         }
     }
+    return Consensus::BASE_SPROUT;
 }
 
 uint32_t CurrentEpochBranchId(int nHeight, const Consensus::Params& params) {


### PR DESCRIPTION
-Wreturn-type error (due to -Werror) on macOS
```
/Users/loki/Desktop/devel/zcash-apple/zcash/zcash_master/depends/x86_64-apple-darwin17.5.0/share/../native/bin/ccache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -mmacosx-version-min=10.8 -stdlib=libc++ -std=c++11 -DHAVE_CONFIG_H -I. -I../src/config  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -I. -I./obj -pthread -I/Users/loki/Desktop/devel/zcash-apple/zcash/zcash_master/depends/x86_64-apple-darwin17.5.0/share/../include -I./leveldb/include -I./leveldb/helpers/memenv -I/Users/loki/Desktop/devel/zcash-apple/zcash/zcash_master/depends/x86_64-apple-darwin17.5.0/include -I/Users/loki/Desktop/devel/zcash-apple/zcash/zcash_master/depends/x86_64-apple-darwin17.5.0/include -I./secp256k1/include -I./snark -I./snark/libsnark -I./univalue/include  -Qunused-arguments -I/Users/loki/Desktop/devel/zcash-apple/zcash/zcash_master/depends/x86_64-apple-darwin17.5.0/share/../include/  -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS -DMAC_OSX  -Wformat -Wformat-security -Wstack-protector -fstack-protector-all -Werror -fPIE -pipe -O2 -g -fwrapv -fno-strict-aliasing -Wno-undefined-var-template -MT consensus/libbitcoin_common_a-upgrades.o -MD -MP -MF consensus/.deps/libbitcoin_common_a-upgrades.Tpo -c -o consensus/libbitcoin_common_a-upgrades.o `test -f 'consensus/upgrades.cpp' || echo './'`consensus/upgrades.cpp
consensus/upgrades.cpp:72:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
1 error generated.
make[4]: *** [consensus/libbitcoin_common_a-upgrades.o] Error 1
make[4]: *** Waiting for unfinished jobs....
mv -f policy/.deps/libbitcoin_server_a-fees.Tpo policy/.deps/libbitcoin_server_a-fees.Po
mv -f script/.deps/libbitcoin_server_a-sigcache.Tpo script/.deps/libbitcoin_server_a-sigcache.Po
mv -f wallet/gtest/.deps/zcash_gtest-test_wallet.Tpo wallet/gtest/.deps/zcash_gtest-test_wallet.Po
make[3]: *** [all-recursive] Error 1
make[2]: *** [all-recursive] Error 1
make[1]: *** [zcash_build] Error 2
make: *** [build] Error 1
```
