### PR TITLE
Always write the empty root down as the best root, since we may roll back

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -184,9 +184,9 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
 
     if (!hashBlock.IsNull())
         batch.Write(DB_BEST_BLOCK, hashBlock);
-    if (!hashSproutAnchor.IsNull() && hashSproutAnchor != SproutMerkleTree::empty_root())
+    if (!hashSproutAnchor.IsNull())
         batch.Write(DB_BEST_SPROUT_ANCHOR, hashSproutAnchor);
-    if (!hashSaplingAnchor.IsNull() && hashSaplingAnchor != SaplingMerkleTree::empty_root())
+    if (!hashSaplingAnchor.IsNull())
         batch.Write(DB_BEST_SAPLING_ANCHOR, hashSaplingAnchor);
 
     LogPrint("coindb", "Committing %u changed transactions (out of %u) to coin database...\n", (unsigned int)changed, (unsigned int)count);


### PR DESCRIPTION
In [`3577de83`](https://github.com/zcash/zcash/commit/3577de83aa126fec4db8bb022dbeecf9a77a3af8) we started not writing the Sapling empty root down as the "best" anchor because we had changed the encodings and didn't want users who compiled from master to have inconsistent coindb's in the future if the encoding changed again for some reason.

However, if we don't write the empty root down then during rollbacks to Sapling activation we leave the best anchor on disk different from what's in the cache, which will trigger an assertion.

This reverts the change from `3577de83` since we've settled on the encodings.