### PR TITLE
[WIP] 3277 Gate calls which result in on-disk Sapling state before Sapling activates

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -17,6 +17,8 @@
 
 using namespace std;
 
+// NOTE: Per issue #3277, do not use the prefix 'X' or 'x' as they were
+// previously used by DB_SAPLING_ANCHOR and DB_BEST_SAPLING_ANCHOR.
 static const char DB_SPROUT_ANCHOR = 'A';
 static const char DB_SAPLING_ANCHOR = 'Z';
 static const char DB_NULLIFIER = 's';


### PR DESCRIPTION
WIP Comments:

We looked at nullifiers yesterday and the prefix should not have been used, since no sapling tx exist yet, so all spend description vectors are empty.

I added a FIXME as part of this PR to query a section of code.

Rebased on master which now uses fixed encoding in librustzcash.