### PR TITLE
Sapling keys in keystore, wallet

### DIFF
--- a/src/gtest/test_keystore.cpp
+++ b/src/gtest/test_keystore.cpp
@@ -55,8 +55,12 @@ TEST(keystore_tests, sapling_keys) {
         EXPECT_EQ(in_viewing_key, in_viewing_key_2);
         
         // Check that the default address from primitives and from sk method are the same
-        auto default_addr = sk.default_address();
-        auto default_addr_2 = in_viewing_key.address(default_d);
+        auto addrOpt = sk.default_address();
+        EXPECT_TRUE(addrOpt);
+        auto default_addr = addrOpt.value();
+        auto addrOpt2 = in_viewing_key.address(default_d);
+        EXPECT_TRUE(addrOpt2);
+        auto default_addr_2 = addrOpt2.value();
         EXPECT_EQ(default_addr, default_addr_2);
         
         auto default_addr_3 = libzcash::SaplingPaymentAddress(default_d, default_pk_d);
@@ -159,6 +163,42 @@ TEST(keystore_tests, StoreAndRetrieveViewingKey) {
     // (and also we only remove viewing keys when adding a spending key)
     EXPECT_TRUE(keyStore.GetNoteDecryptor(addr, decOut));
     EXPECT_EQ(ZCNoteDecryption(sk.receiving_key()), decOut);
+}
+
+// Sapling
+TEST(keystore_tests, StoreAndRetrieveSaplingSpendingKey) {
+    CBasicKeyStore keyStore;
+    libzcash::SaplingSpendingKey skOut;
+    libzcash::SaplingFullViewingKey fvkOut;
+    libzcash::SaplingIncomingViewingKey ivkOut;
+
+    auto sk = libzcash::SaplingSpendingKey::random();
+    auto fvk = sk.full_viewing_key();
+    auto ivk = fvk.in_viewing_key();
+    auto addrOpt = sk.default_address();
+    EXPECT_TRUE(addrOpt);
+    auto addr = addrOpt.value();
+
+    // Sanity-check: we can't get a key we haven't added
+    EXPECT_FALSE(keyStore.HaveSaplingSpendingKey(fvk));
+    EXPECT_FALSE(keyStore.GetSaplingSpendingKey(fvk, skOut));
+    // Sanity-check: we can't get a full viewing key we haven't added
+    EXPECT_FALSE(keyStore.HaveSaplingFullViewingKey(ivk));
+    EXPECT_FALSE(keyStore.GetSaplingFullViewingKey(ivk, fvkOut));
+    // Sanity-check: we can't get an incoming viewing key we haven't added
+    EXPECT_FALSE(keyStore.HaveSaplingIncomingViewingKey(addr));
+    EXPECT_FALSE(keyStore.GetSaplingIncomingViewingKey(addr, ivkOut));
+
+    keyStore.AddSaplingSpendingKey(sk);
+    EXPECT_TRUE(keyStore.HaveSaplingSpendingKey(fvk));
+    EXPECT_TRUE(keyStore.GetSaplingSpendingKey(fvk, skOut));
+    EXPECT_TRUE(keyStore.HaveSaplingFullViewingKey(ivk));
+    EXPECT_TRUE(keyStore.GetSaplingFullViewingKey(ivk, fvkOut));
+    EXPECT_TRUE(keyStore.HaveSaplingIncomingViewingKey(addr));
+    EXPECT_TRUE(keyStore.GetSaplingIncomingViewingKey(addr, ivkOut));
+    EXPECT_EQ(sk, skOut);
+    EXPECT_EQ(fvk, fvkOut);
+    EXPECT_EQ(ivk, ivkOut);
 }
 
 #ifdef ENABLE_WALLET

--- a/src/gtest/test_keystore.cpp
+++ b/src/gtest/test_keystore.cpp
@@ -55,9 +55,7 @@ TEST(keystore_tests, sapling_keys) {
         EXPECT_EQ(in_viewing_key, in_viewing_key_2);
         
         // Check that the default address from primitives and from sk method are the same
-        auto addrOpt = sk.default_address();
-        EXPECT_TRUE(addrOpt);
-        auto default_addr = addrOpt.value();
+        auto default_addr = sk.default_address();
         auto addrOpt2 = in_viewing_key.address(default_d);
         EXPECT_TRUE(addrOpt2);
         auto default_addr_2 = addrOpt2.value();
@@ -175,9 +173,7 @@ TEST(keystore_tests, StoreAndRetrieveSaplingSpendingKey) {
     auto sk = libzcash::SaplingSpendingKey::random();
     auto fvk = sk.full_viewing_key();
     auto ivk = fvk.in_viewing_key();
-    auto addrOpt = sk.default_address();
-    EXPECT_TRUE(addrOpt);
-    auto addr = addrOpt.value();
+    auto addr = sk.default_address();
 
     // Sanity-check: we can't get a key we haven't added
     EXPECT_FALSE(keyStore.HaveSaplingSpendingKey(fvk));

--- a/src/gtest/test_sapling_note.cpp
+++ b/src/gtest/test_sapling_note.cpp
@@ -56,7 +56,7 @@ TEST(SaplingNote, TestVectors)
 TEST(SaplingNote, Random)
 {
     // Test creating random notes using the same spending key
-    auto address = SaplingSpendingKey::random().default_address().get();
+    auto address = SaplingSpendingKey::random().default_address();
     SaplingNote note1(address, GetRand(MAX_MONEY));
     SaplingNote note2(address, GetRand(MAX_MONEY));
 
@@ -66,7 +66,7 @@ TEST(SaplingNote, Random)
     ASSERT_NE(note1.r, note2.r);
 
     // Test diversifier and pk_d are not the same for different spending keys
-    SaplingNote note3(SaplingSpendingKey::random().default_address().get(), GetRand(MAX_MONEY));
+    SaplingNote note3(SaplingSpendingKey::random().default_address(), GetRand(MAX_MONEY));
     ASSERT_NE(note1.d, note3.d);
     ASSERT_NE(note1.pk_d, note3.pk_d);
 }

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -93,6 +93,16 @@ bool CBasicKeyStore::AddSpendingKey(const libzcash::SproutSpendingKey &sk)
     return true;
 }
 
+//! Sapling 
+bool CBasicKeyStore::AddSaplingSpendingKey(const libzcash::SaplingSpendingKey &sk)
+{
+    LOCK(cs_SpendingKeyStore);
+    auto fvk = sk.full_viewing_key();
+    mapSaplingSpendingKeys[fvk] = sk;
+    //! TODO: Note decryptors for Sapling
+    return true;
+}
+
 bool CBasicKeyStore::AddViewingKey(const libzcash::SproutViewingKey &vk)
 {
     LOCK(cs_SpendingKeyStore);

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -106,12 +106,10 @@ bool CBasicKeyStore::AddSaplingSpendingKey(const libzcash::SaplingSpendingKey &s
     // Add addr -> SaplingIncomingViewing to SaplingIncomingViewingKeyMap
     auto ivk = fvk.in_viewing_key();
     auto addrOpt = sk.default_address();
-    if (addrOpt){
-        auto addr = addrOpt.value();
-        mapSaplingIncomingViewingKeys[addr] = ivk;
-    } else {
-        return false;
-    }
+    assert(addrOpt != boost::none);
+    auto addr = addrOpt.value();
+    mapSaplingIncomingViewingKeys[addr] = ivk;
+    
     return true;
 }
 
@@ -129,8 +127,9 @@ bool CBasicKeyStore::AddSaplingFullViewingKey(const libzcash::SaplingFullViewing
     LOCK(cs_SpendingKeyStore);
     auto ivk = fvk.in_viewing_key();
     mapSaplingFullViewingKeys[ivk] = fvk;
+    
     //! TODO: Note decryptors for Sapling
-    // mapNoteDecryptors.insert(std::make_pair(address, ZCNoteDecryption(vk.sk_enc)));
+    
     return true;
 }
 

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -98,16 +98,17 @@ bool CBasicKeyStore::AddSaplingSpendingKey(const libzcash::SaplingSpendingKey &s
 {
     LOCK(cs_SpendingKeyStore);
     auto fvk = sk.full_viewing_key();
-    mapSaplingSpendingKeys[fvk] = sk;
     
     // if SaplingFullViewingKey is not in SaplingFullViewingKeyMap, add it
-    AddSaplingFullViewingKey(fvk);
+    if (!AddSaplingFullViewingKey(fvk)){
+        return false;
+    }
     
+    mapSaplingSpendingKeys[fvk] = sk;
+
     // Add addr -> SaplingIncomingViewing to SaplingIncomingViewingKeyMap
     auto ivk = fvk.in_viewing_key();
-    auto addrOpt = sk.default_address();
-    assert(addrOpt != boost::none);
-    auto addr = addrOpt.value();
+    auto addr = sk.default_address();
     mapSaplingIncomingViewingKeys[addr] = ivk;
     
     return true;

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -262,4 +262,7 @@ typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMate
 typedef std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char> > > CryptedKeyMap;
 typedef std::map<libzcash::SproutPaymentAddress, std::vector<unsigned char> > CryptedSpendingKeyMap;
 
+//! Sapling 
+typedef std::map<libzcash::SaplingFullViewingKey, std::vector<unsigned char> > CryptedSaplingSpendingKeyMap;
+
 #endif // BITCOIN_KEYSTORE_H

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -92,6 +92,7 @@ typedef std::map<libzcash::SproutPaymentAddress, ZCNoteDecryption> NoteDecryptor
 
 // Full viewing key has equivalent functionality to a transparent address
 // When encrypting wallet, encrypt SaplingSpendingKeyMap, while leaving SaplingFullViewingKeyMap unencrypted
+// When implementing ZIP 32, add another map from SaplingFullViewingKey -> SaplingExpandedSpendingKey
 typedef std::map<libzcash::SaplingFullViewingKey, libzcash::SaplingSpendingKey> SaplingSpendingKeyMap;
 typedef std::map<libzcash::SaplingIncomingViewingKey, libzcash::SaplingFullViewingKey> SaplingFullViewingKeyMap;
 // Only maps from default addresses to ivk, may need to be reworked when adding diversified addresses. 

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -62,6 +62,19 @@ public:
     //! Check whether a Sapling spending key corresponding to a given Sapling viewing key is present in the store.
     virtual bool HaveSaplingSpendingKey(const libzcash::SaplingFullViewingKey &fvk) const =0;
     virtual bool GetSaplingSpendingKey(const libzcash::SaplingFullViewingKey &fvk, libzcash::SaplingSpendingKey& skOut) const =0;
+    
+    //! Support for Sapling full viewing keys
+    virtual bool AddSaplingFullViewingKey(const libzcash::SaplingFullViewingKey &fvk) =0;
+    virtual bool HaveSaplingFullViewingKey(const libzcash::SaplingIncomingViewingKey &ivk) const =0;
+    virtual bool GetSaplingFullViewingKey(
+        const libzcash::SaplingIncomingViewingKey &ivk, 
+        libzcash::SaplingFullViewingKey& fvkOut) const =0;
+    
+    //! Sapling incoming viewing keys 
+    virtual bool HaveSaplingIncomingViewingKey(const libzcash::SaplingPaymentAddress &addr) const =0;
+    virtual bool GetSaplingIncomingViewingKey(
+        const libzcash::SaplingPaymentAddress &addr, 
+        libzcash::SaplingIncomingViewingKey& ivkOut) const =0;
 
     //! Support for viewing keys
     virtual bool AddViewingKey(const libzcash::SproutViewingKey &vk) =0;
@@ -77,8 +90,12 @@ typedef std::map<libzcash::SproutPaymentAddress, libzcash::SproutSpendingKey> Sp
 typedef std::map<libzcash::SproutPaymentAddress, libzcash::SproutViewingKey> ViewingKeyMap;
 typedef std::map<libzcash::SproutPaymentAddress, ZCNoteDecryption> NoteDecryptorMap;
 
+// Full viewing key has equivalent functionality to a transparent address
+// When encrypting wallet, encrypt SaplingSpendingKeyMap, while leaving SaplingFullViewingKeyMap unencrypted
 typedef std::map<libzcash::SaplingFullViewingKey, libzcash::SaplingSpendingKey> SaplingSpendingKeyMap;
 typedef std::map<libzcash::SaplingIncomingViewingKey, libzcash::SaplingFullViewingKey> SaplingFullViewingKeyMap;
+// Only maps from default addresses to ivk, may need to be reworked when adding diversified addresses. 
+typedef std::map<libzcash::SaplingPaymentAddress, libzcash::SaplingIncomingViewingKey> SaplingIncomingViewingKeyMap;
 
 /** Basic key store, that keeps keys in an address->secret map */
 class CBasicKeyStore : public CKeyStore
@@ -92,6 +109,8 @@ protected:
     NoteDecryptorMap mapNoteDecryptors;
     
     SaplingSpendingKeyMap mapSaplingSpendingKeys;
+    SaplingFullViewingKeyMap mapSaplingFullViewingKeys;
+    SaplingIncomingViewingKeyMap mapSaplingIncomingViewingKeys;
 
 public:
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
@@ -220,6 +239,17 @@ public:
         }
         return false;
     }
+    
+    virtual bool AddSaplingFullViewingKey(const libzcash::SaplingFullViewingKey &fvk);
+    virtual bool HaveSaplingFullViewingKey(const libzcash::SaplingIncomingViewingKey &ivk) const;
+    virtual bool GetSaplingFullViewingKey(
+        const libzcash::SaplingIncomingViewingKey &ivk, 
+        libzcash::SaplingFullViewingKey& fvkOut) const;
+    
+    virtual bool HaveSaplingIncomingViewingKey(const libzcash::SaplingPaymentAddress &addr) const;
+    virtual bool GetSaplingIncomingViewingKey(
+        const libzcash::SaplingPaymentAddress &addr, 
+        libzcash::SaplingIncomingViewingKey& ivkOut) const;
 
     virtual bool AddViewingKey(const libzcash::SproutViewingKey &vk);
     virtual bool RemoveViewingKey(const libzcash::SproutViewingKey &vk);

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(zs_address_test)
         {
             auto addr = sk.default_address();
 
-            std::string addr_string = EncodePaymentAddress(*addr);
+            std::string addr_string = EncodePaymentAddress(addr);
             BOOST_CHECK(addr_string.compare(0, 2, Params().Bech32HRP(CChainParams::SAPLING_PAYMENT_ADDRESS)) == 0);
 
             auto paymentaddr2 = DecodePaymentAddress(addr_string);

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -129,7 +129,9 @@ class CCryptoKeyStore : public CBasicKeyStore
 private:
     CryptedKeyMap mapCryptedKeys;
     CryptedSpendingKeyMap mapCryptedSpendingKeys;
-
+    
+    CryptedSaplingSpendingKeyMap mapCryptedSaplingSpendingKeys;
+    
     CKeyingMaterial vMasterKey;
 
     //! if fUseCrypto is true, mapKeys and mapSpendingKeys must be empty
@@ -230,6 +232,10 @@ public:
             mi++;
         }
     }
+    //! Sapling 
+    virtual bool AddCryptedSaplingSpendingKey(const libzcash::SaplingFullViewingKey &fvk,
+                                       const std::vector<unsigned char> &vchCryptedSecret);
+    bool AddSaplingSpendingKey(const libzcash::SaplingSpendingKey &sk);
 
     /**
      * Wallet status (encrypted, locked) changed.

--- a/src/wallet/gtest/test_wallet_zkeys.cpp
+++ b/src/wallet/gtest/test_wallet_zkeys.cpp
@@ -8,6 +8,29 @@
 #include <boost/filesystem.hpp>
 
 /**
+ * This test covers Sapling methods on CWallet
+ * GenerateNewSaplingZKey()
+ */
+TEST(wallet_zkeys_tests, store_and_load_sapling_zkeys) {
+    SelectParams(CBaseChainParams::MAIN);
+
+    CWallet wallet;
+
+    auto address = wallet.GenerateNewSaplingZKey();
+    
+    // verify wallet has incoming viewing key for the address
+    ASSERT_TRUE(wallet.HaveSaplingIncomingViewingKey(address));
+    
+    // manually add new spending key to wallet
+    auto sk = libzcash::SaplingSpendingKey::random();
+    ASSERT_TRUE(wallet.AddSaplingZKey(sk));
+
+    // verify wallet did add it
+    auto fvk = sk.full_viewing_key();
+    ASSERT_TRUE(wallet.HaveSaplingSpendingKey(fvk));
+}
+
+/**
  * This test covers methods on CWallet
  * GenerateNewZKey()
  * AddZKey()

--- a/src/wallet/gtest/test_wallet_zkeys.cpp
+++ b/src/wallet/gtest/test_wallet_zkeys.cpp
@@ -8,41 +8,8 @@
 #include <boost/filesystem.hpp>
 
 /**
- * This test covers Sapling methods on CWallet
- * GenerateNewSaplingZKey()
- */
-TEST(wallet_zkeys_tests, store_and_load_sapling_zkeys) {
-    CWallet wallet;
-    
-    // wallet should be empty
-    // std::set<libzcash::SaplingPaymentAddress> addrs;
-    // wallet.GetSaplingPaymentAddresses(addrs);
-    // ASSERT_EQ(0, addrs.size());
-        
-    // wallet should have one key
-    auto saplingAddr = wallet.GenerateNewSaplingZKey();
-    // ASSERT_NE(boost::get<libzcash::SaplingPaymentAddress>(&address), nullptr);
-    // auto sapling_addr = boost::get<libzcash::SaplingPaymentAddress>(saplingAddr);
-    // wallet.GetSaplingPaymentAddresses(addrs);
-    // ASSERT_EQ(1, addrs.size());
-
-    auto sk = libzcash::SaplingSpendingKey::random();
-    auto full_viewing_key = sk.full_viewing_key();
-    ASSERT_TRUE(wallet.AddSaplingSpendingKey(sk));
-    
-    // verify wallet has spending key for the address
-    ASSERT_TRUE(wallet.HaveSaplingSpendingKey(full_viewing_key));
-    
-    // check key is the same
-    libzcash::SaplingSpendingKey keyOut;
-    wallet.GetSaplingSpendingKey(full_viewing_key, keyOut);
-    ASSERT_EQ(sk, keyOut);
-}
-
-/**
  * This test covers methods on CWallet
  * GenerateNewZKey()
- * GenerateNewSaplingZKey()
  * AddZKey()
  * LoadZKey()
  * LoadZKeyMetadata()

--- a/src/wallet/gtest/test_wallet_zkeys.cpp
+++ b/src/wallet/gtest/test_wallet_zkeys.cpp
@@ -8,8 +8,41 @@
 #include <boost/filesystem.hpp>
 
 /**
+ * This test covers Sapling methods on CWallet
+ * GenerateNewSaplingZKey()
+ */
+TEST(wallet_zkeys_tests, store_and_load_sapling_zkeys) {
+    CWallet wallet;
+    
+    // wallet should be empty
+    // std::set<libzcash::SaplingPaymentAddress> addrs;
+    // wallet.GetSaplingPaymentAddresses(addrs);
+    // ASSERT_EQ(0, addrs.size());
+        
+    // wallet should have one key
+    auto saplingAddr = wallet.GenerateNewSaplingZKey();
+    // ASSERT_NE(boost::get<libzcash::SaplingPaymentAddress>(&address), nullptr);
+    // auto sapling_addr = boost::get<libzcash::SaplingPaymentAddress>(saplingAddr);
+    // wallet.GetSaplingPaymentAddresses(addrs);
+    // ASSERT_EQ(1, addrs.size());
+
+    auto sk = libzcash::SaplingSpendingKey::random();
+    auto full_viewing_key = sk.full_viewing_key();
+    ASSERT_TRUE(wallet.AddSaplingSpendingKey(sk));
+    
+    // verify wallet has spending key for the address
+    ASSERT_TRUE(wallet.HaveSaplingSpendingKey(full_viewing_key));
+    
+    // check key is the same
+    libzcash::SaplingSpendingKey keyOut;
+    wallet.GetSaplingSpendingKey(full_viewing_key, keyOut);
+    ASSERT_EQ(sk, keyOut);
+}
+
+/**
  * This test covers methods on CWallet
  * GenerateNewZKey()
+ * GenerateNewSaplingZKey()
  * AddZKey()
  * LoadZKey()
  * LoadZKeyMetadata()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -138,16 +138,12 @@ bool CWallet::AddSaplingZKey(const libzcash::SaplingSpendingKey &sk)
     if (!CCryptoKeyStore::AddSaplingSpendingKey(sk)) {
         return false;
     }
+    
+    if (!fFileBacked) {
+        return true;
+    }
 
-    // // check if we need to remove from viewing keys
-    // if (HaveViewingKey(addr)) {
-    //     RemoveViewingKey(key.viewing_key());
-    // }
-
-    // if (!fFileBacked) {
-    //     return true;
-    // }
-
+    // TODO: Persist to disk
     // if (!IsCrypted()) {
     //     return CWalletDB(strWalletFile).WriteSaplingZKey(addr,
     //                                               sk,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -103,21 +103,16 @@ libzcash::PaymentAddress CWallet::GenerateNewZKey()
 // Generate a new Sapling spending key and return its public payment address
 SaplingPaymentAddress CWallet::GenerateNewSaplingZKey()
 {
-    AssertLockHeld(cs_wallet); // mapZKeyMetadata
+    AssertLockHeld(cs_wallet); // mapSaplingZKeyMetadata
     
-    SaplingSpendingKey sk;
-    boost::optional<SaplingPaymentAddress> addrOpt;
-    while (!addrOpt){
-        sk = SaplingSpendingKey::random();
-        addrOpt = sk.default_address();
-    }
-    
-    auto addr = addrOpt.value();
+    auto sk = SaplingSpendingKey::random();
     auto fvk = sk.full_viewing_key();
+    auto addr = sk.default_address();
     
     // Check for collision, even though it is unlikely to ever occur
-    if (CCryptoKeyStore::HaveSaplingSpendingKey(fvk))
-    throw std::runtime_error("CWallet::GenerateNewSaplingZKey(): Collision detected");
+    if (CCryptoKeyStore::HaveSaplingSpendingKey(fvk)) {
+        throw std::runtime_error("CWallet::GenerateNewSaplingZKey(): Collision detected");
+    }
     
     // Create new metadata
     int64_t nCreationTime = GetTime();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -786,6 +786,7 @@ public:
     std::set<int64_t> setKeyPool;
     std::map<CKeyID, CKeyMetadata> mapKeyMetadata;
     std::map<libzcash::SproutPaymentAddress, CKeyMetadata> mapZKeyMetadata;
+    std::map<libzcash::SaplingPaymentAddress, CKeyMetadata> mapSaplingZKeyMetadata;
 
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
     MasterKeyMap mapMasterKeys;
@@ -977,6 +978,14 @@ public:
     bool RemoveViewingKey(const libzcash::SproutViewingKey &vk);
     //! Adds a viewing key to the store, without saving it to disk (used by LoadWallet)
     bool LoadViewingKey(const libzcash::SproutViewingKey &dest);
+    
+    /**
+      * Sapling ZKeys
+      */
+    //! Generates new Sapling key
+    libzcash::SaplingPaymentAddress GenerateNewSaplingZKey();
+    //! Adds Sapling spending key to the store, and saves it to disk
+    bool AddSaplingZKey(const libzcash::SaplingSpendingKey &key);
 
     /** 
      * Increment the next transaction order id

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -141,7 +141,7 @@ public:
 
     bool WriteViewingKey(const libzcash::SproutViewingKey &vk);
     bool EraseViewingKey(const libzcash::SproutViewingKey &vk);
-    
+
 private:
     CWalletDB(const CWalletDB&);
     void operator=(const CWalletDB&);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -141,7 +141,7 @@ public:
 
     bool WriteViewingKey(const libzcash::SproutViewingKey &vk);
     bool EraseViewingKey(const libzcash::SproutViewingKey &vk);
-
+    
 private:
     CWalletDB(const CWalletDB&);
     void operator=(const CWalletDB&);

--- a/src/zcash/Address.cpp
+++ b/src/zcash/Address.cpp
@@ -39,6 +39,12 @@ SproutPaymentAddress SproutSpendingKey::address() const {
 }
 
 //! Sapling
+uint256 SaplingPaymentAddress::GetHash() const {
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << *this;
+    return Hash(ss.begin(), ss.end());
+}
+
 SaplingFullViewingKey SaplingExpandedSpendingKey::full_viewing_key() const {
     uint256 ak;
     uint256 nk;

--- a/src/zcash/Address.cpp
+++ b/src/zcash/Address.cpp
@@ -75,8 +75,11 @@ boost::optional<SaplingPaymentAddress> SaplingIncomingViewingKey::address(divers
     }
 }
 
-boost::optional<SaplingPaymentAddress> SaplingSpendingKey::default_address() const {
-    return full_viewing_key().in_viewing_key().address(default_diversifier(*this));
+SaplingPaymentAddress SaplingSpendingKey::default_address() const {
+    // Iterates within default_diversifier to ensure a valid address is returned
+    auto addrOpt = full_viewing_key().in_viewing_key().address(default_diversifier(*this));
+    assert(addrOpt != boost::none);
+    return addrOpt.value();
 }
 
 }

--- a/src/zcash/Address.hpp
+++ b/src/zcash/Address.hpp
@@ -202,7 +202,7 @@ public:
     SaplingFullViewingKey full_viewing_key() const;
     
     // Can derive Sapling addr from default diversifier 
-    boost::optional<SaplingPaymentAddress> default_address() const;
+    SaplingPaymentAddress default_address() const;
 };
 
 typedef boost::variant<InvalidEncoding, SproutPaymentAddress, SaplingPaymentAddress> PaymentAddress;

--- a/src/zcash/Address.hpp
+++ b/src/zcash/Address.hpp
@@ -111,6 +111,9 @@ public:
         READWRITE(d);
         READWRITE(pk_d);
     }
+    
+    //! Get the 256-bit SHA256d hash of this payment address.
+    uint256 GetHash() const;
 
     friend inline bool operator==(const SaplingPaymentAddress& a, const SaplingPaymentAddress& b) {
         return a.d == b.d && a.pk_d == b.pk_d;


### PR DESCRIPTION
-  Add/Have/Get SaplingSpendingKey 
- Add/Remove/Have/Get SaplingFullViewingKey
- Have/Get SaplingIncomingViewingKey

- SaplingSpendingKeyMap, SaplingFullViewingKeyMap, SaplingIncomingViewingKeyMap

- GenerateNewSaplingZKey()

Not included: note decryptors, crypted keystore