### PR TITLE
Set Sapling mainnet activation height

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,3 +4,14 @@ release-notes at release time)
 Notable changes
 ===============
 
+Sapling network upgrade
+-----------------------
+
+The activation height for the Sapling network upgrade on mainnet is included
+in this release. Sapling will activate on mainnet at height 419200, which is
+expected to be mined on the 28th of October 2018. Please upgrade to this release,
+or any subsequent release, in order to follow the Sapling network upgrade.
+
+The testnet is being rolled back in this release to Overwinter. Sapling will
+activate on testnet at height 280000. Please update your testnet nodes before
+then.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -104,8 +104,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nProtocolVersion = 170005;
         consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nActivationHeight = 347500;
         consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nProtocolVersion = 170007;
-        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight =
-            Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight = 419200;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000000281b32ff3198a1");
@@ -280,8 +279,8 @@ public:
             Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
         consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nProtocolVersion = 170003;
         consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nActivationHeight = 207500;
-        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nProtocolVersion = 170006;
-        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight = 252500;
+        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nProtocolVersion = 170007;
+        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight = 280000;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000000000001d0c4d9cd");

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 170006;
+static const int PROTOCOL_VERSION = 170007;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
In mainnet, block #419200 is expected to appear on October 28, 2018, Zcash's birthday.

In testnet, block #280000 is expected about a week from now. (Current height is ~275249, plus 4032 blocks for a week, plus a little more just to make the number nice.)

These are the activation heights for Sapling in mainnet and testnet, respectively. Protocol version is also changed.