### PR TITLE
Disable libsnark debug logging in Boost tests

### DIFF
--- a/src/snark/libsnark/common/profiling.cpp
+++ b/src/snark/libsnark/common/profiling.cpp
@@ -89,7 +89,7 @@ static std::list<std::pair<std::string, long long*> > op_data_points = {
 #endif
 };
 
-bool inhibit_profiling_info = false;
+bool inhibit_profiling_info = true;
 bool inhibit_profiling_counters = false;
 
 void clear_profiling_counters()


### PR DESCRIPTION
Initialize `src/snark/libsnark/common/profiling.cpp: inhibit_profiling_info` to false.