### PR TITLE
Rename merkle tree typedefs to include Sprout

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -42,8 +42,8 @@ bool CCoins::Spend(uint32_t nPos)
     Cleanup();
     return true;
 }
-bool CCoinsView::GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const { return false; }
-bool CCoinsView::GetSaplingAnchorAt(const uint256 &rt, ZCSaplingIncrementalMerkleTree &tree) const { return false; }
+bool CCoinsView::GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const { return false; }
+bool CCoinsView::GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const { return false; }
 bool CCoinsView::GetNullifier(const uint256 &nullifier, ShieldedType type) const { return false; }
 bool CCoinsView::GetCoins(const uint256 &txid, CCoins &coins) const { return false; }
 bool CCoinsView::HaveCoins(const uint256 &txid) const { return false; }
@@ -62,8 +62,8 @@ bool CCoinsView::GetStats(CCoinsStats &stats) const { return false; }
 
 CCoinsViewBacked::CCoinsViewBacked(CCoinsView *viewIn) : base(viewIn) { }
 
-bool CCoinsViewBacked::GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const { return base->GetSproutAnchorAt(rt, tree); }
-bool CCoinsViewBacked::GetSaplingAnchorAt(const uint256 &rt, ZCSaplingIncrementalMerkleTree &tree) const { return base->GetSaplingAnchorAt(rt, tree); }
+bool CCoinsViewBacked::GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const { return base->GetSproutAnchorAt(rt, tree); }
+bool CCoinsViewBacked::GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const { return base->GetSaplingAnchorAt(rt, tree); }
 bool CCoinsViewBacked::GetNullifier(const uint256 &nullifier, ShieldedType type) const { return base->GetNullifier(nullifier, type); }
 bool CCoinsViewBacked::GetCoins(const uint256 &txid, CCoins &coins) const { return base->GetCoins(txid, coins); }
 bool CCoinsViewBacked::HaveCoins(const uint256 &txid) const { return base->HaveCoins(txid); }
@@ -117,7 +117,7 @@ CCoinsMap::const_iterator CCoinsViewCache::FetchCoins(const uint256 &txid) const
 }
 
 
-bool CCoinsViewCache::GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const {
+bool CCoinsViewCache::GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const {
     CAnchorsSproutMap::const_iterator it = cacheSproutAnchors.find(rt);
     if (it != cacheSproutAnchors.end()) {
         if (it->second.entered) {
@@ -140,7 +140,7 @@ bool CCoinsViewCache::GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTr
     return true;
 }
 
-bool CCoinsViewCache::GetSaplingAnchorAt(const uint256 &rt, ZCSaplingIncrementalMerkleTree &tree) const {
+bool CCoinsViewCache::GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const {
     CAnchorsSaplingMap::const_iterator it = cacheSaplingAnchors.find(rt);
     if (it != cacheSaplingAnchors.end()) {
         if (it->second.entered) {
@@ -222,9 +222,9 @@ void CCoinsViewCache::AbstractPushAnchor(
     }
 }
 
-template<> void CCoinsViewCache::PushAnchor(const ZCIncrementalMerkleTree &tree)
+template<> void CCoinsViewCache::PushAnchor(const SproutMerkleTree &tree)
 {
-    AbstractPushAnchor<ZCIncrementalMerkleTree, CAnchorsSproutMap, CAnchorsSproutMap::iterator, CAnchorsSproutCacheEntry>(
+    AbstractPushAnchor<SproutMerkleTree, CAnchorsSproutMap, CAnchorsSproutMap::iterator, CAnchorsSproutCacheEntry>(
         tree,
         SPROUT,
         cacheSproutAnchors,
@@ -232,9 +232,9 @@ template<> void CCoinsViewCache::PushAnchor(const ZCIncrementalMerkleTree &tree)
     );
 }
 
-template<> void CCoinsViewCache::PushAnchor(const ZCSaplingIncrementalMerkleTree &tree)
+template<> void CCoinsViewCache::PushAnchor(const SaplingMerkleTree &tree)
 {
-    AbstractPushAnchor<ZCSaplingIncrementalMerkleTree, CAnchorsSaplingMap, CAnchorsSaplingMap::iterator, CAnchorsSaplingCacheEntry>(
+    AbstractPushAnchor<SaplingMerkleTree, CAnchorsSaplingMap, CAnchorsSaplingMap::iterator, CAnchorsSaplingCacheEntry>(
         tree,
         SAPLING,
         cacheSaplingAnchors,
@@ -245,7 +245,7 @@ template<> void CCoinsViewCache::PushAnchor(const ZCSaplingIncrementalMerkleTree
 template<>
 void CCoinsViewCache::BringBestAnchorIntoCache(
     const uint256 &currentRoot,
-    ZCIncrementalMerkleTree &tree
+    SproutMerkleTree &tree
 )
 {
     assert(GetSproutAnchorAt(currentRoot, tree));
@@ -254,7 +254,7 @@ void CCoinsViewCache::BringBestAnchorIntoCache(
 template<>
 void CCoinsViewCache::BringBestAnchorIntoCache(
     const uint256 &currentRoot,
-    ZCSaplingIncrementalMerkleTree &tree
+    SaplingMerkleTree &tree
 )
 {
     assert(GetSaplingAnchorAt(currentRoot, tree));
@@ -295,7 +295,7 @@ void CCoinsViewCache::AbstractPopAnchor(
 void CCoinsViewCache::PopAnchor(const uint256 &newrt, ShieldedType type) {
     switch (type) {
         case SPROUT:
-            AbstractPopAnchor<ZCIncrementalMerkleTree, CAnchorsSproutMap, CAnchorsSproutCacheEntry>(
+            AbstractPopAnchor<SproutMerkleTree, CAnchorsSproutMap, CAnchorsSproutCacheEntry>(
                 newrt,
                 SPROUT,
                 cacheSproutAnchors,
@@ -303,7 +303,7 @@ void CCoinsViewCache::PopAnchor(const uint256 &newrt, ShieldedType type) {
             );
             break;
         case SAPLING:
-            AbstractPopAnchor<ZCSaplingIncrementalMerkleTree, CAnchorsSaplingMap, CAnchorsSaplingCacheEntry>(
+            AbstractPopAnchor<SaplingMerkleTree, CAnchorsSaplingMap, CAnchorsSaplingCacheEntry>(
                 newrt,
                 SAPLING,
                 cacheSaplingAnchors,
@@ -555,7 +555,7 @@ CAmount CCoinsViewCache::GetValueIn(const CTransaction& tx) const
 
 bool CCoinsViewCache::HaveJoinSplitRequirements(const CTransaction& tx) const
 {
-    boost::unordered_map<uint256, ZCIncrementalMerkleTree, CCoinsKeyHasher> intermediates;
+    boost::unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
 
     BOOST_FOREACH(const JSDescription &joinsplit, tx.vjoinsplit)
     {
@@ -568,7 +568,7 @@ bool CCoinsViewCache::HaveJoinSplitRequirements(const CTransaction& tx) const
             }
         }
 
-        ZCIncrementalMerkleTree tree;
+        SproutMerkleTree tree;
         auto it = intermediates.find(joinsplit.anchor);
         if (it != intermediates.end()) {
             tree = it->second;
@@ -588,7 +588,7 @@ bool CCoinsViewCache::HaveJoinSplitRequirements(const CTransaction& tx) const
         if (GetNullifier(spendDescription.nullifier, SAPLING)) // Prevent double spends
             return false;
 
-        ZCSaplingIncrementalMerkleTree tree;
+        SaplingMerkleTree tree;
         if (!GetSaplingAnchorAt(spendDescription.anchor, tree)) {
             return false;
         }

--- a/src/coins.h
+++ b/src/coins.h
@@ -276,7 +276,7 @@ struct CCoinsCacheEntry
 struct CAnchorsSproutCacheEntry
 {
     bool entered; // This will be false if the anchor is removed from the cache
-    ZCIncrementalMerkleTree tree; // The tree itself
+    SproutMerkleTree tree; // The tree itself
     unsigned char flags;
 
     enum Flags {
@@ -289,7 +289,7 @@ struct CAnchorsSproutCacheEntry
 struct CAnchorsSaplingCacheEntry
 {
     bool entered; // This will be false if the anchor is removed from the cache
-    ZCSaplingIncrementalMerkleTree tree; // The tree itself
+    SaplingMerkleTree tree; // The tree itself
     unsigned char flags;
 
     enum Flags {
@@ -341,10 +341,10 @@ class CCoinsView
 {
 public:
     //! Retrieve the tree (Sprout) at a particular anchored root in the chain
-    virtual bool GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const;
+    virtual bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const;
 
     //! Retrieve the tree (Sapling) at a particular anchored root in the chain
-    virtual bool GetSaplingAnchorAt(const uint256 &rt, ZCSaplingIncrementalMerkleTree &tree) const;
+    virtual bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const;
 
     //! Determine whether a nullifier is spent or not
     virtual bool GetNullifier(const uint256 &nullifier, ShieldedType type) const;
@@ -389,8 +389,8 @@ protected:
 
 public:
     CCoinsViewBacked(CCoinsView *viewIn);
-    bool GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const;
-    bool GetSaplingAnchorAt(const uint256 &rt, ZCSaplingIncrementalMerkleTree &tree) const;
+    bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const;
+    bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const;
     bool GetNullifier(const uint256 &nullifier, ShieldedType type) const;
     bool GetCoins(const uint256 &txid, CCoins &coins) const;
     bool HaveCoins(const uint256 &txid) const;
@@ -460,8 +460,8 @@ public:
     ~CCoinsViewCache();
 
     // Standard CCoinsView methods
-    bool GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const;
-    bool GetSaplingAnchorAt(const uint256 &rt, ZCSaplingIncrementalMerkleTree &tree) const;
+    bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const;
+    bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const;
     bool GetNullifier(const uint256 &nullifier, ShieldedType type) const;
     bool GetCoins(const uint256 &txid, CCoins &coins) const;
     bool HaveCoins(const uint256 &txid) const;

--- a/src/gtest/test_circuit.cpp
+++ b/src/gtest/test_circuit.cpp
@@ -106,7 +106,7 @@ bool test_merkle_gadget(
     mgadget1.generate_r1cs_constraints();
     mgadget2.generate_r1cs_constraints();
 
-    ZCIncrementalMerkleTree tree;
+    SproutMerkleTree tree;
     uint256 commitment1_data = uint256S("54d626e08c1c802b305dad30b7e54a82f102390cc92c7d4db112048935236e9c");
     uint256 commitment2_data = uint256S("59d2cde5e65c1414c32ba54f0fe4bdb3d67618125286e6a191317917c812c6d7");
     tree.append(commitment1_data);

--- a/src/gtest/test_joinsplit.cpp
+++ b/src/gtest/test_joinsplit.cpp
@@ -66,7 +66,7 @@ void test_full_api(ZCJoinSplit* js)
     SproutPaymentAddress recipient_addr = recipient_key.address();
 
     // Create the commitment tree
-    ZCIncrementalMerkleTree tree;
+    SproutMerkleTree tree;
 
     // Set up a JoinSplit description
     uint64_t vpub_old = 10;
@@ -106,7 +106,7 @@ void test_full_api(ZCJoinSplit* js)
     // Run tests using both phgr and groth as basis for field values
     for (auto jsdesc : jsdescs)
     {
-        ZCIncrementalMerkleTree tree;
+        SproutMerkleTree tree;
         SproutProofs jsdescs2;
         // Recipient should decrypt
         // Now the recipient should spend the money again
@@ -328,7 +328,7 @@ for test_input in TEST_VECTORS:
 void increment_note_witnesses(
     const uint256& element,
     std::vector<ZCIncrementalWitness>& witnesses,
-    ZCIncrementalMerkleTree& tree
+    SproutMerkleTree& tree
 )
 {
     tree.append(element);
@@ -342,7 +342,7 @@ TEST(joinsplit, full_api_test)
 {
     {
         std::vector<ZCIncrementalWitness> witnesses;
-        ZCIncrementalMerkleTree tree;
+        SproutMerkleTree tree;
         increment_note_witnesses(uint256(), witnesses, tree);
         SproutSpendingKey sk = SproutSpendingKey::random();
         SproutPaymentAddress addr = sk.address();

--- a/src/gtest/test_joinsplit.cpp
+++ b/src/gtest/test_joinsplit.cpp
@@ -327,12 +327,12 @@ for test_input in TEST_VECTORS:
 
 void increment_note_witnesses(
     const uint256& element,
-    std::vector<ZCIncrementalWitness>& witnesses,
+    std::vector<SproutWitness>& witnesses,
     SproutMerkleTree& tree
 )
 {
     tree.append(element);
-    for (ZCIncrementalWitness& w : witnesses) {
+    for (SproutWitness& w : witnesses) {
         w.append(element);
     }
     witnesses.push_back(tree.witness());
@@ -341,7 +341,7 @@ void increment_note_witnesses(
 TEST(joinsplit, full_api_test)
 {
     {
-        std::vector<ZCIncrementalWitness> witnesses;
+        std::vector<SproutWitness> witnesses;
         SproutMerkleTree tree;
         increment_note_witnesses(uint256(), witnesses, tree);
         SproutSpendingKey sk = SproutSpendingKey::random();

--- a/src/gtest/test_mempool.cpp
+++ b/src/gtest/test_mempool.cpp
@@ -19,11 +19,11 @@ class FakeCoinsViewDB : public CCoinsView {
 public:
     FakeCoinsViewDB() {}
 
-    bool GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const {
+    bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const {
         return false;
     }
 
-    bool GetSaplingAnchorAt(const uint256 &rt, ZCSaplingIncrementalMerkleTree &tree) const {
+    bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const {
         return false;
     }
 

--- a/src/gtest/test_merkletree.cpp
+++ b/src/gtest/test_merkletree.cpp
@@ -39,7 +39,7 @@ using namespace std;
 using namespace libsnark;
 
 template<>
-void expect_deser_same(const ZCTestingIncrementalWitness& expected)
+void expect_deser_same(const SproutTestingWitness& expected)
 {
     // Cannot check this; IncrementalWitness cannot be
     // deserialized because it can only be constructed by
@@ -195,7 +195,7 @@ TEST(merkletree, vectors) {
     UniValue path_tests = read_json(MAKE_STRING(json_tests::merkle_path));
     UniValue commitment_tests = read_json(MAKE_STRING(json_tests::merkle_commitments));
 
-    test_tree<ZCTestingIncrementalMerkleTree, ZCTestingIncrementalWitness>(
+    test_tree<SproutTestingMerkleTree, SproutTestingWitness>(
         commitment_tests,
         root_tests,
         ser_tests,
@@ -212,7 +212,7 @@ TEST(merkletree, SaplingVectors) {
     UniValue path_tests = read_json(MAKE_STRING(json_tests::merkle_path_sapling));
     UniValue commitment_tests = read_json(MAKE_STRING(json_tests::merkle_commitments_sapling));
 
-    test_tree<ZCSaplingTestingIncrementalMerkleTree, ZCSaplingTestingIncrementalWitness>(
+    test_tree<SaplingTestingMerkleTree, SaplingTestingWitness>(
         commitment_tests,
         root_tests,
         ser_tests,
@@ -280,7 +280,7 @@ TEST(merkletree, deserializeInvalid) {
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss << newTree;
 
-    ZCTestingIncrementalMerkleTree newTreeSmall;
+    SproutTestingMerkleTree newTreeSmall;
     ASSERT_THROW({ss >> newTreeSmall;}, std::ios_base::failure);
 }
 

--- a/src/gtest/test_merkletree.cpp
+++ b/src/gtest/test_merkletree.cpp
@@ -254,7 +254,7 @@ TEST(merkletree, emptyroot) {
     // an integer which converted to little-endian internally.
     uint256 expected = uint256S("59d2cde5e65c1414c32ba54f0fe4bdb3d67618125286e6a191317917c812c6d7");
 
-    ASSERT_TRUE(ZCIncrementalMerkleTree::empty_root() == expected);
+    ASSERT_TRUE(SproutMerkleTree::empty_root() == expected);
 }
 
 TEST(merkletree, EmptyrootSapling) {
@@ -263,13 +263,13 @@ TEST(merkletree, EmptyrootSapling) {
     // an integer which converted to little-endian internally.
     uint256 expected = uint256S("3e49b5f954aa9d3545bc6c37744661eea48d7c34e3000d82b7f0010c30f4c2fb");
 
-    ASSERT_TRUE(ZCSaplingIncrementalMerkleTree::empty_root() == expected);
+    ASSERT_TRUE(SaplingMerkleTree::empty_root() == expected);
 }
 
 TEST(merkletree, deserializeInvalid) {
     // attempt to deserialize a small tree from a serialized large tree
     // (exceeds depth well-formedness check)
-    ZCIncrementalMerkleTree newTree;
+    SproutMerkleTree newTree;
 
     for (size_t i = 0; i < 16; i++) {
         newTree.append(uint256S("54d626e08c1c802b305dad30b7e54a82f102390cc92c7d4db112048935236e9c"));
@@ -292,7 +292,7 @@ TEST(merkletree, deserializeInvalid2) {
         PROTOCOL_VERSION
     );
 
-    ZCIncrementalMerkleTree tree;
+    SproutMerkleTree tree;
     ASSERT_THROW(ss >> tree, std::ios_base::failure);
 }
 
@@ -304,7 +304,7 @@ TEST(merkletree, deserializeInvalid3) {
         PROTOCOL_VERSION
     );
 
-    ZCIncrementalMerkleTree tree;
+    SproutMerkleTree tree;
     ASSERT_THROW(ss >> tree, std::ios_base::failure);
 }
 
@@ -316,15 +316,15 @@ TEST(merkletree, deserializeInvalid4) {
         PROTOCOL_VERSION
     );
 
-    ZCIncrementalMerkleTree tree;
+    SproutMerkleTree tree;
     ASSERT_THROW(ss >> tree, std::ios_base::failure);
 }
 
 TEST(merkletree, testZeroElements) {
     for (int start = 0; start < 20; start++) {
-        ZCIncrementalMerkleTree newTree;
+        SproutMerkleTree newTree;
 
-        ASSERT_TRUE(newTree.root() == ZCIncrementalMerkleTree::empty_root());
+        ASSERT_TRUE(newTree.root() == SproutMerkleTree::empty_root());
 
         for (int i = start; i > 0; i--) {
             newTree.append(uint256S("54d626e08c1c802b305dad30b7e54a82f102390cc92c7d4db112048935236e9c"));

--- a/src/gtest/test_transaction.cpp
+++ b/src/gtest/test_transaction.cpp
@@ -12,7 +12,7 @@ extern int GenMax(int n);
 
 TEST(Transaction, JSDescriptionRandomized) {
     // construct a merkle tree
-    ZCIncrementalMerkleTree merkleTree;
+    SproutMerkleTree merkleTree;
 
     libzcash::SproutSpendingKey k = libzcash::SproutSpendingKey::random();
     libzcash::SproutPaymentAddress addr = k.address();

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -63,7 +63,7 @@ TEST(TransactionBuilder, Invoke)
     auto maybe_note = maybe_pt.get().note(ivk);
     ASSERT_EQ(static_cast<bool>(maybe_note), true);
     auto note = maybe_note.get();
-    ZCSaplingIncrementalMerkleTree tree;
+    SaplingMerkleTree tree;
     tree.append(tx1.vShieldedOutput[0].cm);
     auto anchor = tree.root();
     auto witness = tree.witness();
@@ -147,7 +147,7 @@ TEST(TransactionBuilder, FailsWithNegativeChange)
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pk, 59999);
     auto cm = note.cm().value();
-    ZCSaplingIncrementalMerkleTree tree;
+    SaplingMerkleTree tree;
     tree.append(cm);
     auto anchor = tree.root();
     auto witness = tree.witness();
@@ -193,7 +193,7 @@ TEST(TransactionBuilder, ChangeOutput)
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pk, 25000);
     auto cm = note.cm().value();
-    ZCSaplingIncrementalMerkleTree tree;
+    SaplingMerkleTree tree;
     tree.append(cm);
     auto anchor = tree.root();
     auto witness = tree.witness();
@@ -291,7 +291,7 @@ TEST(TransactionBuilder, SetFee)
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pk, 50000);
     auto cm = note.cm().value();
-    ZCSaplingIncrementalMerkleTree tree;
+    SaplingMerkleTree tree;
     tree.append(cm);
     auto anchor = tree.root();
     auto witness = tree.witness();

--- a/src/gtest/test_validation.cpp
+++ b/src/gtest/test_validation.cpp
@@ -21,11 +21,11 @@ class FakeCoinsViewDB : public CCoinsView {
 public:
     FakeCoinsViewDB() {}
 
-    bool GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const {
+    bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const {
         return false;
     }
 
-    bool GetSaplingAnchorAt(const uint256 &rt, ZCSaplingIncrementalMerkleTree &tree) const {
+    bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const {
         return false;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2269,7 +2269,7 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
     if (NetworkUpgradeActive(pindex->pprev->nHeight, Params().GetConsensus(), Consensus::UPGRADE_SAPLING)) {
         view.PopAnchor(pindex->pprev->hashFinalSaplingRoot, SAPLING);
     } else {
-        view.PopAnchor(ZCSaplingIncrementalMerkleTree::empty_root(), SAPLING);
+        view.PopAnchor(SaplingMerkleTree::empty_root(), SAPLING);
     }
 
     // move best block pointer to prevout block
@@ -2414,7 +2414,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         if (!fJustCheck) {
             view.SetBestBlock(pindex->GetBlockHash());
             // Before the genesis block, there was an empty tree
-            ZCIncrementalMerkleTree tree;
+            SproutMerkleTree tree;
             pindex->hashSproutAnchor = tree.root();
             // The genesis block contained no JoinSplits
             pindex->hashFinalSproutRoot = pindex->hashSproutAnchor;
@@ -2455,7 +2455,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     if (!fJustCheck) {
         pindex->hashSproutAnchor = old_sprout_tree_root;
     }
-    ZCIncrementalMerkleTree sprout_tree;
+    SproutMerkleTree sprout_tree;
     // This should never fail: we should always be able to get the root
     // that is on the tip of our chain
     assert(view.GetSproutAnchorAt(old_sprout_tree_root, sprout_tree));
@@ -2466,7 +2466,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         assert(sprout_tree.root() == old_sprout_tree_root);
     }
 
-    ZCSaplingIncrementalMerkleTree sapling_tree;
+    SaplingMerkleTree sapling_tree;
     assert(view.GetSaplingAnchorAt(view.GetBestAnchor(SAPLING), sapling_tree));
 
     // Grab the consensus branch ID for the block's height
@@ -2836,8 +2836,8 @@ bool static DisconnectTip(CValidationState &state, bool fBare = false) {
     // Update chainActive and related variables.
     UpdateTip(pindexDelete->pprev);
     // Get the current commitment tree
-    ZCIncrementalMerkleTree newSproutTree;
-    ZCSaplingIncrementalMerkleTree newSaplingTree;
+    SproutMerkleTree newSproutTree;
+    SaplingMerkleTree newSaplingTree;
     assert(pcoinsTip->GetSproutAnchorAt(pcoinsTip->GetBestAnchor(SPROUT), newSproutTree));
     assert(pcoinsTip->GetSaplingAnchorAt(pcoinsTip->GetBestAnchor(SAPLING), newSaplingTree));
     // Let wallets know transactions went from 1-confirmed to
@@ -2872,8 +2872,8 @@ bool static ConnectTip(CValidationState &state, CBlockIndex *pindexNew, CBlock *
         pblock = &block;
     }
     // Get the current commitment tree
-    ZCIncrementalMerkleTree oldSproutTree;
-    ZCSaplingIncrementalMerkleTree oldSaplingTree;
+    SproutMerkleTree oldSproutTree;
+    SaplingMerkleTree oldSaplingTree;
     assert(pcoinsTip->GetSproutAnchorAt(pcoinsTip->GetBestAnchor(SPROUT), oldSproutTree));
     assert(pcoinsTip->GetSaplingAnchorAt(pcoinsTip->GetBestAnchor(SAPLING), oldSaplingTree));
     // Apply the block atomically to the chain state.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -149,7 +149,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
         const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
         CCoinsViewCache view(pcoinsTip);
 
-        ZCSaplingIncrementalMerkleTree sapling_tree;
+        SaplingMerkleTree sapling_tree;
         assert(view.GetSaplingAnchorAt(view.GetBestAnchor(SAPLING), sapling_tree));
 
         // Priority order to process transactions

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -775,7 +775,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("chainwork",             chainActive.Tip()->nChainWork.GetHex()));
     obj.push_back(Pair("pruned",                fPruneMode));
 
-    ZCIncrementalMerkleTree tree;
+    SproutMerkleTree tree;
     pcoinsTip->GetSproutAnchorAt(pcoinsTip->GetBestAnchor(SPROUT), tree);
     obj.push_back(Pair("commitments",           static_cast<uint64_t>(tree.size())));
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -28,25 +28,25 @@ class CCoinsViewTest : public CCoinsView
     uint256 hashBestSproutAnchor_;
     uint256 hashBestSaplingAnchor_;
     std::map<uint256, CCoins> map_;
-    std::map<uint256, ZCIncrementalMerkleTree> mapSproutAnchors_;
-    std::map<uint256, ZCSaplingIncrementalMerkleTree> mapSaplingAnchors_;
+    std::map<uint256, SproutMerkleTree> mapSproutAnchors_;
+    std::map<uint256, SaplingMerkleTree> mapSaplingAnchors_;
     std::map<uint256, bool> mapSproutNullifiers_;
     std::map<uint256, bool> mapSaplingNullifiers_;
 
 public:
     CCoinsViewTest() {
-        hashBestSproutAnchor_ = ZCIncrementalMerkleTree::empty_root();
-        hashBestSaplingAnchor_ = ZCSaplingIncrementalMerkleTree::empty_root();
+        hashBestSproutAnchor_ = SproutMerkleTree::empty_root();
+        hashBestSaplingAnchor_ = SaplingMerkleTree::empty_root();
     }
 
-    bool GetSproutAnchorAt(const uint256& rt, ZCIncrementalMerkleTree &tree) const {
-        if (rt == ZCIncrementalMerkleTree::empty_root()) {
-            ZCIncrementalMerkleTree new_tree;
+    bool GetSproutAnchorAt(const uint256& rt, SproutMerkleTree &tree) const {
+        if (rt == SproutMerkleTree::empty_root()) {
+            SproutMerkleTree new_tree;
             tree = new_tree;
             return true;
         }
 
-        std::map<uint256, ZCIncrementalMerkleTree>::const_iterator it = mapSproutAnchors_.find(rt);
+        std::map<uint256, SproutMerkleTree>::const_iterator it = mapSproutAnchors_.find(rt);
         if (it == mapSproutAnchors_.end()) {
             return false;
         } else {
@@ -55,14 +55,14 @@ public:
         }
     }
 
-    bool GetSaplingAnchorAt(const uint256& rt, ZCSaplingIncrementalMerkleTree &tree) const {
-        if (rt == ZCSaplingIncrementalMerkleTree::empty_root()) {
-            ZCSaplingIncrementalMerkleTree new_tree;
+    bool GetSaplingAnchorAt(const uint256& rt, SaplingMerkleTree &tree) const {
+        if (rt == SaplingMerkleTree::empty_root()) {
+            SaplingMerkleTree new_tree;
             tree = new_tree;
             return true;
         }
 
-        std::map<uint256, ZCSaplingIncrementalMerkleTree>::const_iterator it = mapSaplingAnchors_.find(rt);
+        std::map<uint256, SaplingMerkleTree>::const_iterator it = mapSaplingAnchors_.find(rt);
         if (it == mapSaplingAnchors_.end()) {
             return false;
         } else {
@@ -174,8 +174,8 @@ public:
             mapCoins.erase(it++);
         }
 
-        BatchWriteAnchors<ZCIncrementalMerkleTree, CAnchorsSproutMap>(mapSproutAnchors, mapSproutAnchors_);
-        BatchWriteAnchors<ZCSaplingIncrementalMerkleTree, CAnchorsSaplingMap>(mapSaplingAnchors, mapSaplingAnchors_);
+        BatchWriteAnchors<SproutMerkleTree, CAnchorsSproutMap>(mapSproutAnchors, mapSproutAnchors_);
+        BatchWriteAnchors<SaplingMerkleTree, CAnchorsSaplingMap>(mapSaplingAnchors, mapSaplingAnchors_);
 
         BatchWriteNullifiers(mapSproutNullifiers, mapSproutNullifiers_);
         BatchWriteNullifiers(mapSaplingNullifiers, mapSaplingNullifiers_);
@@ -240,7 +240,7 @@ public:
 
 }
 
-uint256 appendRandomSproutCommitment(ZCIncrementalMerkleTree &tree)
+uint256 appendRandomSproutCommitment(SproutMerkleTree &tree)
 {
     libzcash::SproutSpendingKey k = libzcash::SproutSpendingKey::random();
     libzcash::SproutPaymentAddress addr = k.address();
@@ -253,8 +253,8 @@ uint256 appendRandomSproutCommitment(ZCIncrementalMerkleTree &tree)
 }
 
 template<typename Tree> bool GetAnchorAt(const CCoinsViewCacheTest &cache, const uint256 &rt, Tree &tree);
-template<> bool GetAnchorAt(const CCoinsViewCacheTest &cache, const uint256 &rt, ZCIncrementalMerkleTree &tree) { return cache.GetSproutAnchorAt(rt, tree); }
-template<> bool GetAnchorAt(const CCoinsViewCacheTest &cache, const uint256 &rt, ZCSaplingIncrementalMerkleTree &tree) { return cache.GetSaplingAnchorAt(rt, tree); }
+template<> bool GetAnchorAt(const CCoinsViewCacheTest &cache, const uint256 &rt, SproutMerkleTree &tree) { return cache.GetSproutAnchorAt(rt, tree); }
+template<> bool GetAnchorAt(const CCoinsViewCacheTest &cache, const uint256 &rt, SaplingMerkleTree &tree) { return cache.GetSaplingAnchorAt(rt, tree); }
 
 BOOST_FIXTURE_TEST_SUITE(coins_tests, BasicTestingSetup)
 
@@ -433,10 +433,10 @@ template<typename Tree> void anchorPopRegressionTestImpl(ShieldedType type)
 BOOST_AUTO_TEST_CASE(anchor_pop_regression_test)
 {
     BOOST_TEST_CONTEXT("Sprout") {
-        anchorPopRegressionTestImpl<ZCIncrementalMerkleTree>(SPROUT);
+        anchorPopRegressionTestImpl<SproutMerkleTree>(SPROUT);
     }
     BOOST_TEST_CONTEXT("Sapling") {
-        anchorPopRegressionTestImpl<ZCSaplingIncrementalMerkleTree>(SAPLING);
+        anchorPopRegressionTestImpl<SaplingMerkleTree>(SAPLING);
     }
 }
 
@@ -525,10 +525,10 @@ template<typename Tree> void anchorRegressionTestImpl(ShieldedType type)
 BOOST_AUTO_TEST_CASE(anchor_regression_test)
 {
     BOOST_TEST_CONTEXT("Sprout") {
-        anchorRegressionTestImpl<ZCIncrementalMerkleTree>(SPROUT);
+        anchorRegressionTestImpl<SproutMerkleTree>(SPROUT);
     }
     BOOST_TEST_CONTEXT("Sapling") {
-        anchorRegressionTestImpl<ZCSaplingIncrementalMerkleTree>(SAPLING);
+        anchorRegressionTestImpl<SaplingMerkleTree>(SAPLING);
     }
 }
 
@@ -588,10 +588,10 @@ template<typename Tree> void anchorsFlushImpl(ShieldedType type)
 BOOST_AUTO_TEST_CASE(anchors_flush_test)
 {
     BOOST_TEST_CONTEXT("Sprout") {
-        anchorsFlushImpl<ZCIncrementalMerkleTree>(SPROUT);
+        anchorsFlushImpl<SproutMerkleTree>(SPROUT);
     }
     BOOST_TEST_CONTEXT("Sapling") {
-        anchorsFlushImpl<ZCSaplingIncrementalMerkleTree>(SAPLING);
+        anchorsFlushImpl<SaplingMerkleTree>(SAPLING);
     }
 }
 
@@ -601,7 +601,7 @@ BOOST_AUTO_TEST_CASE(chained_joinsplits)
     CCoinsViewTest base;
     CCoinsViewCacheTest cache(&base);
 
-    ZCIncrementalMerkleTree tree;
+    SproutMerkleTree tree;
 
     JSDescription js1;
     js1.anchor = tree.root();
@@ -746,10 +746,10 @@ template<typename Tree> void anchorsTestImpl(ShieldedType type)
 BOOST_AUTO_TEST_CASE(anchors_test)
 {
     BOOST_TEST_CONTEXT("Sprout") {
-        anchorsTestImpl<ZCIncrementalMerkleTree>(SPROUT);
+        anchorsTestImpl<SproutMerkleTree>(SPROUT);
     }
     BOOST_TEST_CONTEXT("Sapling") {
-        anchorsTestImpl<ZCSaplingIncrementalMerkleTree>(SAPLING);
+        anchorsTestImpl<SaplingMerkleTree>(SAPLING);
     }
 }
 

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -1200,7 +1200,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         static_cast<AsyncRPCOperation_sendmany *>(operation.get())->testmode = true;
 
         AsyncJoinSplitInfo info;
-        std::vector<boost::optional < ZCIncrementalWitness>> witnesses;
+        std::vector<boost::optional < SproutWitness>> witnesses;
         uint256 anchor;
         try {
             proxy.perform_joinsplit(info, witnesses, anchor);
@@ -1736,7 +1736,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_internals)
         static_cast<AsyncRPCOperation_sendmany *>(operation.get())->testmode = true;
 
         MergeToAddressJSInfo info;
-        std::vector<boost::optional < ZCIncrementalWitness>> witnesses;
+        std::vector<boost::optional < SproutWitness>> witnesses;
         uint256 anchor;
         try {
             proxy.perform_joinsplit(info, witnesses, anchor);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(test_basic_joinsplit_verification)
     // integrity of the scheme through its own tests.
 
     // construct a merkle tree
-    ZCIncrementalMerkleTree merkleTree;
+    SproutMerkleTree merkleTree;
 
     auto k = libzcash::SproutSpendingKey::random();
     auto addr = k.address();

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -15,7 +15,7 @@ SpendDescriptionInfo::SpendDescriptionInfo(
     libzcash::SaplingExpandedSpendingKey expsk,
     libzcash::SaplingNote note,
     uint256 anchor,
-    ZCSaplingIncrementalWitness witness) : expsk(expsk), note(note), anchor(anchor), witness(witness)
+    SaplingWitness witness) : expsk(expsk), note(note), anchor(anchor), witness(witness)
 {
     librustzcash_sapling_generate_r(alpha.begin());
 }
@@ -32,7 +32,7 @@ bool TransactionBuilder::AddSaplingSpend(
     libzcash::SaplingExpandedSpendingKey expsk,
     libzcash::SaplingNote note,
     uint256 anchor,
-    ZCSaplingIncrementalWitness witness)
+    SaplingWitness witness)
 {
     // Consistency check: all anchors must equal the first one
     if (!spends.empty()) {

--- a/src/transaction_builder.h
+++ b/src/transaction_builder.h
@@ -23,13 +23,13 @@ struct SpendDescriptionInfo {
     libzcash::SaplingNote note;
     uint256 alpha;
     uint256 anchor;
-    ZCSaplingIncrementalWitness witness;
+    SaplingWitness witness;
 
     SpendDescriptionInfo(
         libzcash::SaplingExpandedSpendingKey expsk,
         libzcash::SaplingNote note,
         uint256 anchor,
-        ZCSaplingIncrementalWitness witness);
+        SaplingWitness witness);
 };
 
 struct OutputDescriptionInfo {
@@ -79,7 +79,7 @@ public:
         libzcash::SaplingExpandedSpendingKey expsk,
         libzcash::SaplingNote note,
         uint256 anchor,
-        ZCSaplingIncrementalWitness witness);
+        SaplingWitness witness);
 
     void AddSaplingOutput(
         libzcash::SaplingFullViewingKey from,

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -44,9 +44,9 @@ CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(Get
 }
 
 
-bool CCoinsViewDB::GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const {
-    if (rt == ZCIncrementalMerkleTree::empty_root()) {
-        ZCIncrementalMerkleTree new_tree;
+bool CCoinsViewDB::GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const {
+    if (rt == SproutMerkleTree::empty_root()) {
+        SproutMerkleTree new_tree;
         tree = new_tree;
         return true;
     }
@@ -56,9 +56,9 @@ bool CCoinsViewDB::GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree 
     return read;
 }
 
-bool CCoinsViewDB::GetSaplingAnchorAt(const uint256 &rt, ZCSaplingIncrementalMerkleTree &tree) const {
-    if (rt == ZCSaplingIncrementalMerkleTree::empty_root()) {
-        ZCSaplingIncrementalMerkleTree new_tree;
+bool CCoinsViewDB::GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const {
+    if (rt == SaplingMerkleTree::empty_root()) {
+        SaplingMerkleTree new_tree;
         tree = new_tree;
         return true;
     }
@@ -105,11 +105,11 @@ uint256 CCoinsViewDB::GetBestAnchor(ShieldedType type) const {
     switch (type) {
         case SPROUT:
             if (!db.Read(DB_BEST_SPROUT_ANCHOR, hashBestAnchor))
-                return ZCIncrementalMerkleTree::empty_root();
+                return SproutMerkleTree::empty_root();
             break;
         case SAPLING:
             if (!db.Read(DB_BEST_SAPLING_ANCHOR, hashBestAnchor))
-                return ZCSaplingIncrementalMerkleTree::empty_root();
+                return SaplingMerkleTree::empty_root();
             break;
         default:
             throw runtime_error("Unknown shielded type");
@@ -176,17 +176,17 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
         mapCoins.erase(itOld);
     }
 
-    ::BatchWriteAnchors<CAnchorsSproutMap, CAnchorsSproutMap::iterator, CAnchorsSproutCacheEntry, ZCIncrementalMerkleTree>(batch, mapSproutAnchors, DB_SPROUT_ANCHOR);
-    ::BatchWriteAnchors<CAnchorsSaplingMap, CAnchorsSaplingMap::iterator, CAnchorsSaplingCacheEntry, ZCSaplingIncrementalMerkleTree>(batch, mapSaplingAnchors, DB_SAPLING_ANCHOR);
+    ::BatchWriteAnchors<CAnchorsSproutMap, CAnchorsSproutMap::iterator, CAnchorsSproutCacheEntry, SproutMerkleTree>(batch, mapSproutAnchors, DB_SPROUT_ANCHOR);
+    ::BatchWriteAnchors<CAnchorsSaplingMap, CAnchorsSaplingMap::iterator, CAnchorsSaplingCacheEntry, SaplingMerkleTree>(batch, mapSaplingAnchors, DB_SAPLING_ANCHOR);
 
     ::BatchWriteNullifiers(batch, mapSproutNullifiers, DB_NULLIFIER);
     ::BatchWriteNullifiers(batch, mapSaplingNullifiers, DB_SAPLING_NULLIFIER);
 
     if (!hashBlock.IsNull())
         batch.Write(DB_BEST_BLOCK, hashBlock);
-    if (!hashSproutAnchor.IsNull() && hashSproutAnchor != ZCIncrementalMerkleTree::empty_root())
+    if (!hashSproutAnchor.IsNull() && hashSproutAnchor != SproutMerkleTree::empty_root())
         batch.Write(DB_BEST_SPROUT_ANCHOR, hashSproutAnchor);
-    if (!hashSaplingAnchor.IsNull() && hashSaplingAnchor != ZCSaplingIncrementalMerkleTree::empty_root())
+    if (!hashSaplingAnchor.IsNull() && hashSaplingAnchor != SaplingMerkleTree::empty_root())
         batch.Write(DB_BEST_SAPLING_ANCHOR, hashSaplingAnchor);
 
     LogPrint("coindb", "Committing %u changed transactions (out of %u) to coin database...\n", (unsigned int)changed, (unsigned int)count);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -35,8 +35,8 @@ protected:
 public:
     CCoinsViewDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 
-    bool GetSproutAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const;
-    bool GetSaplingAnchorAt(const uint256 &rt, ZCSaplingIncrementalMerkleTree &tree) const;
+    bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const;
+    bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const;
     bool GetNullifier(const uint256 &nf, ShieldedType type) const;
     bool GetCoins(const uint256 &txid, CCoins &coins) const;
     bool HaveCoins(const uint256 &txid) const;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -405,14 +405,14 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             i++;
         }
 
-        boost::unordered_map<uint256, ZCIncrementalMerkleTree, CCoinsKeyHasher> intermediates;
+        boost::unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
 
         BOOST_FOREACH(const JSDescription &joinsplit, tx.vjoinsplit) {
             BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
                 assert(!pcoins->GetNullifier(nf, SPROUT));
             }
 
-            ZCIncrementalMerkleTree tree;
+            SproutMerkleTree tree;
             auto it = intermediates.find(joinsplit.anchor);
             if (it != intermediates.end()) {
                 tree = it->second;
@@ -428,7 +428,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             intermediates.insert(std::make_pair(tree.root(), tree));
         }
         for (const SpendDescription &spendDescription : tx.vShieldedSpend) {
-            ZCSaplingIncrementalMerkleTree tree;
+            SaplingMerkleTree tree;
 
             assert(pcoins->GetSaplingAnchorAt(spendDescription.anchor, tree));
             assert(!pcoins->GetNullifier(spendDescription.nullifier, SAPLING));

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -99,7 +99,7 @@ CWalletTx GetValidSpend(ZCJoinSplit& params,
     mtx.joinSplitPubKey = joinSplitPubKey;
 
     // Fake tree for the unused witness
-    ZCIncrementalMerkleTree tree;
+    SproutMerkleTree tree;
 
     libzcash::JSOutput dummyout;
     libzcash::JSInput dummyin;

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -34,7 +34,7 @@ protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindex) {}
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
     virtual void EraseFromWallet(const uint256 &hash) {}
-    virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, ZCIncrementalMerkleTree sproutTree, ZCSaplingIncrementalMerkleTree saplingTree, bool added) {}
+    virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, SproutMerkleTree sproutTree, SaplingMerkleTree saplingTree, bool added) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual void UpdatedTransaction(const uint256 &hash) {}
     virtual void Inventory(const uint256 &hash) {}
@@ -55,7 +55,7 @@ struct CMainSignals {
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming visible). */
     boost::signals2::signal<void (const uint256 &)> UpdatedTransaction;
     /** Notifies listeners of a change to the tip of the active block chain. */
-    boost::signals2::signal<void (const CBlockIndex *, const CBlock *, ZCIncrementalMerkleTree, ZCSaplingIncrementalMerkleTree, bool)> ChainTip;
+    boost::signals2::signal<void (const CBlockIndex *, const CBlock *, SproutMerkleTree, SaplingMerkleTree, bool)> ChainTip;
     /** Notifies listeners of a new active block chain. */
     boost::signals2::signal<void (const CBlockLocator &)> SetBestChain;
     /** Notifies listeners about an inventory item being seen on the network. */

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -342,7 +342,7 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
             JSOutPoint jso = std::get<0>(t);
             std::vector<JSOutPoint> vOutPoints = {jso};
             uint256 inputAnchor;
-            std::vector<boost::optional<ZCIncrementalWitness>> vInputWitnesses;
+            std::vector<boost::optional<SproutWitness>> vInputWitnesses;
             pwalletMain->GetSproutNoteWitnesses(vOutPoints, vInputWitnesses, inputAnchor);
             jsopWitnessAnchorMap[jso.ToString()] = MergeToAddressWitnessAnchorData{vInputWitnesses[0], inputAnchor};
         }
@@ -406,7 +406,7 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
 
         CAmount jsInputValue = 0;
         uint256 jsAnchor;
-        std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
+        std::vector<boost::optional<SproutWitness>> witnesses;
 
         JSDescription prevJoinSplit;
 
@@ -437,7 +437,7 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
             }
 
             assert(changeOutputIndex != -1);
-            boost::optional<ZCIncrementalWitness> changeWitness;
+            boost::optional<SproutWitness> changeWitness;
             int n = 0;
             for (const uint256& commitment : prevJoinSplit.commitments) {
                 tree.append(commitment);
@@ -487,7 +487,7 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
         std::vector<SproutNote> vInputNotes;
         std::vector<SproutSpendingKey> vInputZKeys;
         std::vector<JSOutPoint> vOutPoints;
-        std::vector<boost::optional<ZCIncrementalWitness>> vInputWitnesses;
+        std::vector<boost::optional<SproutWitness>> vInputWitnesses;
         uint256 inputAnchor;
         int numInputsNeeded = (jsChange > 0) ? 1 : 0;
         while (numInputsNeeded++ < ZC_NUM_JS_INPUTS && zInputsDeque.size() > 0) {
@@ -544,7 +544,7 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
                 if (!optionalWitness) {
                     throw JSONRPCError(RPC_WALLET_ERROR, "Witness for note commitment is null");
                 }
-                ZCIncrementalWitness w = *optionalWitness; // could use .get();
+                SproutWitness w = *optionalWitness; // could use .get();
                 if (jsChange > 0) {
                     for (const uint256& commitment : previousCommitments) {
                         w.append(commitment);
@@ -695,7 +695,7 @@ void AsyncRPCOperation_mergetoaddress::sign_send_raw_transaction(UniValue obj)
 
 UniValue AsyncRPCOperation_mergetoaddress::perform_joinsplit(MergeToAddressJSInfo& info)
 {
-    std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
+    std::vector<boost::optional<SproutWitness>> witnesses;
     uint256 anchor;
     {
         LOCK(cs_main);
@@ -707,7 +707,7 @@ UniValue AsyncRPCOperation_mergetoaddress::perform_joinsplit(MergeToAddressJSInf
 
 UniValue AsyncRPCOperation_mergetoaddress::perform_joinsplit(MergeToAddressJSInfo& info, std::vector<JSOutPoint>& outPoints)
 {
-    std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
+    std::vector<boost::optional<SproutWitness>> witnesses;
     uint256 anchor;
     {
         LOCK(cs_main);
@@ -718,7 +718,7 @@ UniValue AsyncRPCOperation_mergetoaddress::perform_joinsplit(MergeToAddressJSInf
 
 UniValue AsyncRPCOperation_mergetoaddress::perform_joinsplit(
     MergeToAddressJSInfo& info,
-    std::vector<boost::optional<ZCIncrementalWitness>> witnesses,
+    std::vector<boost::optional<SproutWitness>> witnesses,
     uint256 anchor)
 {
     if (anchor.IsNull()) {

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -385,7 +385,7 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
     }
 
     // Keep track of treestate within this transaction
-    boost::unordered_map<uint256, ZCIncrementalMerkleTree, CCoinsKeyHasher> intermediates;
+    boost::unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
     std::vector<uint256> previousCommitments;
 
     while (!vpubNewProcessed) {
@@ -428,7 +428,7 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
             LOCK2(cs_main, pwalletMain->cs_wallet);
 
             // Update tree state with previous joinsplit
-            ZCIncrementalMerkleTree tree;
+            SproutMerkleTree tree;
             auto it = intermediates.find(prevJoinSplit.anchor);
             if (it != intermediates.end()) {
                 tree = it->second;

--- a/src/wallet/asyncrpcoperation_mergetoaddress.h
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.h
@@ -45,7 +45,7 @@ struct MergeToAddressJSInfo {
 
 // A struct to help us track the witness and anchor for a given JSOutPoint
 struct MergeToAddressWitnessAnchorData {
-    boost::optional<ZCIncrementalWitness> witness;
+    boost::optional<SproutWitness> witness;
     uint256 anchor;
 };
 
@@ -112,7 +112,7 @@ private:
     // JoinSplit where you have the witnesses and anchor
     UniValue perform_joinsplit(
         MergeToAddressJSInfo& info,
-        std::vector<boost::optional<ZCIncrementalWitness>> witnesses,
+        std::vector<boost::optional<SproutWitness>> witnesses,
         uint256 anchor);
 
     void sign_send_raw_transaction(UniValue obj); // throws exception if there was an error
@@ -172,7 +172,7 @@ public:
 
     UniValue perform_joinsplit(
         MergeToAddressJSInfo& info,
-        std::vector<boost::optional<ZCIncrementalWitness>> witnesses,
+        std::vector<boost::optional<SproutWitness>> witnesses,
         uint256 anchor)
     {
         return delegate->perform_joinsplit(info, witnesses, anchor);

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -419,7 +419,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
             JSOutPoint jso = std::get<0>(t);
             std::vector<JSOutPoint> vOutPoints = { jso };
             uint256 inputAnchor;
-            std::vector<boost::optional<ZCIncrementalWitness>> vInputWitnesses;
+            std::vector<boost::optional<SproutWitness>> vInputWitnesses;
             pwalletMain->GetSproutNoteWitnesses(vOutPoints, vInputWitnesses, inputAnchor);
             jsopWitnessAnchorMap[ jso.ToString() ] = WitnessAnchorData{ vInputWitnesses[0], inputAnchor };
         }
@@ -526,7 +526,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
 
         CAmount jsInputValue = 0;
         uint256 jsAnchor;
-        std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
+        std::vector<boost::optional<SproutWitness>> witnesses;
 
         JSDescription prevJoinSplit;
 
@@ -557,7 +557,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
             }
 
             assert(changeOutputIndex != -1);
-            boost::optional<ZCIncrementalWitness> changeWitness;
+            boost::optional<SproutWitness> changeWitness;
             int n = 0;
             for (const uint256& commitment : prevJoinSplit.commitments) {
                 tree.append(commitment);
@@ -606,7 +606,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
         //
         std::vector<SproutNote> vInputNotes;
         std::vector<JSOutPoint> vOutPoints;
-        std::vector<boost::optional<ZCIncrementalWitness>> vInputWitnesses;
+        std::vector<boost::optional<SproutWitness>> vInputWitnesses;
         uint256 inputAnchor;
         int numInputsNeeded = (jsChange>0) ? 1 : 0;
         while (numInputsNeeded++ < ZC_NUM_JS_INPUTS && zInputsDeque.size() > 0) {
@@ -663,7 +663,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
                 if (!optionalWitness) {
                     throw JSONRPCError(RPC_WALLET_ERROR, "Witness for note commitment is null");
                 }
-                ZCIncrementalWitness w = *optionalWitness; // could use .get();
+                SproutWitness w = *optionalWitness; // could use .get();
                 if (jsChange > 0) {
                     for (const uint256& commitment : previousCommitments) {
                         w.append(commitment);
@@ -920,7 +920,7 @@ bool AsyncRPCOperation_sendmany::find_unspent_notes() {
 }
 
 UniValue AsyncRPCOperation_sendmany::perform_joinsplit(AsyncJoinSplitInfo & info) {
-    std::vector<boost::optional < ZCIncrementalWitness>> witnesses;
+    std::vector<boost::optional < SproutWitness>> witnesses;
     uint256 anchor;
     {
         LOCK(cs_main);
@@ -931,7 +931,7 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(AsyncJoinSplitInfo & info
 
 
 UniValue AsyncRPCOperation_sendmany::perform_joinsplit(AsyncJoinSplitInfo & info, std::vector<JSOutPoint> & outPoints) {
-    std::vector<boost::optional < ZCIncrementalWitness>> witnesses;
+    std::vector<boost::optional < SproutWitness>> witnesses;
     uint256 anchor;
     {
         LOCK(cs_main);
@@ -942,7 +942,7 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(AsyncJoinSplitInfo & info
 
 UniValue AsyncRPCOperation_sendmany::perform_joinsplit(
         AsyncJoinSplitInfo & info,
-        std::vector<boost::optional < ZCIncrementalWitness>> witnesses,
+        std::vector<boost::optional < SproutWitness>> witnesses,
         uint256 anchor)
 {
     if (anchor.IsNull()) {

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -516,7 +516,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
     }
 
     // Keep track of treestate within this transaction
-    boost::unordered_map<uint256, ZCIncrementalMerkleTree, CCoinsKeyHasher> intermediates;
+    boost::unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
     std::vector<uint256> previousCommitments;
 
     while (!vpubNewProcessed) {
@@ -548,7 +548,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
             LOCK2(cs_main, pwalletMain->cs_wallet);
 
             // Update tree state with previous joinsplit
-            ZCIncrementalMerkleTree tree;
+            SproutMerkleTree tree;
             auto it = intermediates.find(prevJoinSplit.anchor);
             if (it != intermediates.end()) {
                 tree = it->second;

--- a/src/wallet/asyncrpcoperation_sendmany.h
+++ b/src/wallet/asyncrpcoperation_sendmany.h
@@ -45,7 +45,7 @@ struct AsyncJoinSplitInfo
 
 // A struct to help us track the witness and anchor for a given JSOutPoint
 struct WitnessAnchorData {
-	boost::optional<ZCIncrementalWitness> witness;
+	boost::optional<SproutWitness> witness;
 	uint256 anchor;
 };
 
@@ -112,7 +112,7 @@ private:
     // JoinSplit where you have the witnesses and anchor
     UniValue perform_joinsplit(
         AsyncJoinSplitInfo & info,
-        std::vector<boost::optional < ZCIncrementalWitness>> witnesses,
+        std::vector<boost::optional < SproutWitness>> witnesses,
         uint256 anchor);
 
     void sign_send_raw_transaction(UniValue obj);     // throws exception if there was an error
@@ -173,7 +173,7 @@ public:
 
     UniValue perform_joinsplit(
         AsyncJoinSplitInfo & info,
-        std::vector<boost::optional < ZCIncrementalWitness>> witnesses,
+        std::vector<boost::optional < SproutWitness>> witnesses,
         uint256 anchor)
     {
         return delegate->perform_joinsplit(info, witnesses, anchor);

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -120,8 +120,8 @@ std::pair<JSOutPoint, SaplingOutPoint> CreateValidBlock(TestWallet& wallet,
 std::pair<uint256, uint256> GetWitnessesAndAnchors(TestWallet& wallet,
                                 std::vector<JSOutPoint>& sproutNotes,
                                 std::vector<SaplingOutPoint>& saplingNotes,
-                                std::vector<boost::optional<ZCIncrementalWitness>>& sproutWitnesses,
-                                std::vector<boost::optional<ZCSaplingIncrementalWitness>>& saplingWitnesses) {
+                                std::vector<boost::optional<SproutWitness>>& sproutWitnesses,
+                                std::vector<boost::optional<SaplingWitness>>& saplingWitnesses) {
     sproutWitnesses.clear();
     saplingWitnesses.clear();
     uint256 sproutAnchor;
@@ -585,8 +585,8 @@ TEST(wallet_tests, cached_witnesses_empty_chain) {
     std::vector<JSOutPoint> sproutNotes {jsoutpt, jsoutpt2};
     std::vector<SaplingOutPoint> saplingNotes = SetSaplingNoteData(wtx);
 
-    std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
-    std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
+    std::vector<boost::optional<SproutWitness>> sproutWitnesses;
+    std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
 
     ::GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
 
@@ -639,8 +639,8 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         // Called to fetch anchor
         std::vector<JSOutPoint> sproutNotes {outpts.first};
         std::vector<SaplingOutPoint> saplingNotes {outpts.second};
-        std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
-        std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
+        std::vector<boost::optional<SproutWitness>> sproutWitnesses;
+        std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
 
         anchors1 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
         EXPECT_NE(anchors1.first, anchors1.second);
@@ -661,8 +661,8 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         wallet.AddToWallet(wtx, true, NULL);
 
         std::vector<JSOutPoint> sproutNotes {jsoutpt};
-        std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
-        std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
+        std::vector<boost::optional<SproutWitness>> sproutWitnesses;
+        std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
 
         GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
 
@@ -709,8 +709,8 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
 
         // Incrementing with the same block again should not change the cache
         wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
-        std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses5;
-        std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses5;
+        std::vector<boost::optional<SproutWitness>> sproutWitnesses5;
+        std::vector<boost::optional<SaplingWitness>> saplingWitnesses5;
 
         auto anchors5 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses5, saplingWitnesses5);
         EXPECT_NE(anchors5.first, anchors5.second);
@@ -750,8 +750,8 @@ TEST(wallet_tests, CachedWitnessesDecrementFirst) {
         // Called to fetch anchor
         std::vector<JSOutPoint> sproutNotes {outpts.first};
         std::vector<SaplingOutPoint> saplingNotes {outpts.second};
-        std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
-        std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
+        std::vector<boost::optional<SproutWitness>> sproutWitnesses;
+        std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
         anchors2 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
     }
 
@@ -770,8 +770,8 @@ TEST(wallet_tests, CachedWitnessesDecrementFirst) {
         wallet.AddToWallet(wtx, true, NULL);
 
         std::vector<JSOutPoint> sproutNotes {jsoutpt};
-        std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
-        std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
+        std::vector<boost::optional<SproutWitness>> sproutWitnesses;
+        std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
 
         auto anchors3 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
 
@@ -814,8 +814,8 @@ TEST(wallet_tests, CachedWitnessesCleanIndex) {
     SproutMerkleTree sproutRiTree = sproutTree;
     SaplingMerkleTree saplingTree;
     SaplingMerkleTree saplingRiTree = saplingTree;
-    std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
-    std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
+    std::vector<boost::optional<SproutWitness>> sproutWitnesses;
+    std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
 
     auto sk = libzcash::SproutSpendingKey::random();
     wallet.AddSpendingKey(sk);
@@ -922,8 +922,8 @@ TEST(wallet_tests, ClearNoteWitnessCache) {
     wallet.AddToWallet(wtx, true, NULL);
 
     std::vector<JSOutPoint> sproutNotes {jsoutpt, jsoutpt2};
-    std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
-    std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
+    std::vector<boost::optional<SproutWitness>> sproutWitnesses;
+    std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
 
     // Before clearing, we should have a witness for one note
     GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2643,7 +2643,7 @@ UniValue zc_sample_joinsplit(const UniValue& params, bool fHelp)
     LOCK(cs_main);
 
     uint256 joinSplitPubKey;
-    uint256 anchor = ZCIncrementalMerkleTree().root();
+    uint256 anchor = SproutMerkleTree().root();
     JSDescription samplejoinsplit(true,
                                   *pzcashParams,
                                   joinSplitPubKey,

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2843,7 +2843,7 @@ UniValue zc_raw_receive(const UniValue& params, bool fHelp)
     SproutNote decrypted_note = npt.note(payment_addr);
 
     assert(pwalletMain != NULL);
-    std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
+    std::vector<boost::optional<SproutWitness>> witnesses;
     uint256 anchor;
     uint256 commitment = decrypted_note.cm();
     pwalletMain->WitnessNoteCommitment(
@@ -2944,7 +2944,7 @@ UniValue zc_raw_joinsplit(const UniValue& params, bool fHelp)
     }
 
     uint256 anchor;
-    std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
+    std::vector<boost::optional<SproutWitness>> witnesses;
     pwalletMain->WitnessNoteCommitment(commitments, witnesses, anchor);
 
     assert(witnesses.size() == notes.size());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -451,8 +451,8 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
 
 void CWallet::ChainTip(const CBlockIndex *pindex, 
                        const CBlock *pblock,
-                       ZCIncrementalMerkleTree sproutTree,
-                       ZCSaplingIncrementalMerkleTree saplingTree, 
+                       SproutMerkleTree sproutTree,
+                       SaplingMerkleTree saplingTree, 
                        bool added)
 {
     if (added) {
@@ -847,8 +847,8 @@ void UpdateWitnessHeights(NoteDataMap& noteDataMap, int indexHeight, int64_t nWi
 
 void CWallet::IncrementNoteWitnesses(const CBlockIndex* pindex,
                                      const CBlock* pblockIn,
-                                     ZCIncrementalMerkleTree& sproutTree,
-                                     ZCSaplingIncrementalMerkleTree& saplingTree)
+                                     SproutMerkleTree& sproutTree,
+                                     SaplingMerkleTree& saplingTree)
 {
     LOCK(cs_wallet);
     for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
@@ -1893,7 +1893,7 @@ void CWallet::WitnessNoteCommitment(std::vector<uint256> commitments,
 {
     witnesses.resize(commitments.size());
     CBlockIndex* pindex = chainActive.Genesis();
-    ZCIncrementalMerkleTree tree;
+    SproutMerkleTree tree;
 
     while (pindex) {
         CBlock block;
@@ -1928,7 +1928,7 @@ void CWallet::WitnessNoteCommitment(std::vector<uint256> commitments,
 
         // Consistency check: we should be able to find the current tree
         // in our CCoins view.
-        ZCIncrementalMerkleTree dummy_tree;
+        SproutMerkleTree dummy_tree;
         assert(pcoinsTip->GetSproutAnchorAt(current_anchor, dummy_tree));
 
         pindex = chainActive.Next(pindex);
@@ -1980,8 +1980,8 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
                     ret++;
             }
 
-            ZCIncrementalMerkleTree sproutTree;
-            ZCSaplingIncrementalMerkleTree saplingTree;
+            SproutMerkleTree sproutTree;
+            SaplingMerkleTree saplingTree;
             // This should never fail: we should always be able to get the tree
             // state on the path to the tip of our chain
             assert(pcoinsTip->GetSproutAnchorAt(pindex->hashSproutAnchor, sproutTree));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1470,7 +1470,7 @@ bool CWallet::IsFromMe(const uint256& nullifier) const
 }
 
 void CWallet::GetSproutNoteWitnesses(std::vector<JSOutPoint> notes,
-                                     std::vector<boost::optional<ZCIncrementalWitness>>& witnesses,
+                                     std::vector<boost::optional<SproutWitness>>& witnesses,
                                      uint256 &final_anchor)
 {
     LOCK(cs_wallet);
@@ -1497,7 +1497,7 @@ void CWallet::GetSproutNoteWitnesses(std::vector<JSOutPoint> notes,
 }
 
 void CWallet::GetSaplingNoteWitnesses(std::vector<SaplingOutPoint> notes,
-                                      std::vector<boost::optional<ZCSaplingIncrementalWitness>>& witnesses,
+                                      std::vector<boost::optional<SaplingWitness>>& witnesses,
                                       uint256 &final_anchor)
 {
     LOCK(cs_wallet);
@@ -1888,7 +1888,7 @@ bool CWalletTx::WriteToDisk(CWalletDB *pwalletdb)
 }
 
 void CWallet::WitnessNoteCommitment(std::vector<uint256> commitments,
-                                    std::vector<boost::optional<ZCIncrementalWitness>>& witnesses,
+                                    std::vector<boost::optional<SproutWitness>>& witnesses,
                                     uint256 &final_anchor)
 {
     witnesses.resize(commitments.size());
@@ -1907,7 +1907,7 @@ void CWallet::WitnessNoteCommitment(std::vector<uint256> commitments,
                 {
                     tree.append(note_commitment);
 
-                    BOOST_FOREACH(boost::optional<ZCIncrementalWitness>& wit, witnesses) {
+                    BOOST_FOREACH(boost::optional<SproutWitness>& wit, witnesses) {
                         if (wit) {
                             wit->append(note_commitment);
                         }
@@ -1937,7 +1937,7 @@ void CWallet::WitnessNoteCommitment(std::vector<uint256> commitments,
     // TODO: #93; Select a root via some heuristic.
     final_anchor = tree.root();
 
-    BOOST_FOREACH(boost::optional<ZCIncrementalWitness>& wit, witnesses) {
+    BOOST_FOREACH(boost::optional<SproutWitness>& wit, witnesses) {
         if (wit) {
             assert(final_anchor == wit->root());
         }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -220,7 +220,7 @@ public:
      * Cached incremental witnesses for spendable Notes.
      * Beginning of the list is the most recent witness.
      */
-    std::list<ZCIncrementalWitness> witnesses;
+    std::list<SproutWitness> witnesses;
 
     /**
      * Block height corresponding to the most current witness.
@@ -272,7 +272,7 @@ public:
      */
     SaplingNoteData() : witnessHeight {-1} { }
 
-    std::list<ZCSaplingIncrementalWitness> witnesses;
+    std::list<SaplingWitness> witnesses;
     int witnessHeight;
 };
 
@@ -1033,7 +1033,7 @@ public:
     void EraseFromWallet(const uint256 &hash);
     void WitnessNoteCommitment(
          std::vector<uint256> commitments,
-         std::vector<boost::optional<ZCIncrementalWitness>>& witnesses,
+         std::vector<boost::optional<SproutWitness>>& witnesses,
          uint256 &final_anchor);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
@@ -1077,11 +1077,11 @@ public:
     bool IsFromMe(const uint256& nullifier) const;
     void GetSproutNoteWitnesses(
          std::vector<JSOutPoint> notes,
-         std::vector<boost::optional<ZCIncrementalWitness>>& witnesses,
+         std::vector<boost::optional<SproutWitness>>& witnesses,
          uint256 &final_anchor);
     void GetSaplingNoteWitnesses(
          std::vector<SaplingOutPoint> notes,
-         std::vector<boost::optional<ZCSaplingIncrementalWitness>>& witnesses,
+         std::vector<boost::optional<SaplingWitness>>& witnesses,
          uint256 &final_anchor);
 
     isminetype IsMine(const CTxIn& txin) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -737,8 +737,8 @@ protected:
      */
     void IncrementNoteWitnesses(const CBlockIndex* pindex,
                                 const CBlock* pblock,
-                                ZCIncrementalMerkleTree& sproutTree,
-                                ZCSaplingIncrementalMerkleTree& saplingTree);
+                                SproutMerkleTree& sproutTree,
+                                SaplingMerkleTree& saplingTree);
     /**
      * pindex is the old tip being disconnected.
      */
@@ -1096,7 +1096,7 @@ public:
     CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetChange(const CTransaction& tx) const;
-    void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, ZCIncrementalMerkleTree sproutTree, ZCSaplingIncrementalMerkleTree saplingTree, bool added);
+    void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, SproutMerkleTree sproutTree, SaplingMerkleTree saplingTree, bool added);
     /** Saves witness caches and best block locator to disk. */
     void SetBestChain(const CBlockLocator& loc);
     std::set<std::pair<libzcash::PaymentAddress, uint256>> GetNullifiersForAddresses(const std::set<libzcash::PaymentAddress> & addresses);

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -249,15 +249,15 @@ EmptyMerkleRoots<Depth, Hash> IncrementalMerkleTree<Depth, Hash>::emptyroots;
 } // end namespace `libzcash`
 
 typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::SHA256Compress> SproutMerkleTree;
-typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::SHA256Compress> ZCTestingIncrementalMerkleTree;
+typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::SHA256Compress> SproutTestingMerkleTree;
 
 typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::SHA256Compress> SproutWitness;
-typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::SHA256Compress> ZCTestingIncrementalWitness;
+typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::SHA256Compress> SproutTestingWitness;
 
 typedef libzcash::IncrementalMerkleTree<SAPLING_INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::PedersenHash> SaplingMerkleTree;
-typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::PedersenHash> ZCSaplingTestingIncrementalMerkleTree;
+typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::PedersenHash> SaplingTestingMerkleTree;
 
 typedef libzcash::IncrementalWitness<SAPLING_INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::PedersenHash> SaplingWitness;
-typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::PedersenHash> ZCSaplingTestingIncrementalWitness;
+typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::PedersenHash> SaplingTestingWitness;
 
 #endif /* ZC_INCREMENTALMERKLETREE_H_ */

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -248,13 +248,13 @@ EmptyMerkleRoots<Depth, Hash> IncrementalMerkleTree<Depth, Hash>::emptyroots;
 
 } // end namespace `libzcash`
 
-typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::SHA256Compress> ZCIncrementalMerkleTree;
+typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::SHA256Compress> SproutMerkleTree;
 typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::SHA256Compress> ZCTestingIncrementalMerkleTree;
 
 typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::SHA256Compress> ZCIncrementalWitness;
 typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::SHA256Compress> ZCTestingIncrementalWitness;
 
-typedef libzcash::IncrementalMerkleTree<SAPLING_INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::PedersenHash> ZCSaplingIncrementalMerkleTree;
+typedef libzcash::IncrementalMerkleTree<SAPLING_INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::PedersenHash> SaplingMerkleTree;
 typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::PedersenHash> ZCSaplingTestingIncrementalMerkleTree;
 
 typedef libzcash::IncrementalWitness<SAPLING_INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::PedersenHash> ZCSaplingIncrementalWitness;

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -251,13 +251,13 @@ EmptyMerkleRoots<Depth, Hash> IncrementalMerkleTree<Depth, Hash>::emptyroots;
 typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::SHA256Compress> SproutMerkleTree;
 typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::SHA256Compress> ZCTestingIncrementalMerkleTree;
 
-typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::SHA256Compress> ZCIncrementalWitness;
+typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::SHA256Compress> SproutWitness;
 typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::SHA256Compress> ZCTestingIncrementalWitness;
 
 typedef libzcash::IncrementalMerkleTree<SAPLING_INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::PedersenHash> SaplingMerkleTree;
 typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::PedersenHash> ZCSaplingTestingIncrementalMerkleTree;
 
-typedef libzcash::IncrementalWitness<SAPLING_INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::PedersenHash> ZCSaplingIncrementalWitness;
+typedef libzcash::IncrementalWitness<SAPLING_INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::PedersenHash> SaplingWitness;
 typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::PedersenHash> ZCSaplingTestingIncrementalWitness;
 
 #endif /* ZC_INCREMENTALMERKLETREE_H_ */

--- a/src/zcash/JoinSplit.cpp
+++ b/src/zcash/JoinSplit.cpp
@@ -428,10 +428,10 @@ JSOutput::JSOutput() : addr(uint256(), uint256()), value(0) {
     addr = a_sk.address();
 }
 
-JSInput::JSInput() : witness(ZCIncrementalMerkleTree().witness()),
+JSInput::JSInput() : witness(SproutMerkleTree().witness()),
                      key(SproutSpendingKey::random()) {
     note = SproutNote(key.address().a_pk, 0, random_uint256(), random_uint256());
-    ZCIncrementalMerkleTree dummy_tree;
+    SproutMerkleTree dummy_tree;
     dummy_tree.append(note.cm());
     witness = dummy_tree.witness();
 }

--- a/src/zcash/JoinSplit.hpp
+++ b/src/zcash/JoinSplit.hpp
@@ -25,12 +25,12 @@ typedef boost::variant<PHGRProof, GrothProof> SproutProof;
 
 class JSInput {
 public:
-    ZCIncrementalWitness witness;
+    SproutWitness witness;
     SproutNote note;
     SproutSpendingKey key;
 
     JSInput();
-    JSInput(ZCIncrementalWitness witness,
+    JSInput(SproutWitness witness,
             SproutNote note,
             SproutSpendingKey key) : witness(witness), note(note), key(key) { }
 

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -112,7 +112,7 @@ double benchmark_create_joinsplit()
     uint256 joinSplitPubKey;
 
     /* Get the anchor of an empty commitment tree. */
-    uint256 anchor = ZCIncrementalMerkleTree().root();
+    uint256 anchor = SproutMerkleTree().root();
 
     struct timeval tv_start;
     timer_start(tv_start);
@@ -298,8 +298,8 @@ double benchmark_try_decrypt_notes(size_t nAddrs)
 double benchmark_increment_note_witnesses(size_t nTxs)
 {
     CWallet wallet;
-    ZCIncrementalMerkleTree sproutTree;
-    ZCSaplingIncrementalMerkleTree saplingTree;
+    SproutMerkleTree sproutTree;
+    SaplingMerkleTree saplingTree;
 
     auto sk = libzcash::SproutSpendingKey::random();
     wallet.AddSpendingKey(sk);
@@ -355,12 +355,12 @@ double benchmark_increment_note_witnesses(size_t nTxs)
 // Fake the input of a given block
 class FakeCoinsViewDB : public CCoinsViewDB {
     uint256 hash;
-    ZCIncrementalMerkleTree t;
+    SproutMerkleTree t;
 
 public:
     FakeCoinsViewDB(std::string dbName, uint256& hash) : CCoinsViewDB(dbName, 100, false, false), hash(hash) {}
 
-    bool GetAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const {
+    bool GetAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const {
         if (rt == t.root()) {
             tree = t;
             return true;


### PR DESCRIPTION
This is to be consistent with the naming convention we have been using to distinguish Sprout/Sapling.