### PR TITLE
Return result of boost::apply_visitor

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -115,7 +115,7 @@ bool JSDescription::Verify(
     const uint256& pubKeyHash
 ) const {
     auto pv = SproutProofVerifier(params, verifier, pubKeyHash, *this);
-    boost::apply_visitor(pv, proof);
+    return boost::apply_visitor(pv, proof);
 }
 
 uint256 JSDescription::h_sig(ZCJoinSplit& params, const uint256& pubKeyHash) const


### PR DESCRIPTION
Not returning a value at the end of a non-void function is undefined behaviour.
Given that this managed to pass our full test suite, I guess that GCC looks for
un-returned values at the end of a function and uses them as the return value,
if the keyword is missing. Clang OTOH complains, which is how we spotted this:
https://ci.z.cash/#/builders/16/builds/282