### PR TITLE
Clarify in sendmany/z_sendmany rpc docs that amounts are not FP

### DIFF
--- a/doc/payment-api.md
+++ b/doc/payment-api.md
@@ -39,7 +39,7 @@ RPC parameter conventions:
 * taddr : Transparent address
 * zaddr : Private address
 * address : Accepts both private and transparent addresses.
-* amount : JSON format double-precision number with 1 ZC expressed as 1.00000000.
+* amount : JSON format decimal number with at most 8 digits of precision, with 1 ZEC expressed as 1.00000000.
 * memo : Metadata expressed in hexadecimal format.  Limited to 512 bytes, the current size of the memo field of a private transaction.  Zero padding is automatic.
 
 ### Accounting

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -960,7 +960,7 @@ UniValue sendmany(const UniValue& params, bool fHelp)
     if (fHelp || params.size() < 2 || params.size() > 5)
         throw runtime_error(
             "sendmany \"fromaccount\" {\"address\":amount,...} ( minconf \"comment\" [\"address\",...] )\n"
-            "\nSend multiple times. Amounts are double-precision floating point numbers."
+            "\nSend multiple times. Amounts are decimal numbers with at most 8 digits of precision."
             + HelpRequiringPassphrase() + "\n"
             "\nArguments:\n"
             "1. \"fromaccount\"         (string, required) MUST be set to the empty string \"\" to represent the default account. Passing any other string will result in an error.\n"
@@ -3583,7 +3583,7 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
     if (fHelp || params.size() < 2 || params.size() > 4)
         throw runtime_error(
             "z_sendmany \"fromaddress\" [{\"address\":... ,\"amount\":...},...] ( minconf ) ( fee )\n"
-            "\nSend multiple times. Amounts are double-precision floating point numbers."
+            "\nSend multiple times. Amounts are decimal numbers with at most 8 digits of precision."
             "\nChange generated from a taddr flows to a new taddr address, while change generated from a zaddr returns to itself."
             "\nWhen sending coinbase UTXOs to a zaddr, change is not allowed. The entire value of the UTXO(s) must be consumed."
             + strprintf("\nBefore Sapling activates, the maximum number of zaddr outputs is %d due to transaction size limits.\n", Z_SENDMANY_MAX_ZADDR_OUTPUTS_BEFORE_SAPLING)


### PR DESCRIPTION
Fixes #3539 

I clarified in the docs that only 8 digits of precision are allowed. For example, if you try 9 digits you will get:
```
zcash-cli z_sendmany $TADDR  "[{\"address\":\"$ZADDR\",\"amount\":0.123456789}]"
error code: -3
error message:
Invalid amount
```