### PR TITLE
Rpc test cleanup

### DIFF
--- a/qa/rpc-tests/mempool_tx_input_limit.py
+++ b/qa/rpc-tests/mempool_tx_input_limit.py
@@ -54,7 +54,7 @@ class MempoolTxInputLimitTest(BitcoinTestFramework):
         myopid = self.nodes[0].z_sendmany(node0_taddr, recipients)
 
         # Spend should fail due to -mempooltxinputlimit
-        wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "Too many transparent inputs 3 > limit 2")
+        wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "Too many transparent inputs 3 > limit 2", 120)
 
         # Mempool should be empty.
         assert_equal(set(self.nodes[0].getrawmempool()), set())

--- a/qa/rpc-tests/mempool_tx_input_limit.py
+++ b/qa/rpc-tests/mempool_tx_input_limit.py
@@ -49,7 +49,7 @@ class MempoolTxInputLimitTest(BitcoinTestFramework):
         node0_zaddr = self.nodes[0].z_getnewaddress()
 
         # Send three inputs from node 0 taddr to zaddr to get out of coinbase
-        node0_taddr = self.nodes[0].getnewaddress();
+        node0_taddr = self.nodes[0].getnewaddress()
         recipients = []
         recipients.append({"address":node0_zaddr, "amount":Decimal('30.0')-Decimal('0.0001')}) # utxo amount less fee
         myopid = self.nodes[0].z_sendmany(node0_taddr, recipients)

--- a/qa/rpc-tests/mempool_tx_input_limit.py
+++ b/qa/rpc-tests/mempool_tx_input_limit.py
@@ -54,22 +54,8 @@ class MempoolTxInputLimitTest(BitcoinTestFramework):
         recipients.append({"address":node0_zaddr, "amount":Decimal('30.0')-Decimal('0.0001')}) # utxo amount less fee
         myopid = self.nodes[0].z_sendmany(node0_taddr, recipients)
 
-        opids = []
-        opids.append(myopid)
-
         # Spend should fail due to -mempooltxinputlimit
-        timeout = 120
-        status = None
-        for x in xrange(1, timeout):
-            results = self.nodes[0].z_getoperationresult(opids)
-            if len(results)==0:
-                time.sleep(1)
-            else:
-                status = results[0]["status"]
-                msg = results[0]["error"]["message"]
-                assert_equal("failed", status)
-                assert_equal("Too many transparent inputs 3 > limit 2", msg)
-                break
+        wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "Too many transparent inputs 3 > limit 2")
 
         # Mempool should be empty.
         assert_equal(set(self.nodes[0].getrawmempool()), set())

--- a/qa/rpc-tests/mempool_tx_input_limit.py
+++ b/qa/rpc-tests/mempool_tx_input_limit.py
@@ -8,7 +8,6 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_node, connect_nodes, wait_and_assert_operationid_status
 
-import time
 from decimal import Decimal
 
 # Test -mempooltxinputlimit

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -383,10 +383,10 @@ def assert_raises(exc, fun, *args, **kwds):
         raise AssertionError("No exception raised")
 
 # Returns txid if operation was a success or None
-def wait_and_assert_operationid_status(node, myopid, in_status='success', in_errormsg=None):
+def wait_and_assert_operationid_status(node, myopid, in_status='success', in_errormsg=None, timeout=300):
     print('waiting for async operation {}'.format(myopid))
     result = None
-    for x in xrange(1, 300): # 300 is the timeout
+    for _ in xrange(1, timeout):
         results = node.z_getoperationresult([myopid])
         if len(results) > 0:
             result = results[0]

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -76,13 +76,13 @@ def initialize_datadir(dirname, n):
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
     with open(os.path.join(datadir, "zcash.conf"), 'w') as f:
-        f.write("regtest=1\n");
-        f.write("showmetrics=0\n");
-        f.write("rpcuser=rt\n");
-        f.write("rpcpassword=rt\n");
-        f.write("port="+str(p2p_port(n))+"\n");
-        f.write("rpcport="+str(rpc_port(n))+"\n");
-        f.write("listenonion=0\n");
+        f.write("regtest=1\n")
+        f.write("showmetrics=0\n")
+        f.write("rpcuser=rt\n")
+        f.write("rpcpassword=rt\n")
+        f.write("port="+str(p2p_port(n))+"\n")
+        f.write("rpcport="+str(rpc_port(n))+"\n")
+        f.write("listenonion=0\n")
     return datadir
 
 def initialize_chain(test_dir):

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -220,7 +220,7 @@ class WalletTest (BitcoinTestFramework):
         for uTx in unspentTxs:
             if uTx['txid'] == zeroValueTxid:
                 found = True
-                assert_equal(uTx['amount'], Decimal('0.00000000'));
+                assert_equal(uTx['amount'], Decimal('0.00000000'))
         assert(found)
 
         #do some -walletbroadcast tests
@@ -232,13 +232,13 @@ class WalletTest (BitcoinTestFramework):
         connect_nodes_bi(self.nodes,0,2)
         self.sync_all()
 
-        txIdNotBroadcasted  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 2);
+        txIdNotBroadcasted  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 2)
         txObjNotBroadcasted = self.nodes[0].gettransaction(txIdNotBroadcasted)
         self.sync_all()
         self.nodes[1].generate(1) #mine a block, tx should not be in there
         self.sync_all()
-        assert_equal(self.nodes[2].getbalance(), Decimal('9.99800000')); #should not be changed because tx was not broadcasted
-        assert_equal(self.nodes[2].getbalance("*"), Decimal('9.99800000')); #should not be changed because tx was not broadcasted
+        assert_equal(self.nodes[2].getbalance(), Decimal('9.99800000')) #should not be changed because tx was not broadcasted
+        assert_equal(self.nodes[2].getbalance("*"), Decimal('9.99800000')) #should not be changed because tx was not broadcasted
 
         #now broadcast from another node, mine a block, sync, and check the balance
         self.nodes[1].sendrawtransaction(txObjNotBroadcasted['hex'])
@@ -246,11 +246,11 @@ class WalletTest (BitcoinTestFramework):
         self.nodes[1].generate(1)
         self.sync_all()
         txObjNotBroadcasted = self.nodes[0].gettransaction(txIdNotBroadcasted)
-        assert_equal(self.nodes[2].getbalance(), Decimal('11.99800000')); #should not be
-        assert_equal(self.nodes[2].getbalance("*"), Decimal('11.99800000')); #should not be
+        assert_equal(self.nodes[2].getbalance(), Decimal('11.99800000')) #should not be
+        assert_equal(self.nodes[2].getbalance("*"), Decimal('11.99800000')) #should not be
 
         #create another tx
-        txIdNotBroadcasted  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 2);
+        txIdNotBroadcasted  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 2)
 
         #restart the nodes with -walletbroadcast=1
         stop_nodes(self.nodes)
@@ -265,18 +265,18 @@ class WalletTest (BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         #tx should be added to balance because after restarting the nodes tx should be broadcastet
-        assert_equal(self.nodes[2].getbalance(), Decimal('13.99800000')); #should not be
-        assert_equal(self.nodes[2].getbalance("*"), Decimal('13.99800000')); #should not be
+        assert_equal(self.nodes[2].getbalance(), Decimal('13.99800000')) #should not be
+        assert_equal(self.nodes[2].getbalance("*"), Decimal('13.99800000')) #should not be
 
         # send from node 0 to node 2 taddr
-        mytaddr = self.nodes[2].getnewaddress();
-        mytxid = self.nodes[0].sendtoaddress(mytaddr, 10.0);
+        mytaddr = self.nodes[2].getnewaddress()
+        mytxid = self.nodes[0].sendtoaddress(mytaddr, 10.0)
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
 
         mybalance = self.nodes[2].z_getbalance(mytaddr)
-        assert_equal(mybalance, Decimal('10.0'));
+        assert_equal(mybalance, Decimal('10.0'))
 
         mytxdetails = self.nodes[2].gettransaction(mytxid)
         myvjoinsplits = mytxdetails["vjoinsplit"]
@@ -365,7 +365,7 @@ class WalletTest (BitcoinTestFramework):
         assert_equal(self.nodes[2].getbalance("*"), node2utxobalance)
 
         # check zaddr balance
-        assert_equal(self.nodes[2].z_getbalance(myzaddr), zsendmanynotevalue);
+        assert_equal(self.nodes[2].z_getbalance(myzaddr), zsendmanynotevalue)
 
         # check via z_gettotalbalance
         resp = self.nodes[2].z_gettotalbalance()
@@ -428,7 +428,7 @@ class WalletTest (BitcoinTestFramework):
         except JSONRPCException,e:
             errorString = e.error['message']
 
-        assert_equal("Invalid amount" in errorString, True);
+        assert_equal("Invalid amount" in errorString, True)
 
         errorString = ""
         try:
@@ -436,7 +436,7 @@ class WalletTest (BitcoinTestFramework):
         except JSONRPCException,e:
             errorString = e.error['message']
 
-        assert_equal("not an integer" in errorString, True);
+        assert_equal("not an integer" in errorString, True)
 
         myzaddr     = self.nodes[0].z_getnewaddress()
         recipients  = [ {"address": myzaddr, "amount": Decimal('0.0') } ]

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -11,7 +11,6 @@ from test_framework.util import assert_equal, assert_greater_than, \
     stop_nodes, sync_blocks, sync_mempools, wait_and_assert_operationid_status, \
     wait_bitcoinds
 
-import time
 from decimal import Decimal
 
 class WalletTest (BitcoinTestFramework):

--- a/qa/rpc-tests/wallet_nullifiers.py
+++ b/qa/rpc-tests/wallet_nullifiers.py
@@ -25,7 +25,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
         recipients = []
         recipients.append({"address":myzaddr0, "amount":Decimal('10.0')-Decimal('0.0001')}) # utxo amount less fee
         
-        wait_and_assert_operationid_status(self.nodes[0], self.nodes[0].z_sendmany(mytaddr, recipients))
+        wait_and_assert_operationid_status(self.nodes[0], self.nodes[0].z_sendmany(mytaddr, recipients), timeout=120)
 
         self.sync_all()
         self.nodes[0].generate(1)
@@ -52,7 +52,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
         recipients = []
         recipients.append({"address":myzaddr, "amount":7.0})
         
-        wait_and_assert_operationid_status(self.nodes[0], self.nodes[0].z_sendmany(myzaddr0, recipients))
+        wait_and_assert_operationid_status(self.nodes[0], self.nodes[0].z_sendmany(myzaddr0, recipients), timeout=120)
 
         self.sync_all()
         self.nodes[0].generate(1)
@@ -70,7 +70,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
         recipients = []
         recipients.append({"address":myzaddr3, "amount":2.0})
 
-        wait_and_assert_operationid_status(self.nodes[2], self.nodes[2].z_sendmany(myzaddr, recipients))
+        wait_and_assert_operationid_status(self.nodes[2], self.nodes[2].z_sendmany(myzaddr, recipients), timeout=120)
 
         self.sync_all()
         self.nodes[2].generate(1)
@@ -97,7 +97,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
         recipients = []
         recipients.append({"address":mytaddr1, "amount":1.0})
         
-        wait_and_assert_operationid_status(self.nodes[1], self.nodes[1].z_sendmany(myzaddr, recipients))
+        wait_and_assert_operationid_status(self.nodes[1], self.nodes[1].z_sendmany(myzaddr, recipients), timeout=120)
 
         self.sync_all()
         self.nodes[1].generate(1)

--- a/qa/rpc-tests/wallet_nullifiers.py
+++ b/qa/rpc-tests/wallet_nullifiers.py
@@ -5,8 +5,8 @@
 
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_true, start_node, \
-    start_nodes, connect_nodes_bi, bitcoind_processes
+from test_framework.util import assert_equal, assert_true, bitcoind_processes, \
+    connect_nodes_bi, start_node, start_nodes, wait_and_assert_operationid_status
 
 import time
 from decimal import Decimal
@@ -25,22 +25,8 @@ class WalletNullifiersTest (BitcoinTestFramework):
         mytaddr = self.nodes[0].getnewaddress();
         recipients = []
         recipients.append({"address":myzaddr0, "amount":Decimal('10.0')-Decimal('0.0001')}) # utxo amount less fee
-        myopid = self.nodes[0].z_sendmany(mytaddr, recipients)
-
-        opids = []
-        opids.append(myopid)
-
-        timeout = 120
-        status = None
-        for x in xrange(1, timeout):
-            results = self.nodes[0].z_getoperationresult(opids)
-            if len(results)==0:
-                time.sleep(1)
-            else:
-                status = results[0]["status"]
-                assert_equal("success", status)
-                mytxid = results[0]["result"]["txid"]
-                break
+        
+        wait_and_assert_operationid_status(self.nodes[0], self.nodes[0].z_sendmany(mytaddr, recipients))
 
         self.sync_all()
         self.nodes[0].generate(1)
@@ -66,22 +52,8 @@ class WalletNullifiersTest (BitcoinTestFramework):
         # send node 0 zaddr to note 2 zaddr
         recipients = []
         recipients.append({"address":myzaddr, "amount":7.0})
-        myopid = self.nodes[0].z_sendmany(myzaddr0, recipients)
-
-        opids = []
-        opids.append(myopid)
-
-        timeout = 120
-        status = None
-        for x in xrange(1, timeout):
-            results = self.nodes[0].z_getoperationresult(opids)
-            if len(results)==0:
-                time.sleep(1)
-            else:
-                status = results[0]["status"]
-                assert_equal("success", status)
-                mytxid = results[0]["result"]["txid"]
-                break
+        
+        wait_and_assert_operationid_status(self.nodes[0], self.nodes[0].z_sendmany(myzaddr0, recipients))
 
         self.sync_all()
         self.nodes[0].generate(1)
@@ -98,22 +70,8 @@ class WalletNullifiersTest (BitcoinTestFramework):
         # send node 2 zaddr to note 3 zaddr
         recipients = []
         recipients.append({"address":myzaddr3, "amount":2.0})
-        myopid = self.nodes[2].z_sendmany(myzaddr, recipients)
 
-        opids = []
-        opids.append(myopid)
-
-        timeout = 120
-        status = None
-        for x in xrange(1, timeout):
-            results = self.nodes[2].z_getoperationresult(opids)
-            if len(results)==0:
-                time.sleep(1)
-            else:
-                status = results[0]["status"]
-                assert_equal("success", status)
-                mytxid = results[0]["result"]["txid"]
-                break
+        wait_and_assert_operationid_status(self.nodes[2], self.nodes[2].z_sendmany(myzaddr, recipients))
 
         self.sync_all()
         self.nodes[2].generate(1)
@@ -139,23 +97,8 @@ class WalletNullifiersTest (BitcoinTestFramework):
         mytaddr1 = self.nodes[1].getnewaddress();
         recipients = []
         recipients.append({"address":mytaddr1, "amount":1.0})
-        myopid = self.nodes[1].z_sendmany(myzaddr, recipients)
-
-        opids = []
-        opids.append(myopid)
-
-        timeout = 120
-        status = None
-        for x in xrange(1, timeout):
-            results = self.nodes[1].z_getoperationresult(opids)
-            if len(results)==0:
-                time.sleep(1)
-            else:
-                status = results[0]["status"]
-                assert_equal("success", status)
-                mytxid = results[0]["result"]["txid"]
-                [mytxid] # hush pyflakes
-                break
+        
+        wait_and_assert_operationid_status(self.nodes[1], self.nodes[1].z_sendmany(myzaddr, recipients))
 
         self.sync_all()
         self.nodes[1].generate(1)
@@ -205,7 +148,6 @@ class WalletNullifiersTest (BitcoinTestFramework):
                 # check all the properties except for change
                 if key != 'change':
                     assert_equal(received2[key], received3[key])
-
 
         # Node 3's balances should be unchanged without explicitly requesting
         # to include watch-only balances

--- a/qa/rpc-tests/wallet_nullifiers.py
+++ b/qa/rpc-tests/wallet_nullifiers.py
@@ -22,7 +22,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
         myzaddr0 = self.nodes[0].z_getnewaddress()
 
         # send node 0 taddr to zaddr to get out of coinbase
-        mytaddr = self.nodes[0].getnewaddress();
+        mytaddr = self.nodes[0].getnewaddress()
         recipients = []
         recipients.append({"address":myzaddr0, "amount":Decimal('10.0')-Decimal('0.0001')}) # utxo amount less fee
         
@@ -94,7 +94,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
         # This requires that node 1 be unlocked, which triggers caching of
         # uncached nullifiers.
         self.nodes[1].walletpassphrase("test", 600)
-        mytaddr1 = self.nodes[1].getnewaddress();
+        mytaddr1 = self.nodes[1].getnewaddress()
         recipients = []
         recipients.append({"address":mytaddr1, "amount":1.0})
         

--- a/qa/rpc-tests/wallet_nullifiers.py
+++ b/qa/rpc-tests/wallet_nullifiers.py
@@ -8,7 +8,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_true, bitcoind_processes, \
     connect_nodes_bi, start_node, start_nodes, wait_and_assert_operationid_status
 
-import time
 from decimal import Decimal
 
 class WalletNullifiersTest (BitcoinTestFramework):

--- a/qa/rpc-tests/wallet_protectcoinbase.py
+++ b/qa/rpc-tests/wallet_protectcoinbase.py
@@ -82,7 +82,7 @@ class WalletProtectCoinbaseTest (BitcoinTestFramework):
         recipients= [{"address":myzaddr, "amount": Decimal('1')}]
         myopid = self.nodes[3].z_sendmany(mytaddr, recipients)
 
-        wait_and_assert_operationid_status(self.nodes[3], myopid, "failed", "no UTXOs found for taddr from address")
+        wait_and_assert_operationid_status(self.nodes[3], myopid, "failed", "no UTXOs found for taddr from address", 10)
 
         # This send will fail because our wallet does not allow any change when protecting a coinbase utxo,
         # as it's currently not possible to specify a change address in z_sendmany.
@@ -90,7 +90,7 @@ class WalletProtectCoinbaseTest (BitcoinTestFramework):
         recipients.append({"address":myzaddr, "amount":Decimal('1.23456789')})
         
         myopid = self.nodes[0].z_sendmany(mytaddr, recipients)
-        error_result = wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "wallet does not allow any change")
+        error_result = wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "wallet does not allow any change", 10)
 
         # Test that the returned status object contains a params field with the operation's input parameters
         assert_equal(error_result["method"], "z_sendmany")

--- a/qa/rpc-tests/wallet_protectcoinbase.py
+++ b/qa/rpc-tests/wallet_protectcoinbase.py
@@ -82,50 +82,25 @@ class WalletProtectCoinbaseTest (BitcoinTestFramework):
         self.nodes[3].importaddress(mytaddr)
         recipients= [{"address":myzaddr, "amount": Decimal('1')}]
         myopid = self.nodes[3].z_sendmany(mytaddr, recipients)
-        errorString=""
-        status = None
-        opids = [myopid]
-        timeout = 10
-        for x in xrange(1, timeout):
-            results = self.nodes[3].z_getoperationresult(opids)
-            if len(results)==0:
-                time.sleep(1)
-            else:
-                status = results[0]["status"]
-                errorString = results[0]["error"]["message"]
-                break
-        assert_equal("failed", status)
-        assert_equal("no UTXOs found for taddr from address" in errorString, True)
+
+        wait_and_assert_operationid_status(self.nodes[3], myopid, "failed", "no UTXOs found for taddr from address")
 
         # This send will fail because our wallet does not allow any change when protecting a coinbase utxo,
         # as it's currently not possible to specify a change address in z_sendmany.
         recipients = []
         recipients.append({"address":myzaddr, "amount":Decimal('1.23456789')})
-        errorString = ""
+        
         myopid = self.nodes[0].z_sendmany(mytaddr, recipients)
-        opids = []
-        opids.append(myopid)
-        timeout = 10
-        status = None
-        for x in xrange(1, timeout):
-            results = self.nodes[0].z_getoperationresult(opids)
-            if len(results)==0:
-                time.sleep(1)
-            else:
-                status = results[0]["status"]
-                errorString = results[0]["error"]["message"]
+        error_result = wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "wallet does not allow any change")
 
-                # Test that the returned status object contains a params field with the operation's input parameters
-                assert_equal(results[0]["method"], "z_sendmany")
-                params =results[0]["params"]
-                assert_equal(params["fee"], Decimal('0.0001')) # default
-                assert_equal(params["minconf"], Decimal('1')) # default
-                assert_equal(params["fromaddress"], mytaddr)
-                assert_equal(params["amounts"][0]["address"], myzaddr)
-                assert_equal(params["amounts"][0]["amount"], Decimal('1.23456789'))
-                break
-        assert_equal("failed", status)
-        assert_equal("wallet does not allow any change" in errorString, True)
+        # Test that the returned status object contains a params field with the operation's input parameters
+        assert_equal(error_result["method"], "z_sendmany")
+        params = error_result["params"]
+        assert_equal(params["fee"], Decimal('0.0001')) # default
+        assert_equal(params["minconf"], Decimal('1')) # default
+        assert_equal(params["fromaddress"], mytaddr)
+        assert_equal(params["amounts"][0]["address"], myzaddr)
+        assert_equal(params["amounts"][0]["amount"], Decimal('1.23456789'))
 
         # Add viewing key for myzaddr to Node 3
         myviewingkey = self.nodes[0].z_exportviewingkey(myzaddr)

--- a/qa/rpc-tests/wallet_protectcoinbase.py
+++ b/qa/rpc-tests/wallet_protectcoinbase.py
@@ -11,7 +11,6 @@ from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, wait_and_assert_operationid_status
 
 import sys
-import time
 import timeit
 from decimal import Decimal
 


### PR DESCRIPTION
The main purpose of this PR was to inline the method 'wait_for_async_operation_id' from util.py in tests where we were doing this manually. To make it work in all cases, I had to change the method to return the result in the case where the call failed. I also did a bit of general clean up (removing semicolons) in the files which I changed.