### PR TITLE
Fast precise runtime-enabled logging (LogPrint()) to debug.log

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -483,6 +483,53 @@ UniValue setmocktime(const UniValue& params, bool fHelp)
     return NullUniValue;
 }
 
+/** The argument is an array of strings, each a category
+ * such as "mempool" or a file or line such as "alert.cpp:230"
+ */
+UniValue enabledebug(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1) {
+        throw runtime_error(
+            "enabledebug [\"category-or-line\",... ]\n"
+            "enable the given LogPrint() categories\n"
+        );
+    }
+    UniValue categories;
+    if (!categories.read(params[0].get_str()) || !categories.isArray()) {
+        throw runtime_error(
+            "enabledebug [\"category-or-line\",... ]\n"
+            "enable the given LogPrint() categories\n"
+        );
+    }
+    for (const UniValue& v : categories.getValues()) {
+        LogPrintf("debug: enabling %s\n", v.get_str());
+        LogFastAdd(v.get_str());
+    }
+    return NullUniValue;
+}
+
+UniValue disabledebug(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1) {
+        throw runtime_error(
+            "disabledebug [\"category-or-line\",... ]\n"
+            "disable the given LogPrint() categories\n"
+        );
+    }
+    UniValue categories;
+    if (!categories.read(params[0].get_str()) || !categories.isArray()) {
+        throw runtime_error(
+            "disabledebug [\"category-or-line\",... ]\n"
+            "disable the given LogPrint() categories\n"
+        );
+    }
+    for (const UniValue& v : categories.getValues()) {
+        LogPrintf("debug: disabling %s\n", v.get_str());
+        LogFastRemove(v.get_str());
+    }
+    return NullUniValue;
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafeMode
   //  --------------------- ------------------------  -----------------------  ----------
@@ -491,6 +538,8 @@ static const CRPCCommand commands[] =
     { "util",               "z_validateaddress",      &z_validateaddress,      true  }, /* uses wallet if enabled */
     { "util",               "createmultisig",         &createmultisig,         true  },
     { "util",               "verifymessage",          &verifymessage,          true  },
+    { "control",            "enabledebug",            &enabledebug,            true  },
+    { "control",            "disabledebug",           &disabledebug,           true  },
 
     /* Not shown in help */
     { "hidden",             "setmocktime",            &setmocktime,            true  },

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -255,8 +255,13 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
     }
     tx_ = CTransaction(rawTx);
 
-    LogPrint(isPureTaddrOnlyTx ? "zrpc" : "zrpcunsafe", "%s: spending %s to send %s with fee %s\n",
-             getId(), FormatMoney(targetAmount), FormatMoney(sendAmount), FormatMoney(minersFee));
+    if (isPureTaddrOnlyTx) {
+        LogPrint("zrpc", "%s: spending %s to send %s with fee %s\n",
+                getId(), FormatMoney(targetAmount), FormatMoney(sendAmount), FormatMoney(minersFee));
+    } else {
+        LogPrint("zrpcunsafe", "%s: spending %s to send %s with fee %s\n",
+                getId(), FormatMoney(targetAmount), FormatMoney(sendAmount), FormatMoney(minersFee));
+    }
     LogPrint("zrpc", "%s: transparent input: %s\n", getId(), FormatMoney(t_inputs_total));
     LogPrint("zrpcunsafe", "%s: private input: %s\n", getId(), FormatMoney(z_inputs_total));
     if (isToTaddr_) {

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -360,8 +360,13 @@ bool AsyncRPCOperation_sendmany::main_impl() {
         }
     }
 
-    LogPrint((isfromtaddr_) ? "zrpc" : "zrpcunsafe", "%s: spending %s to send %s with fee %s\n",
-            getId(), FormatMoney(targetAmount), FormatMoney(sendAmount), FormatMoney(minersFee));
+    if (isfromtaddr_) {
+        LogPrint("zrpc", "%s: spending %s to send %s with fee %s\n",
+                getId(), FormatMoney(targetAmount), FormatMoney(sendAmount), FormatMoney(minersFee));
+    } else {
+        LogPrint("zrpcunsafe", "%s: spending %s to send %s with fee %s\n",
+                getId(), FormatMoney(targetAmount), FormatMoney(sendAmount), FormatMoney(minersFee));
+    }
     LogPrint("zrpc", "%s: transparent input: %s (to choose from)\n", getId(), FormatMoney(t_inputs_total));
     LogPrint("zrpcunsafe", "%s: private input: %s (to choose from)\n", getId(), FormatMoney(z_inputs_total));
     LogPrint("zrpc", "%s: transparent output: %s\n", getId(), FormatMoney(t_outputs_total));


### PR DESCRIPTION
This change is a learning experience for me (so it's less likely for this PR to be approved -- no one has asked for this), but may be useful to our product. There's no ticket for this. This changes the way `LogPrint()` is implemented. LogPrint() takes a `category` string, such as `"rpc"`, and a string (in the form of a C-style format string and arguments). Here's a typical example:

    LogPrint("pow", "  nActualTimespan = %d  before dampening\n", nActualTimespan);

If the category is *enabled*, `LogPrint()` writes the string to `debug.log` (or sends to the console with `--printtoconsole`). Enabling one or more categories is done with the `--debug` command-line `zcashd` argument. When `LogPrint()` executes, it can test if the category is enabled very quickly if `--debug` isn't specified (requiring only a check of a global boolean variable, `fDebug`), but significantly slower if one or more categories are enabled, since `LogPrint()` must check a list (in the form of a global `std::set`) for the presence of the given category. This isn't super expensive, but not trivial either.

This change has the following benefits:
* fast enable checking (test a single global boolean with no function call overhead, even if various categories are enabled)
* ability to enable and disable logging dynamically (using rpc, not implemented yet)
* ability to enable a *particular* `LogPrint()` (at a specific line), rather than having to enable the entire category (would require a new command-line argument or rpc support)
* no change to the 268 existing calls to `LogPrint()`

If this PR is accepted, as mentioned I would like to implement RPC interfaces to dynamically enable and disable categories and single `LogPrint()` statements, and also to list the available categories (and, if requested, the individual lines) and which are currently enabled. In previous projects I've worked on, this turned out to be very useful. Suppose the system is behaving strangely, and there's a logging category that, if enabled, would shed light on the problem. If the only way to enable that category is to restart the process, it's very possible that the problem will disappear (since the memory state gets reinitialized).

After implementing these changes, it occurred to me to check the `bitcoin` repo. I found that our `LogPrint()` comes from `bitcoin`, but they've since (after we forked their code) solved the performance problem in a different way, by replacing the category string with a bit mask (each category being assigned a bit position). This makes the enable test very fast, and also allows a given `LogPrint()` to belong to more than one category (by OR-ing bit masks; so far this feature isn't used). It does not allow specific lines to be enabled. A major downside of their approach is that every call to `LogPrint()` must be updated.

The `bitcoin` repo has also implemented dynamic (rpc) enabling and disabling of logging categories.

It seems to me the alternatives are:
* adopt the changes below (very limited and localized changes)
* adopt the changes below plus rpc enhancements to make enabling and disabling dynamic (port this from`bitcoin`, or at least use as a model)
* port the current `bitcoin` logging (fairly disruptive)
* do nothing, leave as-is

Implementation notes
=================
The basic, somewhat unusual, idea is that `LogPrint()` becomes a macro (it was before, but it's more complex) that statically allocates a small structure that contains the `enabled` flag for this particular call. The first time this line of code is reached, the code hidden within the macro links this structure into a global (unordered) linked list, whether this log is enabled or not. The structure's category and line (pathname and line number) information is also set (and never changes), and `enabled` is computed. So all the (visited, reached) `LogPrint()` sites end up being linked into a list, and this allows their `enabled` flags to be set or cleared based upon which categories are enabled, and also allows individual `LogPrints()`s to be enabled (by pathname and lineno; although there is no mechanism yet to do this, it can be provided via rpc or on the command line).

With this approach, an instance of `LogPrint()` can test if it's enabled by testing a single `bool` variable, no need for locking or even a function call. This means you can add `LogPrint()` calls in performance code paths that may not be practical today.

There will be an rpc to display all the individual `LogPrint()`s (showing category, pathname and line number), but only those that have been reached. It's not possible to display the unreached ones, since they haven't yet been linked into the list. But it will still be possible to enable a particular unreached `LogPrint()`; when it's then reached, it will immediately be enabled. (This is similar to setting a breakpoint in a shared library that hasn't been loaded yet.)

Future
=====
As mentioned, it would be useful to allow categories and individual lines to be enabled and disabled dynamically. The RPC interface is perfect for that. During support investigations, it's often useful to ask the support engineer (or user) to enable a particularly chatty trace for a few seconds and then disable it, and then send the log file. A possible enhancement would be to disable the loggin automatically by adding a `timeout` argument to the enable RPC. It might also be useful to be able to dynamically specify that a given logging category (or line) not be logged more often than once every so many seconds (to prevent the log file from being swamped).