### PR TITLE
Revise help output for z_sendmany

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3567,7 +3567,7 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
         throw runtime_error(
             "z_sendmany \"fromaddress\" [{\"address\":... ,\"amount\":...},...] ( minconf ) ( fee )\n"
             "\nSend multiple times. Amounts are double-precision floating point numbers."
-            "\nChange from a taddr flows to a new taddr address, while change from zaddr returns to itself."
+            "\nChange generated from a taddr flows to a new taddr address, while change generated from a zaddr returns to itself."
             "\nWhen sending coinbase UTXOs to a zaddr, change is not allowed. The entire value of the UTXO(s) must be consumed."
             + strprintf("\nBefore Sapling activates, the maximum number of zaddr outputs is %d due to transaction size limits.\n", Z_SENDMANY_MAX_ZADDR_OUTPUTS_BEFORE_SAPLING)
             + HelpRequiringPassphrase() + "\n"


### PR DESCRIPTION
The previous version of the usage message for z_sendmany used the word "Change"
in an ambiguous way.

The intent was to describe "Change" the noun that indicates the portion of a
transaction's funds that are returned to the payer, however the context did not
provide an immediate cue to differentiate from the verb form meaning
"to alter".  Indeed, in other help strings in the same file that meaning of the
word is correct, i.e. the verb form is used.  Moreover a typo in the form of a
missing "a" later in the same sentence exacerbated the problem, by decreasing
readability precisely where context could reduce confusion.