### PR TITLE
Additional dbwrapper tests

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -90,6 +90,7 @@ CBlockIndex* CBlockIndex::GetAncestor(int height)
             pindexWalk = pindexWalk->pskip;
             heightWalk = heightSkip;
         } else {
+            assert(pindexWalk->pprev);
             pindexWalk = pindexWalk->pprev;
             heightWalk--;
         }

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
     CDBWrapper dbw(ph, (1 << 20), true, false);
     for (int x=0x00; x<10; ++x) {
         for (int y = 0; y < 10; y++) {
-            sprintf(buf, "%d", x);
+            snprintf(buf, sizeof(buf), "%d", x);
             StringContentsSerializer key(buf);
             for (int z = 0; z < y; z++)
                 key += key;
@@ -210,12 +210,12 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
             seek_start = 0;
         else
             seek_start = 5;
-        sprintf(buf, "%d", seek_start);
+        snprintf(buf, sizeof(buf), "%d", seek_start);
         StringContentsSerializer seek_key(buf);
         it->Seek(seek_key);
         for (int x=seek_start; x<10; ++x) {
             for (int y = 0; y < 10; y++) {
-                sprintf(buf, "%d", x);
+                snprintf(buf, sizeof(buf), "%d", x);
                 string exp_key(buf);
                 for (int z = 0; z < y; z++)
                     exp_key += exp_key;

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -190,7 +190,8 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
     CDBWrapper dbw(ph, (1 << 20), true, false);
     for (int x=0x00; x<10; ++x) {
         for (int y = 0; y < 10; y++) {
-            snprintf(buf, sizeof(buf), "%d", x);
+            int n = snprintf(buf, sizeof(buf), "%d", x);
+            assert(n > 0 && n < sizeof(buf));
             StringContentsSerializer key(buf);
             for (int z = 0; z < y; z++)
                 key += key;
@@ -201,12 +202,14 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 
     boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
     for (int seek_start : {0, 5}) {
-        snprintf(buf, sizeof(buf), "%d", seek_start);
+        int n = snprintf(buf, sizeof(buf), "%d", seek_start);
+        assert(n > 0 && n < sizeof(buf));
         StringContentsSerializer seek_key(buf);
         it->Seek(seek_key);
         for (int x=seek_start; x<10; ++x) {
             for (int y = 0; y < 10; y++) {
-                snprintf(buf, sizeof(buf), "%d", x);
+                int n = snprintf(buf, sizeof(buf), "%d", x);
+                assert(n > 0 && n < sizeof(buf));
                 string exp_key(buf);
                 for (int z = 0; z < y; z++)
                     exp_key += exp_key;

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -1,4 +1,5 @@
-// Copyright (c) 2012-2013 The Bitcoin Core developers
+// Copyright (c) 2018 The Zcash developers
+// Copyright (c) 2012-2017 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
         BOOST_CHECK(dbw.Read(key2, res));
         BOOST_CHECK_EQUAL(res.ToString(), in2.ToString());
 
-        // key3 never should've been written
+        // key3 should've never been written
         BOOST_CHECK(dbw.Read(key3, res) == false);
     }
 }

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(iterator_ordering)
 }
 
 struct StringContentsSerializer {
-    // Used to make two serialized objects the same while letting them have a different lengths
+    // Used to make two serialized objects the same while letting them have different lengths
     // This is a terrible idea
     string str;
     StringContentsSerializer() {}

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -151,4 +151,90 @@ BOOST_AUTO_TEST_CASE(iterator_ordering)
     }
 }
 
+struct StringContentsSerializer {
+    // Used to make two serialized objects the same while letting them have a different lengths
+    // This is a terrible idea
+    string str;
+    StringContentsSerializer() {}
+    StringContentsSerializer(const string& inp) : str(inp) {}
+
+    StringContentsSerializer& operator+=(const string& s) {
+        str += s;
+        return *this;
+    }
+    StringContentsSerializer& operator+=(const StringContentsSerializer& s) { return *this += s.str; }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        if (ser_action.ForRead()) {
+            str.clear();
+            char c = 0;
+            while (true) {
+                try {
+                    READWRITE(c);
+                    str.push_back(c);
+                } catch (const std::ios_base::failure& e) {
+                    break;
+                }
+            }
+        } else {
+            for (size_t i = 0; i < str.size(); i++)
+                READWRITE(str[i]);
+        }
+    }
+};
+
+BOOST_AUTO_TEST_CASE(iterator_string_ordering)
+{
+    char buf[10];
+
+    path ph = temp_directory_path() / unique_path();
+    CDBWrapper dbw(ph, (1 << 20), true, false);
+    for (int x=0x00; x<10; ++x) {
+        for (int y = 0; y < 10; y++) {
+            sprintf(buf, "%d", x);
+            StringContentsSerializer key(buf);
+            for (int z = 0; z < y; z++)
+                key += key;
+            uint32_t value = x*x;
+            BOOST_CHECK(dbw.Write(key, value));
+        }
+    }
+
+    boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
+    for (int c=0; c<2; ++c) {
+        int seek_start;
+        if (c == 0)
+            seek_start = 0;
+        else
+            seek_start = 5;
+        sprintf(buf, "%d", seek_start);
+        StringContentsSerializer seek_key(buf);
+        it->Seek(seek_key);
+        for (int x=seek_start; x<10; ++x) {
+            for (int y = 0; y < 10; y++) {
+                sprintf(buf, "%d", x);
+                string exp_key(buf);
+                for (int z = 0; z < y; z++)
+                    exp_key += exp_key;
+                StringContentsSerializer key;
+                uint32_t value;
+                BOOST_CHECK(it->Valid());
+                if (!it->Valid()) // Avoid spurious errors about invalid iterator's key and value in case of failure
+                    break;
+                BOOST_CHECK(it->GetKey(key));
+                BOOST_CHECK(it->GetValue(value));
+                BOOST_CHECK_EQUAL(key.str, exp_key);
+                BOOST_CHECK_EQUAL(value, x*x);
+                it->Next();
+            }
+        }
+        BOOST_CHECK(!it->Valid());
+    }
+}
+
+
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -116,5 +116,39 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
         BOOST_CHECK_EQUAL(it->Valid(), false);
     }
 }
- 
+
+BOOST_AUTO_TEST_CASE(iterator_ordering)
+{
+    path ph = temp_directory_path() / unique_path();
+    CDBWrapper dbw(ph, (1 << 20), true, false);
+    for (int x=0x00; x<256; ++x) {
+        uint8_t key = x;
+        uint32_t value = x*x;
+        BOOST_CHECK(dbw.Write(key, value));
+    }
+
+    boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
+    for (int c=0; c<2; ++c) {
+        int seek_start;
+        if (c == 0)
+            seek_start = 0x00;
+        else
+            seek_start = 0x80;
+        it->Seek((uint8_t)seek_start);
+        for (int x=seek_start; x<256; ++x) {
+            uint8_t key;
+            uint32_t value;
+            BOOST_CHECK(it->Valid());
+            if (!it->Valid()) // Avoid spurious errors about invalid iterator's key and value in case of failure
+                break;
+            BOOST_CHECK(it->GetKey(key));
+            BOOST_CHECK(it->GetValue(value));
+            BOOST_CHECK_EQUAL(key, x);
+            BOOST_CHECK_EQUAL(value, x*x);
+            it->Next();
+        }
+        BOOST_CHECK(!it->Valid());
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -128,12 +128,7 @@ BOOST_AUTO_TEST_CASE(iterator_ordering)
     }
 
     boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
-    for (int c=0; c<2; ++c) {
-        int seek_start;
-        if (c == 0)
-            seek_start = 0x00;
-        else
-            seek_start = 0x80;
+    for (int seek_start : {0x00, 0x80}) {
         it->Seek((uint8_t)seek_start);
         for (int x=seek_start; x<256; ++x) {
             uint8_t key;
@@ -204,12 +199,7 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
     }
 
     boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
-    for (int c=0; c<2; ++c) {
-        int seek_start;
-        if (c == 0)
-            seek_start = 0;
-        else
-            seek_start = 5;
+    for (int seek_start : {0, 5}) {
         snprintf(buf, sizeof(buf), "%d", seek_start);
         StringContentsSerializer seek_key(buf);
         it->Seek(seek_key);


### PR DESCRIPTION
Cherry-picked from the following upstream PRs:

- bitcoin/bitcoin#7992
- bitcoin/bitcoin#9867
  - Only the commit affecting dbwrapper tests
- bitcoin/bitcoin#9610
  - Only the change affecting dbwrapper tests
- bitcoin/bitcoin#10844