### PR TITLE
Fix copyright attribution to match upstream

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,6 @@
 Copyright (c) 2016-2018 The Zcash developers
 Copyright (c) 2009-2018 The Bitcoin Core developers
+Copyright (c) 2009-2018 Bitcoin Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This has to be included to not violate the license.

Ref: https://github.com/bitcoin/bitcoin/blob/master/COPYING