### PR TITLE
Remove extra slash from lockfile path

### DIFF
--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -140,7 +140,7 @@ function lock() {
         fi
     else
         # create lock file
-        eval "exec 200>/$lockfile"
+        eval "exec 200>$lockfile"
         # acquire the lock
         flock -n 200 \
             && return 0 \


### PR DESCRIPTION
Issue: https://github.com/zcash/zcash/issues/3415

After this change I can successfully run `fetch-params` in an msys2 environment.