### PR TITLE
Sapling note plaintext (encryption and decryption)

### DIFF
--- a/src/gtest/test_noteencryption.cpp
+++ b/src/gtest/test_noteencryption.cpp
@@ -113,7 +113,7 @@ TEST(noteencryption, NotePlaintext)
     ASSERT_TRUE(decrypted_out_ct_unwrapped.esk == out_pt.esk);
 
     // Test sender can decrypt the note ciphertext.
-    foo = SaplingNotePlaintext::decryptUsingFullViewingKey(
+    foo = SaplingNotePlaintext::decrypt(
         ct,
         epk,
         decrypted_out_ct_unwrapped.esk,

--- a/src/gtest/test_noteencryption.cpp
+++ b/src/gtest/test_noteencryption.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <stdexcept>
 
+#include "zcash/Note.hpp"
 #include "zcash/NoteEncryption.hpp"
 #include "zcash/prf.h"
 #include "zcash/Address.hpp"
@@ -18,6 +19,99 @@ public:
         pk_enc = to;
     }
 };
+
+TEST(noteencryption, NotePlaintext)
+{
+    using namespace libzcash;
+    auto sk = SaplingSpendingKey(uint256()).expanded_spending_key();
+    auto vk = sk.full_viewing_key();
+    auto ivk = vk.in_viewing_key();
+    SaplingPaymentAddress addr = *ivk.address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+    std::array<unsigned char, ZC_MEMO_SIZE> memo;
+    for (size_t i = 0; i < ZC_MEMO_SIZE; i++) {
+        // Fill the message with dummy data
+        memo[i] = (unsigned char) i;
+    }
+
+    SaplingNote note(addr, 39393);
+    SaplingNotePlaintext pt(note, memo);
+
+    auto res = pt.encrypt(addr.pk_d);
+    if (!res) {
+        FAIL();
+    }
+
+    auto enc = res.get();
+
+    auto ct = enc.first;
+    auto encryptor = enc.second;
+    auto epk = encryptor.get_epk();
+
+    // Try to decrypt
+    auto foo = SaplingNotePlaintext::decrypt(
+        ct,
+        ivk,
+        epk
+    );
+
+    if (!foo) {
+        FAIL();
+    }
+
+    auto bar = foo.get();
+
+    ASSERT_TRUE(bar.value() == pt.value());
+    ASSERT_TRUE(bar.memo() == pt.memo());
+    ASSERT_TRUE(bar.d == pt.d);
+    ASSERT_TRUE(bar.rcm == pt.rcm);
+
+    auto foobar = bar.note(ivk);
+
+    if (!foobar) {
+        FAIL();
+    }
+
+    auto new_note = foobar.get();
+
+    ASSERT_TRUE(note.value() == new_note.value());
+    ASSERT_TRUE(note.d == new_note.d);
+    ASSERT_TRUE(note.pk_d == new_note.pk_d);
+    ASSERT_TRUE(note.r == new_note.r);
+    ASSERT_TRUE(note.cm() == new_note.cm());
+
+    SaplingOutgoingPlaintext out_pt;
+    out_pt.pk_d = note.pk_d;
+    out_pt.esk = encryptor.get_esk();
+
+    auto ovk = random_uint256();
+    auto cv = random_uint256();
+    auto cm = random_uint256();
+
+    auto out_ct = out_pt.encrypt(
+        ovk,
+        cv,
+        cm,
+        encryptor
+    );
+
+    auto decrypted_out_ct = out_pt.decrypt(
+        out_ct,
+        ovk,
+        cv,
+        cm,
+        encryptor.get_epk()
+    );
+
+    if (!decrypted_out_ct) {
+        FAIL();
+    }
+
+    auto decrypted_out_ct_unwrapped = decrypted_out_ct.get();
+
+    ASSERT_TRUE(decrypted_out_ct_unwrapped.pk_d == out_pt.pk_d);
+    ASSERT_TRUE(decrypted_out_ct_unwrapped.esk == out_pt.esk);
+}
 
 TEST(noteencryption, SaplingApi)
 {

--- a/src/gtest/test_noteencryption.cpp
+++ b/src/gtest/test_noteencryption.cpp
@@ -111,6 +111,25 @@ TEST(noteencryption, NotePlaintext)
 
     ASSERT_TRUE(decrypted_out_ct_unwrapped.pk_d == out_pt.pk_d);
     ASSERT_TRUE(decrypted_out_ct_unwrapped.esk == out_pt.esk);
+
+    // Test sender can decrypt the note ciphertext.
+    foo = SaplingNotePlaintext::decryptUsingFullViewingKey(
+        ct,
+        epk,
+        decrypted_out_ct_unwrapped.esk,
+        decrypted_out_ct_unwrapped.pk_d
+    );
+
+    if (!foo) {
+        FAIL();
+    }
+
+    bar = foo.get();
+
+    ASSERT_TRUE(bar.value() == pt.value());
+    ASSERT_TRUE(bar.memo() == pt.memo());
+    ASSERT_TRUE(bar.d == pt.d);
+    ASSERT_TRUE(bar.rcm == pt.rcm);
 }
 
 TEST(noteencryption, SaplingApi)

--- a/src/gtest/test_noteencryption.cpp
+++ b/src/gtest/test_noteencryption.cpp
@@ -23,9 +23,9 @@ public:
 TEST(noteencryption, NotePlaintext)
 {
     using namespace libzcash;
-    auto sk = SaplingSpendingKey(uint256()).expanded_spending_key();
-    auto vk = sk.full_viewing_key();
-    auto ivk = vk.in_viewing_key();
+    auto xsk = SaplingSpendingKey(uint256()).expanded_spending_key();
+    auto fvk = xsk.full_viewing_key();
+    auto ivk = fvk.in_viewing_key();
     SaplingPaymentAddress addr = *ivk.address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
 
     std::array<unsigned char, ZC_MEMO_SIZE> memo;

--- a/src/zcash/Note.cpp
+++ b/src/zcash/Note.cpp
@@ -154,12 +154,59 @@ boost::optional<SaplingNote> SaplingNotePlaintext::note(const SaplingIncomingVie
 {
     auto addr = ivk.address( d );
     if (addr) {
-        return SaplingNote(addr.get(), value_);
+        return SaplingNote(d, addr.get().pk_d, value_, rcm);
     } else {
         return boost::none;
     }
 }
 
+boost::optional<SaplingOutgoingPlaintext> SaplingOutgoingPlaintext::decrypt(
+    const SaplingOutCiphertext &ciphertext,
+    const uint256& ovk,
+    const uint256& cv,
+    const uint256& cm,
+    const uint256& epk
+)
+{
+    auto pt = AttemptSaplingOutDecryption(ciphertext, ovk, cv, cm, epk);
+    if (!pt) {
+        return boost::none;
+    }
+
+    // Deserialize from the plaintext
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << pt.get();
+
+    SaplingOutgoingPlaintext ret;
+    ss >> ret;
+
+    assert(ss.size() == 0);
+
+    return ret;
+}
+
+boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
+    const SaplingEncCiphertext &ciphertext,
+    const uint256 &ivk,
+    const uint256 &epk
+)
+{
+    auto pt = AttemptSaplingEncDecryption(ciphertext, ivk, epk);
+    if (!pt) {
+        return boost::none;
+    }
+
+    // Deserialize from the plaintext
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << pt.get();
+
+    SaplingNotePlaintext ret;
+    ss >> ret;
+
+    assert(ss.size() == 0);
+
+    return ret;
+}
 
 boost::optional<SaplingNotePlaintextEncryptionResult> SaplingNotePlaintext::encrypt(const uint256& pk_d) const
 {

--- a/src/zcash/Note.cpp
+++ b/src/zcash/Note.cpp
@@ -208,6 +208,30 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
     return ret;
 }
 
+boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decryptUsingFullViewingKey(
+    const SaplingEncCiphertext &ciphertext,
+    const uint256 &epk,
+    const uint256 &esk,
+    const uint256 &pk_d
+)
+{
+    auto pt = AttemptSaplingEncDecryptionUsingFullViewingKey(ciphertext, epk, esk, pk_d);
+    if (!pt) {
+        return boost::none;
+    }
+
+    // Deserialize from the plaintext
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << pt.get();
+
+    SaplingNotePlaintext ret;
+    ss >> ret;
+
+    assert(ss.size() == 0);
+
+    return ret;
+}
+
 boost::optional<SaplingNotePlaintextEncryptionResult> SaplingNotePlaintext::encrypt(const uint256& pk_d) const
 {
     // Get the encryptor

--- a/src/zcash/Note.cpp
+++ b/src/zcash/Note.cpp
@@ -208,14 +208,14 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
     return ret;
 }
 
-boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decryptUsingFullViewingKey(
+boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
     const SaplingEncCiphertext &ciphertext,
     const uint256 &epk,
     const uint256 &esk,
     const uint256 &pk_d
 )
 {
-    auto pt = AttemptSaplingEncDecryptionUsingFullViewingKey(ciphertext, epk, esk, pk_d);
+    auto pt = AttemptSaplingEncDecryption(ciphertext, epk, esk, pk_d);
     if (!pt) {
         return boost::none;
     }

--- a/src/zcash/Note.cpp
+++ b/src/zcash/Note.cpp
@@ -152,7 +152,7 @@ SaplingNotePlaintext::SaplingNotePlaintext(
 
 boost::optional<SaplingNote> SaplingNotePlaintext::note(const SaplingIncomingViewingKey& ivk) const
 {
-    auto addr = ivk.address( d );
+    auto addr = ivk.address(d);
     if (addr) {
         return SaplingNote(d, addr.get().pk_d, value_, rcm);
     } else {

--- a/src/zcash/Note.hpp
+++ b/src/zcash/Note.hpp
@@ -133,6 +133,13 @@ public:
         const uint256 &epk
     );
 
+    static boost::optional<SaplingNotePlaintext> decryptUsingFullViewingKey(
+        const SaplingEncCiphertext &ciphertext,
+        const uint256 &epk,
+        const uint256 &esk,
+        const uint256 &pk_d
+    );
+
     boost::optional<SaplingNote> note(const SaplingIncomingViewingKey& ivk) const;
 
     virtual ~SaplingNotePlaintext() {}

--- a/src/zcash/Note.hpp
+++ b/src/zcash/Note.hpp
@@ -133,7 +133,7 @@ public:
         const uint256 &epk
     );
 
-    static boost::optional<SaplingNotePlaintext> decryptUsingFullViewingKey(
+    static boost::optional<SaplingNotePlaintext> decrypt(
         const SaplingEncCiphertext &ciphertext,
         const uint256 &epk,
         const uint256 &esk,

--- a/src/zcash/Note.hpp
+++ b/src/zcash/Note.hpp
@@ -116,7 +116,7 @@ public:
                                         ) const;
 };
 
-typedef std::pair<std::reference_wrapper<const SaplingEncCiphertext>, std::reference_wrapper<const SaplingNoteEncryption>> SaplingNotePlaintextEncryptionResult;
+typedef std::pair<SaplingEncCiphertext, SaplingNoteEncryption> SaplingNotePlaintextEncryptionResult;
 
 class SaplingNotePlaintext : public BaseNotePlaintext {
 public:
@@ -126,6 +126,12 @@ public:
     SaplingNotePlaintext() {}
 
     SaplingNotePlaintext(const SaplingNote& note, std::array<unsigned char, ZC_MEMO_SIZE> memo);
+
+    static boost::optional<SaplingNotePlaintext> decrypt(
+        const SaplingEncCiphertext &ciphertext,
+        const uint256 &ivk,
+        const uint256 &epk
+    );
 
     boost::optional<SaplingNote> note(const SaplingIncomingViewingKey& ivk) const;
 
@@ -168,6 +174,14 @@ public:
         READWRITE(pk_d);        // 8 bytes
         READWRITE(esk);         // 8 bytes
     }
+
+    static boost::optional<SaplingOutgoingPlaintext> decrypt(
+        const SaplingOutCiphertext &ciphertext,
+        const uint256& ovk,
+        const uint256& cv,
+        const uint256& cm,
+        const uint256& epk
+    );
 
     SaplingOutCiphertext encrypt(
         const uint256& ovk,

--- a/src/zcash/NoteEncryption.cpp
+++ b/src/zcash/NoteEncryption.cpp
@@ -187,7 +187,7 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
     return plaintext;
 }
 
-boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryptionUsingFullViewingKey (
+boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
     const SaplingEncCiphertext &ciphertext,
     const uint256 &epk,
     const uint256 &esk,

--- a/src/zcash/NoteEncryption.hpp
+++ b/src/zcash/NoteEncryption.hpp
@@ -73,6 +73,15 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
     const uint256 &epk
 );
 
+// Attempts to decrypt a Sapling note using full viewing key.
+// This will not check that the contents of the ciphertext are correct.
+boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryptionUsingFullViewingKey (
+    const SaplingEncCiphertext &ciphertext,
+    const uint256 &epk,
+    const uint256 &esk,
+    const uint256 &pk_d
+);
+
 // Attempts to decrypt a Sapling note. This will not check that the contents
 // of the ciphertext are correct.
 boost::optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(

--- a/src/zcash/NoteEncryption.hpp
+++ b/src/zcash/NoteEncryption.hpp
@@ -73,9 +73,9 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
     const uint256 &epk
 );
 
-// Attempts to decrypt a Sapling note using full viewing key.
+// Attempts to decrypt a Sapling note using outgoing plaintext.
 // This will not check that the contents of the ciphertext are correct.
-boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryptionUsingFullViewingKey (
+boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
     const SaplingEncCiphertext &ciphertext,
     const uint256 &epk,
     const uint256 &esk,


### PR DESCRIPTION
Add encryption and decryption of SaplingNotePlaintext and SaplingOutgoingPlaintext classes.

This is part of #3061 to add Sapling note functionality.