### PR TITLE
Bech32 encoding support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -124,6 +124,7 @@ BITCOIN_CORE_H = \
   asyncrpcoperation.h \
   asyncrpcqueue.h \
   base58.h \
+  bech32.h \
   bloom.h \
   chain.h \
   chainparams.h \
@@ -358,6 +359,7 @@ libbitcoin_common_a_SOURCES = \
   amount.cpp \
   arith_uint256.cpp \
   base58.cpp \
+  bech32.cpp \
   chainparams.cpp \
   coins.cpp \
   compressor.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -48,6 +48,7 @@ BITCOIN_TESTS =\
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \
+  test/bech32_tests.cpp \
   test/bip32_tests.cpp \
   test/bloom_tests.cpp \
   test/checkblock_tests.cpp \

--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -1,0 +1,191 @@
+// Copyright (c) 2017 Pieter Wuille
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bech32.h"
+
+namespace
+{
+
+typedef std::vector<uint8_t> data;
+
+/** The Bech32 character set for encoding. */
+const char* CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+/** The Bech32 character set for decoding. */
+const int8_t CHARSET_REV[128] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    15, -1, 10, 17, 21, 20, 26, 30,  7,  5, -1, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+     1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+     1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
+};
+
+/** Concatenate two byte arrays. */
+data Cat(data x, const data& y)
+{
+    x.insert(x.end(), y.begin(), y.end());
+    return x;
+}
+
+/** This function will compute what 6 5-bit values to XOR into the last 6 input values, in order to
+ *  make the checksum 0. These 6 values are packed together in a single 30-bit integer. The higher
+ *  bits correspond to earlier values. */
+uint32_t PolyMod(const data& v)
+{
+    // The input is interpreted as a list of coefficients of a polynomial over F = GF(32), with an
+    // implicit 1 in front. If the input is [v0,v1,v2,v3,v4], that polynomial is v(x) =
+    // 1*x^5 + v0*x^4 + v1*x^3 + v2*x^2 + v3*x + v4. The implicit 1 guarantees that
+    // [v0,v1,v2,...] has a distinct checksum from [0,v0,v1,v2,...].
+
+    // The output is a 30-bit integer whose 5-bit groups are the coefficients of the remainder of
+    // v(x) mod g(x), where g(x) is the Bech32 generator,
+    // x^6 + {29}x^5 + {22}x^4 + {20}x^3 + {21}x^2 + {29}x + {18}. g(x) is chosen in such a way
+    // that the resulting code is a BCH code, guaranteeing detection of up to 3 errors within a
+    // window of 1023 characters. Among the various possible BCH codes, one was selected to in
+    // fact guarantee detection of up to 4 errors within a window of 89 characters.
+
+    // Note that the coefficients are elements of GF(32), here represented as decimal numbers
+    // between {}. In this finite field, addition is just XOR of the corresponding numbers. For
+    // example, {27} + {13} = {27 ^ 13} = {22}. Multiplication is more complicated, and requires
+    // treating the bits of values themselves as coefficients of a polynomial over a smaller field,
+    // GF(2), and multiplying those polynomials mod a^5 + a^3 + 1. For example, {5} * {26} =
+    // (a^2 + 1) * (a^4 + a^3 + a) = (a^4 + a^3 + a) * a^2 + (a^4 + a^3 + a) = a^6 + a^5 + a^4 + a
+    // = a^3 + 1 (mod a^5 + a^3 + 1) = {9}.
+
+    // During the course of the loop below, `c` contains the bitpacked coefficients of the
+    // polynomial constructed from just the values of v that were processed so far, mod g(x). In
+    // the above example, `c` initially corresponds to 1 mod (x), and after processing 2 inputs of
+    // v, it corresponds to x^2 + v0*x + v1 mod g(x). As 1 mod g(x) = 1, that is the starting value
+    // for `c`.
+    uint32_t c = 1;
+    for (auto v_i : v) {
+        // We want to update `c` to correspond to a polynomial with one extra term. If the initial
+        // value of `c` consists of the coefficients of c(x) = f(x) mod g(x), we modify it to
+        // correspond to c'(x) = (f(x) * x + v_i) mod g(x), where v_i is the next input to
+        // process. Simplifying:
+        // c'(x) = (f(x) * x + v_i) mod g(x)
+        //         ((f(x) mod g(x)) * x + v_i) mod g(x)
+        //         (c(x) * x + v_i) mod g(x)
+        // If c(x) = c0*x^5 + c1*x^4 + c2*x^3 + c3*x^2 + c4*x + c5, we want to compute
+        // c'(x) = (c0*x^5 + c1*x^4 + c2*x^3 + c3*x^2 + c4*x + c5) * x + v_i mod g(x)
+        //       = c0*x^6 + c1*x^5 + c2*x^4 + c3*x^3 + c4*x^2 + c5*x + v_i mod g(x)
+        //       = c0*(x^6 mod g(x)) + c1*x^5 + c2*x^4 + c3*x^3 + c4*x^2 + c5*x + v_i
+        // If we call (x^6 mod g(x)) = k(x), this can be written as
+        // c'(x) = (c1*x^5 + c2*x^4 + c3*x^3 + c4*x^2 + c5*x + v_i) + c0*k(x)
+
+        // First, determine the value of c0:
+        uint8_t c0 = c >> 25;
+
+        // Then compute c1*x^5 + c2*x^4 + c3*x^3 + c4*x^2 + c5*x + v_i:
+        c = ((c & 0x1ffffff) << 5) ^ v_i;
+
+        // Finally, for each set bit n in c0, conditionally add {2^n}k(x):
+        if (c0 & 1)  c ^= 0x3b6a57b2; //     k(x) = {29}x^5 + {22}x^4 + {20}x^3 + {21}x^2 + {29}x + {18}
+        if (c0 & 2)  c ^= 0x26508e6d; //  {2}k(x) = {19}x^5 +  {5}x^4 +     x^3 +  {3}x^2 + {19}x + {13}
+        if (c0 & 4)  c ^= 0x1ea119fa; //  {4}k(x) = {15}x^5 + {10}x^4 +  {2}x^3 +  {6}x^2 + {15}x + {26}
+        if (c0 & 8)  c ^= 0x3d4233dd; //  {8}k(x) = {30}x^5 + {20}x^4 +  {4}x^3 + {12}x^2 + {30}x + {29}
+        if (c0 & 16) c ^= 0x2a1462b3; // {16}k(x) = {21}x^5 +     x^4 +  {8}x^3 + {24}x^2 + {21}x + {19}
+    }
+    return c;
+}
+
+/** Convert to lower case. */
+inline unsigned char LowerCase(unsigned char c)
+{
+    return (c >= 'A' && c <= 'Z') ? (c - 'A') + 'a' : c;
+}
+
+/** Expand a HRP for use in checksum computation. */
+data ExpandHRP(const std::string& hrp)
+{
+    data ret;
+    ret.reserve(hrp.size() + 90);
+    ret.resize(hrp.size() * 2 + 1);
+    for (size_t i = 0; i < hrp.size(); ++i) {
+        unsigned char c = hrp[i];
+        ret[i] = c >> 5;
+        ret[i + hrp.size() + 1] = c & 0x1f;
+    }
+    ret[hrp.size()] = 0;
+    return ret;
+}
+
+/** Verify a checksum. */
+bool VerifyChecksum(const std::string& hrp, const data& values)
+{
+    // PolyMod computes what value to xor into the final values to make the checksum 0. However,
+    // if we required that the checksum was 0, it would be the case that appending a 0 to a valid
+    // list of values would result in a new valid list. For that reason, Bech32 requires the
+    // resulting checksum to be 1 instead.
+    return PolyMod(Cat(ExpandHRP(hrp), values)) == 1;
+}
+
+/** Create a checksum. */
+data CreateChecksum(const std::string& hrp, const data& values)
+{
+    data enc = Cat(ExpandHRP(hrp), values);
+    enc.resize(enc.size() + 6); // Append 6 zeroes
+    uint32_t mod = PolyMod(enc) ^ 1; // Determine what to XOR into those 6 zeroes.
+    data ret(6);
+    for (size_t i = 0; i < 6; ++i) {
+        // Convert the 5-bit groups in mod to checksum values.
+        ret[i] = (mod >> (5 * (5 - i))) & 31;
+    }
+    return ret;
+}
+
+} // namespace
+
+namespace bech32
+{
+
+/** Encode a Bech32 string. */
+std::string Encode(const std::string& hrp, const data& values) {
+    data checksum = CreateChecksum(hrp, values);
+    data combined = Cat(values, checksum);
+    std::string ret = hrp + '1';
+    ret.reserve(ret.size() + combined.size());
+    for (auto c : combined) {
+        ret += CHARSET[c];
+    }
+    return ret;
+}
+
+/** Decode a Bech32 string. */
+std::pair<std::string, data> Decode(const std::string& str) {
+    bool lower = false, upper = false;
+    for (size_t i = 0; i < str.size(); ++i) {
+        unsigned char c = str[i];
+        if (c < 33 || c > 126) return {};
+        if (c >= 'a' && c <= 'z') lower = true;
+        if (c >= 'A' && c <= 'Z') upper = true;
+    }
+    if (lower && upper) return {};
+    size_t pos = str.rfind('1');
+    if (str.size() > 90 || pos == str.npos || pos == 0 || pos + 7 > str.size()) {
+        return {};
+    }
+    data values(str.size() - 1 - pos);
+    for (size_t i = 0; i < str.size() - 1 - pos; ++i) {
+        unsigned char c = str[i + pos + 1];
+        int8_t rev = (c < 33 || c > 126) ? -1 : CHARSET_REV[c];
+        if (rev == -1) {
+            return {};
+        }
+        values[i] = rev;
+    }
+    std::string hrp;
+    for (size_t i = 0; i < pos; ++i) {
+        hrp += LowerCase(str[i]);
+    }
+    if (!VerifyChecksum(hrp, values)) {
+        return {};
+    }
+    return {hrp, data(values.begin(), values.end() - 6)};
+}
+
+} // namespace bech32

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2017 Pieter Wuille
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Bech32 is a string encoding format used in newer address types.
+// The output consists of a human-readable part (alphanumeric), a
+// separator character (1), and a base32 data section, the last
+// 6 characters of which are a checksum.
+//
+// For more information, see BIP 173.
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+namespace bech32
+{
+
+/** Encode a Bech32 string. Returns the empty string in case of failure. */
+std::string Encode(const std::string& hrp, const std::vector<uint8_t>& values);
+
+/** Decode a Bech32 string. Returns (hrp, data). Empty hrp means failure. */
+std::pair<std::string, std::vector<uint8_t>> Decode(const std::string& str);
+
+} // namespace bech32

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -9,6 +9,9 @@
 //
 // For more information, see BIP 173.
 
+#ifndef BITCOIN_BECH32_H
+#define BITCOIN_BECH32_H
+
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -23,3 +26,5 @@ std::string Encode(const std::string& hrp, const std::vector<uint8_t>& values);
 std::pair<std::string, std::vector<uint8_t>> Decode(const std::string& str);
 
 } // namespace bech32
+
+#endif // BITCOIN_BECH32_H

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -121,7 +121,6 @@ public:
 BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
 {
     UniValue tests = read_json(std::string(json_tests::base58_keys_valid, json_tests::base58_keys_valid + sizeof(json_tests::base58_keys_valid)));
-    std::vector<unsigned char> result;
     CBitcoinSecret secret;
     CTxDestination destination;
     SelectParams(CBaseChainParams::MAIN);
@@ -177,7 +176,6 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
 BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
 {
     UniValue tests = read_json(std::string(json_tests::base58_keys_valid, json_tests::base58_keys_valid + sizeof(json_tests::base58_keys_valid)));
-    std::vector<unsigned char> result;
 
     for (size_t idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
@@ -239,7 +237,6 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
 BOOST_AUTO_TEST_CASE(base58_keys_invalid)
 {
     UniValue tests = read_json(std::string(json_tests::base58_keys_invalid, json_tests::base58_keys_invalid + sizeof(json_tests::base58_keys_invalid))); // Negative testcases
-    std::vector<unsigned char> result;
     CBitcoinSecret secret;
     CTxDestination destination;
 

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -10,15 +10,16 @@
 
 #include "key.h"
 #include "script/script.h"
+#include "test/test_bitcoin.h"
 #include "uint256.h"
 #include "util.h"
 #include "utilstrencodings.h"
-#include "test/test_bitcoin.h"
+
+#include <univalue.h>
 
 #include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <univalue.h>
 
 extern UniValue read_json(const std::string& jsondata);
 
@@ -73,50 +74,6 @@ BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
     BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
 }
 
-// Visitor to check address type
-class TestAddrTypeVisitor : public boost::static_visitor<bool>
-{
-private:
-    std::string exp_addrType;
-public:
-    TestAddrTypeVisitor(const std::string &exp_addrType) : exp_addrType(exp_addrType) { }
-    bool operator()(const CKeyID &id) const
-    {
-        return (exp_addrType == "pubkey");
-    }
-    bool operator()(const CScriptID &id) const
-    {
-        return (exp_addrType == "script");
-    }
-    bool operator()(const CNoDestination &no) const
-    {
-        return (exp_addrType == "none");
-    }
-};
-
-// Visitor to check address payload
-class TestPayloadVisitor : public boost::static_visitor<bool>
-{
-private:
-    std::vector<unsigned char> exp_payload;
-public:
-    TestPayloadVisitor(std::vector<unsigned char> &exp_payload) : exp_payload(exp_payload) { }
-    bool operator()(const CKeyID &id) const
-    {
-        uint160 exp_key(exp_payload);
-        return exp_key == id;
-    }
-    bool operator()(const CScriptID &id) const
-    {
-        uint160 exp_key(exp_payload);
-        return exp_key == id;
-    }
-    bool operator()(const CNoDestination &no) const
-    {
-        return exp_payload.size() == 0;
-    }
-};
-
 // Goal: check that parsed keys match test payload
 BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
 {
@@ -128,8 +85,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
     for (size_t idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
         std::string strTest = test.write();
-        if (test.size() < 3) // Allow for extra stuff (useful for comments)
-        {
+        if (test.size() < 3) { // Allow for extra stuff (useful for comments)
             BOOST_ERROR("Bad test: " << strTest);
             continue;
         }
@@ -137,13 +93,13 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
         std::vector<unsigned char> exp_payload = ParseHex(test[1].get_str());
         const UniValue &metadata = test[2].get_obj();
         bool isPrivkey = find_value(metadata, "isPrivkey").get_bool();
-        bool isTestnet = find_value(metadata, "isTestnet").get_bool();
-        if (isTestnet)
+        bool isTestnet = find_value(metadata, "chain").get_str() == "testnet";
+        if (isTestnet) {
             SelectParams(CBaseChainParams::TESTNET);
-        else
+        } else {
             SelectParams(CBaseChainParams::MAIN);
-        if(isPrivkey)
-        {
+        }
+        if (isPrivkey) {
             bool isCompressed = find_value(metadata, "isCompressed").get_bool();
             // Must be valid private key
             BOOST_CHECK_MESSAGE(secret.SetString(exp_base58string), "!SetString:"+ strTest);
@@ -155,15 +111,12 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
             // Private key must be invalid public key
             destination = DecodeDestination(exp_base58string);
             BOOST_CHECK_MESSAGE(!IsValidDestination(destination), "IsValid privkey as pubkey:" + strTest);
-        }
-        else
-        {
-            std::string exp_addrType = find_value(metadata, "addrType").get_str(); // "script" or "pubkey"
+        } else {
             // Must be valid public key
             destination = DecodeDestination(exp_base58string);
+            CScript script = GetScriptForDestination(destination);
             BOOST_CHECK_MESSAGE(IsValidDestination(destination), "!IsValid:" + strTest);
-            BOOST_CHECK_MESSAGE((boost::get<CScriptID>(&destination) != nullptr) == (exp_addrType == "script"), "isScript mismatch" + strTest);
-            BOOST_CHECK_MESSAGE(boost::apply_visitor(TestAddrTypeVisitor(exp_addrType), destination), "addrType mismatch" + strTest);
+            BOOST_CHECK_EQUAL(HexStr(script), HexStr(exp_payload));
 
             // Public key must be invalid private key
             secret.SetString(exp_base58string);
@@ -189,13 +142,13 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
         std::vector<unsigned char> exp_payload = ParseHex(test[1].get_str());
         const UniValue &metadata = test[2].get_obj();
         bool isPrivkey = find_value(metadata, "isPrivkey").get_bool();
-        bool isTestnet = find_value(metadata, "isTestnet").get_bool();
-        if (isTestnet)
+        bool isTestnet = find_value(metadata, "chain").get_str() == "testnet";
+        if (isTestnet) {
             SelectParams(CBaseChainParams::TESTNET);
-        else
+        } else {
             SelectParams(CBaseChainParams::MAIN);
-        if(isPrivkey)
-        {
+        }
+        if (isPrivkey) {
             bool isCompressed = find_value(metadata, "isCompressed").get_bool();
             CKey key;
             key.Set(exp_payload.begin(), exp_payload.end(), isCompressed);
@@ -203,30 +156,12 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
             CBitcoinSecret secret;
             secret.SetKey(key);
             BOOST_CHECK_MESSAGE(secret.ToString() == exp_base58string, "result mismatch: " + strTest);
-        }
-        else
-        {
-            std::string exp_addrType = find_value(metadata, "addrType").get_str();
+        } else {
             CTxDestination dest;
-            if(exp_addrType == "pubkey")
-            {
-                dest = CKeyID(uint160(exp_payload));
-            }
-            else if(exp_addrType == "script")
-            {
-                dest = CScriptID(uint160(exp_payload));
-            }
-            else if(exp_addrType == "none")
-            {
-                dest = CNoDestination();
-            }
-            else
-            {
-                BOOST_ERROR("Bad addrtype: " << strTest);
-                continue;
-            }
+            CScript exp_script(exp_payload.begin(), exp_payload.end());
+            ExtractDestination(exp_script, dest);
             std::string address = EncodeDestination(dest);
-            BOOST_CHECK_MESSAGE(address == exp_base58string, "mismatch: " + strTest);
+            BOOST_CHECK_EQUAL(address, exp_base58string);
         }
     }
 

--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2017 Pieter Wuille
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bech32.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(bech32_tests, BasicTestingSetup)
+
+bool CaseInsensitiveEqual(const std::string &s1, const std::string &s2)
+{
+    if (s1.size() != s2.size()) return false;
+    for (size_t i = 0; i < s1.size(); ++i) {
+        char c1 = s1[i];
+        if (c1 >= 'A' && c1 <= 'Z') c1 -= ('A' - 'a');
+        char c2 = s2[i];
+        if (c2 >= 'A' && c2 <= 'Z') c2 -= ('A' - 'a');
+        if (c1 != c2) return false;
+    }
+    return true;
+}
+
+BOOST_AUTO_TEST_CASE(bip173_testvectors_valid)
+{
+    static const std::string CASES[] = {
+        "A12UEL5L",
+        "a12uel5l",
+        "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
+        "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
+        "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
+        "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
+        "?1ezyfcl",
+    };
+    for (const std::string& str : CASES) {
+        auto ret = bech32::Decode(str);
+        BOOST_CHECK(!ret.first.empty());
+        std::string recode = bech32::Encode(ret.first, ret.second);
+        BOOST_CHECK(!recode.empty());
+        BOOST_CHECK(CaseInsensitiveEqual(str, recode));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(bip173_testvectors_invalid)
+{
+    static const std::string CASES[] = {
+        " 1nwldj5",
+        "\x7f""1axkwrx",
+        "\x80""1eym55h",
+        "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
+        "pzry9x0s0muk",
+        "1pzry9x0s0muk",
+        "x1b4n0q5v",
+        "li1dgmt3",
+        "de1lg7wt\xff",
+        "A1G7SGD8",
+        "10a06t8",
+        "1qzzfhee",
+    };
+    for (const std::string& str : CASES) {
+        auto ret = bech32::Decode(str);
+        BOOST_CHECK(ret.first.empty());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/data/base58_keys_valid.json
+++ b/src/test/data/base58_keys_valid.json
@@ -1,452 +1,426 @@
 [
     [
-        "t1T8yaLVhNqxA5KJcmiqqFN88e8DNp2PBfF", 
-        "65a16059864a2fdbc7c99a4723a8395bc6f188eb", 
+        "t1T8yaLVhNqxA5KJcmiqqFN88e8DNp2PBfF",
+        "76a91465a16059864a2fdbc7c99a4723a8395bc6f188eb88ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "t3VDyGHn9mbyCf448m2cHTu5uXvsJpKHbiZ", 
-        "74f209f6ea907e2ea48f74fae05782ae8a665257", 
+        "t3VDyGHn9mbyCf448m2cHTu5uXvsJpKHbiZ",
+        "a91474f209f6ea907e2ea48f74fae05782ae8a66525787",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "tmHMBeeYRuc2eVicLNfP15YLxbQsooCA6jb", 
-        "53c0307d6851aa0ce7825ba883c6bd9ad242b486", 
+        "tmHMBeeYRuc2eVicLNfP15YLxbQsooCA6jb",
+        "76a91453c0307d6851aa0ce7825ba883c6bd9ad242b48688ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t2Fbo6DBKKVYw1SfrY8bEgz56hYEhywhEN6", 
-        "6349a418fc4578d10a372b54b45c280cc8c4382f", 
+        "t2Fbo6DBKKVYw1SfrY8bEgz56hYEhywhEN6",
+        "a9146349a418fc4578d10a372b54b45c280cc8c4382f87",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "5Kd3NBUAdUnhyzenEwVLy9pBKxSwXvE9FMPyR4UKZvpe6E3AgLr", 
-        "eddbdc1168f1daeadbd3e44c1e3f8f5a284c2029f78ad26af98583a499de5b19", 
+        "5Kd3NBUAdUnhyzenEwVLy9pBKxSwXvE9FMPyR4UKZvpe6E3AgLr",
+        "eddbdc1168f1daeadbd3e44c1e3f8f5a284c2029f78ad26af98583a499de5b19",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "Kz6UJmQACJmLtaQj5A3JAge4kVTNQ8gbvXuwbmCj7bsaabudb3RD", 
-        "55c9bccb9ed68446d1b75273bbce89d7fe013a8acd1625514420fb2aca1a21c4", 
+        "Kz6UJmQACJmLtaQj5A3JAge4kVTNQ8gbvXuwbmCj7bsaabudb3RD",
+        "55c9bccb9ed68446d1b75273bbce89d7fe013a8acd1625514420fb2aca1a21c4",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "9213qJab2HNEpMpYNBa7wHGFKKbkDn24jpANDs2huN3yi4J11ko", 
-        "36cb93b9ab1bdabf7fb9f2c04f1b9cc879933530ae7842398eef5a63a56800c2", 
+        "9213qJab2HNEpMpYNBa7wHGFKKbkDn24jpANDs2huN3yi4J11ko",
+        "36cb93b9ab1bdabf7fb9f2c04f1b9cc879933530ae7842398eef5a63a56800c2",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "cTpB4YiyKiBcPxnefsDpbnDxFDffjqJob8wGCEDXxgQ7zQoMXJdH", 
-        "b9f4892c9e8282028fea1d2667c4dc5213564d41fc5783896a0d843fc15089f3", 
+        "cTpB4YiyKiBcPxnefsDpbnDxFDffjqJob8wGCEDXxgQ7zQoMXJdH",
+        "b9f4892c9e8282028fea1d2667c4dc5213564d41fc5783896a0d843fc15089f3",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t1TpfguJj5zxKUfWcsNTrh6eod2XXsTKtvB", 
-        "6d23156cbbdcc82a5a47eee4c2c7c583c18b6bf4", 
+        "t1TpfguJj5zxKUfWcsNTrh6eod2XXsTKtvB",
+        "76a9146d23156cbbdcc82a5a47eee4c2c7c583c18b6bf488ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "t3hc9Y2stuEWjS2dRDtGdiu3enMpxAbeUiK", 
-        "fcc5460dd6e2487c7d75b1963625da0e8f4c5975", 
+        "t3hc9Y2stuEWjS2dRDtGdiu3enMpxAbeUiK",
+        "a914fcc5460dd6e2487c7d75b1963625da0e8f4c597587",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "tmXm2g5ouU8Pzksmqx3KYmeoeaWrAvj3rB5", 
-        "f1d470f9b02370fdec2e6b708b08ac431bf7a5f7", 
+        "tmXm2g5ouU8Pzksmqx3KYmeoeaWrAvj3rB5",
+        "76a914f1d470f9b02370fdec2e6b708b08ac431bf7a5f788ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t2QYxHjM8btztWTsMnFnZNurm7RXENk9ZhR", 
-        "c579342c2c4c9220205e2cdc285617040c924a0a", 
+        "t2QYxHjM8btztWTsMnFnZNurm7RXENk9ZhR",
+        "a914c579342c2c4c9220205e2cdc285617040c924a0a87",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "5K494XZwps2bGyeL71pWid4noiSNA2cfCibrvRWqcHSptoFn7rc", 
-        "a326b95ebae30164217d7a7f57d72ab2b54e3be64928a19da0210b9568d4015e", 
+        "5K494XZwps2bGyeL71pWid4noiSNA2cfCibrvRWqcHSptoFn7rc",
+        "a326b95ebae30164217d7a7f57d72ab2b54e3be64928a19da0210b9568d4015e",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "L1RrrnXkcKut5DEMwtDthjwRcTTwED36thyL1DebVrKuwvohjMNi", 
-        "7d998b45c219a1e38e99e7cbd312ef67f77a455a9b50c730c27f02c6f730dfb4", 
+        "L1RrrnXkcKut5DEMwtDthjwRcTTwED36thyL1DebVrKuwvohjMNi",
+        "7d998b45c219a1e38e99e7cbd312ef67f77a455a9b50c730c27f02c6f730dfb4",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "93DVKyFYwSN6wEo3E2fCrFPUp17FtrtNi2Lf7n4G3garFb16CRj", 
-        "d6bca256b5abc5602ec2e1c121a08b0da2556587430bcf7e1898af2224885203", 
+        "93DVKyFYwSN6wEo3E2fCrFPUp17FtrtNi2Lf7n4G3garFb16CRj",
+        "d6bca256b5abc5602ec2e1c121a08b0da2556587430bcf7e1898af2224885203",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "cTDVKtMGVYWTHCb1AFjmVbEbWjvKpKqKgMaR3QJxToMSQAhmCeTN", 
-        "a81ca4e8f90181ec4b61b6a7eb998af17b2cb04de8a03b504b9e34c4c61db7d9", 
+        "cTDVKtMGVYWTHCb1AFjmVbEbWjvKpKqKgMaR3QJxToMSQAhmCeTN",
+        "a81ca4e8f90181ec4b61b6a7eb998af17b2cb04de8a03b504b9e34c4c61db7d9",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t1UxCT4RrCbGH36etfQaPF1svNtZVhsqs5A", 
-        "7987ccaa53d02c8873487ef919677cd3db7a6912", 
+        "t1UxCT4RrCbGH36etfQaPF1svNtZVhsqs5A",
+        "76a9147987ccaa53d02c8873487ef919677cd3db7a691288ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "t3Teyxv1gF8FZ9MW8WN4MvTxQ4JScABsKfL", 
-        "63bcc565f9e68ee0189dd5cc67f1b0e5f02f45cb", 
+        "t3Teyxv1gF8FZ9MW8WN4MvTxQ4JScABsKfL",
+        "a91463bcc565f9e68ee0189dd5cc67f1b0e5f02f45cb87",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "tmXYBLe2Q9MbXfgGb2QqdN7RWdi7tQ2z8ya", 
-        "ef66444b5b17f14e8fae6e7e19b045a78c54fd79", 
+        "tmXYBLe2Q9MbXfgGb2QqdN7RWdi7tQ2z8ya",
+        "76a914ef66444b5b17f14e8fae6e7e19b045a78c54fd7988ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t2QQcXALz4745JEgzuAEsJNgt6nBQpsqegu", 
-        "c3e55fceceaa4391ed2a9677f4a4d34eacd021a0", 
+        "t2QQcXALz4745JEgzuAEsJNgt6nBQpsqegu",
+        "a914c3e55fceceaa4391ed2a9677f4a4d34eacd021a087",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "5KaBW9vNtWNhc3ZEDyNCiXLPdVPHCikRxSBWwV9NrpLLa4LsXi9", 
-        "e75d936d56377f432f404aabb406601f892fd49da90eb6ac558a733c93b47252", 
+        "5KaBW9vNtWNhc3ZEDyNCiXLPdVPHCikRxSBWwV9NrpLLa4LsXi9",
+        "e75d936d56377f432f404aabb406601f892fd49da90eb6ac558a733c93b47252",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "L1axzbSyynNYA8mCAhzxkipKkfHtAXYF4YQnhSKcLV8YXA874fgT", 
-        "8248bd0375f2f75d7e274ae544fb920f51784480866b102384190b1addfbaa5c", 
+        "L1axzbSyynNYA8mCAhzxkipKkfHtAXYF4YQnhSKcLV8YXA874fgT",
+        "8248bd0375f2f75d7e274ae544fb920f51784480866b102384190b1addfbaa5c",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "927CnUkUbasYtDwYwVn2j8GdTuACNnKkjZ1rpZd2yBB1CLcnXpo", 
-        "44c4f6a096eac5238291a94cc24c01e3b19b8d8cef72874a079e00a242237a52", 
+        "927CnUkUbasYtDwYwVn2j8GdTuACNnKkjZ1rpZd2yBB1CLcnXpo",
+        "44c4f6a096eac5238291a94cc24c01e3b19b8d8cef72874a079e00a242237a52",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "cUcfCMRjiQf85YMzzQEk9d1s5A4K7xL5SmBCLrezqXFuTVefyhY7", 
-        "d1de707020a9059d6d3abaf85e17967c6555151143db13dbb06db78df0f15c69", 
+        "cUcfCMRjiQf85YMzzQEk9d1s5A4K7xL5SmBCLrezqXFuTVefyhY7",
+        "d1de707020a9059d6d3abaf85e17967c6555151143db13dbb06db78df0f15c69",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t1ZiM4oLF7hvboF4LPqhbBg7RLgJCCJC6Tj", 
-        "adc1cc2081a27206fae25792f28bbc55b831549d", 
+        "t1ZiM4oLF7hvboF4LPqhbBg7RLgJCCJC6Tj",
+        "76a914adc1cc2081a27206fae25792f28bbc55b831549d88ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "t3LoV8q8R44fSbe84DBKDk3sAEoYum4hQYj", 
-        "188f91a931947eddd7432d6e614387e32b244709", 
+        "t3LoV8q8R44fSbe84DBKDk3sAEoYum4hQYj",
+        "a914188f91a931947eddd7432d6e614387e32b24470987",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "tmBmkeJmwF3UgVXqJLzEin49ftK1HmsqYup", 
-        "1694f5bc1a7295b600f40018a618a6ea48eeb498", 
+        "tmBmkeJmwF3UgVXqJLzEin49ftK1HmsqYup",
+        "76a9141694f5bc1a7295b600f40018a618a6ea48eeb49888ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t2Byypnbxh2Pfk7VqLMzYfiNeD72o6yvtqX", 
-        "3b9b3fd7a50d4f08d1a5b0f62f644fa7115ae2f3", 
+        "t2Byypnbxh2Pfk7VqLMzYfiNeD72o6yvtqX",
+        "a9143b9b3fd7a50d4f08d1a5b0f62f644fa7115ae2f387",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "5HtH6GdcwCJA4ggWEL1B3jzBBUB8HPiBi9SBc5h9i4Wk4PSeApR", 
-        "091035445ef105fa1bb125eccfb1882f3fe69592265956ade751fd095033d8d0", 
+        "5HtH6GdcwCJA4ggWEL1B3jzBBUB8HPiBi9SBc5h9i4Wk4PSeApR",
+        "091035445ef105fa1bb125eccfb1882f3fe69592265956ade751fd095033d8d0",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "L2xSYmMeVo3Zek3ZTsv9xUrXVAmrWxJ8Ua4cw8pkfbQhcEFhkXT8", 
-        "ab2b4bcdfc91d34dee0ae2a8c6b6668dadaeb3a88b9859743156f462325187af", 
+        "L2xSYmMeVo3Zek3ZTsv9xUrXVAmrWxJ8Ua4cw8pkfbQhcEFhkXT8",
+        "ab2b4bcdfc91d34dee0ae2a8c6b6668dadaeb3a88b9859743156f462325187af",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "92xFEve1Z9N8Z641KQQS7ByCSb8kGjsDzw6fAmjHN1LZGKQXyMq", 
-        "b4204389cef18bbe2b353623cbf93e8678fbc92a475b664ae98ed594e6cf0856", 
+        "92xFEve1Z9N8Z641KQQS7ByCSb8kGjsDzw6fAmjHN1LZGKQXyMq",
+        "b4204389cef18bbe2b353623cbf93e8678fbc92a475b664ae98ed594e6cf0856",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "cVM65tdYu1YK37tNoAyGoJTR13VBYFva1vg9FLuPAsJijGvG6NEA", 
-        "e7b230133f1b5489843260236b06edca25f66adb1be455fbd38d4010d48faeef", 
+        "cVM65tdYu1YK37tNoAyGoJTR13VBYFva1vg9FLuPAsJijGvG6NEA",
+        "e7b230133f1b5489843260236b06edca25f66adb1be455fbd38d4010d48faeef",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t1boxWWuUs3dVUFeUMiPqCdwD4QtL1AMx9G", 
-        "c4c1b72491ede1eedaca00618407ee0b772cad0d", 
+        "t1boxWWuUs3dVUFeUMiPqCdwD4QtL1AMx9G",
+        "76a914c4c1b72491ede1eedaca00618407ee0b772cad0d88ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "t3h5bvzkCXkiMttmQScK56UjVcqeD3NnReW", 
-        "f6fe69bcb548a829cce4c57bf6fff8af3a5981f9", 
+        "t3h5bvzkCXkiMttmQScK56UjVcqeD3NnReW",
+        "a914f6fe69bcb548a829cce4c57bf6fff8af3a5981f987",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "tmDBvm2S5yAj5pVAvB4th1DDVpLq3KuN8S1", 
-        "261f83568a098a8638844bd7aeca039d5f2352c0", 
+        "tmDBvm2S5yAj5pVAvB4th1DDVpLq3KuN8S1",
+        "76a914261f83568a098a8638844bd7aeca039d5f2352c088ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t2TooyZ7BmQTBkgCVhdNQsPfeVdQoWqsHQa", 
-        "e930e1834a4d234702773951d627cce82fbb5d2e", 
+        "t2TooyZ7BmQTBkgCVhdNQsPfeVdQoWqsHQa",
+        "a914e930e1834a4d234702773951d627cce82fbb5d2e87",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "5KQmDryMNDcisTzRp3zEq9e4awRmJrEVU1j5vFRTKpRNYPqYrMg", 
-        "d1fab7ab7385ad26872237f1eb9789aa25cc986bacc695e07ac571d6cdac8bc0", 
+        "5KQmDryMNDcisTzRp3zEq9e4awRmJrEVU1j5vFRTKpRNYPqYrMg",
+        "d1fab7ab7385ad26872237f1eb9789aa25cc986bacc695e07ac571d6cdac8bc0",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "L39Fy7AC2Hhj95gh3Yb2AU5YHh1mQSAHgpNixvm27poizcJyLtUi", 
-        "b0bbede33ef254e8376aceb1510253fc3550efd0fcf84dcd0c9998b288f166b3", 
+        "L39Fy7AC2Hhj95gh3Yb2AU5YHh1mQSAHgpNixvm27poizcJyLtUi",
+        "b0bbede33ef254e8376aceb1510253fc3550efd0fcf84dcd0c9998b288f166b3",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "91cTVUcgydqyZLgaANpf1fvL55FH53QMm4BsnCADVNYuWuqdVys", 
-        "037f4192c630f399d9271e26c575269b1d15be553ea1a7217f0cb8513cef41cb", 
+        "91cTVUcgydqyZLgaANpf1fvL55FH53QMm4BsnCADVNYuWuqdVys",
+        "037f4192c630f399d9271e26c575269b1d15be553ea1a7217f0cb8513cef41cb",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "cQspfSzsgLeiJGB2u8vrAiWpCU4MxUT6JseWo2SjXy4Qbzn2fwDw", 
-        "6251e205e8ad508bab5596bee086ef16cd4b239e0cc0c5d7c4e6035441e7d5de", 
+        "cQspfSzsgLeiJGB2u8vrAiWpCU4MxUT6JseWo2SjXy4Qbzn2fwDw",
+        "6251e205e8ad508bab5596bee086ef16cd4b239e0cc0c5d7c4e6035441e7d5de",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t1SWDbHDTatR1ag8yTFLdVWd1erfu7Pbbjk", 
-        "5eadaf9bb7121f0f192561a5a62f5e5f54210292", 
+        "t1SWDbHDTatR1ag8yTFLdVWd1erfu7Pbbjk",
+        "76a9145eadaf9bb7121f0f192561a5a62f5e5f5421029288ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "t3QKR6mLBwPY6DeqHwjJCxUwSsGUToB5sWJ", 
-        "3f210e7277c899c3a155cc1c90f4106cbddeec6e", 
+        "t3QKR6mLBwPY6DeqHwjJCxUwSsGUToB5sWJ",
+        "a9143f210e7277c899c3a155cc1c90f4106cbddeec6e87",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "tmU1EeoNHCfmWpeZWeRnKmNeVdHJgZjse5G", 
-        "c8a3c2a09a298592c3e180f02487cd91ba3400b5", 
+        "tmU1EeoNHCfmWpeZWeRnKmNeVdHJgZjse5G",
+        "76a914c8a3c2a09a298592c3e180f02487cd91ba3400b588ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t2LZVwB5A2n5U9odwMbLd1g5Bz9Z3ZFoCJH", 
-        "99b31df7c9068d1481b596578ddbb4d3bd90baeb", 
+        "t2LZVwB5A2n5U9odwMbLd1g5Bz9Z3ZFoCJH",
+        "a91499b31df7c9068d1481b596578ddbb4d3bd90baeb87",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": true
+            "isPrivkey": false,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "5KL6zEaMtPRXZKo1bbMq7JDjjo1bJuQcsgL33je3oY8uSJCR5b4", 
-        "c7666842503db6dc6ea061f092cfb9c388448629a6fe868d068c42a488b478ae", 
+        "5KL6zEaMtPRXZKo1bbMq7JDjjo1bJuQcsgL33je3oY8uSJCR5b4",
+        "c7666842503db6dc6ea061f092cfb9c388448629a6fe868d068c42a488b478ae",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "KwV9KAfwbwt51veZWNscRTeZs9CKpojyu1MsPnaKTF5kz69H1UN2", 
-        "07f0803fc5399e773555ab1e8939907e9badacc17ca129e67a2f5f2ff84351dd", 
+        "KwV9KAfwbwt51veZWNscRTeZs9CKpojyu1MsPnaKTF5kz69H1UN2",
+        "07f0803fc5399e773555ab1e8939907e9badacc17ca129e67a2f5f2ff84351dd",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": false
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "93N87D6uxSBzwXvpokpzg8FFmfQPmvX4xHoWQe3pLdYpbiwT5YV", 
-        "ea577acfb5d1d14d3b7b195c321566f12f87d2b77ea3a53f68df7ebf8604a801", 
+        "93N87D6uxSBzwXvpokpzg8FFmfQPmvX4xHoWQe3pLdYpbiwT5YV",
+        "ea577acfb5d1d14d3b7b195c321566f12f87d2b77ea3a53f68df7ebf8604a801",
         {
-            "isCompressed": false, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": false,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "cMxXusSihaX58wpJ3tNuuUcZEQGt6DKJ1wEpxys88FFaQCYjku9h", 
-        "0b3b34f0958d8a268193a9814da92c3e8b58b4a4378a542863e34ac289cd830c", 
+        "cMxXusSihaX58wpJ3tNuuUcZEQGt6DKJ1wEpxys88FFaQCYjku9h",
+        "0b3b34f0958d8a268193a9814da92c3e8b58b4a4378a542863e34ac289cd830c",
         {
-            "isCompressed": true, 
-            "isPrivkey": true, 
-            "isTestnet": true
+            "isCompressed": true,
+            "isPrivkey": true,
+            "chain": "testnet"
         }
-    ], 
+    ],
     [
-        "t1Lgcj4m5r7eDWctWQM7ete85hHivQxMjBZ", 
-        "1ed467017f043e91ed4c44b4e8dd674db211c4e6", 
+        "t1Lgcj4m5r7eDWctWQM7ete85hHivQxMjBZ",
+        "76a9141ed467017f043e91ed4c44b4e8dd674db211c4e688ac",
         {
-            "addrType": "pubkey", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
-    ], 
+    ],
     [
-        "t3TCuHUxH3LGnsFYTUbSwHrRXxTaEA8hAaf", 
-        "5ece0cadddc415b1980f001785947120acdb36fc", 
+        "t3TCuHUxH3LGnsFYTUbSwHrRXxTaEA8hAaf",
+        "a9145ece0cadddc415b1980f001785947120acdb36fc87",
         {
-            "addrType": "script", 
-            "isPrivkey": false, 
-            "isTestnet": false
+            "isPrivkey": false,
+            "chain": "mainnet"
         }
     ]
 ]

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -120,7 +120,6 @@ BOOST_AUTO_TEST_CASE(pmt_malleability)
     std::vector<bool> vMatch = boost::assign::list_of(false)(false)(false)(false)(false)(false)(false)(false)(false)(true)(true)(false);
 
     CPartialMerkleTree tree(vTxid, vMatch);
-    std::vector<uint256> vTxid2;
     BOOST_CHECK(tree.ExtractMatches(vTxid).IsNull());
 }
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -234,11 +234,7 @@ BOOST_AUTO_TEST_CASE(util_IsHex)
 
 BOOST_AUTO_TEST_CASE(util_seed_insecure_rand)
 {
-    int i;
-    int count=0;
-
     seed_insecure_rand(true);
-
     for (int mod=2;mod<11;mod++)
     {
         int mask = 1;
@@ -247,10 +243,9 @@ BOOST_AUTO_TEST_CASE(util_seed_insecure_rand)
         //mask is 2^ceil(log2(mod))-1
         while(mask<mod-1)mask=(mask<<1)+1;
 
-        count = 0;
+        int count = 0;
         //How often does it get a zero from the uniform range [0,mod)?
-        for (i=0;i<10000;i++)
-        {
+        for (int i = 0; i < 10000; i++) {
             uint32_t rval;
             do{
                 rval=insecure_rand()&mask;


### PR DESCRIPTION
Cherry-picked from the following upstream PRs:

- bitcoin/bitcoin#8578
- bitcoin/bitcoin#11167
  - Only the second and third commits (first is in #3228, fourth depends on #2390, later ones are SegWit-specific).
- bitcoin/bitcoin#12757
  - Only the change to `src/bech32.h`

Part of #3058.