### PR TITLE
z_validateviewingkey

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -398,6 +398,7 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "z_listaddresses",        &z_listaddresses,        true  },
     { "wallet",             "z_exportkey",            &z_exportkey,            true  },
     { "wallet",             "z_importkey",            &z_importkey,            true  },
+    { "wallet",             "z_validateviewingkey",   &z_validateviewingkey,   true  },
     { "wallet",             "z_exportviewingkey",     &z_exportviewingkey,     true  },
     { "wallet",             "z_importviewingkey",     &z_importviewingkey,     true  },
     { "wallet",             "z_exportwallet",         &z_exportwallet,         true  },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -280,6 +280,7 @@ extern UniValue getblocksubsidy(const UniValue& params, bool fHelp);
 
 extern UniValue z_exportkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue z_importkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
+extern UniValue z_validateviewingkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue z_exportviewingkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue z_importviewingkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue z_getnewaddress(const UniValue& params, bool fHelp); // in rpcwallet.cpp

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -346,8 +346,6 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_validateviewingkey)
     UniValue resultObj = retValue.get_obj();
     bool b = find_value(resultObj, "isvalid").get_bool();
     BOOST_CHECK_EQUAL(b, false);
-    b = find_value(resultObj, "ismine").get_bool();
-    BOOST_CHECK_EQUAL(b, false);
 }
 
 /**

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -346,6 +346,18 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_validateviewingkey)
     UniValue resultObj = retValue.get_obj();
     bool b = find_value(resultObj, "isvalid").get_bool();
     BOOST_CHECK_EQUAL(b, false);
+
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("z_validateviewingkey ZiVKp4WNCjCsE8f1gAMySa6d8SmixgoErWnnuZG7wAVTDV3G9K5NP5gFNji61M4rTiVYhSwW4tnjF6vocC1HiN7WgkihUiyXZ"));
+    resultObj = retValue.get_obj();
+
+    b = find_value(resultObj, "isvalid").get_bool();
+    BOOST_CHECK_EQUAL(b, true);
+
+    b = find_value(resultObj, "isvalid").get_bool();
+    BOOST_CHECK_EQUAL(b, true);
+
+    BOOST_CHECK_EQUAL(find_value(resultObj, "address").get_str(), "zcZyj19oczCcQkEVR4fAkVRzhrNko8e17HD1JX5mdge4jpRJz5AhoP2cQknPec15zXzYUCd2JUeSrhgNgVgfWLaNa9UED2e");
+    BOOST_CHECK_EQUAL(find_value(resultObj, "viewingkey").get_str(), "ZiVKp4WNCjCsE8f1gAMySa6d8SmixgoErWnnuZG7wAVTDV3G9K5NP5gFNji61M4rTiVYhSwW4tnjF6vocC1HiN7WgkihUiyXZ");
 }
 
 /**

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -328,6 +328,29 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_getbalance)
 }
 
 /**
+ * This test covers RPC command z_validateviewingkey
+ */
+BOOST_AUTO_TEST_CASE(rpc_wallet_z_validateviewingkey)
+{
+    SelectParams(CBaseChainParams::MAIN);
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    UniValue retValue;
+
+    // Check number of args
+    BOOST_CHECK_THROW(CallRPC("z_validateviewingkey"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("z_validateviewingkey toomany args"), runtime_error);
+
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("z_validateviewingkey VKstuff"));
+    UniValue resultObj = retValue.get_obj();
+    bool b = find_value(resultObj, "isvalid").get_bool();
+    BOOST_CHECK_EQUAL(b, false);
+    b = find_value(resultObj, "ismine").get_bool();
+    BOOST_CHECK_EQUAL(b, false);
+}
+
+/**
  * This test covers RPC command z_validateaddress
  */
 BOOST_AUTO_TEST_CASE(rpc_wallet_z_validateaddress)

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -353,9 +353,6 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_validateviewingkey)
     b = find_value(resultObj, "isvalid").get_bool();
     BOOST_CHECK_EQUAL(b, true);
 
-    b = find_value(resultObj, "isvalid").get_bool();
-    BOOST_CHECK_EQUAL(b, true);
-
     BOOST_CHECK_EQUAL(find_value(resultObj, "address").get_str(), "zcZyj19oczCcQkEVR4fAkVRzhrNko8e17HD1JX5mdge4jpRJz5AhoP2cQknPec15zXzYUCd2JUeSrhgNgVgfWLaNa9UED2e");
     BOOST_CHECK_EQUAL(find_value(resultObj, "viewingkey").get_str(), "ZiVKp4WNCjCsE8f1gAMySa6d8SmixgoErWnnuZG7wAVTDV3G9K5NP5gFNji61M4rTiVYhSwW4tnjF6vocC1HiN7WgkihUiyXZ");
 }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -651,6 +651,51 @@ UniValue z_importkey(const UniValue& params, bool fHelp)
     return NullUniValue;
 }
 
+UniValue z_validateviewingkey(const UniValue& params, bool fHelp)
+{
+    if (!EnsureWalletIsAvailable(fHelp))
+        return NullUniValue;
+
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "z_validateviewingkey \"vkey\"\n"
+            "\nReturn information about the given Zcash viewing key.\n"
+            "\nArguments:\n"
+            "1. \"vkey\"             (string, required) The viewing key (see z_exportviewingkey)\n"
+            "\nExamples:\n"
+            "\nValidate a viewing key\n"
+            + HelpExampleCli("z_validateviewingkey", "\"vkey\"") +
+            "\nAs a JSON-RPC call\n"
+            + HelpExampleRpc("z_validateviewingkey", "\"vkey\"")
+        );
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    EnsureWalletIsUnlocked();
+
+    string strVKey  = params[0].get_str();
+    auto viewingkey = DecodeViewingKey(strVKey);
+
+    // TODO: Add Sapling support. For now, ensure we can freely convert.
+    assert(boost::get<libzcash::SproutViewingKey>(&viewingkey) != nullptr);
+
+    auto vkey       = boost::get<libzcash::SproutViewingKey>(viewingkey);
+    auto addr       = vkey.address();
+    bool isValid    = IsValidViewingKey(viewingkey);
+    bool isMine     = pwalletMain->HaveSpendingKey(addr);
+
+    UniValue ret(UniValue::VOBJ);
+    ret.push_back(Pair("isvalid", isValid));
+
+    if (isValid) {
+	ret.push_back(Pair("address", addr.GetHash().ToString() ));
+	ret.push_back(Pair("viewingkey", strVKey));
+	ret.push_back(Pair("ismine", isMine));
+    }
+
+    return ret;
+}
+
 UniValue z_importviewingkey(const UniValue& params, bool fHelp)
 {
     if (!EnsureWalletIsAvailable(fHelp))


### PR DESCRIPTION
This implements a new viewing key RPC method `z_validateviewingkey`, inspired by `z_validateaddress` which greatly improves the usability of viewing keys from the perspective of application developers.

In the course of implementing parts of HushList protocol which use viewing keys, I found myself yearning for something like this RPC to answer many basic questions when using viewing keys dynamically and programmatically:

* Which zaddr does this viewing key correspond to?
* Has this viewing key been imported already?
* Does this wallet own the spending key corresponding to this viewing key?

The current RPC interface does not allow for any of these to be answered, which leads to various hacky workaround and caching viewingkeys in memory or disk when they should just be looked up as needed.

Here is an example (which corresponds to the included C++ unit test) of the RPC being used from `zcash-cli`:
```
$ ./src/zcash-cli z_validateviewingkey ZiVKp4WNCjCsE8f1gAMySa6d8SmixgoErWnnuZG7wAVTDV3G9K5NP5gFNji61M4rTiVYhSwW4tnjF6vocC1HiN7WgkihUiyXZ
{
  "isvalid": true,
  "address": "zcZyj19oczCcQkEVR4fAkVRzhrNko8e17HD1JX5mdge4jpRJz5AhoP2cQknPec15zXzYUCd2JUeSrhgNgVgfWLaNa9UED2e",
  "viewingkey": "ZiVKp4WNCjCsE8f1gAMySa6d8SmixgoErWnnuZG7wAVTDV3G9K5NP5gFNji61M4rTiVYhSwW4tnjF6vocC1HiN7WgkihUiyXZ",
  "ismine": true,
  "isimported": false
}
```

At first I was going to prototype this on Hush but realized it fit better upstream and I also wanted the feedback of upstream devs. My hope is that this RPC landing upstream can lead to wider adoption and more use cases for viewing keys in all Zcash protocol downstreams.