### PR TITLE
Don't add the FORTIFY defines when using --enable-debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -476,12 +476,14 @@ if test x$use_hardening != xno; then
   AX_CHECK_COMPILE_FLAG([-Wstack-protector],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -Wstack-protector"],[AC_MSG_ERROR(Cannot enable -Wstack-protector)])
   AX_CHECK_COMPILE_FLAG([-fstack-protector-all],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-protector-all"],[AC_MSG_ERROR(Cannot enable -fstack-protector-all)])
 
-  AX_CHECK_PREPROC_FLAG([-D_FORTIFY_SOURCE=2],[
-    AX_CHECK_PREPROC_FLAG([-U_FORTIFY_SOURCE],[
-      HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -U_FORTIFY_SOURCE"
-    ],[AC_MSG_ERROR(Cannot enable -U_FORTIFY_SOURCE)])
-    HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -D_FORTIFY_SOURCE=2"
-  ],[AC_MSG_ERROR(Cannot enable -D_FORTIFY_SOURCE=2)])
+  if test x$enable_debug != xyes; then
+    AX_CHECK_PREPROC_FLAG([-D_FORTIFY_SOURCE=2],[
+      AX_CHECK_PREPROC_FLAG([-U_FORTIFY_SOURCE],[
+        HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -U_FORTIFY_SOURCE"
+      ],[AC_MSG_ERROR(Cannot enable -U_FORTIFY_SOURCE)])
+      HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -D_FORTIFY_SOURCE=2"
+    ],[AC_MSG_ERROR(Cannot enable -D_FORTIFY_SOURCE=2)])
+  fi
 
   if test x$BUILD_OS = xdarwin || test x$TARGET_OS = xwindows; then
     # Xcode's ld (at least ld64-302.3) doesn't support -z

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -94,8 +94,12 @@ Development tips and tricks
 
 **compiling for debugging**
 
-Run configure with the --enable-debug option, then make. Or run configure with
-CXXFLAGS="-g -ggdb -O0" or whatever debug flags you need.
+The following command will add `-g3 -O0` to the compile command line, which makes debugging with `gdb` much easier:
+```sh
+CONFIGURE_FLAGS='--enable-debug' zcutil/build.sh
+```
+Note that this disables stack protector and Fortify hardening support
+(this is relevant mainly when trying to debug a problem that would have triggered this hardening protection).
 
 **debug.log**
 


### PR DESCRIPTION
Fixes the following warning:

```sh
$ CONFIGURE_FLAGS='--enable-debug' zcutil/build.sh
...
/usr/include/features.h:376:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^~~~~~~
cc1plus: all warnings being treated as errors
```