### PR TITLE
Load Sapling testnet parameters into memory

### DIFF
--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -3,8 +3,8 @@ $(package)_version=0.1
 $(package)_download_path=https://github.com/zcash/$(package)/archive/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=a6554609ac0cbcc99ad33513a8203bec4ec1c64fa25b4be515377ccf2e0afcd7
-$(package)_git_commit=2a86c912f6ec32ae62c4403c214b2a93a5fcb61e
+$(package)_sha256_hash=fd57825e51a49a435a0a456e16bb2e9ddff6578cfd7cb0a80fc96a2a019eb3bd
+$(package)_git_commit=170397b5a5ebfa2f6823bb631ca7b248f17823ac
 $(package)_dependencies=rust $(rust_crates)
 $(package)_patches=cargo.config
 

--- a/src/gtest/main.cpp
+++ b/src/gtest/main.cpp
@@ -7,6 +7,8 @@
 #include <libsnark/common/default_types/r1cs_ppzksnark_pp.hpp>
 #include <libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp>
 
+#include "librustzcash.h"
+
 struct ECCryptoClosure
 {
     ECCVerifyHandle handle;
@@ -24,6 +26,20 @@ int main(int argc, char **argv) {
   boost::filesystem::path pk_path = ZC_GetParamsDir() / "sprout-proving.key";
   boost::filesystem::path vk_path = ZC_GetParamsDir() / "sprout-verifying.key";
   params = ZCJoinSplit::Prepared(vk_path.string(), pk_path.string());
+
+  boost::filesystem::path sapling_spend = ZC_GetParamsDir() / "sapling-spend-testnet.params";
+  boost::filesystem::path sapling_output = ZC_GetParamsDir() / "sapling-output-testnet.params";
+  boost::filesystem::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16-testnet.params";
+
+  std::string sapling_spend_str = sapling_spend.string();
+  std::string sapling_output_str = sapling_output.string();
+  std::string sprout_groth16_str = sprout_groth16.string();
+
+  librustzcash_init_zksnark_params(
+      sapling_spend_str.c_str(),
+      sapling_output_str.c_str(),
+      sprout_groth16_str.c_str()
+  );
   
   testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -66,6 +66,8 @@
 #include "amqp/amqpnotificationinterface.h"
 #endif
 
+#include "librustzcash.h"
+
 using namespace std;
 
 extern void ThreadSendAlert();
@@ -677,15 +679,34 @@ bool InitSanityCheck(void)
 }
 
 
-static void ZC_LoadParams()
+static void ZC_LoadParams(
+    const CChainParams& chainparams
+)
 {
     struct timeval tv_start, tv_end;
     float elapsed;
 
     boost::filesystem::path pk_path = ZC_GetParamsDir() / "sprout-proving.key";
     boost::filesystem::path vk_path = ZC_GetParamsDir() / "sprout-verifying.key";
+    boost::filesystem::path sapling_spend = ZC_GetParamsDir() / "sapling-spend-testnet.params";
+    boost::filesystem::path sapling_output = ZC_GetParamsDir() / "sapling-output-testnet.params";
+    boost::filesystem::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16-testnet.params";
 
-    if (!(boost::filesystem::exists(pk_path) && boost::filesystem::exists(vk_path))) {
+    bool sapling_paths_valid = true;
+
+    // We don't load Sapling zk-SNARK params if mainnet is configured
+    if (chainparams.NetworkIDString() != "main") {
+        sapling_paths_valid =
+            boost::filesystem::exists(sapling_spend) &&
+            boost::filesystem::exists(sapling_output) &&
+            boost::filesystem::exists(sprout_groth16);
+    }
+
+    if (!(
+        boost::filesystem::exists(pk_path) &&
+        boost::filesystem::exists(vk_path) &&
+        sapling_paths_valid
+    )) {
         uiInterface.ThreadSafeMessageBox(strprintf(
             _("Cannot find the Zcash network parameters in the following directory:\n"
               "%s\n"
@@ -704,6 +725,29 @@ static void ZC_LoadParams()
     gettimeofday(&tv_end, 0);
     elapsed = float(tv_end.tv_sec-tv_start.tv_sec) + (tv_end.tv_usec-tv_start.tv_usec)/float(1000000);
     LogPrintf("Loaded verifying key in %fs seconds.\n", elapsed);
+
+    if (chainparams.NetworkIDString() != "main") {
+        std::string sapling_spend_str = sapling_spend.string();
+        std::string sapling_output_str = sapling_output.string();
+        std::string sprout_groth16_str = sprout_groth16.string();
+
+        LogPrintf("Loading Sapling (Spend) parameters from %s\n", sapling_spend_str.c_str());
+        LogPrintf("Loading Sapling (Output) parameters from %s\n", sapling_output_str.c_str());
+        LogPrintf("Loading Sapling (Sprout Groth16) parameters from %s\n", sprout_groth16_str.c_str());
+        gettimeofday(&tv_start, 0);
+
+        librustzcash_init_zksnark_params(
+            sapling_spend_str.c_str(),
+            sapling_output_str.c_str(),
+            sprout_groth16_str.c_str()
+        );
+
+        gettimeofday(&tv_end, 0);
+        elapsed = float(tv_end.tv_sec-tv_start.tv_sec) + (tv_end.tv_usec-tv_start.tv_usec)/float(1000000);
+        LogPrintf("Loaded Sapling parameters in %fs seconds.\n", elapsed);
+    } else {
+        LogPrintf("Not loading Sapling parameters in mainnet\n");
+    }
 }
 
 bool AppInitServers(boost::thread_group& threadGroup)
@@ -1167,7 +1211,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     libsnark::inhibit_profiling_counters = true;
 
     // Initialize Zcash circuit parameters
-    ZC_LoadParams();
+    ZC_LoadParams(chainparams);
 
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -24,6 +24,8 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
 
+#include "librustzcash.h"
+
 CClientUIInterface uiInterface; // Declared but not defined in ui_interface.h
 CWallet* pwalletMain;
 ZCJoinSplit *pzcashParams;
@@ -36,6 +38,20 @@ JoinSplitTestingSetup::JoinSplitTestingSetup()
     boost::filesystem::path pk_path = ZC_GetParamsDir() / "sprout-proving.key";
     boost::filesystem::path vk_path = ZC_GetParamsDir() / "sprout-verifying.key";
     pzcashParams = ZCJoinSplit::Prepared(vk_path.string(), pk_path.string());
+
+    boost::filesystem::path sapling_spend = ZC_GetParamsDir() / "sapling-spend-testnet.params";
+    boost::filesystem::path sapling_output = ZC_GetParamsDir() / "sapling-output-testnet.params";
+    boost::filesystem::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16-testnet.params";
+
+    std::string sapling_spend_str = sapling_spend.string();
+    std::string sapling_output_str = sapling_output.string();
+    std::string sprout_groth16_str = sprout_groth16.string();
+
+    librustzcash_init_zksnark_params(
+        sapling_spend_str.c_str(),
+        sapling_output_str.c_str(),
+        sprout_groth16_str.c_str()
+    );
 }
 
 JoinSplitTestingSetup::~JoinSplitTestingSetup()

--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -10,6 +10,9 @@ fi
 
 SPROUT_PKEY_NAME='sprout-proving.key'
 SPROUT_VKEY_NAME='sprout-verifying.key'
+SAPLING_SPEND_NAME='sapling-spend-testnet.params'
+SAPLING_OUTPUT_NAME='sapling-output-testnet.params'
+SAPLING_SPROUT_GROTH16_NAME='sprout-groth16-testnet.params'
 SPROUT_URL="https://z.cash/downloads"
 SPROUT_IPFS="/ipfs/QmZKKx7Xup7LiAtFRhYsE1M7waXcv9ir9eCECyXAFGxhEo"
 
@@ -161,6 +164,10 @@ Zcash - fetch-params.sh
 This script will fetch the Zcash zkSNARK parameters and verify their
 integrity with sha256sum.
 
+NOTE: If you're using testnet or regtest, you will need to invoke this
+script with --testnet in order to download additional parameters. This
+is temporary.
+
 If they already exist locally, it will exit now and do nothing else.
 EOF
 
@@ -193,8 +200,16 @@ EOF
 
     fetch_params "$SPROUT_PKEY_NAME" "$PARAMS_DIR/$SPROUT_PKEY_NAME" "8bc20a7f013b2b58970cddd2e7ea028975c88ae7ceb9259a5344a16bc2c0eef7"
     fetch_params "$SPROUT_VKEY_NAME" "$PARAMS_DIR/$SPROUT_VKEY_NAME" "4bd498dae0aacfd8e98dc306338d017d9c08dd0918ead18172bd0aec2fc5df82"
+
+    if [ "x${1:-}" = 'x--testnet' ]
+    then
+        echo "(NOTE) Testnet parameters enabled."
+        fetch_params "$SAPLING_SPEND_NAME" "$PARAMS_DIR/$SAPLING_SPEND_NAME" "0ed6e26abae38daa80405b44da73af4fda2a9cacdaa3d20da4e81acdce43b7d1"
+        fetch_params "$SAPLING_OUTPUT_NAME" "$PARAMS_DIR/$SAPLING_OUTPUT_NAME" "fd36323771e3d3a63289fb7cedc9e41508bd0ae5053eb760340cc4e75d5b5805"
+        fetch_params "$SAPLING_SPROUT_GROTH16_NAME" "$PARAMS_DIR/$SAPLING_SPROUT_GROTH16_NAME" "7bae010c761ce11f149466aec6c50a7a2264076b6a75f352d9f60268c1d778b9"
+    fi
 }
 
-main
+main ${1:-}
 rm -f /tmp/fetch_params.lock
 exit 0


### PR DESCRIPTION
This PR depends on https://github.com/zcash/librustzcash/pull/4.

**The parameters have not yet been uplodaded.** When they are, to download them the CI will need to invoke `fetch-params.sh` with `--testnet` (as implemented) to download the testnet Sapling parameters. The parameters are not loaded into memory if `zcashd` is configured as a mainnet node -- this is something we can change in the weeks before `2.0.0`.