### PR TITLE
add extra help how to enable experimental features

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -599,6 +599,16 @@ std::string HelpExampleRpc(const std::string& methodname, const std::string& arg
         "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:8232/\n";
 }
 
+string experimentalDisabledHelpMsg(const string& rpc, const string& enableArg)
+{
+    return "\nWARNING: " + rpc + " is disabled.\n"
+        "To enable it, restart zcashd with the -experimentalfeatures and\n"
+        "-" + enableArg + " commandline options, or add these two lines\n"
+        "to the zcash.conf file:\n\n"
+        "experimentalfeatures=1\n"
+        + enableArg + "=1\n";
+}
+
 void RPCRegisterTimerInterface(RPCTimerInterface *iface)
 {
     timerInterfaces.push_back(iface);

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -305,4 +305,6 @@ void InterruptRPC();
 void StopRPC();
 std::string JSONRPCExecBatch(const UniValue& vReq);
 
+extern std::string experimentalDisabledHelpMsg(const std::string& rpc, const std::string& enableArg);
+
 #endif // BITCOIN_RPCSERVER_H

--- a/src/wallet/rpcdisclosure.cpp
+++ b/src/wallet/rpcdisclosure.cpp
@@ -41,10 +41,11 @@ UniValue z_getpaymentdisclosure(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    auto fEnablePaymentDisclosure = fExperimentalMode && GetBoolArg("-paymentdisclosure", false);
+    string enableArg = "paymentdisclosure";
+    auto fEnablePaymentDisclosure = fExperimentalMode && GetBoolArg("-" + enableArg, false);
     string strPaymentDisclosureDisabledMsg = "";
     if (!fEnablePaymentDisclosure) {
-        strPaymentDisclosureDisabledMsg = "\nWARNING: Payment disclosure is currently DISABLED. This call always fails.\n";
+        strPaymentDisclosureDisabledMsg = experimentalDisabledHelpMsg("z_getpaymentdisclosure", enableArg);
     }
 
     if (fHelp || params.size() < 3 || params.size() > 4 )
@@ -147,10 +148,11 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    auto fEnablePaymentDisclosure = fExperimentalMode && GetBoolArg("-paymentdisclosure", false);
+    string enableArg = "paymentdisclosure";
+    auto fEnablePaymentDisclosure = fExperimentalMode && GetBoolArg("-" + enableArg, false);
     string strPaymentDisclosureDisabledMsg = "";
     if (!fEnablePaymentDisclosure) {
-        strPaymentDisclosureDisabledMsg = "\nWARNING: Payment disclosure is curretly DISABLED. This call always fails.\n";
+        strPaymentDisclosureDisabledMsg = experimentalDisabledHelpMsg("z_validatepaymentdisclosure", enableArg);
     }
 
     if (fHelp || params.size() != 1)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2031,11 +2031,12 @@ UniValue encryptwallet(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    auto fEnableWalletEncryption = fExperimentalMode && GetBoolArg("-developerencryptwallet", false);
+    string enableArg = "developerencryptwallet";
+    auto fEnableWalletEncryption = fExperimentalMode && GetBoolArg("-" + enableArg, false);
 
     std::string strWalletEncryptionDisabledMsg = "";
     if (!fEnableWalletEncryption) {
-        strWalletEncryptionDisabledMsg = "\nWARNING: Wallet encryption is DISABLED. This call always fails.\n";
+        strWalletEncryptionDisabledMsg = experimentalDisabledHelpMsg("encryptwallet", enableArg);
     }
 
     if (!pwalletMain->IsCrypted() && (fHelp || params.size() != 1))
@@ -3949,10 +3950,11 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    auto fEnableMergeToAddress = fExperimentalMode && GetBoolArg("-zmergetoaddress", false);
+    string enableArg = "zmergetoaddress";
+    auto fEnableMergeToAddress = fExperimentalMode && GetBoolArg("-" + enableArg, false);
     std::string strDisabledMsg = "";
     if (!fEnableMergeToAddress) {
-        strDisabledMsg = "\nWARNING: z_mergetoaddress is DISABLED but can be enabled as an experimental feature.\n";
+        strDisabledMsg = experimentalDisabledHelpMsg("z_mergetoaddress", enableArg);
     }
 
     if (fHelp || params.size() < 2 || params.size() > 6)
@@ -3965,8 +3967,8 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
             "\nare unlocked.  The RPC call `listlockunspent` can be used to return a list of locked UTXOs."
             "\n\nThe number of UTXOs and notes selected for merging can be limited by the caller.  If the transparent limit"
             "\nparameter is set to zero, and Overwinter is not yet active, the -mempooltxinputlimit option will determine the"
-            "\nnumber of UTXOs.  Any limit is constrained by the consensus rule defining a maximum transaction size of "
-            + strprintf("%d bytes before Sapling, and %d bytes once Sapling activates.", MAX_TX_SIZE_BEFORE_SAPLING, MAX_TX_SIZE_AFTER_SAPLING)
+            "\nnumber of UTXOs.  Any limit is constrained by the consensus rule defining a maximum transaction size of"
+            + strprintf("\n%d bytes before Sapling, and %d bytes once Sapling activates.", MAX_TX_SIZE_BEFORE_SAPLING, MAX_TX_SIZE_AFTER_SAPLING)
             + HelpRequiringPassphrase() + "\n"
             "\nArguments:\n"
             "1. fromaddresses         (string, required) A JSON array with addresses.\n"


### PR DESCRIPTION
Closes #2728. When the user attempts to execute a disabled experimental RPC, print some nice text explaining how to enable the RPC (either command-line or adding lines to zcash.conf).