### PR TITLE
Cache Sapling witnesses in the wallet

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -149,6 +149,11 @@ std::string COutPoint::ToString() const
     return strprintf("COutPoint(%s, %u)", hash.ToString().substr(0,10), n);
 }
 
+std::string SaplingOutPoint::ToString() const
+{
+    return strprintf("SaplingOutPoint(%s, %u)", hash.ToString().substr(0, 10), n);
+}
+
 CTxIn::CTxIn(COutPoint prevoutIn, CScript scriptSigIn, uint32_t nSequenceIn)
 {
     prevout = prevoutIn;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -309,15 +309,14 @@ public:
     }
 };
 
-/** An outpoint - a combination of a transaction hash and an index n into its vout */
-class COutPoint
+class BaseOutPoint
 {
 public:
     uint256 hash;
     uint32_t n;
 
-    COutPoint() { SetNull(); }
-    COutPoint(uint256 hashIn, uint32_t nIn) { hash = hashIn; n = nIn; }
+    BaseOutPoint() { SetNull(); }
+    BaseOutPoint(uint256 hashIn, uint32_t nIn) { hash = hashIn; n = nIn; }
 
     ADD_SERIALIZE_METHODS;
 
@@ -330,21 +329,38 @@ public:
     void SetNull() { hash.SetNull(); n = (uint32_t) -1; }
     bool IsNull() const { return (hash.IsNull() && n == (uint32_t) -1); }
 
-    friend bool operator<(const COutPoint& a, const COutPoint& b)
+    friend bool operator<(const BaseOutPoint& a, const BaseOutPoint& b)
     {
         return (a.hash < b.hash || (a.hash == b.hash && a.n < b.n));
     }
 
-    friend bool operator==(const COutPoint& a, const COutPoint& b)
+    friend bool operator==(const BaseOutPoint& a, const BaseOutPoint& b)
     {
         return (a.hash == b.hash && a.n == b.n);
     }
 
-    friend bool operator!=(const COutPoint& a, const COutPoint& b)
+    friend bool operator!=(const BaseOutPoint& a, const BaseOutPoint& b)
     {
         return !(a == b);
     }
+};
 
+/** An outpoint - a combination of a transaction hash and an index n into its vout */
+class COutPoint : public BaseOutPoint
+{
+public:
+    COutPoint() : BaseOutPoint() {};
+    COutPoint(uint256 hashIn, uint32_t nIn) : BaseOutPoint(hashIn, nIn) {};
+    std::string ToString() const;
+};
+
+/** An outpoint - a combination of a transaction hash and an index n into its sapling
+ * output description (vShieldedOutput) */
+class SaplingOutPoint : public BaseOutPoint
+{
+public:
+    SaplingOutPoint() : BaseOutPoint() {};
+    SaplingOutPoint(uint256 hashIn, uint32_t nIn) : BaseOutPoint(hashIn, nIn) {}; 
     std::string ToString() const;
 };
 

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -10,9 +10,10 @@
 
 CWalletTx GetValidReceive(ZCJoinSplit& params,
                           const libzcash::SproutSpendingKey& sk, CAmount value,
-                          bool randomInputs) {
+                          bool randomInputs,
+                          int32_t version /* = 2 */) {
     CMutableTransaction mtx;
-    mtx.nVersion = 2; // Enable JoinSplits
+    mtx.nVersion = version;
     mtx.vin.resize(2);
     if (randomInputs) {
         mtx.vin[0].prevout.hash = GetRandHash();
@@ -46,9 +47,11 @@ CWalletTx GetValidReceive(ZCJoinSplit& params,
                           inputs, outputs, 2*value, 0, false};
     mtx.vjoinsplit.push_back(jsdesc);
 
-    // Shielded Output
-    OutputDescription od;
-    mtx.vShieldedOutput.push_back(od);
+    if (version >= 4) {
+        // Shielded Output
+        OutputDescription od;
+        mtx.vShieldedOutput.push_back(od);
+    }
 
     // Empty output script.
     uint32_t consensusBranchId = SPROUT_BRANCH_ID;

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -46,6 +46,10 @@ CWalletTx GetValidReceive(ZCJoinSplit& params,
                           inputs, outputs, 2*value, 0, false};
     mtx.vjoinsplit.push_back(jsdesc);
 
+    // Shielded Output
+    OutputDescription od;
+    mtx.vShieldedOutput.push_back(od);
+
     // Empty output script.
     uint32_t consensusBranchId = SPROUT_BRANCH_ID;
     CScript scriptCode;

--- a/src/utiltest.h
+++ b/src/utiltest.h
@@ -9,7 +9,8 @@
 
 CWalletTx GetValidReceive(ZCJoinSplit& params,
                           const libzcash::SproutSpendingKey& sk, CAmount value,
-                          bool randomInputs);
+                          bool randomInputs,
+                          int32_t version = 2);
 libzcash::SproutNote GetNote(ZCJoinSplit& params,
                        const libzcash::SproutSpendingKey& sk,
                        const CTransaction& tx, size_t js, size_t n);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,7 +17,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
     g_signals.EraseTransaction.connect(boost::bind(&CValidationInterface::EraseFromWallet, pwalletIn, _1));
     g_signals.UpdatedTransaction.connect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
-    g_signals.ChainTip.connect(boost::bind(&CValidationInterface::ChainTip, pwalletIn, _1, _2, _3, _4));
+    g_signals.ChainTip.connect(boost::bind(&CValidationInterface::ChainTip, pwalletIn, _1, _2, _3, _4, _5));
     g_signals.SetBestChain.connect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.Broadcast.connect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));
@@ -28,7 +28,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.BlockChecked.disconnect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
     g_signals.Broadcast.disconnect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));
     g_signals.Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
-    g_signals.ChainTip.disconnect(boost::bind(&CValidationInterface::ChainTip, pwalletIn, _1, _2, _3, _4));
+    g_signals.ChainTip.disconnect(boost::bind(&CValidationInterface::ChainTip, pwalletIn, _1, _2, _3, _4, _5));
     g_signals.SetBestChain.disconnect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.UpdatedTransaction.disconnect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.EraseTransaction.disconnect(boost::bind(&CValidationInterface::EraseFromWallet, pwalletIn, _1));

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -34,7 +34,7 @@ protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindex) {}
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
     virtual void EraseFromWallet(const uint256 &hash) {}
-    virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, ZCIncrementalMerkleTree tree, bool added) {}
+    virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, ZCIncrementalMerkleTree sproutTree, ZCSaplingIncrementalMerkleTree saplingTree, bool added) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual void UpdatedTransaction(const uint256 &hash) {}
     virtual void Inventory(const uint256 &hash) {}
@@ -55,7 +55,7 @@ struct CMainSignals {
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming visible). */
     boost::signals2::signal<void (const uint256 &)> UpdatedTransaction;
     /** Notifies listeners of a change to the tip of the active block chain. */
-    boost::signals2::signal<void (const CBlockIndex *, const CBlock *, ZCIncrementalMerkleTree, bool)> ChainTip;
+    boost::signals2::signal<void (const CBlockIndex *, const CBlock *, ZCIncrementalMerkleTree, ZCSaplingIncrementalMerkleTree, bool)> ChainTip;
     /** Notifies listeners of a new active block chain. */
     boost::signals2::signal<void (const CBlockLocator &)> SetBestChain;
     /** Notifies listeners about an inventory item being seen on the network. */

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -343,7 +343,7 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
             std::vector<JSOutPoint> vOutPoints = {jso};
             uint256 inputAnchor;
             std::vector<boost::optional<ZCIncrementalWitness>> vInputWitnesses;
-            pwalletMain->GetNoteWitnesses(vOutPoints, vInputWitnesses, inputAnchor);
+            pwalletMain->GetSproutNoteWitnesses(vOutPoints, vInputWitnesses, inputAnchor);
             jsopWitnessAnchorMap[jso.ToString()] = MergeToAddressWitnessAnchorData{vInputWitnesses[0], inputAnchor};
         }
     }
@@ -711,7 +711,7 @@ UniValue AsyncRPCOperation_mergetoaddress::perform_joinsplit(MergeToAddressJSInf
     uint256 anchor;
     {
         LOCK(cs_main);
-        pwalletMain->GetNoteWitnesses(outPoints, witnesses, anchor);
+        pwalletMain->GetSproutNoteWitnesses(outPoints, witnesses, anchor);
     }
     return perform_joinsplit(info, witnesses, anchor);
 }

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -420,7 +420,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
             std::vector<JSOutPoint> vOutPoints = { jso };
             uint256 inputAnchor;
             std::vector<boost::optional<ZCIncrementalWitness>> vInputWitnesses;
-            pwalletMain->GetNoteWitnesses(vOutPoints, vInputWitnesses, inputAnchor);
+            pwalletMain->GetSproutNoteWitnesses(vOutPoints, vInputWitnesses, inputAnchor);
             jsopWitnessAnchorMap[ jso.ToString() ] = WitnessAnchorData{ vInputWitnesses[0], inputAnchor };
         }
     }
@@ -935,7 +935,7 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(AsyncJoinSplitInfo & info
     uint256 anchor;
     {
         LOCK(cs_main);
-        pwalletMain->GetNoteWitnesses(outPoints, witnesses, anchor);
+        pwalletMain->GetSproutNoteWitnesses(outPoints, witnesses, anchor);
     }
     return perform_joinsplit(info, witnesses, anchor);
 }

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -97,7 +97,7 @@ JSOutPoint CreateValidBlock(TestWallet& wallet,
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
     SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
-    wtx.SetNoteData(noteData);
+    wtx.SetSproutNoteData(noteData);
     wallet.AddToWallet(wtx, true, NULL);
 
     block.vtx.push_back(wtx);
@@ -152,7 +152,7 @@ TEST(wallet_tests, find_unspent_notes) {
     SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
-    wtx.SetNoteData(noteData);
+    wtx.SetSproutNoteData(noteData);
     wallet.AddToWallet(wtx, true, NULL);
     EXPECT_FALSE(wallet.IsSpent(nullifier));
 
@@ -247,7 +247,7 @@ TEST(wallet_tests, find_unspent_notes) {
         SproutNoteData nd {sk.address(), nullifier};
         noteData[jsoutpt] = nd;
 
-        wtx.SetNoteData(noteData);
+        wtx.SetSproutNoteData(noteData);
         wallet.AddToWallet(wtx, true, NULL);
         EXPECT_FALSE(wallet.IsSpent(nullifier));
 
@@ -308,7 +308,7 @@ TEST(wallet_tests, set_note_addrs_in_cwallettx) {
     SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
-    wtx.SetNoteData(noteData);
+    wtx.SetSproutNoteData(noteData);
     EXPECT_EQ(noteData, wtx.mapSproutNoteData);
 }
 
@@ -322,7 +322,7 @@ TEST(wallet_tests, set_invalid_note_addrs_in_cwallettx) {
     SproutNoteData nd {sk.address(), uint256()};
     noteData[jsoutpt] = nd;
 
-    EXPECT_THROW(wtx.SetNoteData(noteData), std::logic_error);
+    EXPECT_THROW(wtx.SetSproutNoteData(noteData), std::logic_error);
 }
 
 TEST(wallet_tests, GetNoteNullifier) {
@@ -497,7 +497,7 @@ TEST(wallet_tests, navigate_from_nullifier_to_note) {
     SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
-    wtx.SetNoteData(noteData);
+    wtx.SetSproutNoteData(noteData);
 
     EXPECT_EQ(0, wallet.mapNullifiersToNotes.count(nullifier));
 
@@ -527,7 +527,7 @@ TEST(wallet_tests, spent_note_is_from_me) {
     SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
-    wtx.SetNoteData(noteData);
+    wtx.SetSproutNoteData(noteData);
     EXPECT_FALSE(wallet.IsFromMe(wtx));
     EXPECT_FALSE(wallet.IsFromMe(wtx2));
 
@@ -555,19 +555,19 @@ TEST(wallet_tests, cached_witnesses_empty_chain) {
     SproutNoteData nd2 {sk.address(), nullifier2};
     noteData[jsoutpt] = nd;
     noteData[jsoutpt2] = nd2;
-    wtx.SetNoteData(noteData);
+    wtx.SetSproutNoteData(noteData);
 
     std::vector<JSOutPoint> notes {jsoutpt, jsoutpt2};
     std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
     uint256 anchor;
 
-    wallet.GetNoteWitnesses(notes, witnesses, anchor);
+    wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
     EXPECT_FALSE((bool) witnesses[0]);
     EXPECT_FALSE((bool) witnesses[1]);
 
     wallet.AddToWallet(wtx, true, NULL);
     witnesses.clear();
-    wallet.GetNoteWitnesses(notes, witnesses, anchor);
+    wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
     EXPECT_FALSE((bool) witnesses[0]);
     EXPECT_FALSE((bool) witnesses[1]);
 
@@ -578,7 +578,7 @@ TEST(wallet_tests, cached_witnesses_empty_chain) {
     ZCSaplingIncrementalMerkleTree saplingTree;
     wallet.IncrementNoteWitnesses(&index, &block, sproutTree, saplingTree);
     witnesses.clear();
-    wallet.GetNoteWitnesses(notes, witnesses, anchor);
+    wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
     EXPECT_TRUE((bool) witnesses[0]);
     EXPECT_TRUE((bool) witnesses[1]);
 
@@ -606,7 +606,7 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         // Called to fetch anchor
         std::vector<JSOutPoint> notes {jsoutpt};
         std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
-        wallet.GetNoteWitnesses(notes, witnesses, anchor1);
+        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor1);
     }
 
     {
@@ -619,14 +619,14 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
         SproutNoteData nd {sk.address(), nullifier};
         noteData[jsoutpt] = nd;
-        wtx.SetNoteData(noteData);
+        wtx.SetSproutNoteData(noteData);
         wallet.AddToWallet(wtx, true, NULL);
 
         std::vector<JSOutPoint> notes {jsoutpt};
         std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
         uint256 anchor2;
 
-        wallet.GetNoteWitnesses(notes, witnesses, anchor2);
+        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor2);
         EXPECT_FALSE((bool) witnesses[0]);
 
         // Second block
@@ -639,7 +639,7 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         ZCSaplingIncrementalMerkleTree saplingTree2 {saplingTree};
         wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree2, saplingTree2);
         witnesses.clear();
-        wallet.GetNoteWitnesses(notes, witnesses, anchor2);
+        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor2);
         EXPECT_TRUE((bool) witnesses[0]);
         EXPECT_NE(anchor1, anchor2);
 
@@ -647,7 +647,7 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         uint256 anchor3;
         wallet.DecrementNoteWitnesses(&index2);
         witnesses.clear();
-        wallet.GetNoteWitnesses(notes, witnesses, anchor3);
+        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor3);
         EXPECT_FALSE((bool) witnesses[0]);
         // Should not equal first anchor because none of these notes had witnesses
         EXPECT_NE(anchor1, anchor3);
@@ -656,7 +656,7 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         uint256 anchor4;
         wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
         witnesses.clear();
-        wallet.GetNoteWitnesses(notes, witnesses, anchor4);
+        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor4);
         EXPECT_TRUE((bool) witnesses[0]);
         EXPECT_EQ(anchor2, anchor4);
 
@@ -664,7 +664,7 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         uint256 anchor5;
         wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
         std::vector<boost::optional<ZCIncrementalWitness>> witnesses5;
-        wallet.GetNoteWitnesses(notes, witnesses5, anchor5);
+        wallet.GetSproutNoteWitnesses(notes, witnesses5, anchor5);
         EXPECT_EQ(witnesses, witnesses5);
         EXPECT_EQ(anchor4, anchor5);
     }
@@ -697,7 +697,7 @@ TEST(wallet_tests, CachedWitnessesDecrementFirst) {
         // Called to fetch anchor
         std::vector<JSOutPoint> notes {jsoutpt};
         std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
-        wallet.GetNoteWitnesses(notes, witnesses, anchor2);
+        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor2);
     }
 
     {
@@ -710,14 +710,14 @@ TEST(wallet_tests, CachedWitnessesDecrementFirst) {
         JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
         SproutNoteData nd {sk.address(), nullifier};
         noteData[jsoutpt] = nd;
-        wtx.SetNoteData(noteData);
+        wtx.SetSproutNoteData(noteData);
         wallet.AddToWallet(wtx, true, NULL);
 
         std::vector<JSOutPoint> notes {jsoutpt};
         std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
         uint256 anchor3;
 
-        wallet.GetNoteWitnesses(notes, witnesses, anchor3);
+        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor3);
         EXPECT_FALSE((bool) witnesses[0]);
 
         // Decrementing (before the transaction has ever seen an increment)
@@ -725,7 +725,7 @@ TEST(wallet_tests, CachedWitnessesDecrementFirst) {
         uint256 anchor4;
         wallet.DecrementNoteWitnesses(&index2);
         witnesses.clear();
-        wallet.GetNoteWitnesses(notes, witnesses, anchor4);
+        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor4);
         EXPECT_FALSE((bool) witnesses[0]);
         // Should not equal second anchor because none of these notes had witnesses
         EXPECT_NE(anchor2, anchor4);
@@ -734,7 +734,7 @@ TEST(wallet_tests, CachedWitnessesDecrementFirst) {
         uint256 anchor5;
         wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
         witnesses.clear();
-        wallet.GetNoteWitnesses(notes, witnesses, anchor5);
+        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor5);
         EXPECT_FALSE((bool) witnesses[0]);
         EXPECT_EQ(anchor3, anchor5);
     }
@@ -768,7 +768,7 @@ TEST(wallet_tests, CachedWitnessesCleanIndex) {
 
         witnesses.clear();
         uint256 anchor;
-        wallet.GetNoteWitnesses(notes, witnesses, anchor);
+        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
         for (size_t j = 0; j <= i; j++) {
             EXPECT_TRUE((bool) witnesses[j]);
         }
@@ -783,7 +783,7 @@ TEST(wallet_tests, CachedWitnessesCleanIndex) {
         wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), sproutRiTree, saplingRiTree);
         witnesses.clear();
         uint256 anchor;
-        wallet.GetNoteWitnesses(notes, witnesses, anchor);
+        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
         for (size_t j = 0; j < numBlocks; j++) {
             EXPECT_TRUE((bool) witnesses[j]);
         }
@@ -796,7 +796,7 @@ TEST(wallet_tests, CachedWitnessesCleanIndex) {
                 wallet.DecrementNoteWitnesses(&(indices[i]));
                 witnesses.clear();
                 uint256 anchor;
-                wallet.GetNoteWitnesses(notes, witnesses, anchor);
+                wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
                 for (size_t j = 0; j < numBlocks; j++) {
                     EXPECT_TRUE((bool) witnesses[j]);
                 }
@@ -808,7 +808,7 @@ TEST(wallet_tests, CachedWitnessesCleanIndex) {
                 wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), sproutRiPrevTree, saplingRiPrevTree);
                 witnesses.clear();
                 uint256 anchor;
-                wallet.GetNoteWitnesses(notes, witnesses, anchor);
+                wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
                 for (size_t j = 0; j < numBlocks; j++) {
                     EXPECT_TRUE((bool) witnesses[j]);
                 }
@@ -835,7 +835,7 @@ TEST(wallet_tests, ClearNoteWitnessCache) {
     JSOutPoint jsoutpt2 {wtx.GetHash(), 0, 1};
     SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
-    wtx.SetNoteData(noteData);
+    wtx.SetSproutNoteData(noteData);
 
     // Pretend we mined the tx by adding a fake witness
     ZCIncrementalMerkleTree tree;
@@ -850,7 +850,7 @@ TEST(wallet_tests, ClearNoteWitnessCache) {
     uint256 anchor2;
 
     // Before clearing, we should have a witness for one note
-    wallet.GetNoteWitnesses(notes, witnesses, anchor2);
+    wallet.GetSproutNoteWitnesses(notes, witnesses, anchor2);
     EXPECT_TRUE((bool) witnesses[0]);
     EXPECT_FALSE((bool) witnesses[1]);
     EXPECT_EQ(1, wallet.mapWallet[hash].mapSproutNoteData[jsoutpt].witnessHeight);
@@ -859,7 +859,7 @@ TEST(wallet_tests, ClearNoteWitnessCache) {
     // After clearing, we should not have a witness for either note
     wallet.ClearNoteWitnessCache();
     witnesses.clear();
-    wallet.GetNoteWitnesses(notes, witnesses, anchor2);
+    wallet.GetSproutNoteWitnesses(notes, witnesses, anchor2);
     EXPECT_FALSE((bool) witnesses[0]);
     EXPECT_FALSE((bool) witnesses[1]);
     EXPECT_EQ(-1, wallet.mapWallet[hash].mapSproutNoteData[jsoutpt].witnessHeight);
@@ -962,7 +962,7 @@ TEST(wallet_tests, UpdateNullifierNoteMap) {
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
     SproutNoteData nd {sk.address()};
     noteData[jsoutpt] = nd;
-    wtx.SetNoteData(noteData);
+    wtx.SetSproutNoteData(noteData);
 
     wallet.AddToWallet(wtx, true, NULL);
     EXPECT_EQ(0, wallet.mapNullifiersToNotes.count(nullifier));
@@ -997,7 +997,7 @@ TEST(wallet_tests, UpdatedNoteData) {
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 0};
     SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
-    wtx.SetNoteData(noteData);
+    wtx.SetSproutNoteData(noteData);
 
     // Pretend we mined the tx by adding a fake witness
     ZCIncrementalMerkleTree tree;
@@ -1010,7 +1010,7 @@ TEST(wallet_tests, UpdatedNoteData) {
     JSOutPoint jsoutpt2 {wtx2.GetHash(), 0, 1};
     SproutNoteData nd2 {sk.address(), nullifier2};
     noteData[jsoutpt2] = nd2;
-    wtx2.SetNoteData(noteData);
+    wtx2.SetSproutNoteData(noteData);
 
     // The txs should initially be different
     EXPECT_NE(wtx.mapSproutNoteData, wtx2.mapSproutNoteData);
@@ -1042,7 +1042,7 @@ TEST(wallet_tests, MarkAffectedTransactionsDirty) {
     SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
-    wtx.SetNoteData(noteData);
+    wtx.SetSproutNoteData(noteData);
     wallet.AddToWallet(wtx, true, NULL);
     wallet.MarkAffectedTransactionsDirty(wtx);
 

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -83,7 +83,17 @@ CWalletTx GetValidSpend(const libzcash::SproutSpendingKey& sk,
     return GetValidSpend(*params, sk, note, value);
 }
 
-JSOutPoint CreateValidBlock(TestWallet& wallet,
+std::vector<SaplingOutPoint> SetSaplingNoteData(CWalletTx& wtx) {
+    mapSaplingNoteData_t saplingNoteData;
+    SaplingOutPoint saplingOutPoint = {wtx.GetHash(), 0};
+    SaplingNoteData saplingNd;
+    saplingNoteData[saplingOutPoint] = saplingNd;
+    wtx.SetSaplingNoteData(saplingNoteData);
+    std::vector<SaplingOutPoint> saplingNotes {saplingOutPoint};
+    return saplingNotes;
+}
+
+std::pair<JSOutPoint, SaplingOutPoint> CreateValidBlock(TestWallet& wallet,
                             const libzcash::SproutSpendingKey& sk,
                             const CBlockIndex& index,
                             CBlock& block,
@@ -98,12 +108,27 @@ JSOutPoint CreateValidBlock(TestWallet& wallet,
     SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
     wtx.SetSproutNoteData(noteData);
+    auto saplingNotes = SetSaplingNoteData(wtx);
     wallet.AddToWallet(wtx, true, NULL);
 
     block.vtx.push_back(wtx);
     wallet.IncrementNoteWitnesses(&index, &block, sproutTree, saplingTree);
 
-    return jsoutpt;
+    return std::make_pair(jsoutpt, saplingNotes[0]);
+}
+
+std::pair<uint256, uint256> GetWitnessesAndAnchors(TestWallet& wallet,
+                                std::vector<JSOutPoint>& sproutNotes,
+                                std::vector<SaplingOutPoint>& saplingNotes,
+                                std::vector<boost::optional<ZCIncrementalWitness>>& sproutWitnesses,
+                                std::vector<boost::optional<ZCSaplingIncrementalWitness>>& saplingWitnesses) {
+    sproutWitnesses.clear();
+    saplingWitnesses.clear();
+    uint256 sproutAnchor;
+    uint256 saplingAnchor;
+    wallet.GetSproutNoteWitnesses(sproutNotes, sproutWitnesses, sproutAnchor);
+    wallet.GetSaplingNoteWitnesses(saplingNotes, saplingWitnesses, saplingAnchor);
+    return std::make_pair(sproutAnchor, saplingAnchor);
 }
 
 TEST(wallet_tests, setup_datadir_location_run_as_first_test) {
@@ -548,28 +573,34 @@ TEST(wallet_tests, cached_witnesses_empty_chain) {
     auto nullifier = note.nullifier(sk);
     auto nullifier2 = note2.nullifier(sk);
 
-    mapSproutNoteData_t noteData;
+    mapSproutNoteData_t sproutNoteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 0};
     JSOutPoint jsoutpt2 {wtx.GetHash(), 0, 1};
     SproutNoteData nd {sk.address(), nullifier};
     SproutNoteData nd2 {sk.address(), nullifier2};
-    noteData[jsoutpt] = nd;
-    noteData[jsoutpt2] = nd2;
-    wtx.SetSproutNoteData(noteData);
+    sproutNoteData[jsoutpt] = nd;
+    sproutNoteData[jsoutpt2] = nd2;
+    wtx.SetSproutNoteData(sproutNoteData);
 
-    std::vector<JSOutPoint> notes {jsoutpt, jsoutpt2};
-    std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
-    uint256 anchor;
+    std::vector<JSOutPoint> sproutNotes {jsoutpt, jsoutpt2};
+    std::vector<SaplingOutPoint> saplingNotes = SetSaplingNoteData(wtx);
 
-    wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
-    EXPECT_FALSE((bool) witnesses[0]);
-    EXPECT_FALSE((bool) witnesses[1]);
+    std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
+    std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
+
+    ::GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+
+    EXPECT_FALSE((bool) sproutWitnesses[0]);
+    EXPECT_FALSE((bool) sproutWitnesses[1]);
+    EXPECT_FALSE((bool) saplingWitnesses[0]);
 
     wallet.AddToWallet(wtx, true, NULL);
-    witnesses.clear();
-    wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
-    EXPECT_FALSE((bool) witnesses[0]);
-    EXPECT_FALSE((bool) witnesses[1]);
+
+    ::GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+
+    EXPECT_FALSE((bool) sproutWitnesses[0]);
+    EXPECT_FALSE((bool) sproutWitnesses[1]);
+    EXPECT_FALSE((bool) saplingWitnesses[0]);
 
     CBlock block;
     block.vtx.push_back(wtx);
@@ -577,10 +608,12 @@ TEST(wallet_tests, cached_witnesses_empty_chain) {
     ZCIncrementalMerkleTree sproutTree;
     ZCSaplingIncrementalMerkleTree saplingTree;
     wallet.IncrementNoteWitnesses(&index, &block, sproutTree, saplingTree);
-    witnesses.clear();
-    wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
-    EXPECT_TRUE((bool) witnesses[0]);
-    EXPECT_TRUE((bool) witnesses[1]);
+
+    ::GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+
+    EXPECT_TRUE((bool) sproutWitnesses[0]);
+    EXPECT_TRUE((bool) sproutWitnesses[1]);
+    EXPECT_TRUE((bool) saplingWitnesses[0]);
 
     // Until #1302 is implemented, this should triggger an assertion
     EXPECT_DEATH(wallet.DecrementNoteWitnesses(&index),
@@ -589,7 +622,7 @@ TEST(wallet_tests, cached_witnesses_empty_chain) {
 
 TEST(wallet_tests, cached_witnesses_chain_tip) {
     TestWallet wallet;
-    uint256 anchor1;
+    std::pair<uint256, uint256> anchors1;
     CBlock block1;
     ZCIncrementalMerkleTree sproutTree;
     ZCSaplingIncrementalMerkleTree saplingTree;
@@ -601,12 +634,16 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         // First block (case tested in _empty_chain)
         CBlockIndex index1(block1);
         index1.nHeight = 1;
-        auto jsoutpt = CreateValidBlock(wallet, sk, index1, block1, sproutTree, saplingTree);
+        auto outpts = CreateValidBlock(wallet, sk, index1, block1, sproutTree, saplingTree);
 
         // Called to fetch anchor
-        std::vector<JSOutPoint> notes {jsoutpt};
-        std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
-        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor1);
+        std::vector<JSOutPoint> sproutNotes {outpts.first};
+        std::vector<SaplingOutPoint> saplingNotes {outpts.second};
+        std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
+        std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
+
+        anchors1 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+        EXPECT_NE(anchors1.first, anchors1.second);
     }
 
     {
@@ -615,19 +652,22 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         auto note = GetNote(sk, wtx, 0, 1);
         auto nullifier = note.nullifier(sk);
 
-        mapSproutNoteData_t noteData;
+        mapSproutNoteData_t sproutNoteData;
         JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
         SproutNoteData nd {sk.address(), nullifier};
-        noteData[jsoutpt] = nd;
-        wtx.SetSproutNoteData(noteData);
+        sproutNoteData[jsoutpt] = nd;
+        wtx.SetSproutNoteData(sproutNoteData);
+        std::vector<SaplingOutPoint> saplingNotes = SetSaplingNoteData(wtx);
         wallet.AddToWallet(wtx, true, NULL);
 
-        std::vector<JSOutPoint> notes {jsoutpt};
-        std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
-        uint256 anchor2;
+        std::vector<JSOutPoint> sproutNotes {jsoutpt};
+        std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
+        std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
 
-        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor2);
-        EXPECT_FALSE((bool) witnesses[0]);
+        GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+
+        EXPECT_FALSE((bool) sproutWitnesses[0]);
+        EXPECT_FALSE((bool) saplingWitnesses[0]);
 
         // Second block
         CBlock block2;
@@ -638,43 +678,52 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         ZCIncrementalMerkleTree sproutTree2 {sproutTree};
         ZCSaplingIncrementalMerkleTree saplingTree2 {saplingTree};
         wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree2, saplingTree2);
-        witnesses.clear();
-        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor2);
-        EXPECT_TRUE((bool) witnesses[0]);
-        EXPECT_NE(anchor1, anchor2);
+
+        auto anchors2 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+        EXPECT_NE(anchors2.first, anchors2.second);
+
+        EXPECT_TRUE((bool) sproutWitnesses[0]);
+        EXPECT_TRUE((bool) saplingWitnesses[0]);
+        EXPECT_NE(anchors1.first, anchors2.first);
+        EXPECT_NE(anchors1.second, anchors2.second);
 
         // Decrementing should give us the previous anchor
-        uint256 anchor3;
         wallet.DecrementNoteWitnesses(&index2);
-        witnesses.clear();
-        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor3);
-        EXPECT_FALSE((bool) witnesses[0]);
+        auto anchors3 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+
+        EXPECT_FALSE((bool) sproutWitnesses[0]);
+        EXPECT_FALSE((bool) saplingWitnesses[0]);
         // Should not equal first anchor because none of these notes had witnesses
-        EXPECT_NE(anchor1, anchor3);
+        EXPECT_NE(anchors1.first, anchors3.first);
+        EXPECT_NE(anchors1.second, anchors3.second);
 
         // Re-incrementing with the same block should give the same result
-        uint256 anchor4;
         wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
-        witnesses.clear();
-        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor4);
-        EXPECT_TRUE((bool) witnesses[0]);
-        EXPECT_EQ(anchor2, anchor4);
+        auto anchors4 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+        EXPECT_NE(anchors4.first, anchors4.second);
+
+        EXPECT_TRUE((bool) sproutWitnesses[0]);
+        EXPECT_TRUE((bool) saplingWitnesses[0]);
+        EXPECT_EQ(anchors2.first, anchors4.first);
+        EXPECT_EQ(anchors2.second, anchors4.second);
 
         // Incrementing with the same block again should not change the cache
-        uint256 anchor5;
         wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
-        std::vector<boost::optional<ZCIncrementalWitness>> witnesses5;
-        wallet.GetSproutNoteWitnesses(notes, witnesses5, anchor5);
-        EXPECT_EQ(witnesses, witnesses5);
-        EXPECT_EQ(anchor4, anchor5);
+        std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses5;
+        std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses5;
+
+        auto anchors5 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses5, saplingWitnesses5);
+        EXPECT_NE(anchors5.first, anchors5.second);
+
+        EXPECT_EQ(sproutWitnesses, sproutWitnesses5);
+        EXPECT_EQ(saplingWitnesses, saplingWitnesses5);
+        EXPECT_EQ(anchors4.first, anchors5.first);
+        EXPECT_EQ(anchors4.second, anchors5.second);
     }
 }
 
 TEST(wallet_tests, CachedWitnessesDecrementFirst) {
     TestWallet wallet;
-    uint256 anchor2;
-    CBlock block2;
-    CBlockIndex index2(block2);
     ZCIncrementalMerkleTree sproutTree;
     ZCSaplingIncrementalMerkleTree saplingTree;
 
@@ -689,18 +738,24 @@ TEST(wallet_tests, CachedWitnessesDecrementFirst) {
         CreateValidBlock(wallet, sk, index1, block1, sproutTree, saplingTree);
     }
 
+    std::pair<uint256, uint256> anchors2;
+    CBlock block2;
+    CBlockIndex index2(block2);
+
     {
         // Second block (case tested in _chain_tip)
         index2.nHeight = 2;
-        auto jsoutpt = CreateValidBlock(wallet, sk, index2, block2, sproutTree, saplingTree);
+        auto outpts = CreateValidBlock(wallet, sk, index2, block2, sproutTree, saplingTree);
 
         // Called to fetch anchor
-        std::vector<JSOutPoint> notes {jsoutpt};
-        std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
-        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor2);
+        std::vector<JSOutPoint> sproutNotes {outpts.first};
+        std::vector<SaplingOutPoint> saplingNotes {outpts.second};
+        std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
+        std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
+        anchors2 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
     }
 
-    {
+{
         // Third transaction - never mined
         auto wtx = GetValidReceive(sk, 20, true);
         auto note = GetNote(sk, wtx, 0, 1);
@@ -711,32 +766,39 @@ TEST(wallet_tests, CachedWitnessesDecrementFirst) {
         SproutNoteData nd {sk.address(), nullifier};
         noteData[jsoutpt] = nd;
         wtx.SetSproutNoteData(noteData);
+        std::vector<SaplingOutPoint> saplingNotes = SetSaplingNoteData(wtx);
         wallet.AddToWallet(wtx, true, NULL);
 
-        std::vector<JSOutPoint> notes {jsoutpt};
-        std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
-        uint256 anchor3;
+        std::vector<JSOutPoint> sproutNotes {jsoutpt};
+        std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
+        std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
 
-        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor3);
-        EXPECT_FALSE((bool) witnesses[0]);
+        auto anchors3 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+
+        EXPECT_FALSE((bool) sproutWitnesses[0]);
+        EXPECT_FALSE((bool) saplingWitnesses[0]);
 
         // Decrementing (before the transaction has ever seen an increment)
         // should give us the previous anchor
-        uint256 anchor4;
         wallet.DecrementNoteWitnesses(&index2);
-        witnesses.clear();
-        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor4);
-        EXPECT_FALSE((bool) witnesses[0]);
+
+        auto anchors4 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+
+        EXPECT_FALSE((bool) sproutWitnesses[0]);
+        EXPECT_FALSE((bool) saplingWitnesses[0]);
         // Should not equal second anchor because none of these notes had witnesses
-        EXPECT_NE(anchor2, anchor4);
+        EXPECT_NE(anchors2.first, anchors4.first);
+        EXPECT_NE(anchors2.second, anchors4.second);
 
         // Re-incrementing with the same block should give the same result
-        uint256 anchor5;
         wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
-        witnesses.clear();
-        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor5);
-        EXPECT_FALSE((bool) witnesses[0]);
-        EXPECT_EQ(anchor3, anchor5);
+
+        auto anchors5 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+
+        EXPECT_FALSE((bool) sproutWitnesses[0]);
+        EXPECT_FALSE((bool) saplingWitnesses[0]);
+        EXPECT_EQ(anchors3.first, anchors5.first);
+        EXPECT_EQ(anchors3.second, anchors5.second);
     }
 }
 
@@ -744,13 +806,16 @@ TEST(wallet_tests, CachedWitnessesCleanIndex) {
     TestWallet wallet;
     std::vector<CBlock> blocks;
     std::vector<CBlockIndex> indices;
-    std::vector<JSOutPoint> notes;
-    std::vector<uint256> anchors;
+    std::vector<JSOutPoint> sproutNotes;
+    std::vector<SaplingOutPoint> saplingNotes;
+    std::vector<uint256> sproutAnchors;
+    std::vector<uint256> saplingAnchors;
     ZCIncrementalMerkleTree sproutTree;
     ZCIncrementalMerkleTree sproutRiTree = sproutTree;
     ZCSaplingIncrementalMerkleTree saplingTree;
     ZCSaplingIncrementalMerkleTree saplingRiTree = saplingTree;
-    std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
+    std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
+    std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
 
     auto sk = libzcash::SproutSpendingKey::random();
     wallet.AddSpendingKey(sk);
@@ -761,18 +826,21 @@ TEST(wallet_tests, CachedWitnessesCleanIndex) {
     indices.resize(numBlocks);
     for (size_t i = 0; i < numBlocks; i++) {
         indices[i].nHeight = i;
-        auto old = sproutTree.root();
-        auto jsoutpt = CreateValidBlock(wallet, sk, indices[i], blocks[i], sproutTree, saplingTree);
-        EXPECT_NE(old, sproutTree.root());
-        notes.push_back(jsoutpt);
+        auto oldSproutRoot = sproutTree.root();
+        auto oldSaplingRoot = saplingTree.root();
+        auto outpts = CreateValidBlock(wallet, sk, indices[i], blocks[i], sproutTree, saplingTree);
+        EXPECT_NE(oldSproutRoot, sproutTree.root());
+        EXPECT_NE(oldSaplingRoot, saplingTree.root());
+        sproutNotes.push_back(outpts.first);
+        saplingNotes.push_back(outpts.second);
 
-        witnesses.clear();
-        uint256 anchor;
-        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
+        auto anchors = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
         for (size_t j = 0; j <= i; j++) {
-            EXPECT_TRUE((bool) witnesses[j]);
+            EXPECT_TRUE((bool) sproutWitnesses[j]);
+            EXPECT_TRUE((bool) saplingWitnesses[j]);
         }
-        anchors.push_back(anchor);
+        sproutAnchors.push_back(anchors.first);
+        saplingAnchors.push_back(anchors.second);
     }
 
     // Now pretend we are reindexing: the chain is cleared, and each block is
@@ -781,39 +849,41 @@ TEST(wallet_tests, CachedWitnessesCleanIndex) {
         ZCIncrementalMerkleTree sproutRiPrevTree {sproutRiTree};
         ZCSaplingIncrementalMerkleTree saplingRiPrevTree {saplingRiTree};
         wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), sproutRiTree, saplingRiTree);
-        witnesses.clear();
-        uint256 anchor;
-        wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
+
+        auto anchors = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
         for (size_t j = 0; j < numBlocks; j++) {
-            EXPECT_TRUE((bool) witnesses[j]);
+            EXPECT_TRUE((bool) sproutWitnesses[j]);
+            EXPECT_TRUE((bool) saplingWitnesses[j]);
         }
         // Should equal final anchor because witness cache unaffected
-        EXPECT_EQ(anchors.back(), anchor);
+        EXPECT_EQ(sproutAnchors.back(), anchors.first);
+        EXPECT_EQ(saplingAnchors.back(), anchors.second);
 
         if ((i == 5) || (i == 50)) {
             // Pretend a reorg happened that was recorded in the block files
             {
                 wallet.DecrementNoteWitnesses(&(indices[i]));
-                witnesses.clear();
-                uint256 anchor;
-                wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
+
+                auto anchors = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
                 for (size_t j = 0; j < numBlocks; j++) {
-                    EXPECT_TRUE((bool) witnesses[j]);
+                    EXPECT_TRUE((bool) sproutWitnesses[j]);
+                    EXPECT_TRUE((bool) saplingWitnesses[j]);
                 }
                 // Should equal final anchor because witness cache unaffected
-                EXPECT_EQ(anchors.back(), anchor);
+                EXPECT_EQ(sproutAnchors.back(), anchors.first);
+                EXPECT_EQ(saplingAnchors.back(), anchors.second);
             }
 
             {
                 wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), sproutRiPrevTree, saplingRiPrevTree);
-                witnesses.clear();
-                uint256 anchor;
-                wallet.GetSproutNoteWitnesses(notes, witnesses, anchor);
+                auto anchors = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
                 for (size_t j = 0; j < numBlocks; j++) {
-                    EXPECT_TRUE((bool) witnesses[j]);
+                    EXPECT_TRUE((bool) sproutWitnesses[j]);
+                    EXPECT_TRUE((bool) saplingWitnesses[j]);
                 }
                 // Should equal final anchor because witness cache unaffected
-                EXPECT_EQ(anchors.back(), anchor);
+                EXPECT_EQ(sproutAnchors.back(), anchors.first);
+                EXPECT_EQ(saplingAnchors.back(), anchors.second);
             }
         }
     }
@@ -836,33 +906,44 @@ TEST(wallet_tests, ClearNoteWitnessCache) {
     SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
     wtx.SetSproutNoteData(noteData);
+    auto saplingNotes = SetSaplingNoteData(wtx);
 
     // Pretend we mined the tx by adding a fake witness
-    ZCIncrementalMerkleTree tree;
-    wtx.mapSproutNoteData[jsoutpt].witnesses.push_front(tree.witness());
+    ZCIncrementalMerkleTree sproutTree;
+    wtx.mapSproutNoteData[jsoutpt].witnesses.push_front(sproutTree.witness());
     wtx.mapSproutNoteData[jsoutpt].witnessHeight = 1;
     wallet.nWitnessCacheSize = 1;
 
+    ZCSaplingIncrementalMerkleTree saplingTree;
+    wtx.mapSaplingNoteData[saplingNotes[0]].witnesses.push_front(saplingTree.witness());
+    wtx.mapSaplingNoteData[saplingNotes[0]].witnessHeight = 1;
+    wallet.nWitnessCacheSize = 2;
+
     wallet.AddToWallet(wtx, true, NULL);
 
-    std::vector<JSOutPoint> notes {jsoutpt, jsoutpt2};
-    std::vector<boost::optional<ZCIncrementalWitness>> witnesses;
-    uint256 anchor2;
+    std::vector<JSOutPoint> sproutNotes {jsoutpt, jsoutpt2};
+    std::vector<boost::optional<ZCIncrementalWitness>> sproutWitnesses;
+    std::vector<boost::optional<ZCSaplingIncrementalWitness>> saplingWitnesses;
 
     // Before clearing, we should have a witness for one note
-    wallet.GetSproutNoteWitnesses(notes, witnesses, anchor2);
-    EXPECT_TRUE((bool) witnesses[0]);
-    EXPECT_FALSE((bool) witnesses[1]);
+    GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+    EXPECT_TRUE((bool) sproutWitnesses[0]);
+    EXPECT_FALSE((bool) sproutWitnesses[1]);
+    EXPECT_TRUE((bool) saplingWitnesses[0]);
+    EXPECT_FALSE((bool) saplingWitnesses[1]);
     EXPECT_EQ(1, wallet.mapWallet[hash].mapSproutNoteData[jsoutpt].witnessHeight);
-    EXPECT_EQ(1, wallet.nWitnessCacheSize);
+    EXPECT_EQ(1, wallet.mapWallet[hash].mapSaplingNoteData[saplingNotes[0]].witnessHeight);
+    EXPECT_EQ(2, wallet.nWitnessCacheSize);
 
     // After clearing, we should not have a witness for either note
     wallet.ClearNoteWitnessCache();
-    witnesses.clear();
-    wallet.GetSproutNoteWitnesses(notes, witnesses, anchor2);
-    EXPECT_FALSE((bool) witnesses[0]);
-    EXPECT_FALSE((bool) witnesses[1]);
+    auto anchros2 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+    EXPECT_FALSE((bool) sproutWitnesses[0]);
+    EXPECT_FALSE((bool) sproutWitnesses[1]);
+    EXPECT_FALSE((bool) saplingWitnesses[0]);
+    EXPECT_FALSE((bool) saplingWitnesses[1]);
     EXPECT_EQ(-1, wallet.mapWallet[hash].mapSproutNoteData[jsoutpt].witnessHeight);
+    EXPECT_EQ(-1, wallet.mapWallet[hash].mapSaplingNoteData[saplingNotes[0]].witnessHeight);
     EXPECT_EQ(0, wallet.nWitnessCacheSize);
 }
 

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -69,8 +69,8 @@ public:
     }
 };
 
-CWalletTx GetValidReceive(const libzcash::SproutSpendingKey& sk, CAmount value, bool randomInputs) {
-    return GetValidReceive(*params, sk, value, randomInputs);
+CWalletTx GetValidReceive(const libzcash::SproutSpendingKey& sk, CAmount value, bool randomInputs, int32_t version = 2) {
+    return GetValidReceive(*params, sk, value, randomInputs, version);
 }
 
 libzcash::SproutNote GetNote(const libzcash::SproutSpendingKey& sk,
@@ -99,7 +99,7 @@ std::pair<JSOutPoint, SaplingOutPoint> CreateValidBlock(TestWallet& wallet,
                             CBlock& block,
                             ZCIncrementalMerkleTree& sproutTree,
                             ZCSaplingIncrementalMerkleTree& saplingTree) {
-    auto wtx = GetValidReceive(sk, 50, true);
+    auto wtx = GetValidReceive(sk, 50, true, 4);
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
@@ -567,7 +567,7 @@ TEST(wallet_tests, cached_witnesses_empty_chain) {
     auto sk = libzcash::SproutSpendingKey::random();
     wallet.AddSpendingKey(sk);
 
-    auto wtx = GetValidReceive(sk, 10, true);
+    auto wtx = GetValidReceive(sk, 10, true, 4);
     auto note = GetNote(sk, wtx, 0, 0);
     auto note2 = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
@@ -648,7 +648,7 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
 
     {
         // Second transaction
-        auto wtx = GetValidReceive(sk, 50, true);
+        auto wtx = GetValidReceive(sk, 50, true, 4);
         auto note = GetNote(sk, wtx, 0, 1);
         auto nullifier = note.nullifier(sk);
 
@@ -757,7 +757,7 @@ TEST(wallet_tests, CachedWitnessesDecrementFirst) {
 
 {
         // Third transaction - never mined
-        auto wtx = GetValidReceive(sk, 20, true);
+        auto wtx = GetValidReceive(sk, 20, true, 4);
         auto note = GetNote(sk, wtx, 0, 1);
         auto nullifier = note.nullifier(sk);
 
@@ -895,7 +895,7 @@ TEST(wallet_tests, ClearNoteWitnessCache) {
     auto sk = libzcash::SproutSpendingKey::random();
     wallet.AddSpendingKey(sk);
 
-    auto wtx = GetValidReceive(sk, 10, true);
+    auto wtx = GetValidReceive(sk, 10, true, 4);
     auto hash = wtx.GetHash();
     auto note = GetNote(sk, wtx, 0, 0);
     auto nullifier = note.nullifier(sk);

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -91,9 +91,9 @@ JSOutPoint CreateValidBlock(TestWallet& wallet,
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
     wtx.SetNoteData(noteData);
     wallet.AddToWallet(wtx, true, NULL);
@@ -117,9 +117,9 @@ TEST(wallet_tests, note_data_serialisation) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd {sk.address(), nullifier};
     ZCIncrementalMerkleTree tree;
     nd.witnesses.push_front(tree.witness());
     noteData[jsoutpt] = nd;
@@ -127,7 +127,7 @@ TEST(wallet_tests, note_data_serialisation) {
     CDataStream ss(SER_DISK, CLIENT_VERSION);
     ss << noteData;
 
-    mapNoteData_t noteData2;
+    mapSproutNoteData_t noteData2;
     ss >> noteData2;
 
     EXPECT_EQ(noteData, noteData2);
@@ -145,9 +145,9 @@ TEST(wallet_tests, find_unspent_notes) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
     wtx.SetNoteData(noteData);
@@ -240,9 +240,9 @@ TEST(wallet_tests, find_unspent_notes) {
         auto note = GetNote(sk, wtx, 0, 1);
         auto nullifier = note.nullifier(sk);
 
-        mapNoteData_t noteData;
+        mapSproutNoteData_t noteData;
         JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-        CNoteData nd {sk.address(), nullifier};
+        SproutNoteData nd {sk.address(), nullifier};
         noteData[jsoutpt] = nd;
 
         wtx.SetNoteData(noteData);
@@ -299,25 +299,25 @@ TEST(wallet_tests, set_note_addrs_in_cwallettx) {
     auto wtx = GetValidReceive(sk, 10, true);
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
-    EXPECT_EQ(0, wtx.mapNoteData.size());
+    EXPECT_EQ(0, wtx.mapSproutNoteData.size());
 
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
     wtx.SetNoteData(noteData);
-    EXPECT_EQ(noteData, wtx.mapNoteData);
+    EXPECT_EQ(noteData, wtx.mapSproutNoteData);
 }
 
 TEST(wallet_tests, set_invalid_note_addrs_in_cwallettx) {
     CWalletTx wtx;
-    EXPECT_EQ(0, wtx.mapNoteData.size());
+    EXPECT_EQ(0, wtx.mapSproutNoteData.size());
 
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     auto sk = libzcash::SproutSpendingKey::random();
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address(), uint256()};
+    SproutNoteData nd {sk.address(), uint256()};
     noteData[jsoutpt] = nd;
 
     EXPECT_THROW(wtx.SetNoteData(noteData), std::logic_error);
@@ -374,7 +374,7 @@ TEST(wallet_tests, FindMyNotes) {
     EXPECT_EQ(2, noteMap.size());
 
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd {sk.address(), nullifier};
     EXPECT_EQ(1, noteMap.count(jsoutpt));
     EXPECT_EQ(nd, noteMap[jsoutpt]);
 }
@@ -397,7 +397,7 @@ TEST(wallet_tests, FindMyNotesInEncryptedWallet) {
     EXPECT_EQ(2, noteMap.size());
 
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd {sk.address(), nullifier};
     EXPECT_EQ(1, noteMap.count(jsoutpt));
     EXPECT_NE(nd, noteMap[jsoutpt]);
 
@@ -490,9 +490,9 @@ TEST(wallet_tests, navigate_from_nullifier_to_note) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
     wtx.SetNoteData(noteData);
@@ -520,9 +520,9 @@ TEST(wallet_tests, spent_note_is_from_me) {
     EXPECT_FALSE(wallet.IsFromMe(wtx));
     EXPECT_FALSE(wallet.IsFromMe(wtx2));
 
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
     wtx.SetNoteData(noteData);
@@ -546,11 +546,11 @@ TEST(wallet_tests, cached_witnesses_empty_chain) {
     auto nullifier = note.nullifier(sk);
     auto nullifier2 = note2.nullifier(sk);
 
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 0};
     JSOutPoint jsoutpt2 {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
-    CNoteData nd2 {sk.address(), nullifier2};
+    SproutNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd2 {sk.address(), nullifier2};
     noteData[jsoutpt] = nd;
     noteData[jsoutpt2] = nd2;
     wtx.SetNoteData(noteData);
@@ -611,9 +611,9 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
         auto note = GetNote(sk, wtx, 0, 1);
         auto nullifier = note.nullifier(sk);
 
-        mapNoteData_t noteData;
+        mapSproutNoteData_t noteData;
         JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-        CNoteData nd {sk.address(), nullifier};
+        SproutNoteData nd {sk.address(), nullifier};
         noteData[jsoutpt] = nd;
         wtx.SetNoteData(noteData);
         wallet.AddToWallet(wtx, true, NULL);
@@ -700,9 +700,9 @@ TEST(wallet_tests, CachedWitnessesDecrementFirst) {
         auto note = GetNote(sk, wtx, 0, 1);
         auto nullifier = note.nullifier(sk);
 
-        mapNoteData_t noteData;
+        mapSproutNoteData_t noteData;
         JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-        CNoteData nd {sk.address(), nullifier};
+        SproutNoteData nd {sk.address(), nullifier};
         noteData[jsoutpt] = nd;
         wtx.SetNoteData(noteData);
         wallet.AddToWallet(wtx, true, NULL);
@@ -821,17 +821,17 @@ TEST(wallet_tests, ClearNoteWitnessCache) {
     auto note = GetNote(sk, wtx, 0, 0);
     auto nullifier = note.nullifier(sk);
 
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 0};
     JSOutPoint jsoutpt2 {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
     wtx.SetNoteData(noteData);
 
     // Pretend we mined the tx by adding a fake witness
     ZCIncrementalMerkleTree tree;
-    wtx.mapNoteData[jsoutpt].witnesses.push_front(tree.witness());
-    wtx.mapNoteData[jsoutpt].witnessHeight = 1;
+    wtx.mapSproutNoteData[jsoutpt].witnesses.push_front(tree.witness());
+    wtx.mapSproutNoteData[jsoutpt].witnessHeight = 1;
     wallet.nWitnessCacheSize = 1;
 
     wallet.AddToWallet(wtx, true, NULL);
@@ -844,7 +844,7 @@ TEST(wallet_tests, ClearNoteWitnessCache) {
     wallet.GetNoteWitnesses(notes, witnesses, anchor2);
     EXPECT_TRUE((bool) witnesses[0]);
     EXPECT_FALSE((bool) witnesses[1]);
-    EXPECT_EQ(1, wallet.mapWallet[hash].mapNoteData[jsoutpt].witnessHeight);
+    EXPECT_EQ(1, wallet.mapWallet[hash].mapSproutNoteData[jsoutpt].witnessHeight);
     EXPECT_EQ(1, wallet.nWitnessCacheSize);
 
     // After clearing, we should not have a witness for either note
@@ -853,7 +853,7 @@ TEST(wallet_tests, ClearNoteWitnessCache) {
     wallet.GetNoteWitnesses(notes, witnesses, anchor2);
     EXPECT_FALSE((bool) witnesses[0]);
     EXPECT_FALSE((bool) witnesses[1]);
-    EXPECT_EQ(-1, wallet.mapWallet[hash].mapNoteData[jsoutpt].witnessHeight);
+    EXPECT_EQ(-1, wallet.mapWallet[hash].mapSproutNoteData[jsoutpt].witnessHeight);
     EXPECT_EQ(0, wallet.nWitnessCacheSize);
 }
 
@@ -949,9 +949,9 @@ TEST(wallet_tests, UpdateNullifierNoteMap) {
     auto nullifier = note.nullifier(sk);
 
     // Pretend that we called FindMyNotes while the wallet was locked
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-    CNoteData nd {sk.address()};
+    SproutNoteData nd {sk.address()};
     noteData[jsoutpt] = nd;
     wtx.SetNoteData(noteData);
 
@@ -984,35 +984,35 @@ TEST(wallet_tests, UpdatedNoteData) {
 
     // First pretend we added the tx to the wallet and
     // we don't have the key for the second note
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 0};
-    CNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
     wtx.SetNoteData(noteData);
 
     // Pretend we mined the tx by adding a fake witness
     ZCIncrementalMerkleTree tree;
-    wtx.mapNoteData[jsoutpt].witnesses.push_front(tree.witness());
-    wtx.mapNoteData[jsoutpt].witnessHeight = 100;
+    wtx.mapSproutNoteData[jsoutpt].witnesses.push_front(tree.witness());
+    wtx.mapSproutNoteData[jsoutpt].witnessHeight = 100;
 
     // Now pretend we added the key for the second note, and
     // the tx was "added" to the wallet again to update it.
     // This happens via the 'z_importkey' RPC method.
     JSOutPoint jsoutpt2 {wtx2.GetHash(), 0, 1};
-    CNoteData nd2 {sk.address(), nullifier2};
+    SproutNoteData nd2 {sk.address(), nullifier2};
     noteData[jsoutpt2] = nd2;
     wtx2.SetNoteData(noteData);
 
     // The txs should initially be different
-    EXPECT_NE(wtx.mapNoteData, wtx2.mapNoteData);
-    EXPECT_EQ(1, wtx.mapNoteData[jsoutpt].witnesses.size());
-    EXPECT_EQ(100, wtx.mapNoteData[jsoutpt].witnessHeight);
+    EXPECT_NE(wtx.mapSproutNoteData, wtx2.mapSproutNoteData);
+    EXPECT_EQ(1, wtx.mapSproutNoteData[jsoutpt].witnesses.size());
+    EXPECT_EQ(100, wtx.mapSproutNoteData[jsoutpt].witnessHeight);
 
     // After updating, they should be the same
     EXPECT_TRUE(wallet.UpdatedNoteData(wtx2, wtx));
-    EXPECT_EQ(wtx.mapNoteData, wtx2.mapNoteData);
-    EXPECT_EQ(1, wtx.mapNoteData[jsoutpt].witnesses.size());
-    EXPECT_EQ(100, wtx.mapNoteData[jsoutpt].witnessHeight);
+    EXPECT_EQ(wtx.mapSproutNoteData, wtx2.mapSproutNoteData);
+    EXPECT_EQ(1, wtx.mapSproutNoteData[jsoutpt].witnesses.size());
+    EXPECT_EQ(100, wtx.mapSproutNoteData[jsoutpt].witnessHeight);
     // TODO: The new note should get witnessed (but maybe not here) (#1350)
 }
 
@@ -1028,9 +1028,9 @@ TEST(wallet_tests, MarkAffectedTransactionsDirty) {
     auto nullifier = note.nullifier(sk);
     auto wtx2 = GetValidSpend(sk, note, 5);
 
-    mapNoteData_t noteData;
+    mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {hash, 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    SproutNoteData nd {sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
     wtx.SetNoteData(noteData);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -891,12 +891,6 @@ void CWallet::DecrementNoteWitnesses(const CBlockIndex* pindex)
                 // height is one below it.
                 nd->witnessHeight = pindex->nHeight - 1;
             }
-        }
-    }
-    nWitnessCacheSize -= 1;
-    for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-        for (mapSproutNoteData_t::value_type& item : wtxItem.second.mapSproutNoteData) {
-            SproutNoteData* nd = &(item.second);
             // Check the validity of the cache
             // Technically if there are notes witnessed above the current
             // height, their cache will now be invalid (relative to the new
@@ -908,10 +902,13 @@ void CWallet::DecrementNoteWitnesses(const CBlockIndex* pindex)
             // reindex because the on-disk blocks had already resulted in a
             // chain that didn't trigger the assertion below.
             if (nd->witnessHeight < pindex->nHeight) {
-                assert(nWitnessCacheSize  >= nd->witnesses.size());
+                // Subtract 1 to compare to what nWitnessCacheSize will be after
+                // decrementing.
+                assert((nWitnessCacheSize - 1) >= nd->witnesses.size());
             }
         }
     }
+    nWitnessCacheSize -= 1;
     // TODO: If nWitnessCache is zero, we need to regenerate the caches (#1302)
     assert(nWitnessCacheSize > 0);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1322,8 +1322,9 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
             CWalletTx wtx(this,tx);
 
             if (noteData.size() > 0) {
-                wtx.SetNoteData(noteData);
+                wtx.SetSproutNoteData(noteData);
             }
+            // TODO: Sapling note data
 
             // Get merkle branch if transaction was found in a block
             if (pblock)
@@ -1468,9 +1469,9 @@ bool CWallet::IsFromMe(const uint256& nullifier) const
     return false;
 }
 
-void CWallet::GetNoteWitnesses(std::vector<JSOutPoint> notes,
-                               std::vector<boost::optional<ZCIncrementalWitness>>& witnesses,
-                               uint256 &final_anchor)
+void CWallet::GetSproutNoteWitnesses(std::vector<JSOutPoint> notes,
+                                     std::vector<boost::optional<ZCIncrementalWitness>>& witnesses,
+                                     uint256 &final_anchor)
 {
     {
         LOCK(cs_wallet);
@@ -1628,7 +1629,7 @@ CAmount CWallet::GetChange(const CTransaction& tx) const
     return nChange;
 }
 
-void CWalletTx::SetNoteData(mapSproutNoteData_t &noteData)
+void CWalletTx::SetSproutNoteData(mapSproutNoteData_t &noteData)
 {
     mapSproutNoteData.clear();
     for (const std::pair<JSOutPoint, SproutNoteData> nd : noteData) {
@@ -1639,7 +1640,7 @@ void CWalletTx::SetNoteData(mapSproutNoteData_t &noteData)
         } else {
             // If FindMyNotes() was used to obtain noteData,
             // this should never happen
-            throw std::logic_error("CWalletTx::SetNoteData(): Invalid note");
+            throw std::logic_error("CWalletTx::SetSproutNoteData(): Invalid note");
         }
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -748,6 +748,10 @@ void CWallet::ClearNoteWitnessCache()
             item.second.witnesses.clear();
             item.second.witnessHeight = -1;
         }
+        for (mapSaplingNoteData_t::value_type& item : wtxItem.second.mapSaplingNoteData) {
+            item.second.witnesses.clear();
+            item.second.witnessHeight = -1;
+        }
     }
     nWitnessCacheSize = 0;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1986,7 +1986,9 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
             // state on the path to the tip of our chain
             assert(pcoinsTip->GetSproutAnchorAt(pindex->hashSproutAnchor, sproutTree));
             if (pindex->pprev) {
-               assert(pcoinsTip->GetSaplingAnchorAt(pindex->pprev->hashFinalSaplingRoot, saplingTree));
+                if (NetworkUpgradeActive(pindex->pprev->nHeight, Params().GetConsensus(), Consensus::UPGRADE_SAPLING)) {
+                    assert(pcoinsTip->GetSaplingAnchorAt(pindex->pprev->hashFinalSaplingRoot, saplingTree));
+                }
             }
             // Increment note witness caches
             IncrementNoteWitnesses(pindex, &block, sproutTree, saplingTree);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1473,28 +1473,26 @@ void CWallet::GetSproutNoteWitnesses(std::vector<JSOutPoint> notes,
                                      std::vector<boost::optional<ZCIncrementalWitness>>& witnesses,
                                      uint256 &final_anchor)
 {
-    {
-        LOCK(cs_wallet);
-        witnesses.resize(notes.size());
-        boost::optional<uint256> rt;
-        int i = 0;
-        for (JSOutPoint note : notes) {
-            if (mapWallet.count(note.hash) &&
-                    mapWallet[note.hash].mapSproutNoteData.count(note) &&
-                    mapWallet[note.hash].mapSproutNoteData[note].witnesses.size() > 0) {
-                witnesses[i] = mapWallet[note.hash].mapSproutNoteData[note].witnesses.front();
-                if (!rt) {
-                    rt = witnesses[i]->root();
-                } else {
-                    assert(*rt == witnesses[i]->root());
-                }
+    LOCK(cs_wallet);
+    witnesses.resize(notes.size());
+    boost::optional<uint256> rt;
+    int i = 0;
+    for (JSOutPoint note : notes) {
+        if (mapWallet.count(note.hash) &&
+                mapWallet[note.hash].mapSproutNoteData.count(note) &&
+                mapWallet[note.hash].mapSproutNoteData[note].witnesses.size() > 0) {
+            witnesses[i] = mapWallet[note.hash].mapSproutNoteData[note].witnesses.front();
+            if (!rt) {
+                rt = witnesses[i]->root();
+            } else {
+                assert(*rt == witnesses[i]->root());
             }
-            i++;
         }
-        // All returned witnesses have the same anchor
-        if (rt) {
-            final_anchor = *rt;
-        }
+        i++;
+    }
+    // All returned witnesses have the same anchor
+    if (rt) {
+        final_anchor = *rt;
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -472,7 +472,7 @@ std::set<std::pair<libzcash::PaymentAddress, uint256>> CWallet::GetNullifiersFor
 {
     std::set<std::pair<libzcash::PaymentAddress, uint256>> nullifierSet;
     for (const auto & txPair : mapWallet) {
-        for (const auto & noteDataPair : txPair.second.mapNoteData) {
+        for (const auto & noteDataPair : txPair.second.mapSproutNoteData) {
             if (noteDataPair.second.nullifier && addresses.count(noteDataPair.second.address)) {
                 nullifierSet.insert(std::make_pair(noteDataPair.second.address, noteDataPair.second.nullifier.get()));
             }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -197,14 +197,14 @@ public:
     std::string ToString() const;
 };
 
-class CNoteData
+class SproutNoteData
 {
 public:
     libzcash::SproutPaymentAddress address;
 
     /**
      * Cached note nullifier. May not be set if the wallet was not unlocked when
-     * this was CNoteData was created. If not set, we always assume that the
+     * this was SproutNoteData was created. If not set, we always assume that the
      * note has not been spent.
      *
      * It's okay to cache the nullifier in the wallet, because we are storing
@@ -225,7 +225,7 @@ public:
     /**
      * Block height corresponding to the most current witness.
      *
-     * When we first create a CNoteData in CWallet::FindMyNotes, this is set to
+     * When we first create a SproutNoteData in CWallet::FindMyNotes, this is set to
      * -1 as a placeholder. The next time CWallet::ChainTip is called, we can
      * determine what height the witness cache for this note is valid for (even
      * if no witnesses were cached), and so can set the correct value in
@@ -233,10 +233,10 @@ public:
      */
     int witnessHeight;
 
-    CNoteData() : address(), nullifier(), witnessHeight {-1} { }
-    CNoteData(libzcash::SproutPaymentAddress a) :
+    SproutNoteData() : address(), nullifier(), witnessHeight {-1} { }
+    SproutNoteData(libzcash::SproutPaymentAddress a) :
             address {a}, nullifier(), witnessHeight {-1} { }
-    CNoteData(libzcash::SproutPaymentAddress a, uint256 n) :
+    SproutNoteData(libzcash::SproutPaymentAddress a, uint256 n) :
             address {a}, nullifier {n}, witnessHeight {-1} { }
 
     ADD_SERIALIZE_METHODS;
@@ -249,21 +249,21 @@ public:
         READWRITE(witnessHeight);
     }
 
-    friend bool operator<(const CNoteData& a, const CNoteData& b) {
+    friend bool operator<(const SproutNoteData& a, const SproutNoteData& b) {
         return (a.address < b.address ||
                 (a.address == b.address && a.nullifier < b.nullifier));
     }
 
-    friend bool operator==(const CNoteData& a, const CNoteData& b) {
+    friend bool operator==(const SproutNoteData& a, const SproutNoteData& b) {
         return (a.address == b.address && a.nullifier == b.nullifier);
     }
 
-    friend bool operator!=(const CNoteData& a, const CNoteData& b) {
+    friend bool operator!=(const SproutNoteData& a, const SproutNoteData& b) {
         return !(a == b);
     }
 };
 
-typedef std::map<JSOutPoint, CNoteData> mapNoteData_t;
+typedef std::map<JSOutPoint, SproutNoteData> mapSproutNoteData_t;
 
 /** Decrypted note and its location in a transaction. */
 struct CSproutNotePlaintextEntry
@@ -350,7 +350,7 @@ private:
 
 public:
     mapValue_t mapValue;
-    mapNoteData_t mapNoteData;
+    mapSproutNoteData_t mapSproutNoteData;
     std::vector<std::pair<std::string, std::string> > vOrderForm;
     unsigned int fTimeReceivedIsTxTime;
     unsigned int nTimeReceived; //! time received by this node
@@ -403,7 +403,7 @@ public:
     {
         pwallet = pwalletIn;
         mapValue.clear();
-        mapNoteData.clear();
+        mapSproutNoteData.clear();
         vOrderForm.clear();
         fTimeReceivedIsTxTime = false;
         nTimeReceived = 0;
@@ -453,7 +453,7 @@ public:
         std::vector<CMerkleTx> vUnused; //! Used to be vtxPrev
         READWRITE(vUnused);
         READWRITE(mapValue);
-        READWRITE(mapNoteData);
+        READWRITE(mapSproutNoteData);
         READWRITE(vOrderForm);
         READWRITE(fTimeReceivedIsTxTime);
         READWRITE(nTimeReceived);
@@ -495,7 +495,7 @@ public:
         MarkDirty();
     }
 
-    void SetNoteData(mapNoteData_t &noteData);
+    void SetNoteData(mapSproutNoteData_t &noteData);
 
     //! filter decides which addresses will count towards the debit
     CAmount GetDebit(const isminefilter& filter) const;
@@ -842,7 +842,7 @@ public:
      *
      * - GetFilteredNotes can't filter out spent notes.
      *
-     *   - Per the comment in CNoteData, we assume that if we don't have a
+     *   - Per the comment in SproutNoteData, we assume that if we don't have a
      *     cached nullifier, the note is not spent.
      *
      * Another more problematic implication is that the wallet can fail to
@@ -1053,7 +1053,7 @@ public:
         const ZCNoteDecryption& dec,
         const uint256& hSig,
         uint8_t n) const;
-    mapNoteData_t FindMyNotes(const CTransaction& tx) const;
+    mapSproutNoteData_t FindMyNotes(const CTransaction& tx) const;
     bool IsFromMe(const uint256& nullifier) const;
     void GetNoteWitnesses(
          std::vector<JSOutPoint> notes,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -730,7 +730,8 @@ protected:
      */
     void IncrementNoteWitnesses(const CBlockIndex* pindex,
                                 const CBlock* pblock,
-                                ZCIncrementalMerkleTree& tree);
+                                ZCIncrementalMerkleTree& sproutTree,
+                                ZCSaplingIncrementalMerkleTree& saplingTree);
     /**
      * pindex is the old tip being disconnected.
      */
@@ -1084,7 +1085,7 @@ public:
     CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetChange(const CTransaction& tx) const;
-    void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, ZCIncrementalMerkleTree tree, bool added);
+    void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, ZCIncrementalMerkleTree sproutTree, ZCSaplingIncrementalMerkleTree saplingTree, bool added);
     /** Saves witness caches and best block locator to disk. */
     void SetBestChain(const CBlockLocator& loc);
     std::set<std::pair<libzcash::PaymentAddress, uint256>> GetNullifiersForAddresses(const std::set<libzcash::PaymentAddress> & addresses);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -266,7 +266,13 @@ public:
 class SaplingNoteData
 {
 public:
-    std::list<ZCIncrementalWitness> witnesses;
+    /**
+     * We initialize the hight to -1 for the same reason as we do in SproutNoteData.
+     * See the comment in that class for a full description.
+     */
+    SaplingNoteData() : witnessHeight {-1} { }
+
+    std::list<ZCSaplingIncrementalWitness> witnesses;
     int witnessHeight;
 };
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -263,7 +263,15 @@ public:
     }
 };
 
+class SaplingNoteData
+{
+public:
+    std::list<ZCIncrementalWitness> witnesses;
+    int witnessHeight;
+};
+
 typedef std::map<JSOutPoint, SproutNoteData> mapSproutNoteData_t;
+typedef std::map<SaplingOutPoint, SaplingNoteData> mapSaplingNoteData_t;
 
 /** Decrypted note and its location in a transaction. */
 struct CSproutNotePlaintextEntry
@@ -351,6 +359,7 @@ private:
 public:
     mapValue_t mapValue;
     mapSproutNoteData_t mapSproutNoteData;
+    mapSaplingNoteData_t mapSaplingNoteData;
     std::vector<std::pair<std::string, std::string> > vOrderForm;
     unsigned int fTimeReceivedIsTxTime;
     unsigned int nTimeReceived; //! time received by this node
@@ -404,6 +413,7 @@ public:
         pwallet = pwalletIn;
         mapValue.clear();
         mapSproutNoteData.clear();
+        mapSaplingNoteData.clear();
         vOrderForm.clear();
         fTimeReceivedIsTxTime = false;
         nTimeReceived = 0;
@@ -459,6 +469,8 @@ public:
         READWRITE(nTimeReceived);
         READWRITE(fFromMe);
         READWRITE(fSpent);
+        // TODO:
+        //READWRITE(mapSaplingNoteData);
 
         if (ser_action.ForRead())
         {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -513,7 +513,7 @@ public:
         MarkDirty();
     }
 
-    void SetNoteData(mapSproutNoteData_t &noteData);
+    void SetSproutNoteData(mapSproutNoteData_t &noteData);
 
     //! filter decides which addresses will count towards the debit
     CAmount GetDebit(const isminefilter& filter) const;
@@ -1074,7 +1074,7 @@ public:
         uint8_t n) const;
     mapSproutNoteData_t FindMyNotes(const CTransaction& tx) const;
     bool IsFromMe(const uint256& nullifier) const;
-    void GetNoteWitnesses(
+    void GetSproutNoteWitnesses(
          std::vector<JSOutPoint> notes,
          std::vector<boost::optional<ZCIncrementalWitness>>& witnesses,
          uint256 &final_anchor);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -514,6 +514,7 @@ public:
     }
 
     void SetSproutNoteData(mapSproutNoteData_t &noteData);
+    void SetSaplingNoteData(mapSaplingNoteData_t &noteData);
 
     //! filter decides which addresses will count towards the debit
     CAmount GetDebit(const isminefilter& filter) const;
@@ -1077,6 +1078,10 @@ public:
     void GetSproutNoteWitnesses(
          std::vector<JSOutPoint> notes,
          std::vector<boost::optional<ZCIncrementalWitness>>& witnesses,
+         uint256 &final_anchor);
+    void GetSaplingNoteWitnesses(
+         std::vector<SaplingOutPoint> notes,
+         std::vector<boost::optional<ZCSaplingIncrementalWitness>>& witnesses,
          uint256 &final_anchor);
 
     isminetype IsMine(const CTxIn& txin) const;

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -298,7 +298,8 @@ double benchmark_try_decrypt_notes(size_t nAddrs)
 double benchmark_increment_note_witnesses(size_t nTxs)
 {
     CWallet wallet;
-    ZCIncrementalMerkleTree tree;
+    ZCIncrementalMerkleTree sproutTree;
+    ZCSaplingIncrementalMerkleTree saplingTree;
 
     auto sk = libzcash::SproutSpendingKey::random();
     wallet.AddSpendingKey(sk);
@@ -323,7 +324,7 @@ double benchmark_increment_note_witnesses(size_t nTxs)
     index1.nHeight = 1;
 
     // Increment to get transactions witnessed
-    wallet.ChainTip(&index1, &block1, tree, true);
+    wallet.ChainTip(&index1, &block1, sproutTree, saplingTree, true);
 
     // Second block
     CBlock block2;
@@ -347,7 +348,7 @@ double benchmark_increment_note_witnesses(size_t nTxs)
 
     struct timeval tv_start;
     timer_start(tv_start);
-    wallet.ChainTip(&index2, &block2, tree, true);
+    wallet.ChainTip(&index2, &block2, sproutTree, saplingTree, true);
     return timer_stop(tv_start);
 }
 

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -316,7 +316,7 @@ double benchmark_increment_note_witnesses(size_t nTxs)
         SproutNoteData nd {sk.address(), nullifier};
         noteData[jsoutpt] = nd;
 
-        wtx.SetNoteData(noteData);
+        wtx.SetSproutNoteData(noteData);
         wallet.AddToWallet(wtx, true, NULL);
         block1.vtx.push_back(wtx);
     }
@@ -339,7 +339,7 @@ double benchmark_increment_note_witnesses(size_t nTxs)
         SproutNoteData nd {sk.address(), nullifier};
         noteData[jsoutpt] = nd;
 
-        wtx.SetNoteData(noteData);
+        wtx.SetSproutNoteData(noteData);
         wallet.AddToWallet(wtx, true, NULL);
         block2.vtx.push_back(wtx);
     }

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -310,9 +310,9 @@ double benchmark_increment_note_witnesses(size_t nTxs)
         auto note = GetNote(*pzcashParams, sk, wtx, 0, 1);
         auto nullifier = note.nullifier(sk);
 
-        mapNoteData_t noteData;
+        mapSproutNoteData_t noteData;
         JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-        CNoteData nd {sk.address(), nullifier};
+        SproutNoteData nd {sk.address(), nullifier};
         noteData[jsoutpt] = nd;
 
         wtx.SetNoteData(noteData);
@@ -333,9 +333,9 @@ double benchmark_increment_note_witnesses(size_t nTxs)
         auto note = GetNote(*pzcashParams, sk, wtx, 0, 1);
         auto nullifier = note.nullifier(sk);
 
-        mapNoteData_t noteData;
+        mapSproutNoteData_t noteData;
         JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
-        CNoteData nd {sk.address(), nullifier};
+        SproutNoteData nd {sk.address(), nullifier};
         noteData[jsoutpt] = nd;
 
         wtx.SetNoteData(noteData);


### PR DESCRIPTION
Closes #3062 

I have not update the tests in test_wallet.cpp. Also, there are several other methods in the wallet that have to do with witnesses and note data which will need to be updated, but this PR focuses on IncrementNoteWitnesses and DecrementNoteWitnesses.