### PR TITLE
Add call to sync_all() after (z_sendmany, wait)

### DIFF
--- a/qa/rpc-tests/mempool_tx_input_limit.py
+++ b/qa/rpc-tests/mempool_tx_input_limit.py
@@ -100,6 +100,7 @@ class MempoolTxInputLimitTest(BitcoinTestFramework):
 
         myopid = self.nodes[0].z_sendmany(node0_zaddr, recipients)
         wait_and_assert_operationid_status(self.nodes[0], myopid)
+        self.sync_all()
         self.nodes[1].generate(1)
         self.sync_all()
 


### PR DESCRIPTION
Closes #2929. Add missing call to `self.sync_all()` after sending coins (and waiting for the send to complete). This matches what is done in other python test scripts.