### PR TITLE
Fix assertion failure in circuit.merkle_tree_gadget_weirdness test on Windows

### DIFF
--- a/src/snark/libsnark/algebra/curves/alt_bn128/alt_bn128_pairing.cpp
+++ b/src/snark/libsnark/algebra/curves/alt_bn128/alt_bn128_pairing.cpp
@@ -324,7 +324,7 @@ alt_bn128_ate_G2_precomp alt_bn128_ate_precompute_G2(const alt_bn128_G2& Q)
     bool found_one = false;
     alt_bn128_ate_ell_coeffs c;
 
-    for (long i = loop_count.max_bits(); i >= 0; --i)
+    for (int64_t i = loop_count.max_bits(); i >= 0; --i)
     {
         const bool bit = loop_count.test_bit(i);
         if (!found_one)
@@ -378,7 +378,7 @@ alt_bn128_Fq12 alt_bn128_ate_miller_loop(const alt_bn128_ate_G1_precomp &prec_P,
     const bigint<alt_bn128_Fr::num_limbs> &loop_count = alt_bn128_ate_loop_count;
     alt_bn128_ate_ell_coeffs c;
 
-    for (long i = loop_count.max_bits(); i >= 0; --i)
+    for (int64_t i = loop_count.max_bits(); i >= 0; --i)
     {
         const bool bit = loop_count.test_bit(i);
         if (!found_one)
@@ -432,7 +432,7 @@ alt_bn128_Fq12 alt_bn128_ate_double_miller_loop(const alt_bn128_ate_G1_precomp &
     size_t idx = 0;
 
     const bigint<alt_bn128_Fr::num_limbs> &loop_count = alt_bn128_ate_loop_count;
-    for (long i = loop_count.max_bits(); i >= 0; --i)
+    for (int64_t i = loop_count.max_bits(); i >= 0; --i)
     {
         const bool bit = loop_count.test_bit(i);
         if (!found_one)

--- a/src/snark/libsnark/algebra/curves/curve_utils.tcc
+++ b/src/snark/libsnark/algebra/curves/curve_utils.tcc
@@ -16,7 +16,7 @@ GroupT scalar_mul(const GroupT &base, const bigint<m> &scalar)
     GroupT result = GroupT::zero();
 
     bool found_one = false;
-    for (long i = scalar.max_bits() - 1; i >= 0; --i)
+    for (int64_t i = scalar.max_bits() - 1; i >= 0; --i)
     {
         if (found_one)
         {

--- a/src/snark/libsnark/algebra/exponentiation/exponentiation.tcc
+++ b/src/snark/libsnark/algebra/exponentiation/exponentiation.tcc
@@ -25,7 +25,7 @@ FieldT power(const FieldT &base, const bigint<m> &exponent)
 
     bool found_one = false;
 
-    for (long i = exponent.max_bits() - 1; i >= 0; --i)
+    for (int64_t i = exponent.max_bits() - 1; i >= 0; --i)
     {
         if (found_one)
         {

--- a/src/snark/libsnark/algebra/fields/bigint.tcc
+++ b/src/snark/libsnark/algebra/fields/bigint.tcc
@@ -124,7 +124,7 @@ size_t bigint<n>::num_bits() const
         }
         else
         {
-            return ((i+1) * GMP_NUMB_BITS) - __builtin_clzl(x);
+            return ((i+1) * GMP_NUMB_BITS) - __builtin_clzll(x);
         }
     }
     return 0;

--- a/src/snark/libsnark/algebra/fields/bigint.tcc
+++ b/src/snark/libsnark/algebra/fields/bigint.tcc
@@ -105,7 +105,7 @@ template<mp_size_t n>
 size_t bigint<n>::num_bits() const
 {
 /*
-    for (long i = max_bits(); i >= 0; --i)
+    for (int64_t i = max_bits(); i >= 0; --i)
     {
         if (this->test_bit(i))
         {
@@ -115,7 +115,7 @@ size_t bigint<n>::num_bits() const
 
     return 0;
 */
-    for (long i = n-1; i >= 0; --i)
+    for (int64_t i = n-1; i >= 0; --i)
     {
         mp_limb_t x = this->data[i];
         if (x == 0)

--- a/src/snark/libsnark/algebra/fields/bigint.tcc
+++ b/src/snark/libsnark/algebra/fields/bigint.tcc
@@ -124,6 +124,7 @@ size_t bigint<n>::num_bits() const
         }
         else
         {
+            static_assert(GMP_NUMB_MAX <= ULLONG_MAX, "coercing limb to unsigned long long might truncate");
             return ((i+1) * GMP_NUMB_BITS) - __builtin_clzll(x);
         }
     }

--- a/src/snark/libsnark/algebra/fields/field_utils.tcc
+++ b/src/snark/libsnark/algebra/fields/field_utils.tcc
@@ -171,7 +171,7 @@ void batch_invert(std::vector<FieldT> &vec)
 
     FieldT acc_inverse = acc.inverse();
 
-    for (long i = vec.size()-1; i >= 0; --i)
+    for (int64_t i = vec.size()-1; i >= 0; --i)
     {
         const FieldT old_el = vec[i];
         vec[i] = acc_inverse * prod[i];

--- a/src/snark/libsnark/algebra/fields/fp.hpp
+++ b/src/snark/libsnark/algebra/fields/fp.hpp
@@ -67,7 +67,7 @@ public:
 
     Fp_model() {};
     Fp_model(const bigint<n> &b);
-    Fp_model(const long x, const bool is_unsigned=false);
+    Fp_model(const int64_t x, const bool is_unsigned=false);
 
     void set_uint64(const uint64_t x);
 

--- a/src/snark/libsnark/algebra/fields/fp.tcc
+++ b/src/snark/libsnark/algebra/fields/fp.tcc
@@ -194,7 +194,7 @@ Fp_model<n,modulus>::Fp_model(const bigint<n> &b)
 }
 
 template<mp_size_t n, const bigint<n>& modulus>
-Fp_model<n,modulus>::Fp_model(const long x, const bool is_unsigned)
+Fp_model<n,modulus>::Fp_model(const int64_t x, const bool is_unsigned)
 {
     if (is_unsigned || x >= 0)
     {

--- a/src/snark/libsnark/algebra/fields/fp.tcc
+++ b/src/snark/libsnark/algebra/fields/fp.tcc
@@ -690,7 +690,7 @@ Fp_model<n, modulus> Fp_model<n,modulus>::random_element() /// returns random el
             const std::size_t part = bitno/GMP_NUMB_BITS;
             const std::size_t bit = bitno - (GMP_NUMB_BITS*part);
 
-            r.mont_repr.data[part] &= ~(((mp_limb_t) 1)<<bit);
+            r.mont_repr.data[part] &= ~(UINT64_C(1)<<bit);
 
             bitno--;
         }

--- a/src/snark/libsnark/algebra/fields/fp12_2over3over2.tcc
+++ b/src/snark/libsnark/algebra/fields/fp12_2over3over2.tcc
@@ -339,9 +339,9 @@ Fp12_2over3over2_model<n, modulus> Fp12_2over3over2_model<n,modulus>::cyclotomic
     Fp12_2over3over2_model<n,modulus> res = Fp12_2over3over2_model<n,modulus>::one();
 
     bool found_one = false;
-    for (long i = m-1; i >= 0; --i)
+    for (int64_t i = m-1; i >= 0; --i)
     {
-        for (long j = GMP_NUMB_BITS - 1; j >= 0; --j)
+        for (int64_t j = GMP_NUMB_BITS - 1; j >= 0; --j)
         {
             if (found_one)
             {

--- a/src/snark/libsnark/algebra/scalar_multiplication/multiexp.tcc
+++ b/src/snark/libsnark/algebra/scalar_multiplication/multiexp.tcc
@@ -40,7 +40,7 @@ public:
 #if defined(__x86_64__) && defined(USE_ASM)
         if (n == 3)
         {
-            long res;
+            int64_t res;
             __asm__
                 ("// check for overflow           \n\t"
                  "mov $0, %[res]                  \n\t"
@@ -58,7 +58,7 @@ public:
         }
         else if (n == 4)
         {
-            long res;
+            int64_t res;
             __asm__
                 ("// check for overflow           \n\t"
                  "mov $0, %[res]                  \n\t"
@@ -77,7 +77,7 @@ public:
         }
         else if (n == 5)
         {
-            long res;
+            int64_t res;
             __asm__
                 ("// check for overflow           \n\t"
                  "mov $0, %[res]                  \n\t"
@@ -389,7 +389,7 @@ size_t get_exp_window_size(const size_t num_scalars)
 #endif
     }
     size_t window = 1;
-    for (long i = T::fixed_base_exp_window_table.size()-1; i >= 0; --i)
+    for (int64_t i = T::fixed_base_exp_window_table.size()-1; i >= 0; --i)
     {
 #ifdef DEBUG
         if (!inhibit_profiling_info)

--- a/src/snark/libsnark/algebra/scalar_multiplication/wnaf.hpp
+++ b/src/snark/libsnark/algebra/scalar_multiplication/wnaf.hpp
@@ -18,7 +18,7 @@ namespace libsnark {
  * Find the wNAF representation of the given scalar relative to the given window size.
  */
 template<mp_size_t n>
-std::vector<long> find_wnaf(const size_t window_size, const bigint<n> &scalar);
+std::vector<int64_t> find_wnaf(const size_t window_size, const bigint<n> &scalar);
 
 /**
  * In additive notation, use wNAF exponentiation (with the given window size) to compute scalar * base.

--- a/src/snark/libsnark/algebra/scalar_multiplication/wnaf.tcc
+++ b/src/snark/libsnark/algebra/scalar_multiplication/wnaf.tcc
@@ -17,15 +17,15 @@
 namespace libsnark {
 
 template<mp_size_t n>
-std::vector<long> find_wnaf(const size_t window_size, const bigint<n> &scalar)
+std::vector<int64_t> find_wnaf(const size_t window_size, const bigint<n> &scalar)
 {
     const size_t length = scalar.max_bits(); // upper bound
-    std::vector<long> res(length+1);
+    std::vector<int64_t> res(length+1);
     bigint<n> c = scalar;
-    long j = 0;
+    int64_t j = 0;
     while (!c.is_zero())
     {
-        long u;
+        int64_t u;
         if ((c.data[0] & 1) == 1)
         {
             u = c.data[0] % (1u << (window_size+1));
@@ -59,7 +59,7 @@ std::vector<long> find_wnaf(const size_t window_size, const bigint<n> &scalar)
 template<typename T, mp_size_t n>
 T fixed_window_wnaf_exp(const size_t window_size, const T &base, const bigint<n> &scalar)
 {
-    std::vector<long> naf = find_wnaf(window_size, scalar);
+    std::vector<int64_t> naf = find_wnaf(window_size, scalar);
     std::vector<T> table(UINT64_C(1)<<(window_size-1));
     T tmp = base;
     T dbl = base.dbl();
@@ -71,7 +71,7 @@ T fixed_window_wnaf_exp(const size_t window_size, const T &base, const bigint<n>
 
     T res = T::zero();
     bool found_nonzero = false;
-    for (long i = naf.size()-1; i >= 0; --i)
+    for (int64_t i = naf.size()-1; i >= 0; --i)
     {
         if (found_nonzero)
         {
@@ -99,7 +99,7 @@ template<typename T, mp_size_t n>
 T opt_window_wnaf_exp(const T &base, const bigint<n> &scalar, const size_t scalar_bits)
 {
     size_t best = 0;
-    for (long i = T::wnaf_window_table.size() - 1; i >= 0; --i)
+    for (int64_t i = T::wnaf_window_table.size() - 1; i >= 0; --i)
     {
         if (scalar_bits >= T::wnaf_window_table[i])
         {

--- a/src/snark/libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.tcc
+++ b/src/snark/libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.tcc
@@ -144,7 +144,7 @@ void test_merkle_tree_check_read_gadget()
     bit_vector address_bits;
 
     size_t address = 0;
-    for (long level = tree_depth-1; level >= 0; --level)
+    for (int64_t level = tree_depth-1; level >= 0; --level)
     {
         const bool computed_is_right = (std::rand() % 2);
         address |= (computed_is_right ? UINT64_C(1) << (tree_depth-1-level) : 0);

--- a/src/snark/libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.tcc
+++ b/src/snark/libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.tcc
@@ -197,7 +197,7 @@ void test_merkle_tree_check_update_gadget()
     bit_vector address_bits;
 
     size_t address = 0;
-    for (long level = tree_depth-1; level >= 0; --level)
+    for (int64_t level = tree_depth-1; level >= 0; --level)
     {
         const bool computed_is_right = (std::rand() % 2);
         address |= (computed_is_right ? UINT64_C(1) << (tree_depth-1-level) : 0);

--- a/src/snark/libsnark/relations/variable.hpp
+++ b/src/snark/libsnark/relations/variable.hpp
@@ -26,7 +26,7 @@ namespace libsnark {
  * Mnemonic typedefs.
  */
 typedef size_t var_index_t;
-typedef long integer_coeff_t;
+typedef int64_t integer_coeff_t;
 
 /**
  * Forward declaration.


### PR DESCRIPTION
zcash-gtest.exe fails
```
[ RUN      ] circuit.merkle_tree_gadget_weirdness
Assertion failed!

Program: C:\zcash-gtest.exe
File: ./snark/libsnark/gadgetlib1/gadgets/basic_gadgets.tcc, Line 50

Expression: this->pb.lc_val(packed).as_bigint().num_bits() <= bits.size()
```

The argument type of `__builtin_clzl()` function is unsigned long.
So, we need to replace `__builtin_clzl` with `__builtin_clzll`. (The argument type of `__builtin_clzll()` is unsigned long long (64bit)).