### PR TITLE
Remove now-unshadowed serialization lines that do nothing

### DIFF
--- a/src/alert.h
+++ b/src/alert.h
@@ -51,7 +51,6 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(this->nVersion);
-        nVersion = this->nVersion;
         READWRITE(nRelayUntil);
         READWRITE(nExpiration);
         READWRITE(nID);

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -42,7 +42,6 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(this->nVersion);
-        nVersion = this->nVersion;
         READWRITE(hashPrevBlock);
         READWRITE(hashMerkleRoot);
         READWRITE(hashReserved);


### PR DESCRIPTION
Previously we had both nVersion as a class parameter *and* a serialization
argument, and in several inherited serializers the latter was set to the former,
in order to pass the serialized object's version into underlying parsers. #3180
pulled in the upstream changes to clean this up, and in doing so these lines
became no-ops - setting the class parameter to itself. Clang throws warnings on
this, which turn into errors on the MacOS builder.

We can just remove these, because upstream already had done so in earlier PRs,
indicating that they were not being relied on by underlying parsers.