### PR TITLE
Missing comma in debian package copyright license

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -6,7 +6,7 @@ Source: https://github.com/zcash/zcash
 Files: *
 Copyright: 2016-2018, The Zcash developers
  2009-2018, Bitcoin Core developers
- 2009-2018 Bitcoin Developers
+ 2009-2018, Bitcoin Developers
 License: Expat
 Comment: The Bitcoin Core developers encompasses the current developers listed on bitcoin.org,
  as well as the numerous contributors to the project.


### PR DESCRIPTION
Missing comma in debian package copyright license