### PR TITLE
add link to public keys

### DIFF
--- a/doc/security-warnings.md
+++ b/doc/security-warnings.md
@@ -108,3 +108,9 @@ out of time. We have brainstormed and documented a variety of such possibilities
 in [issue #826](https://github.com/zcash/zcash/issues/826), and believe that we
 have changed or done everything that was necessary for the 1.0.0 launch. Users
 may want to review this list themselves.
+
+
+Report a Vulnerability
+----------------------
+
+If you need to report a sensitive Zcash vulnerability, please contact security@z.cash rather than opening a public issue. The relevant public keys for encrypting your communications with us are [on the Zcash Company website](https://z.cash/support/pubkeys.html).


### PR DESCRIPTION
After reading this post about the Bitcoin Cash disclosure process: https://medium.com/mit-media-lab-digital-currency-initiative/http-coryfields-com-cash-48a99b85aad4

It occurred to me to look into the process for Zcash. I bounced from this page: https://z.cash/support/security/index.html

to the main GitHub readme, and then to here: https://github.com/zcash/zcash/blob/master/doc/security-warnings.md (the file I'm proposing to modify)

before eventually going back to the website and finding, via the footer: https://z.cash/support/pubkeys.html

I think we could streamline that process for potential vuln reporters by including a link to the public keys page on the website (I emailed Paige about that) and in this file. Hence the PR you're reading.

Thanks!