### PR TITLE
Naming improvements

### DIFF
--- a/src/gtest/test_joinsplit.cpp
+++ b/src/gtest/test_joinsplit.cpp
@@ -39,7 +39,7 @@ void test_full_api(ZCJoinSplit* js)
     uint256 randomSeed;
     uint64_t vpub_old = 10;
     uint64_t vpub_new = 0;
-    uint256 pubKeyHash = random_uint256();
+    uint256 joinSplitPubKey = random_uint256();
     std::array<uint256, 2> macs;
     std::array<uint256, 2> nullifiers;
     std::array<uint256, 2> commitments;
@@ -68,7 +68,7 @@ void test_full_api(ZCJoinSplit* js)
             output_notes,
             ciphertexts,
             ephemeralKey,
-            pubKeyHash,
+            joinSplitPubKey,
             randomSeed,
             macs,
             nullifiers,
@@ -79,13 +79,13 @@ void test_full_api(ZCJoinSplit* js)
         );
     }
 
-    auto sprout_proof = boost::get<ZCProof>(proof);
+    auto sprout_proof = boost::get<PHGRProof>(proof);
 
     // Verify the transaction:
     ASSERT_TRUE(js->verify(
         sprout_proof,
         verifier,
-        pubKeyHash,
+        joinSplitPubKey,
         randomSeed,
         macs,
         nullifiers,
@@ -97,7 +97,7 @@ void test_full_api(ZCJoinSplit* js)
 
     // Recipient should decrypt
     // Now the recipient should spend the money again
-    auto h_sig = js->h_sig(randomSeed, nullifiers, pubKeyHash);
+    auto h_sig = js->h_sig(randomSeed, nullifiers, joinSplitPubKey);
     ZCNoteDecryption decryptor(recipient_key.receiving_key());
 
     auto note_pt = SproutNotePlaintext::decrypt(
@@ -120,7 +120,7 @@ void test_full_api(ZCJoinSplit* js)
     vpub_old = 0;
     vpub_new = 1;
     rt = tree.root();
-    pubKeyHash = random_uint256();
+    joinSplitPubKey = random_uint256();
 
     {
         std::array<JSInput, 2> inputs = {
@@ -146,7 +146,7 @@ void test_full_api(ZCJoinSplit* js)
             output_notes,
             ciphertexts,
             ephemeralKey,
-            pubKeyHash,
+            joinSplitPubKey,
             randomSeed,
             macs,
             nullifiers,
@@ -157,13 +157,13 @@ void test_full_api(ZCJoinSplit* js)
         );
     }
 
-    sprout_proof = boost::get<ZCProof>(proof);
+    sprout_proof = boost::get<PHGRProof>(proof);
 
     // Verify the transaction:
     ASSERT_TRUE(js->verify(
         sprout_proof,
         verifier,
-        pubKeyHash,
+        joinSplitPubKey,
         randomSeed,
         macs,
         nullifiers,
@@ -186,7 +186,7 @@ void invokeAPI(
 ) {
     uint256 ephemeralKey;
     uint256 randomSeed;
-    uint256 pubKeyHash = random_uint256();
+    uint256 joinSplitPubKey = random_uint256();
     std::array<uint256, 2> macs;
     std::array<uint256, 2> nullifiers;
     std::array<uint256, 2> commitments;
@@ -201,7 +201,7 @@ void invokeAPI(
         output_notes,
         ciphertexts,
         ephemeralKey,
-        pubKeyHash,
+        joinSplitPubKey,
         randomSeed,
         macs,
         nullifiers,
@@ -241,9 +241,9 @@ TEST(joinsplit, h_sig)
 import pyblake2
 import binascii
 
-def hSig(randomSeed, nf1, nf2, pubKeyHash):
+def hSig(randomSeed, nf1, nf2, joinSplitPubKey):
     return pyblake2.blake2b(
-        data=(randomSeed + nf1 + nf2 + pubKeyHash),
+        data=(randomSeed + nf1 + nf2 + joinSplitPubKey),
         digest_size=32,
         person=b"ZcashComputehSig"
     ).digest()

--- a/src/gtest/test_proofs.cpp
+++ b/src/gtest/test_proofs.cpp
@@ -241,7 +241,7 @@ TEST(proofs, sqrt_fq2)
 
 TEST(proofs, size_is_expected)
 {
-    ZCProof p;
+    PHGRProof p;
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss << p;
 
@@ -444,7 +444,7 @@ TEST(proofs, zksnark_serializes_properly)
     auto vkprecomp = libsnark::r1cs_ppzksnark_verifier_process_vk(kp.vk);
 
     for (size_t i = 0; i < 20; i++) {
-        auto badproof = ZCProof::random_invalid();
+        auto badproof = PHGRProof::random_invalid();
         auto proof = badproof.to_libsnark_proof<libsnark::r1cs_ppzksnark_proof<curve_pp>>();
         
         auto verifierEnabled = ProofVerifier::Strict();
@@ -496,12 +496,12 @@ TEST(proofs, zksnark_serializes_properly)
             proof
         ));
 
-        ZCProof compressed_proof_0(proof);
+        PHGRProof compressed_proof_0(proof);
 
         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
         ss << compressed_proof_0;
 
-        ZCProof compressed_proof_1;
+        PHGRProof compressed_proof_1;
         ss >> compressed_proof_1;
 
         ASSERT_TRUE(compressed_proof_0 == compressed_proof_1);

--- a/src/gtest/test_transaction.cpp
+++ b/src/gtest/test_transaction.cpp
@@ -31,7 +31,7 @@ TEST(Transaction, JSDescriptionRandomized) {
     auto witness = merkleTree.witness();
 
     // create JSDescription
-    uint256 pubKeyHash;
+    uint256 joinSplitPubKey;
     std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS> inputs = {
         libzcash::JSInput(witness, note, k),
         libzcash::JSInput() // dummy input of zero value
@@ -46,7 +46,7 @@ TEST(Transaction, JSDescriptionRandomized) {
     {
         auto jsdesc = JSDescription::Randomized(
             false,
-            *params, pubKeyHash, rt,
+            *params, joinSplitPubKey, rt,
             inputs, outputs,
             inputMap, outputMap,
             0, 0, false);
@@ -63,7 +63,7 @@ TEST(Transaction, JSDescriptionRandomized) {
     {
         auto jsdesc = JSDescription::Randomized(
             false,
-            *params, pubKeyHash, rt,
+            *params, joinSplitPubKey, rt,
             inputs, outputs,
             inputMap, outputMap,
             0, 0, false, nullptr, GenZero);
@@ -77,7 +77,7 @@ TEST(Transaction, JSDescriptionRandomized) {
     {
         auto jsdesc = JSDescription::Randomized(
             false,
-            *params, pubKeyHash, rt,
+            *params, joinSplitPubKey, rt,
             inputs, outputs,
             inputMap, outputMap,
             0, 0, false, nullptr, GenMax);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -154,7 +154,7 @@ class SproutProofSerializer : public boost::static_visitor<>
 public:
     SproutProofSerializer(Stream& s, bool useGroth) : s(s), useGroth(useGroth) {}
 
-    void operator()(const libzcash::ZCProof& proof) const
+    void operator()(const libzcash::PHGRProof& proof) const
     {
         if (useGroth) {
             throw std::ios_base::failure("Invalid Sprout proof for transaction format (expected GrothProof, found PHGRProof)");
@@ -186,7 +186,7 @@ inline void SerReadWriteSproutProof(Stream& s, T& proof, bool useGroth, CSerActi
         ::Unserialize(s, grothProof);
         proof = grothProof;
     } else {
-        libzcash::ZCProof pghrProof;
+        libzcash::PHGRProof pghrProof;
         ::Unserialize(s, pghrProof);
         proof = pghrProof;
     }
@@ -245,7 +245,7 @@ public:
     JSDescription(
             bool makeGrothProof,
             ZCJoinSplit& params,
-            const uint256& pubKeyHash,
+            const uint256& joinSplitPubKey,
             const uint256& rt,
             const std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS>& inputs,
             const std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS>& outputs,
@@ -258,7 +258,7 @@ public:
     static JSDescription Randomized(
             bool makeGrothProof,
             ZCJoinSplit& params,
-            const uint256& pubKeyHash,
+            const uint256& joinSplitPubKey,
             const uint256& rt,
             std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS>& inputs,
             std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS>& outputs,
@@ -275,11 +275,11 @@ public:
     bool Verify(
         ZCJoinSplit& params,
         libzcash::ProofVerifier& verifier,
-        const uint256& pubKeyHash
+        const uint256& joinSplitPubKey
     ) const;
 
     // Returns the calculated h_sig
-    uint256 h_sig(ZCJoinSplit& params, const uint256& pubKeyHash) const;
+    uint256 h_sig(ZCJoinSplit& params, const uint256& joinSplitPubKey) const;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -188,7 +188,7 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle, uint32_t co
                 randombytes_buf(zkproof.begin(), zkproof.size());
                 jsdesc.proof = zkproof;
             } else {
-                jsdesc.proof = libzcash::ZCProof::random_invalid();
+                jsdesc.proof = libzcash::PHGRProof::random_invalid();
             }
             jsdesc.macs[0] = GetRandHash();
             jsdesc.macs[1] = GetRandHash();

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE(test_basic_joinsplit_verification)
     auto witness = merkleTree.witness();
 
     // create JSDescription
-    uint256 pubKeyHash;
+    uint256 joinSplitPubKey;
     std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS> inputs = {
         libzcash::JSInput(witness, note, k),
         libzcash::JSInput() // dummy input of zero value
@@ -373,8 +373,8 @@ BOOST_AUTO_TEST_CASE(test_basic_joinsplit_verification)
     auto verifier = libzcash::ProofVerifier::Strict();
 
     {
-        JSDescription jsdesc(false, *pzcashParams, pubKeyHash, rt, inputs, outputs, 0, 0);
-        BOOST_CHECK(jsdesc.Verify(*pzcashParams, verifier, pubKeyHash));
+        JSDescription jsdesc(false, *pzcashParams, joinSplitPubKey, rt, inputs, outputs, 0, 0);
+        BOOST_CHECK(jsdesc.Verify(*pzcashParams, verifier, joinSplitPubKey));
 
         CDataStream ss(SER_DISK, CLIENT_VERSION);
         ss << jsdesc;
@@ -383,20 +383,20 @@ BOOST_AUTO_TEST_CASE(test_basic_joinsplit_verification)
         ss >> jsdesc_deserialized;
 
         BOOST_CHECK(jsdesc_deserialized == jsdesc);
-        BOOST_CHECK(jsdesc_deserialized.Verify(*pzcashParams, verifier, pubKeyHash));
+        BOOST_CHECK(jsdesc_deserialized.Verify(*pzcashParams, verifier, joinSplitPubKey));
     }
 
     {
         // Ensure that the balance equation is working.
-        BOOST_CHECK_THROW(JSDescription(false, *pzcashParams, pubKeyHash, rt, inputs, outputs, 10, 0), std::invalid_argument);
-        BOOST_CHECK_THROW(JSDescription(false, *pzcashParams, pubKeyHash, rt, inputs, outputs, 0, 10), std::invalid_argument);
+        BOOST_CHECK_THROW(JSDescription(false, *pzcashParams, joinSplitPubKey, rt, inputs, outputs, 10, 0), std::invalid_argument);
+        BOOST_CHECK_THROW(JSDescription(false, *pzcashParams, joinSplitPubKey, rt, inputs, outputs, 0, 10), std::invalid_argument);
     }
 
     {
         // Ensure that it won't verify if the root is changed.
-        auto test = JSDescription(false, *pzcashParams, pubKeyHash, rt, inputs, outputs, 0, 0);
+        auto test = JSDescription(false, *pzcashParams, joinSplitPubKey, rt, inputs, outputs, 0, 0);
         test.anchor = GetRandHash();
-        BOOST_CHECK(!test.Verify(*pzcashParams, verifier, pubKeyHash));
+        BOOST_CHECK(!test.Verify(*pzcashParams, verifier, joinSplitPubKey));
     }
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2638,11 +2638,11 @@ UniValue zc_sample_joinsplit(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
 
-    uint256 pubKeyHash;
+    uint256 joinSplitPubKey;
     uint256 anchor = ZCIncrementalMerkleTree().root();
     JSDescription samplejoinsplit(true,
                                   *pzcashParams,
-                                  pubKeyHash,
+                                  joinSplitPubKey,
                                   anchor,
                                   {JSInput(), JSInput()},
                                   {JSOutput(), JSOutput()},

--- a/src/zcash/JoinSplit.hpp
+++ b/src/zcash/JoinSplit.hpp
@@ -21,7 +21,7 @@ static constexpr size_t GROTH_PROOF_SIZE = (
     48); // π_C
 
 typedef std::array<unsigned char, GROTH_PROOF_SIZE> GrothProof;
-typedef boost::variant<ZCProof, GrothProof> SproutProof;
+typedef boost::variant<PHGRProof, GrothProof> SproutProof;
 
 class JSInput {
 public:
@@ -64,9 +64,10 @@ public:
 
     static uint256 h_sig(const uint256& randomSeed,
                          const std::array<uint256, NumInputs>& nullifiers,
-                         const uint256& pubKeyHash
+                         const uint256& joinSplitPubKey
                         );
 
+    // Compute nullifiers, macs, note commitments & encryptions, and SNARK proof
     virtual SproutProof prove(
         bool makeGrothProof,
         const std::array<JSInput, NumInputs>& inputs,
@@ -74,7 +75,7 @@ public:
         std::array<SproutNote, NumOutputs>& out_notes,
         std::array<ZCNoteEncryption::Ciphertext, NumOutputs>& out_ciphertexts,
         uint256& out_ephemeralKey,
-        const uint256& pubKeyHash,
+        const uint256& joinSplitPubKey,
         uint256& out_randomSeed,
         std::array<uint256, NumInputs>& out_hmacs,
         std::array<uint256, NumInputs>& out_nullifiers,
@@ -90,9 +91,9 @@ public:
     ) = 0;
 
     virtual bool verify(
-        const ZCProof& proof,
+        const PHGRProof& proof,
         ProofVerifier& verifier,
-        const uint256& pubKeyHash,
+        const uint256& joinSplitPubKey,
         const uint256& randomSeed,
         const std::array<uint256, NumInputs>& hmacs,
         const std::array<uint256, NumInputs>& nullifiers,

--- a/src/zcash/Proof.cpp
+++ b/src/zcash/Proof.cpp
@@ -171,7 +171,7 @@ curve_G2 CompressedG2::to_libsnark_g2() const
 }
 
 template<>
-ZCProof::ZCProof(const r1cs_ppzksnark_proof<curve_pp> &proof)
+PHGRProof::PHGRProof(const r1cs_ppzksnark_proof<curve_pp> &proof)
 {
     g_A = CompressedG1(proof.g_A.g);
     g_A_prime = CompressedG1(proof.g_A.h);
@@ -184,7 +184,7 @@ ZCProof::ZCProof(const r1cs_ppzksnark_proof<curve_pp> &proof)
 }
 
 template<>
-r1cs_ppzksnark_proof<curve_pp> ZCProof::to_libsnark_proof() const
+r1cs_ppzksnark_proof<curve_pp> PHGRProof::to_libsnark_proof() const
 {
     r1cs_ppzksnark_proof<curve_pp> proof;
 
@@ -200,9 +200,9 @@ r1cs_ppzksnark_proof<curve_pp> ZCProof::to_libsnark_proof() const
     return proof;
 }
 
-ZCProof ZCProof::random_invalid()
+PHGRProof PHGRProof::random_invalid()
 {
-    ZCProof p;
+    PHGRProof p;
     p.g_A = curve_G1::random_element();
     p.g_A_prime = curve_G1::random_element();
     p.g_B = curve_G2::random_element();

--- a/src/zcash/Proof.hpp
+++ b/src/zcash/Proof.hpp
@@ -176,7 +176,7 @@ public:
 };
 
 // Compressed zkSNARK proof
-class ZCProof {
+class PHGRProof {
 private:
     CompressedG1 g_A;
     CompressedG1 g_A_prime;
@@ -188,18 +188,18 @@ private:
     CompressedG1 g_H;
 
 public:
-    ZCProof() : g_A(), g_A_prime(), g_B(), g_B_prime(), g_C(), g_C_prime(), g_K(), g_H() { }
+    PHGRProof() : g_A(), g_A_prime(), g_B(), g_B_prime(), g_C(), g_C_prime(), g_K(), g_H() { }
 
     // Produces a compressed proof using a libsnark zkSNARK proof
     template<typename libsnark_proof>
-    ZCProof(const libsnark_proof& proof);
+    PHGRProof(const libsnark_proof& proof);
 
     // Produces a libsnark zkSNARK proof out of this proof,
     // or throws an exception if it is invalid.
     template<typename libsnark_proof>
     libsnark_proof to_libsnark_proof() const;
 
-    static ZCProof random_invalid();
+    static PHGRProof random_invalid();
 
     ADD_SERIALIZE_METHODS;
 
@@ -215,7 +215,7 @@ public:
         READWRITE(g_H);
     }
 
-    friend bool operator==(const ZCProof& a, const ZCProof& b)
+    friend bool operator==(const PHGRProof& a, const PHGRProof& b)
     {
         return (
             a.g_A == b.g_A &&
@@ -229,7 +229,7 @@ public:
         );
     }
 
-    friend bool operator!=(const ZCProof& a, const ZCProof& b)
+    friend bool operator!=(const PHGRProof& a, const PHGRProof& b)
     {
         return !(a == b);
     }

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -109,7 +109,7 @@ double benchmark_parameter_loading()
 
 double benchmark_create_joinsplit()
 {
-    uint256 pubKeyHash;
+    uint256 joinSplitPubKey;
 
     /* Get the anchor of an empty commitment tree. */
     uint256 anchor = ZCIncrementalMerkleTree().root();
@@ -118,7 +118,7 @@ double benchmark_create_joinsplit()
     timer_start(tv_start);
     JSDescription jsdesc(true,
                          *pzcashParams,
-                         pubKeyHash,
+                         joinSplitPubKey,
                          anchor,
                          {JSInput(), JSInput()},
                          {JSOutput(), JSOutput()},
@@ -127,7 +127,7 @@ double benchmark_create_joinsplit()
     double ret = timer_stop(tv_start);
 
     auto verifier = libzcash::ProofVerifier::Strict();
-    assert(jsdesc.Verify(*pzcashParams, verifier, pubKeyHash));
+    assert(jsdesc.Verify(*pzcashParams, verifier, joinSplitPubKey));
     return ret;
 }
 
@@ -156,9 +156,9 @@ double benchmark_verify_joinsplit(const JSDescription &joinsplit)
 {
     struct timeval tv_start;
     timer_start(tv_start);
-    uint256 pubKeyHash;
+    uint256 joinSplitPubKey;
     auto verifier = libzcash::ProofVerifier::Strict();
-    joinsplit.Verify(*pzcashParams, verifier, pubKeyHash);
+    joinsplit.Verify(*pzcashParams, verifier, joinSplitPubKey);
     return timer_stop(tv_start);
 }
 


### PR DESCRIPTION
- `ZCProof` is a too general name, now that we also have `GrothProof` used in sprout proofs.
So I changed the name of this object to `PHGRProof`.

- In some files `pubKeyHash` was used as a var name, whereas it wasn't the pubkey hash,
but the pubkey itself. So I changed the var name to `joinSplitPubKey`
