### PR TITLE
Fix parsing parameters in getnetworksolps

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -32,6 +32,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "generate", 0 },
     { "getnetworkhashps", 0 },
     { "getnetworkhashps", 1 },
+    { "getnetworksolps", 0 },
+    { "getnetworksolps", 1 },
     { "sendtoaddress", 1 },
     { "sendtoaddress", 4 },
     { "settxfee", 0 },

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -335,5 +335,11 @@ BOOST_AUTO_TEST_CASE(rpc_raw_create_overwinter_v3)
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
+BOOST_AUTO_TEST_CASE(rpc_getnetworksolps)
+{
+    BOOST_CHECK_NO_THROW(CallRPC("getnetworksolps"));
+    BOOST_CHECK_NO_THROW(CallRPC("getnetworksolps 120"));
+    BOOST_CHECK_NO_THROW(CallRPC("getnetworksolps 120 -1"));
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This fixes https://github.com/zcash/zcash/issues/3298. The parameters were not correctly being converted.