### PR TITLE
Track Sapling notes and nullifiers in the wallet (in-memory only, no persistence to disk)

### DIFF
--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -56,7 +56,7 @@ TEST(TransactionBuilder, Invoke)
 
     // Prepare to spend the note that was just created
     auto maybe_pt = libzcash::SaplingNotePlaintext::decrypt(
-        tx1.vShieldedOutput[0].encCiphertext, ivk, tx1.vShieldedOutput[0].ephemeralKey);
+        tx1.vShieldedOutput[0].encCiphertext, ivk, tx1.vShieldedOutput[0].ephemeralKey, tx1.vShieldedOutput[0].cm);
     ASSERT_EQ(static_cast<bool>(maybe_pt), true);
     auto maybe_note = maybe_pt.get().note(ivk);
     ASSERT_EQ(static_cast<bool>(maybe_note), true);

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -179,7 +179,7 @@ TEST(WalletTests, FindUnspentNotes) {
 
     wtx.SetSproutNoteData(noteData);
     wallet.AddToWallet(wtx, true, NULL);
-    EXPECT_FALSE(wallet.IsSpent(nullifier));
+    EXPECT_FALSE(wallet.IsSproutSpent(nullifier));
 
     // We currently have an unspent and unconfirmed note in the wallet (depth of -1)
     std::vector<CSproutNotePlaintextEntry> entries;
@@ -204,7 +204,7 @@ TEST(WalletTests, FindUnspentNotes) {
 
     wtx.SetMerkleBranch(block);
     wallet.AddToWallet(wtx, true, NULL);
-    EXPECT_FALSE(wallet.IsSpent(nullifier));
+    EXPECT_FALSE(wallet.IsSproutSpent(nullifier));
 
 
     // We now have an unspent and confirmed note in the wallet (depth of 1)
@@ -222,7 +222,7 @@ TEST(WalletTests, FindUnspentNotes) {
     // Let's spend the note.
     auto wtx2 = GetValidSpend(sk, note, 5);
     wallet.AddToWallet(wtx2, true, NULL);
-    EXPECT_FALSE(wallet.IsSpent(nullifier));
+    EXPECT_FALSE(wallet.IsSproutSpent(nullifier));
 
     // Fake-mine a spend transaction
     EXPECT_EQ(0, chainActive.Height());
@@ -240,7 +240,7 @@ TEST(WalletTests, FindUnspentNotes) {
 
     wtx2.SetMerkleBranch(block2);
     wallet.AddToWallet(wtx2, true, NULL);
-    EXPECT_TRUE(wallet.IsSpent(nullifier));
+    EXPECT_TRUE(wallet.IsSproutSpent(nullifier));
 
     // The note has been spent.  By default, GetFilteredNotes() ignores spent notes.
     wallet.GetFilteredNotes(entries, "", 0);
@@ -274,7 +274,7 @@ TEST(WalletTests, FindUnspentNotes) {
 
         wtx.SetSproutNoteData(noteData);
         wallet.AddToWallet(wtx, true, NULL);
-        EXPECT_FALSE(wallet.IsSpent(nullifier));
+        EXPECT_FALSE(wallet.IsSproutSpent(nullifier));
 
         wtx3 = wtx;
     }
@@ -490,14 +490,14 @@ TEST(WalletTests, NullifierIsSpent) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    EXPECT_FALSE(wallet.IsSpent(nullifier));
+    EXPECT_FALSE(wallet.IsSproutSpent(nullifier));
 
     wallet.AddToWallet(wtx, true, NULL);
-    EXPECT_FALSE(wallet.IsSpent(nullifier));
+    EXPECT_FALSE(wallet.IsSproutSpent(nullifier));
 
     auto wtx2 = GetValidSpend(sk, note, 5);
     wallet.AddToWallet(wtx2, true, NULL);
-    EXPECT_FALSE(wallet.IsSpent(nullifier));
+    EXPECT_FALSE(wallet.IsSproutSpent(nullifier));
 
     // Fake-mine the transaction
     EXPECT_EQ(-1, chainActive.Height());
@@ -513,7 +513,7 @@ TEST(WalletTests, NullifierIsSpent) {
 
     wtx2.SetMerkleBranch(block);
     wallet.AddToWallet(wtx2, true, NULL);
-    EXPECT_TRUE(wallet.IsSpent(nullifier));
+    EXPECT_TRUE(wallet.IsSproutSpent(nullifier));
 
     // Tear down
     chainActive.SetTip(NULL);

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -350,6 +350,19 @@ TEST(WalletTests, SetInvalidNoteAddrsInCWalletTx) {
     EXPECT_THROW(wtx.SetSproutNoteData(noteData), std::logic_error);
 }
 
+// Cannot add note data for an index which does not exist in tx.vShieldedOutput
+TEST(WalletTests, SetInvalidSaplingNoteDataInCWalletTx) {
+    CWalletTx wtx;
+    EXPECT_EQ(0, wtx.mapSaplingNoteData.size());
+
+    mapSaplingNoteData_t noteData;
+    SaplingOutPoint op {uint256(), 1};
+    SaplingNoteData nd;
+    noteData.insert(std::make_pair(op, nd));
+
+    EXPECT_THROW(wtx.SetSaplingNoteData(noteData), std::logic_error);
+}
+
 TEST(WalletTests, GetSproutNoteNullifier) {
     CWallet wallet;
 

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -1304,7 +1304,7 @@ TEST(WalletTests, ClearNoteWitnessCache) {
 
     // After clearing, we should not have a witness for either note
     wallet.ClearNoteWitnessCache();
-    auto anchros2 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
+    auto anchors2 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
     EXPECT_FALSE((bool) sproutWitnesses[0]);
     EXPECT_FALSE((bool) sproutWitnesses[1]);
     EXPECT_FALSE((bool) saplingWitnesses[0]);

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -131,14 +131,14 @@ std::pair<uint256, uint256> GetWitnessesAndAnchors(TestWallet& wallet,
     return std::make_pair(sproutAnchor, saplingAnchor);
 }
 
-TEST(wallet_tests, setup_datadir_location_run_as_first_test) {
+TEST(WalletTests, SetupDatadirLocationRunAsFirstTest) {
     // Get temporary and unique path for file.
     boost::filesystem::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
     boost::filesystem::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 }
 
-TEST(wallet_tests, note_data_serialisation) {
+TEST(WalletTests, NoteDataSerialisation) {
     auto sk = libzcash::SproutSpendingKey::random();
     auto wtx = GetValidReceive(sk, 10, true);
     auto note = GetNote(sk, wtx, 0, 1);
@@ -162,7 +162,7 @@ TEST(wallet_tests, note_data_serialisation) {
 }
 
 
-TEST(wallet_tests, find_unspent_notes) {
+TEST(WalletTests, FindUnspentNotes) {
     SelectParams(CBaseChainParams::TESTNET);
     CWallet wallet;
     auto sk = libzcash::SproutSpendingKey::random();
@@ -321,7 +321,7 @@ TEST(wallet_tests, find_unspent_notes) {
 }
 
 
-TEST(wallet_tests, set_note_addrs_in_cwallettx) {
+TEST(WalletTests, SetNoteAddrsInCWalletTx) {
     auto sk = libzcash::SproutSpendingKey::random();
     auto wtx = GetValidReceive(sk, 10, true);
     auto note = GetNote(sk, wtx, 0, 1);
@@ -337,7 +337,7 @@ TEST(wallet_tests, set_note_addrs_in_cwallettx) {
     EXPECT_EQ(noteData, wtx.mapSproutNoteData);
 }
 
-TEST(wallet_tests, set_invalid_note_addrs_in_cwallettx) {
+TEST(WalletTests, SetInvalidNoteAddrsInCWalletTx) {
     CWalletTx wtx;
     EXPECT_EQ(0, wtx.mapSproutNoteData.size());
 
@@ -350,7 +350,7 @@ TEST(wallet_tests, set_invalid_note_addrs_in_cwallettx) {
     EXPECT_THROW(wtx.SetSproutNoteData(noteData), std::logic_error);
 }
 
-TEST(wallet_tests, GetSproutNoteNullifier) {
+TEST(WalletTests, GetSproutNoteNullifier) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -381,7 +381,7 @@ TEST(wallet_tests, GetSproutNoteNullifier) {
     EXPECT_EQ(nullifier, ret);
 }
 
-TEST(wallet_tests, FindMySproutNotes) {
+TEST(WalletTests, FindMySproutNotes) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -406,7 +406,7 @@ TEST(wallet_tests, FindMySproutNotes) {
     EXPECT_EQ(nd, noteMap[jsoutpt]);
 }
 
-TEST(wallet_tests, FindMySproutNotesInEncryptedWallet) {
+TEST(WalletTests, FindMySproutNotesInEncryptedWallet) {
     TestWallet wallet;
     uint256 r {GetRandHash()};
     CKeyingMaterial vMasterKey (r.begin(), r.end());
@@ -436,7 +436,7 @@ TEST(wallet_tests, FindMySproutNotesInEncryptedWallet) {
     EXPECT_EQ(nd, noteMap[jsoutpt]);
 }
 
-TEST(wallet_tests, get_conflicted_notes) {
+TEST(WalletTests, GetConflictedNotes) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -467,7 +467,7 @@ TEST(wallet_tests, get_conflicted_notes) {
     EXPECT_EQ(std::set<uint256>({hash2, hash3}), c3);
 }
 
-TEST(wallet_tests, nullifier_is_spent) {
+TEST(WalletTests, NullifierIsSpent) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -507,7 +507,7 @@ TEST(wallet_tests, nullifier_is_spent) {
     mapBlockIndex.erase(blockHash);
 }
 
-TEST(wallet_tests, navigate_from_nullifier_to_note) {
+TEST(WalletTests, NavigateFromNullifierToNote) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -533,7 +533,7 @@ TEST(wallet_tests, navigate_from_nullifier_to_note) {
     EXPECT_EQ(1, wallet.mapSproutNullifiersToNotes[nullifier].n);
 }
 
-TEST(wallet_tests, spent_note_is_from_me) {
+TEST(WalletTests, SpentNoteIsFromMe) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -561,7 +561,7 @@ TEST(wallet_tests, spent_note_is_from_me) {
     EXPECT_TRUE(wallet.IsFromMe(wtx2));
 }
 
-TEST(wallet_tests, cached_witnesses_empty_chain) {
+TEST(WalletTests, CachedWitnessesEmptyChain) {
     TestWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -620,7 +620,7 @@ TEST(wallet_tests, cached_witnesses_empty_chain) {
                  ".*nWitnessCacheSize > 0.*");
 }
 
-TEST(wallet_tests, cached_witnesses_chain_tip) {
+TEST(WalletTests, CachedWitnessesChainTip) {
     TestWallet wallet;
     std::pair<uint256, uint256> anchors1;
     CBlock block1;
@@ -722,7 +722,7 @@ TEST(wallet_tests, cached_witnesses_chain_tip) {
     }
 }
 
-TEST(wallet_tests, CachedWitnessesDecrementFirst) {
+TEST(WalletTests, CachedWitnessesDecrementFirst) {
     TestWallet wallet;
     SproutMerkleTree sproutTree;
     SaplingMerkleTree saplingTree;
@@ -802,7 +802,7 @@ TEST(wallet_tests, CachedWitnessesDecrementFirst) {
     }
 }
 
-TEST(wallet_tests, CachedWitnessesCleanIndex) {
+TEST(WalletTests, CachedWitnessesCleanIndex) {
     TestWallet wallet;
     std::vector<CBlock> blocks;
     std::vector<CBlockIndex> indices;
@@ -889,7 +889,7 @@ TEST(wallet_tests, CachedWitnessesCleanIndex) {
     }
 }
 
-TEST(wallet_tests, ClearNoteWitnessCache) {
+TEST(WalletTests, ClearNoteWitnessCache) {
     TestWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -947,7 +947,7 @@ TEST(wallet_tests, ClearNoteWitnessCache) {
     EXPECT_EQ(0, wallet.nWitnessCacheSize);
 }
 
-TEST(wallet_tests, WriteWitnessCache) {
+TEST(WalletTests, WriteWitnessCache) {
     TestWallet wallet;
     MockWalletDB walletdb;
     CBlockLocator loc;
@@ -1024,7 +1024,7 @@ TEST(wallet_tests, WriteWitnessCache) {
     wallet.SetBestChain(walletdb, loc);
 }
 
-TEST(wallet_tests, UpdateNullifierNoteMap) {
+TEST(WalletTests, UpdateNullifierNoteMap) {
     TestWallet wallet;
     uint256 r {GetRandHash()};
     CKeyingMaterial vMasterKey (r.begin(), r.end());
@@ -1059,7 +1059,7 @@ TEST(wallet_tests, UpdateNullifierNoteMap) {
     EXPECT_EQ(1, wallet.mapSproutNullifiersToNotes[nullifier].n);
 }
 
-TEST(wallet_tests, UpdatedNoteData) {
+TEST(WalletTests, UpdatedNoteData) {
     TestWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -1106,7 +1106,7 @@ TEST(wallet_tests, UpdatedNoteData) {
     // TODO: The new note should get witnessed (but maybe not here) (#1350)
 }
 
-TEST(wallet_tests, MarkAffectedTransactionsDirty) {
+TEST(WalletTests, MarkAffectedTransactionsDirty) {
     TestWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -1137,7 +1137,7 @@ TEST(wallet_tests, MarkAffectedTransactionsDirty) {
     EXPECT_FALSE(wallet.mapWallet[hash].fDebitCached);
 }
 
-TEST(wallet_tests, NoteLocking) {
+TEST(WalletTests, NoteLocking) {
     TestWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -139,7 +139,7 @@ TEST(WalletTests, SetupDatadirLocationRunAsFirstTest) {
     mapArgs["-datadir"] = pathTemp.string();
 }
 
-TEST(WalletTests, NoteDataSerialisation) {
+TEST(WalletTests, SproutNoteDataSerialisation) {
     auto sk = libzcash::SproutSpendingKey::random();
     auto wtx = GetValidReceive(sk, 10, true);
     auto note = GetNote(sk, wtx, 0, 1);
@@ -163,7 +163,7 @@ TEST(WalletTests, NoteDataSerialisation) {
 }
 
 
-TEST(WalletTests, FindUnspentNotes) {
+TEST(WalletTests, FindUnspentSproutNotes) {
     SelectParams(CBaseChainParams::TESTNET);
     CWallet wallet;
     auto sk = libzcash::SproutSpendingKey::random();
@@ -322,7 +322,7 @@ TEST(WalletTests, FindUnspentNotes) {
 }
 
 
-TEST(WalletTests, SetNoteAddrsInCWalletTx) {
+TEST(WalletTests, SetSproutNoteAddrsInCWalletTx) {
     auto sk = libzcash::SproutSpendingKey::random();
     auto wtx = GetValidReceive(sk, 10, true);
     auto note = GetNote(sk, wtx, 0, 1);
@@ -338,7 +338,7 @@ TEST(WalletTests, SetNoteAddrsInCWalletTx) {
     EXPECT_EQ(noteData, wtx.mapSproutNoteData);
 }
 
-TEST(WalletTests, SetInvalidNoteAddrsInCWalletTx) {
+TEST(WalletTests, SetSproutInvalidNoteAddrsInCWalletTx) {
     CWalletTx wtx;
     EXPECT_EQ(0, wtx.mapSproutNoteData.size());
 
@@ -493,7 +493,7 @@ TEST(WalletTests, FindMySproutNotesInEncryptedWallet) {
     EXPECT_EQ(nd, noteMap[jsoutpt]);
 }
 
-TEST(WalletTests, GetConflictedNotes) {
+TEST(WalletTests, GetConflictedSproutNotes) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -524,7 +524,7 @@ TEST(WalletTests, GetConflictedNotes) {
     EXPECT_EQ(std::set<uint256>({hash2, hash3}), c3);
 }
 
-TEST(WalletTests, NullifierIsSpent) {
+TEST(WalletTests, SproutNullifierIsSpent) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -629,7 +629,7 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
     mapBlockIndex.erase(blockHash);
 }
 
-TEST(WalletTests, NavigateFromNullifierToNote) {
+TEST(WalletTests, NavigateFromSproutNullifierToNote) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -755,7 +755,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     mapBlockIndex.erase(blockHash);
 }
 
-TEST(WalletTests, SpentNoteIsFromMe) {
+TEST(WalletTests, SpentSproutNoteIsFromMe) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -1391,7 +1391,7 @@ TEST(WalletTests, WriteWitnessCache) {
     wallet.SetBestChain(walletdb, loc);
 }
 
-TEST(WalletTests, UpdateNullifierNoteMap) {
+TEST(WalletTests, UpdateSproutNullifierNoteMap) {
     TestWallet wallet;
     uint256 r {GetRandHash()};
     CKeyingMaterial vMasterKey (r.begin(), r.end());
@@ -1426,7 +1426,7 @@ TEST(WalletTests, UpdateNullifierNoteMap) {
     EXPECT_EQ(1, wallet.mapSproutNullifiersToNotes[nullifier].n);
 }
 
-TEST(WalletTests, UpdatedNoteData) {
+TEST(WalletTests, UpdatedSproutNoteData) {
     TestWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -1619,7 +1619,7 @@ TEST(WalletTests, MarkAffectedTransactionsDirty) {
     EXPECT_FALSE(wallet.mapWallet[hash].fDebitCached);
 }
 
-TEST(WalletTests, NoteLocking) {
+TEST(WalletTests, SproutNoteLocking) {
     TestWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -350,7 +350,7 @@ TEST(wallet_tests, set_invalid_note_addrs_in_cwallettx) {
     EXPECT_THROW(wtx.SetSproutNoteData(noteData), std::logic_error);
 }
 
-TEST(wallet_tests, GetNoteNullifier) {
+TEST(wallet_tests, GetSproutNoteNullifier) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -364,7 +364,7 @@ TEST(wallet_tests, GetNoteNullifier) {
     auto hSig = wtx.vjoinsplit[0].h_sig(
         *params, wtx.joinSplitPubKey);
 
-    auto ret = wallet.GetNoteNullifier(
+    auto ret = wallet.GetSproutNoteNullifier(
         wtx.vjoinsplit[0],
         address,
         dec,
@@ -373,7 +373,7 @@ TEST(wallet_tests, GetNoteNullifier) {
 
     wallet.AddSproutSpendingKey(sk);
 
-    ret = wallet.GetNoteNullifier(
+    ret = wallet.GetSproutNoteNullifier(
         wtx.vjoinsplit[0],
         address,
         dec,

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -603,7 +603,7 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
     ASSERT_TRUE(nf);
     uint256 nullifier = nf.get();
 
-    // Verify nullifier is unused
+    // Verify note has not been spent
     EXPECT_FALSE(wallet.IsSaplingSpent(nullifier));
 
     // Fake-mine the transaction
@@ -621,7 +621,7 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
     wtx.SetMerkleBranch(block);
     wallet.AddToWallet(wtx, true, NULL);
 
-    // Verify nullifier is unused
+    // Verify note has been spent
     EXPECT_TRUE(wallet.IsSaplingSpent(nullifier));
 
     // Tear down

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -395,6 +395,10 @@ TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
     EXPECT_EQ(nullifier, wtx.mapSaplingNoteData[op].nullifier);
     EXPECT_EQ(nd.witnessHeight, wtx.mapSaplingNoteData[op].witnessHeight);
     EXPECT_TRUE(witness == wtx.mapSaplingNoteData[op].witnesses.front());
+
+    // Revert to default
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, SetSproutInvalidNoteAddrsInCWalletTx) {
@@ -498,6 +502,10 @@ TEST(WalletTests, FindMySaplingNotes) {
     ASSERT_TRUE(wallet.HaveSaplingSpendingKey(fvk));
     noteMap = wallet.FindMySaplingNotes(wtx);
     EXPECT_EQ(2, noteMap.size());
+
+    // Revert to default
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, FindMySproutNotes) {
@@ -708,6 +716,10 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
     // Tear down
     chainActive.SetTip(NULL);
     mapBlockIndex.erase(blockHash);
+
+    // Revert to default
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, SproutNullifierIsSpent) {
@@ -813,6 +825,10 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
     // Tear down
     chainActive.SetTip(NULL);
     mapBlockIndex.erase(blockHash);
+
+    // Revert to default
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, NavigateFromSproutNullifierToNote) {
@@ -939,6 +955,10 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     // Tear down
     chainActive.SetTip(NULL);
     mapBlockIndex.erase(blockHash);
+
+    // Revert to default
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, SpentSproutNoteIsFromMe) {
@@ -1112,6 +1132,10 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     chainActive.SetTip(NULL);
     mapBlockIndex.erase(blockHash);
     mapBlockIndex.erase(blockHash2);
+
+    // Revert to default
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, CachedWitnessesEmptyChain) {
@@ -1772,6 +1796,10 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
     // Tear down
     chainActive.SetTip(NULL);
     mapBlockIndex.erase(blockHash);
+
+    // Revert to default
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, MarkAffectedSproutTransactionsDirty) {
@@ -1919,6 +1947,10 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     // Tear down
     chainActive.SetTip(NULL);
     mapBlockIndex.erase(blockHash);
+
+    // Revert to default
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, SproutNoteLocking) {

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -381,7 +381,7 @@ TEST(wallet_tests, GetNoteNullifier) {
     EXPECT_EQ(nullifier, ret);
 }
 
-TEST(wallet_tests, FindMyNotes) {
+TEST(wallet_tests, FindMySproutNotes) {
     CWallet wallet;
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -392,12 +392,12 @@ TEST(wallet_tests, FindMyNotes) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    auto noteMap = wallet.FindMyNotes(wtx);
+    auto noteMap = wallet.FindMySproutNotes(wtx);
     EXPECT_EQ(0, noteMap.size());
 
     wallet.AddSproutSpendingKey(sk);
 
-    noteMap = wallet.FindMyNotes(wtx);
+    noteMap = wallet.FindMySproutNotes(wtx);
     EXPECT_EQ(2, noteMap.size());
 
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
@@ -406,7 +406,7 @@ TEST(wallet_tests, FindMyNotes) {
     EXPECT_EQ(nd, noteMap[jsoutpt]);
 }
 
-TEST(wallet_tests, FindMyNotesInEncryptedWallet) {
+TEST(wallet_tests, FindMySproutNotesInEncryptedWallet) {
     TestWallet wallet;
     uint256 r {GetRandHash()};
     CKeyingMaterial vMasterKey (r.begin(), r.end());
@@ -420,7 +420,7 @@ TEST(wallet_tests, FindMyNotesInEncryptedWallet) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    auto noteMap = wallet.FindMyNotes(wtx);
+    auto noteMap = wallet.FindMySproutNotes(wtx);
     EXPECT_EQ(2, noteMap.size());
 
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
@@ -430,7 +430,7 @@ TEST(wallet_tests, FindMyNotesInEncryptedWallet) {
 
     ASSERT_TRUE(wallet.Unlock(vMasterKey));
 
-    noteMap = wallet.FindMyNotes(wtx);
+    noteMap = wallet.FindMySproutNotes(wtx);
     EXPECT_EQ(2, noteMap.size());
     EXPECT_EQ(1, noteMap.count(jsoutpt));
     EXPECT_EQ(nd, noteMap[jsoutpt]);
@@ -1038,7 +1038,7 @@ TEST(wallet_tests, UpdateNullifierNoteMap) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    // Pretend that we called FindMyNotes while the wallet was locked
+    // Pretend that we called FindMySproutNotes while the wallet was locked
     mapSproutNoteData_t noteData;
     JSOutPoint jsoutpt {wtx.GetHash(), 0, 1};
     SproutNoteData nd {sk.address()};

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -356,7 +356,7 @@ TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
     auto ivk = fvk.in_viewing_key();
 
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().value();
+    auto cm = note.cm().get();
     SaplingMerkleTree tree;
     tree.append(cm);
     auto anchor = tree.root();
@@ -477,7 +477,7 @@ TEST(WalletTests, FindMySaplingNotes) {
 
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().value();
+    auto cm = note.cm().get();
     SaplingMerkleTree tree;
     tree.append(cm);
     auto anchor = tree.root();
@@ -615,7 +615,7 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
 
     // Generate note A
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().value();
+    auto cm = note.cm().get();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);
     auto anchor = saplingTree.root();
@@ -778,7 +778,7 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
 
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().value();
+    auto cm = note.cm().get();
     SaplingMerkleTree tree;
     tree.append(cm);
     auto anchor = tree.root();
@@ -873,7 +873,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
 
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().value();
+    auto cm = note.cm().get();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);
     auto anchor = saplingTree.root();
@@ -1007,7 +1007,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
 
     // Generate Sapling note A
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().value();
+    auto cm = note.cm().get();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);
     auto anchor = saplingTree.root();
@@ -1704,7 +1704,7 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
 
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().value();
+    auto cm = note.cm().get();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);
     auto anchor = saplingTree.root();

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -524,13 +524,13 @@ TEST(wallet_tests, navigate_from_nullifier_to_note) {
 
     wtx.SetSproutNoteData(noteData);
 
-    EXPECT_EQ(0, wallet.mapNullifiersToNotes.count(nullifier));
+    EXPECT_EQ(0, wallet.mapSproutNullifiersToNotes.count(nullifier));
 
     wallet.AddToWallet(wtx, true, NULL);
-    EXPECT_EQ(1, wallet.mapNullifiersToNotes.count(nullifier));
-    EXPECT_EQ(wtx.GetHash(), wallet.mapNullifiersToNotes[nullifier].hash);
-    EXPECT_EQ(0, wallet.mapNullifiersToNotes[nullifier].js);
-    EXPECT_EQ(1, wallet.mapNullifiersToNotes[nullifier].n);
+    EXPECT_EQ(1, wallet.mapSproutNullifiersToNotes.count(nullifier));
+    EXPECT_EQ(wtx.GetHash(), wallet.mapSproutNullifiersToNotes[nullifier].hash);
+    EXPECT_EQ(0, wallet.mapSproutNullifiersToNotes[nullifier].js);
+    EXPECT_EQ(1, wallet.mapSproutNullifiersToNotes[nullifier].n);
 }
 
 TEST(wallet_tests, spent_note_is_from_me) {
@@ -1046,17 +1046,17 @@ TEST(wallet_tests, UpdateNullifierNoteMap) {
     wtx.SetSproutNoteData(noteData);
 
     wallet.AddToWallet(wtx, true, NULL);
-    EXPECT_EQ(0, wallet.mapNullifiersToNotes.count(nullifier));
+    EXPECT_EQ(0, wallet.mapSproutNullifiersToNotes.count(nullifier));
 
     EXPECT_FALSE(wallet.UpdateNullifierNoteMap());
 
     ASSERT_TRUE(wallet.Unlock(vMasterKey));
 
     EXPECT_TRUE(wallet.UpdateNullifierNoteMap());
-    EXPECT_EQ(1, wallet.mapNullifiersToNotes.count(nullifier));
-    EXPECT_EQ(wtx.GetHash(), wallet.mapNullifiersToNotes[nullifier].hash);
-    EXPECT_EQ(0, wallet.mapNullifiersToNotes[nullifier].js);
-    EXPECT_EQ(1, wallet.mapNullifiersToNotes[nullifier].n);
+    EXPECT_EQ(1, wallet.mapSproutNullifiersToNotes.count(nullifier));
+    EXPECT_EQ(wtx.GetHash(), wallet.mapSproutNullifiersToNotes[nullifier].hash);
+    EXPECT_EQ(0, wallet.mapSproutNullifiersToNotes[nullifier].js);
+    EXPECT_EQ(1, wallet.mapSproutNullifiersToNotes[nullifier].n);
 }
 
 TEST(wallet_tests, UpdatedNoteData) {

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -491,7 +491,7 @@ TEST(WalletTests, FindMySaplingNotes) {
     ASSERT_EQ(static_cast<bool>(maybe_tx), true);
     auto tx = maybe_tx.get();
 
-    // No Sapling notes can be found in tx which belong to the wallet
+    // No Sapling notes can be found in tx which does not belong to the wallet
     CWalletTx wtx {&wallet, tx};
     ASSERT_FALSE(wallet.HaveSaplingSpendingKey(fvk));
     auto noteMap = wallet.FindMySaplingNotes(wtx);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1617,8 +1617,8 @@ mapSaplingNoteData_t CWallet::FindMySaplingNotes(const CTransaction &tx) const
     // Protocol Spec: 4.19 Block Chain Scanning (Sapling)
     for (uint32_t i = 0; i < tx.vShieldedOutput.size(); ++i) {
         const OutputDescription output = tx.vShieldedOutput[i];
-        for (auto it = mapSaplingIncomingViewingKeys.begin(); it != mapSaplingIncomingViewingKeys.end(); ++it) {
-            SaplingIncomingViewingKey ivk = it->second;
+        for (auto it = mapSaplingFullViewingKeys.begin(); it != mapSaplingFullViewingKeys.end(); ++it) {
+            SaplingIncomingViewingKey ivk = it->first;
             auto result = SaplingNotePlaintext::decrypt(output.encCiphertext, ivk, output.ephemeralKey, output.cm);
             if (!result) {
                 continue;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -712,8 +712,7 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n) const
  * Note is spent if any non-conflicted transaction
  * spends it:
  */
-bool CWallet::IsSpent(const uint256& nullifier) const
-{
+bool CWallet::IsSproutSpent(const uint256& nullifier) const {
     pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range;
     range = mapTxSproutNullifiers.equal_range(nullifier);
 
@@ -724,7 +723,11 @@ bool CWallet::IsSpent(const uint256& nullifier) const
             return true; // Spent
         }
     }
+    return false;
+}
 
+bool CWallet::IsSaplingSpent(const uint256& nullifier) const {
+    pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range;
     range = mapTxSaplingNullifiers.equal_range(nullifier);
 
     for (TxNullifiers::const_iterator it = range.first; it != range.second; ++it) {
@@ -4123,7 +4126,7 @@ void CWallet::GetFilteredNotes(
             }
 
             // skip note which has been spent
-            if (ignoreSpent && nd.nullifier && IsSpent(*nd.nullifier)) {
+            if (ignoreSpent && nd.nullifier && IsSproutSpent(*nd.nullifier)) {
                 continue;
             }
 
@@ -4204,7 +4207,7 @@ void CWallet::GetUnspentFilteredNotes(
             }
 
             // skip note which has been spent
-            if (nd.nullifier && IsSpent(*nd.nullifier)) {
+            if (nd.nullifier && IsSproutSpent(*nd.nullifier)) {
                 continue;
             }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1148,7 +1148,7 @@ bool CWallet::UpdateNullifierNoteMap()
                         auto i = item.first.js;
                         auto hSig = wtxItem.second.vjoinsplit[i].h_sig(
                             *pzcashParams, wtxItem.second.joinSplitPubKey);
-                        item.second.nullifier = GetNoteNullifier(
+                        item.second.nullifier = GetSproutNoteNullifier(
                             wtxItem.second.vjoinsplit[i],
                             item.second.address,
                             dec,
@@ -1403,11 +1403,11 @@ void CWallet::EraseFromWallet(const uint256 &hash)
  * Returns a nullifier if the SpendingKey is available
  * Throws std::runtime_error if the decryptor doesn't match this note
  */
-boost::optional<uint256> CWallet::GetNoteNullifier(const JSDescription& jsdesc,
-                                                   const libzcash::SproutPaymentAddress& address,
-                                                   const ZCNoteDecryption& dec,
-                                                   const uint256& hSig,
-                                                   uint8_t n) const
+boost::optional<uint256> CWallet::GetSproutNoteNullifier(const JSDescription &jsdesc,
+                                                         const libzcash::SproutPaymentAddress &address,
+                                                         const ZCNoteDecryption &dec,
+                                                         const uint256 &hSig,
+                                                         uint8_t n) const
 {
     boost::optional<uint256> ret;
     auto note_pt = libzcash::SproutNotePlaintext::decrypt(
@@ -1448,7 +1448,7 @@ mapSproutNoteData_t CWallet::FindMySproutNotes(const CTransaction &tx) const
                 try {
                     auto address = item.first;
                     JSOutPoint jsoutpt {hash, i, j};
-                    auto nullifier = GetNoteNullifier(
+                    auto nullifier = GetSproutNoteNullifier(
                         tx.vjoinsplit[i],
                         address,
                         item.second,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1566,6 +1566,18 @@ bool CWallet::IsSproutNullifierFromMe(const uint256& nullifier) const
     return false;
 }
 
+bool CWallet::IsSaplingNullifierFromMe(const uint256& nullifier) const
+{
+    {
+        LOCK(cs_wallet);
+        if (mapSaplingNullifiersToNotes.count(nullifier) &&
+                mapWallet.count(mapSaplingNullifiersToNotes.at(nullifier).hash)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void CWallet::GetSproutNoteWitnesses(std::vector<JSOutPoint> notes,
                                      std::vector<boost::optional<SproutWitness>>& witnesses,
                                      uint256 &final_anchor)
@@ -1710,6 +1722,11 @@ bool CWallet::IsFromMe(const CTransaction& tx) const
             if (IsSproutNullifierFromMe(nullifier)) {
                 return true;
             }
+        }
+    }
+    for (const SpendDescription &spend : tx.vShieldedSpend) {
+        if (IsSaplingNullifierFromMe(spend.nullifier)) {
+            return true;
         }
     }
     return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -724,6 +724,16 @@ bool CWallet::IsSpent(const uint256& nullifier) const
             return true; // Spent
         }
     }
+
+    range = mapTxSaplingNullifiers.equal_range(nullifier);
+
+    for (TxNullifiers::const_iterator it = range.first; it != range.second; ++it) {
+        const uint256& wtxid = it->second;
+        std::map<uint256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
+        if (mit != mapWallet.end() && mit->second.GetDepthInMainChain() >= 0) {
+            return true; // Spent
+        }
+    }
     return false;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1384,9 +1384,17 @@ void CWallet::MarkAffectedTransactionsDirty(const CTransaction& tx)
     for (const JSDescription& jsdesc : tx.vjoinsplit) {
         for (const uint256& nullifier : jsdesc.nullifiers) {
             if (mapSproutNullifiersToNotes.count(nullifier) &&
-                    mapWallet.count(mapSproutNullifiersToNotes[nullifier].hash)) {
+                mapWallet.count(mapSproutNullifiersToNotes[nullifier].hash)) {
                 mapWallet[mapSproutNullifiersToNotes[nullifier].hash].MarkDirty();
             }
+        }
+    }
+
+    for (const SpendDescription &spend : tx.vShieldedSpend) {
+        uint256 nullifier = spend.nullifier;
+        if (mapSaplingNullifiersToNotes.count(nullifier) &&
+            mapWallet.count(mapSaplingNullifiersToNotes[nullifier].hash)) {
+            mapWallet[mapSaplingNullifiersToNotes[nullifier].hash].MarkDirty();
         }
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1164,7 +1164,7 @@ bool CWallet::UpdateNullifierNoteMap()
 }
 
 /**
- * Update mapNullifiersToNotes with the cached nullifiers in this tx.
+ * Update mapSproutNullifiersToNotes with the cached nullifiers in this tx.
  */
 void CWallet::UpdateNullifierNoteMapWithTx(const CWalletTx& wtx)
 {
@@ -1172,7 +1172,7 @@ void CWallet::UpdateNullifierNoteMapWithTx(const CWalletTx& wtx)
         LOCK(cs_wallet);
         for (const mapSproutNoteData_t::value_type& item : wtx.mapSproutNoteData) {
             if (item.second.nullifier) {
-                mapNullifiersToNotes[*item.second.nullifier] = item.first;
+                mapSproutNullifiersToNotes[*item.second.nullifier] = item.first;
             }
         }
     }
@@ -1378,9 +1378,9 @@ void CWallet::MarkAffectedTransactionsDirty(const CTransaction& tx)
     }
     for (const JSDescription& jsdesc : tx.vjoinsplit) {
         for (const uint256& nullifier : jsdesc.nullifiers) {
-            if (mapNullifiersToNotes.count(nullifier) &&
-                    mapWallet.count(mapNullifiersToNotes[nullifier].hash)) {
-                mapWallet[mapNullifiersToNotes[nullifier].hash].MarkDirty();
+            if (mapSproutNullifiersToNotes.count(nullifier) &&
+                    mapWallet.count(mapSproutNullifiersToNotes[nullifier].hash)) {
+                mapWallet[mapSproutNullifiersToNotes[nullifier].hash].MarkDirty();
             }
         }
     }
@@ -1478,8 +1478,8 @@ bool CWallet::IsFromMe(const uint256& nullifier) const
 {
     {
         LOCK(cs_wallet);
-        if (mapNullifiersToNotes.count(nullifier) &&
-                mapWallet.count(mapNullifiersToNotes.at(nullifier).hash)) {
+        if (mapSproutNullifiersToNotes.count(nullifier) &&
+                mapWallet.count(mapSproutNullifiersToNotes.at(nullifier).hash)) {
             return true;
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -687,7 +687,7 @@ void CWallet::SyncMetaData(pair<typename TxSpendMap<T>::iterator, typename TxSpe
         CWalletTx* copyTo = &mapWallet[hash];
         if (copyFrom == copyTo) continue;
         copyTo->mapValue = copyFrom->mapValue;
-        // mapSproutNoteData not copied on purpose
+        // mapSproutNoteData and mapSaplingNoteData not copied on purpose
         // (it is always set correctly for each CWalletTx)
         copyTo->vOrderForm = copyFrom->vOrderForm;
         // fTimeReceivedIsTxTime not copied on purpose

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -593,6 +593,19 @@ set<uint256> CWallet::GetConflicts(const uint256& txid) const
             }
         }
     }
+
+    std::pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range_o;
+
+    for (const SpendDescription &spend : wtx.vShieldedSpend) {
+        uint256 nullifier = spend.nullifier;
+        if (mapTxSaplingNullifiers.count(nullifier) <= 1) {
+            continue;  // No conflict if zero or one spends
+        }
+        range_o = mapTxSaplingNullifiers.equal_range(nullifier);
+        for (TxNullifiers::const_iterator it = range_o.first; it != range_o.second; ++it) {
+            result.insert(it->second);
+        }
+    }
     return result;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -583,10 +583,10 @@ set<uint256> CWallet::GetConflicts(const uint256& txid) const
 
     for (const JSDescription& jsdesc : wtx.vjoinsplit) {
         for (const uint256& nullifier : jsdesc.nullifiers) {
-            if (mapTxNullifiers.count(nullifier) <= 1) {
+            if (mapTxSproutNullifiers.count(nullifier) <= 1) {
                 continue;  // No conflict if zero or one spends
             }
-            range_n = mapTxNullifiers.equal_range(nullifier);
+            range_n = mapTxSproutNullifiers.equal_range(nullifier);
             for (TxNullifiers::const_iterator it = range_n.first; it != range_n.second; ++it) {
                 result.insert(it->second);
             }
@@ -713,7 +713,7 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n) const
 bool CWallet::IsSpent(const uint256& nullifier) const
 {
     pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range;
-    range = mapTxNullifiers.equal_range(nullifier);
+    range = mapTxSproutNullifiers.equal_range(nullifier);
 
     for (TxNullifiers::const_iterator it = range.first; it != range.second; ++it) {
         const uint256& wtxid = it->second;
@@ -736,10 +736,10 @@ void CWallet::AddToTransparentSpends(const COutPoint& outpoint, const uint256& w
 
 void CWallet::AddToSproutSpends(const uint256& nullifier, const uint256& wtxid)
 {
-    mapTxNullifiers.insert(make_pair(nullifier, wtxid));
+    mapTxSproutNullifiers.insert(make_pair(nullifier, wtxid));
 
     pair<TxNullifiers::iterator, TxNullifiers::iterator> range;
-    range = mapTxNullifiers.equal_range(nullifier);
+    range = mapTxSproutNullifiers.equal_range(nullifier);
     SyncMetaData<uint256>(range);
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1856,9 +1856,8 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
 
     // Compute fee if we sent this transaction.
     if (isFromMyTaddr) {
-        CAmount nValueOut = GetValueOut();  // transparent outputs plus all vpub_old
-        CAmount nValueIn = 0;
-        nValueIn += GetShieldedValueIn();
+        CAmount nValueOut = GetValueOut();  // transparent outputs plus all Sprout vpub_old and negative Sapling valueBalance
+        CAmount nValueIn = GetShieldedValueIn();
         nFee = nDebit - nValueOut + nValueIn;
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1554,7 +1554,7 @@ mapSaplingNoteData_t CWallet::FindMySaplingNotes(const CTransaction &tx) const
     return noteData;
 }
 
-bool CWallet::IsFromMe(const uint256& nullifier) const
+bool CWallet::IsSproutNullifierFromMe(const uint256& nullifier) const
 {
     {
         LOCK(cs_wallet);
@@ -1707,7 +1707,7 @@ bool CWallet::IsFromMe(const CTransaction& tx) const
     }
     for (const JSDescription& jsdesc : tx.vjoinsplit) {
         for (const uint256& nullifier : jsdesc.nullifiers) {
-            if (IsFromMe(nullifier)) {
+            if (IsSproutNullifierFromMe(nullifier)) {
                 return true;
             }
         }
@@ -1841,7 +1841,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
     bool isFromMyZaddr = false;
     for (const JSDescription& js : vjoinsplit) {
         for (const uint256& nullifier : js.nullifiers) {
-            if (pwallet->IsFromMe(nullifier)) {
+            if (pwallet->IsSproutNullifierFromMe(nullifier)) {
                 isFromMyZaddr = true;
                 break;
             }
@@ -1868,7 +1868,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
 
             // Check input side
             for (const uint256& nullifier : js.nullifiers) {
-                if (pwallet->IsFromMe(nullifier)) {
+                if (pwallet->IsSproutNullifierFromMe(nullifier)) {
                     fMyJSDesc = true;
                     break;
                 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1906,6 +1906,18 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
         }
     }
 
+    // If we sent utxos from this transaction, create output for value taken from (negative valueBalance)
+    // or added (positive valueBalance) to the transparent value pool by Sapling shielding and unshielding.
+    if (isFromMyTaddr) {
+        if (valueBalance < 0) {
+            COutputEntry output = {CNoDestination(), -valueBalance, (int) vout.size()};
+            listSent.push_back(output);
+        } else if (valueBalance > 0) {
+            COutputEntry output = {CNoDestination(), valueBalance, (int) vout.size()};
+            listReceived.push_back(output);
+        }
+    }
+
     // Sent/received.
     for (unsigned int i = 0; i < vout.size(); ++i)
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -725,7 +725,7 @@ bool CWallet::IsSpent(const uint256& nullifier) const
     return false;
 }
 
-void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
+void CWallet::AddToTransparentSpends(const COutPoint& outpoint, const uint256& wtxid)
 {
     mapTxSpends.insert(make_pair(outpoint, wtxid));
 
@@ -734,7 +734,7 @@ void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
     SyncMetaData<COutPoint>(range);
 }
 
-void CWallet::AddToSpends(const uint256& nullifier, const uint256& wtxid)
+void CWallet::AddToSproutSpends(const uint256& nullifier, const uint256& wtxid)
 {
     mapTxNullifiers.insert(make_pair(nullifier, wtxid));
 
@@ -751,11 +751,11 @@ void CWallet::AddToSpends(const uint256& wtxid)
         return;
 
     for (const CTxIn& txin : thisTx.vin) {
-        AddToSpends(txin.prevout, wtxid);
+        AddToTransparentSpends(txin.prevout, wtxid);
     }
     for (const JSDescription& jsdesc : thisTx.vjoinsplit) {
         for (const uint256& nullifier : jsdesc.nullifiers) {
-            AddToSpends(nullifier, wtxid);
+            AddToSproutSpends(nullifier, wtxid);
         }
     }
 }
@@ -1248,7 +1248,12 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
                              wtxIn.GetHash().ToString(),
                              wtxIn.hashBlock.ToString());
             }
+<<<<<<< HEAD
+            AddToSproutSpends(hash);
+=======
             AddToSpends(hash);
+            AddToSaplingSpends(hash);
+>>>>>>> e9b1ce0... fix
         }
 
         bool fUpdated = false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -758,6 +758,18 @@ void CWallet::AddToSpends(const uint256& wtxid)
             AddToSproutSpends(nullifier, wtxid);
         }
     }
+    for (const SpendDescription &spend : thisTx.vShieldedSpend) {
+        AddToSaplingSpends(spend.nullifier, wtxid);
+    }
+}
+
+void CWallet::AddToSaplingSpends(const uint256& nullifier, const uint256& wtxid)
+{
+    mapTxSaplingNullifiers.insert(make_pair(nullifier, wtxid));
+
+    pair<TxNullifiers::iterator, TxNullifiers::iterator> range;
+    range = mapTxSaplingNullifiers.equal_range(nullifier);
+    SyncMetaData<uint256>(range);
 }
 
 void CWallet::ClearNoteWitnessCache()
@@ -1248,12 +1260,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
                              wtxIn.GetHash().ToString(),
                              wtxIn.hashBlock.ToString());
             }
-<<<<<<< HEAD
-            AddToSproutSpends(hash);
-=======
             AddToSpends(hash);
-            AddToSaplingSpends(hash);
->>>>>>> e9b1ce0... fix
         }
 
         bool fUpdated = false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1854,20 +1854,6 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
     CAmount nDebit = GetDebit(filter);
     bool isFromMyTaddr = nDebit > 0; // debit>0 means we signed/sent this transaction
 
-    // Does this tx spend my notes?
-    bool isFromMyZaddr = false;
-    for (const JSDescription& js : vjoinsplit) {
-        for (const uint256& nullifier : js.nullifiers) {
-            if (pwallet->IsSproutNullifierFromMe(nullifier)) {
-                isFromMyZaddr = true;
-                break;
-            }
-        }
-        if (isFromMyZaddr) {
-            break;
-        }
-    }
-
     // Compute fee if we sent this transaction.
     if (isFromMyTaddr) {
         CAmount nValueOut = GetValueOut();  // transparent outputs plus all vpub_old

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1333,7 +1333,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
         AssertLockHeld(cs_wallet);
         bool fExisted = mapWallet.count(tx.GetHash()) != 0;
         if (fExisted && !fUpdate) return false;
-        auto noteData = FindMyNotes(tx);
+        auto noteData = FindMySproutNotes(tx);
         if (fExisted || IsMine(tx) || IsFromMe(tx) || noteData.size() > 0)
         {
             CWalletTx wtx(this,tx);
@@ -1432,10 +1432,10 @@ boost::optional<uint256> CWallet::GetNoteNullifier(const JSDescription& jsdesc,
  * PaymentAddresses in this wallet.
  *
  * It should never be necessary to call this method with a CWalletTx, because
- * the result of FindMyNotes (for the addresses available at the time) will
+ * the result of FindMySproutNotes (for the addresses available at the time) will
  * already have been cached in CWalletTx.mapSproutNoteData.
  */
-mapSproutNoteData_t CWallet::FindMyNotes(const CTransaction& tx) const
+mapSproutNoteData_t CWallet::FindMySproutNotes(const CTransaction &tx) const
 {
     LOCK(cs_SpendingKeyStore);
     uint256 hash = tx.GetHash();
@@ -1465,7 +1465,7 @@ mapSproutNoteData_t CWallet::FindMyNotes(const CTransaction& tx) const
                     // Couldn't decrypt with this decryptor
                 } catch (const std::exception &exc) {
                     // Unexpected failure
-                    LogPrintf("FindMyNotes(): Unexpected error while testing decrypt:\n");
+                    LogPrintf("FindMySproutNotes(): Unexpected error while testing decrypt:\n");
                     LogPrintf("%s\n", exc.what());
                 }
             }
@@ -1680,7 +1680,7 @@ void CWalletTx::SetSproutNoteData(mapSproutNoteData_t &noteData)
             // Store the address and nullifier for the Note
             mapSproutNoteData[nd.first] = nd.second;
         } else {
-            // If FindMyNotes() was used to obtain noteData,
+            // If FindMySproutNotes() was used to obtain noteData,
             // this should never happen
             throw std::logic_error("CWalletTx::SetSproutNoteData(): Invalid note");
         }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1098,7 +1098,7 @@ public:
         uint8_t n) const;
     mapSproutNoteData_t FindMySproutNotes(const CTransaction& tx) const;
     mapSaplingNoteData_t FindMySaplingNotes(const CTransaction& tx) const;
-    bool IsFromMe(const uint256& nullifier) const;
+    bool IsSproutNullifierFromMe(const uint256& nullifier) const;
     void GetSproutNoteWitnesses(
          std::vector<JSOutPoint> notes,
          std::vector<boost::optional<SproutWitness>>& witnesses,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1076,7 +1076,7 @@ public:
 
     std::set<CTxDestination> GetAccountAddresses(const std::string& strAccount) const;
 
-    boost::optional<uint256> GetNoteNullifier(
+    boost::optional<uint256> GetSproutNoteNullifier(
         const JSDescription& jsdesc,
         const libzcash::SproutPaymentAddress& address,
         const ZCNoteDecryption& dec,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -270,12 +270,14 @@ public:
      * We initialize the height to -1 for the same reason as we do in SproutNoteData.
      * See the comment in that class for a full description.
      */
-    SaplingNoteData() : witnessHeight {-1} { }
-    SaplingNoteData(libzcash::SaplingIncomingViewingKey ivk) : ivk {ivk}, witnessHeight {-1} { }
+    SaplingNoteData() : witnessHeight {-1}, nullifier() { }
+    SaplingNoteData(libzcash::SaplingIncomingViewingKey ivk) : ivk {ivk}, witnessHeight {-1}, nullifier() { }
+    SaplingNoteData(libzcash::SaplingIncomingViewingKey ivk, uint256 n) : ivk {ivk}, witnessHeight {-1}, nullifier(n) { }
 
     std::list<SaplingWitness> witnesses;
     int witnessHeight;
     libzcash::SaplingIncomingViewingKey ivk;
+    boost::optional<uint256> nullifier;
 
     friend bool operator==(const SaplingNoteData& a, const SaplingNoteData& b) {
         return (a.ivk == b.ivk && a.nullifier == b.nullifier && a.witnessHeight == b.witnessHeight);
@@ -1050,6 +1052,8 @@ public:
     void MarkDirty();
     bool UpdateNullifierNoteMap();
     void UpdateNullifierNoteMapWithTx(const CWalletTx& wtx);
+    void UpdateSaplingNullifierNoteMapWithTx(CWalletTx& tx);
+    void UpdateSaplingNullifierNoteMapForBlock(const CBlock* pblock);
     bool AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletDB* pwalletdb);
     void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -267,13 +267,23 @@ class SaplingNoteData
 {
 public:
     /**
-     * We initialize the hight to -1 for the same reason as we do in SproutNoteData.
+     * We initialize the height to -1 for the same reason as we do in SproutNoteData.
      * See the comment in that class for a full description.
      */
     SaplingNoteData() : witnessHeight {-1} { }
+    SaplingNoteData(libzcash::SaplingIncomingViewingKey ivk) : ivk {ivk}, witnessHeight {-1} { }
 
     std::list<SaplingWitness> witnesses;
     int witnessHeight;
+    libzcash::SaplingIncomingViewingKey ivk;
+
+    friend bool operator==(const SaplingNoteData& a, const SaplingNoteData& b) {
+        return (a.ivk == b.ivk && a.nullifier == b.nullifier && a.witnessHeight == b.witnessHeight);
+    }
+
+    friend bool operator!=(const SaplingNoteData& a, const SaplingNoteData& b) {
+        return !(a == b);
+    }
 };
 
 typedef std::map<JSOutPoint, SproutNoteData> mapSproutNoteData_t;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -717,8 +717,8 @@ private:
     typedef TxSpendMap<uint256> TxNullifiers;
     TxNullifiers mapTxNullifiers;
 
-    void AddToSpends(const COutPoint& outpoint, const uint256& wtxid);
-    void AddToSpends(const uint256& nullifier, const uint256& wtxid);
+    void AddToTransparentSpends(const COutPoint& outpoint, const uint256& wtxid);
+    void AddToSproutSpends(const uint256& nullifier, const uint256& wtxid);
     void AddToSpends(const uint256& wtxid);
 
 public:

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -895,7 +895,7 @@ public:
      * - Restarting the node with -reindex (which operates on a locked wallet
      *   but with the now-cached nullifiers).
      */
-    std::map<uint256, JSOutPoint> mapNullifiersToNotes;
+    std::map<uint256, JSOutPoint> mapSproutNullifiersToNotes;
 
     std::map<uint256, CWalletTx> mapWallet;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -715,7 +715,7 @@ private:
      * detect and report conflicts (double-spends).
      */
     typedef TxSpendMap<uint256> TxNullifiers;
-    TxNullifiers mapTxNullifiers;
+    TxNullifiers mapTxSproutNullifiers;
 
     void AddToTransparentSpends(const COutPoint& outpoint, const uint256& wtxid);
     void AddToSproutSpends(const uint256& nullifier, const uint256& wtxid);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -726,10 +726,12 @@ private:
      */
     typedef TxSpendMap<uint256> TxNullifiers;
     TxNullifiers mapTxSproutNullifiers;
+    TxNullifiers mapTxSaplingNullifiers;
 
     void AddToTransparentSpends(const COutPoint& outpoint, const uint256& wtxid);
     void AddToSproutSpends(const uint256& nullifier, const uint256& wtxid);
     void AddToSpends(const uint256& wtxid);
+    void AddToSaplingSpends(const uint256& nullifier, const uint256& wtxid);
 
 public:
     /*

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1097,6 +1097,7 @@ public:
         const uint256& hSig,
         uint8_t n) const;
     mapSproutNoteData_t FindMySproutNotes(const CTransaction& tx) const;
+    mapSaplingNoteData_t FindMySaplingNotes(const CTransaction& tx) const;
     bool IsFromMe(const uint256& nullifier) const;
     void GetSproutNoteWitnesses(
          std::vector<JSOutPoint> notes,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -936,7 +936,8 @@ public:
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;
-    bool IsSpent(const uint256& nullifier) const;
+    bool IsSproutSpent(const uint256& nullifier) const;
+    bool IsSaplingSpent(const uint256& nullifier) const;
 
     bool IsLockedCoin(uint256 hash, unsigned int n) const;
     void LockCoin(COutPoint& output);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1053,7 +1053,7 @@ public:
     void MarkDirty();
     bool UpdateNullifierNoteMap();
     void UpdateNullifierNoteMapWithTx(const CWalletTx& wtx);
-    void UpdateSaplingNullifierNoteMapWithTx(CWalletTx& tx);
+    void UpdateSaplingNullifierNoteMapWithTx(CWalletTx& wtx);
     void UpdateSaplingNullifierNoteMapForBlock(const CBlock* pblock);
     bool AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletDB* pwalletdb);
     void SyncTransaction(const CTransaction& tx, const CBlock* pblock);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1099,6 +1099,8 @@ public:
     mapSproutNoteData_t FindMySproutNotes(const CTransaction& tx) const;
     mapSaplingNoteData_t FindMySaplingNotes(const CTransaction& tx) const;
     bool IsSproutNullifierFromMe(const uint256& nullifier) const;
+    bool IsSaplingNullifierFromMe(const uint256& nullifier) const;
+
     void GetSproutNoteWitnesses(
          std::vector<JSOutPoint> notes,
          std::vector<boost::optional<SproutWitness>>& witnesses,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -907,6 +907,8 @@ public:
      */
     std::map<uint256, JSOutPoint> mapSproutNullifiersToNotes;
 
+    std::map<uint256, SaplingOutPoint> mapSaplingNullifiersToNotes;
+
     std::map<uint256, CWalletTx> mapWallet;
 
     int64_t nOrderPosNext;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -225,7 +225,7 @@ public:
     /**
      * Block height corresponding to the most current witness.
      *
-     * When we first create a SproutNoteData in CWallet::FindMyNotes, this is set to
+     * When we first create a SproutNoteData in CWallet::FindMySproutNotes, this is set to
      * -1 as a placeholder. The next time CWallet::ChainTip is called, we can
      * determine what height the witness cache for this note is valid for (even
      * if no witnesses were cached), and so can set the correct value in
@@ -1082,7 +1082,7 @@ public:
         const ZCNoteDecryption& dec,
         const uint256& hSig,
         uint8_t n) const;
-    mapSproutNoteData_t FindMyNotes(const CTransaction& tx) const;
+    mapSproutNoteData_t FindMySproutNotes(const CTransaction& tx) const;
     bool IsFromMe(const uint256& nullifier) const;
     void GetSproutNoteWitnesses(
          std::vector<JSOutPoint> notes,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -732,8 +732,8 @@ private:
 
     void AddToTransparentSpends(const COutPoint& outpoint, const uint256& wtxid);
     void AddToSproutSpends(const uint256& nullifier, const uint256& wtxid);
-    void AddToSpends(const uint256& wtxid);
     void AddToSaplingSpends(const uint256& nullifier, const uint256& wtxid);
+    void AddToSpends(const uint256& wtxid);
 
 public:
     /*

--- a/src/zcash/Note.cpp
+++ b/src/zcash/Note.cpp
@@ -187,7 +187,8 @@ boost::optional<SaplingOutgoingPlaintext> SaplingOutgoingPlaintext::decrypt(
 boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
     const SaplingEncCiphertext &ciphertext,
     const uint256 &ivk,
-    const uint256 &epk
+    const uint256 &epk,
+    const uint256 &cmu
 )
 {
     auto pt = AttemptSaplingEncDecryption(ciphertext, ivk, epk);
@@ -204,6 +205,27 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
 
     assert(ss.size() == 0);
 
+    uint256 pk_d;
+    if (!librustzcash_ivk_to_pkd(ivk.begin(), ret.d.data(), pk_d.begin())) {
+        return boost::none;
+    }
+
+    uint256 cmu_expected;
+    if (!librustzcash_sapling_compute_cm(
+        ret.d.data(),
+        pk_d.begin(),
+        ret.value(),
+        ret.rcm.begin(),
+        cmu_expected.begin()
+    ))
+    {
+        return boost::none;
+    }
+
+    if (cmu_expected != cmu) {
+        return boost::none;
+    }
+
     return ret;
 }
 
@@ -211,7 +233,8 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
     const SaplingEncCiphertext &ciphertext,
     const uint256 &epk,
     const uint256 &esk,
-    const uint256 &pk_d
+    const uint256 &pk_d,
+    const uint256 &cmu
 )
 {
     auto pt = AttemptSaplingEncDecryption(ciphertext, epk, esk, pk_d);
@@ -225,6 +248,22 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
 
     SaplingNotePlaintext ret;
     ss >> ret;
+
+    uint256 cmu_expected;
+    if (!librustzcash_sapling_compute_cm(
+        ret.d.data(),
+        pk_d.begin(),
+        ret.value(),
+        ret.rcm.begin(),
+        cmu_expected.begin()
+    ))
+    {
+        return boost::none;
+    }
+
+    if (cmu_expected != cmu) {
+        return boost::none;
+    }
 
     assert(ss.size() == 0);
 

--- a/src/zcash/Note.hpp
+++ b/src/zcash/Note.hpp
@@ -130,14 +130,16 @@ public:
     static boost::optional<SaplingNotePlaintext> decrypt(
         const SaplingEncCiphertext &ciphertext,
         const uint256 &ivk,
-        const uint256 &epk
+        const uint256 &epk,
+        const uint256 &cmu
     );
 
     static boost::optional<SaplingNotePlaintext> decrypt(
         const SaplingEncCiphertext &ciphertext,
         const uint256 &epk,
         const uint256 &esk,
-        const uint256 &pk_d
+        const uint256 &pk_d,
+        const uint256 &cmu
     );
 
     boost::optional<SaplingNote> note(const SaplingIncomingViewingKey& ivk) const;

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -291,7 +291,7 @@ double benchmark_try_decrypt_notes(size_t nAddrs)
 
     struct timeval tv_start;
     timer_start(tv_start);
-    auto nd = wallet.FindMyNotes(tx);
+    auto nd = wallet.FindMySproutNotes(tx);
     return timer_stop(tv_start);
 }
 


### PR DESCRIPTION
Part of #3061.  Add in-memory tracking of Sapling notes and nullifiers to the wallet. 