### PR TITLE
Make it clear that CWallet::GenerateNewZKey is Sprout specific

### DIFF
--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -404,7 +404,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_exportwallet)
     BOOST_CHECK(addrs.size()==0);
 
     // wallet should have one key
-    auto address = pwalletMain->GenerateNewZKey();
+    auto address = pwalletMain->GenerateNewSproutZKey();
     BOOST_CHECK(IsValidPaymentAddress(address));
     BOOST_ASSERT(boost::get<libzcash::SproutPaymentAddress>(&address) != nullptr);
     auto addr = boost::get<libzcash::SproutPaymentAddress>(address);
@@ -603,7 +603,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_importexport)
 
     // Make new addresses for the set
     for (int i=0; i<n2; i++) {
-        myaddrs.insert(EncodePaymentAddress(pwalletMain->GenerateNewZKey()));
+        myaddrs.insert(EncodePaymentAddress(pwalletMain->GenerateNewSproutZKey()));
     }
 
     // Verify number of addresses stored in wallet is n1+n2
@@ -956,7 +956,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_parameters)
     std::vector<char> v (2 * (ZC_MEMO_SIZE+1));     // x2 for hexadecimal string format
     std::fill(v.begin(),v.end(), 'A');
     std::string badmemo(v.begin(), v.end());
-    auto pa = pwalletMain->GenerateNewZKey();
+    auto pa = pwalletMain->GenerateNewSproutZKey();
     std::string zaddr1 = EncodePaymentAddress(pa);
     BOOST_CHECK_THROW(CallRPC(string("z_sendmany tmRr6yJonqGK23UVhrKuyvTpF8qxQQjKigJ ")
             + "[{\"address\":\"" + zaddr1 + "\", \"amount\":123.456}]"), runtime_error);
@@ -1034,7 +1034,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
     // add keys manually
     BOOST_CHECK_NO_THROW(retValue = CallRPC("getnewaddress"));
     std::string taddr1 = retValue.get_str();
-    auto pa = pwalletMain->GenerateNewZKey();
+    auto pa = pwalletMain->GenerateNewSproutZKey();
     std::string zaddr1 = EncodePaymentAddress(pa);
 
     // there are no utxos to spend
@@ -1620,7 +1620,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_shieldcoinbase_internals)
     mapArgs["-mempooltxinputlimit"] = "1";
 
     // Add keys manually
-    auto pa = pwalletMain->GenerateNewZKey();
+    auto pa = pwalletMain->GenerateNewSproutZKey();
     std::string zaddr = EncodePaymentAddress(pa);
 
     // Supply 2 inputs when mempool limit is 1
@@ -1745,7 +1745,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_parameters)
     std::vector<char> v (2 * (ZC_MEMO_SIZE+1));     // x2 for hexadecimal string format
     std::fill(v.begin(),v.end(), 'A');
     std::string badmemo(v.begin(), v.end());
-    auto pa = pwalletMain->GenerateNewZKey();
+    auto pa = pwalletMain->GenerateNewSproutZKey();
     std::string zaddr1 = EncodePaymentAddress(pa);
     BOOST_CHECK_THROW(CallRPC(string("z_mergetoaddress [\"tmRr6yJonqGK23UVhrKuyvTpF8qxQQjKigJ\"] ")
             + zaddr1 + " 0.0001 100 100 " + badmemo), runtime_error);
@@ -1816,7 +1816,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_internals)
     // Add keys manually
     BOOST_CHECK_NO_THROW(retValue = CallRPC("getnewaddress"));
     MergeToAddressRecipient taddr1(retValue.get_str(), "");
-    auto pa = pwalletMain->GenerateNewZKey();
+    auto pa = pwalletMain->GenerateNewSproutZKey();
     MergeToAddressRecipient zaddr1(EncodePaymentAddress(pa), "DEADBEEF");
 
     // Supply 2 inputs when mempool limit is 1

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -404,8 +404,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_exportwallet)
     BOOST_CHECK(addrs.size()==0);
 
     // wallet should have one key
-    auto addr = pwalletMain->GenerateNewSproutZKey();
-    BOOST_CHECK(IsValidPaymentAddress(addr));
+    libzcash::SproutPaymentAddress addr = pwalletMain->GenerateNewSproutZKey();
     pwalletMain->GetSproutPaymentAddresses(addrs);
     BOOST_CHECK(addrs.size()==1);
 

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -404,10 +404,8 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_exportwallet)
     BOOST_CHECK(addrs.size()==0);
 
     // wallet should have one key
-    auto address = pwalletMain->GenerateNewSproutZKey();
-    BOOST_CHECK(IsValidPaymentAddress(address));
-    BOOST_ASSERT(boost::get<libzcash::SproutPaymentAddress>(&address) != nullptr);
-    auto addr = boost::get<libzcash::SproutPaymentAddress>(address);
+    auto addr = pwalletMain->GenerateNewSproutZKey();
+    BOOST_CHECK(IsValidPaymentAddress(addr));
     pwalletMain->GetSproutPaymentAddresses(addrs);
     BOOST_CHECK(addrs.size()==1);
 

--- a/src/wallet/gtest/test_wallet_zkeys.cpp
+++ b/src/wallet/gtest/test_wallet_zkeys.cpp
@@ -121,9 +121,7 @@ TEST(wallet_zkeys_tests, store_and_load_zkeys) {
     ASSERT_EQ(0, addrs.size());
 
     // wallet should have one key
-    auto address = wallet.GenerateNewSproutZKey();
-    ASSERT_NE(boost::get<libzcash::SproutPaymentAddress>(&address), nullptr);
-    auto addr = boost::get<libzcash::SproutPaymentAddress>(address);
+    auto addr = wallet.GenerateNewSproutZKey();
     wallet.GetSproutPaymentAddresses(addrs);
     ASSERT_EQ(1, addrs.size());
 
@@ -353,9 +351,7 @@ TEST(wallet_zkeys_tests, write_cryptedzkey_direct_to_db) {
     ASSERT_EQ(0, addrs.size());
 
     // Add random key to the wallet
-    auto address = wallet.GenerateNewSproutZKey();
-    ASSERT_NE(boost::get<libzcash::SproutPaymentAddress>(&address), nullptr);
-    auto paymentAddress = boost::get<libzcash::SproutPaymentAddress>(address);
+    auto paymentAddress = wallet.GenerateNewSproutZKey();
 
     // wallet should have one key
     wallet.GetSproutPaymentAddresses(addrs);
@@ -372,9 +368,7 @@ TEST(wallet_zkeys_tests, write_cryptedzkey_direct_to_db) {
     
     // unlock wallet and then add
     wallet.Unlock(strWalletPass);
-    auto address2 = wallet.GenerateNewSproutZKey();
-    ASSERT_NE(boost::get<libzcash::SproutPaymentAddress>(&address2), nullptr);
-    auto paymentAddress2 = boost::get<libzcash::SproutPaymentAddress>(address2);
+    auto paymentAddress2 = wallet.GenerateNewSproutZKey();
 
     // Create a new wallet from the existing wallet path
     CWallet wallet2("wallet_crypted.dat");

--- a/src/wallet/gtest/test_wallet_zkeys.cpp
+++ b/src/wallet/gtest/test_wallet_zkeys.cpp
@@ -105,7 +105,7 @@ TEST(wallet_zkeys_tests, StoreAndLoadSaplingZkeys) {
 
 /**
  * This test covers methods on CWallet
- * GenerateNewZKey()
+ * GenerateNewSproutZKey()
  * AddSproutZKey()
  * LoadZKey()
  * LoadZKeyMetadata()
@@ -121,7 +121,7 @@ TEST(wallet_zkeys_tests, store_and_load_zkeys) {
     ASSERT_EQ(0, addrs.size());
 
     // wallet should have one key
-    auto address = wallet.GenerateNewZKey();
+    auto address = wallet.GenerateNewSproutZKey();
     ASSERT_NE(boost::get<libzcash::SproutPaymentAddress>(&address), nullptr);
     auto addr = boost::get<libzcash::SproutPaymentAddress>(address);
     wallet.GetSproutPaymentAddresses(addrs);
@@ -236,7 +236,7 @@ TEST(wallet_zkeys_tests, write_zkey_direct_to_db) {
     ASSERT_EQ(0, addrs.size());
 
     // Add random key to the wallet
-    auto paymentAddress = wallet.GenerateNewZKey();
+    auto paymentAddress = wallet.GenerateNewSproutZKey();
 
     // wallet should have one key
     wallet.GetSproutPaymentAddresses(addrs);
@@ -353,7 +353,7 @@ TEST(wallet_zkeys_tests, write_cryptedzkey_direct_to_db) {
     ASSERT_EQ(0, addrs.size());
 
     // Add random key to the wallet
-    auto address = wallet.GenerateNewZKey();
+    auto address = wallet.GenerateNewSproutZKey();
     ASSERT_NE(boost::get<libzcash::SproutPaymentAddress>(&address), nullptr);
     auto paymentAddress = boost::get<libzcash::SproutPaymentAddress>(address);
 
@@ -368,11 +368,11 @@ TEST(wallet_zkeys_tests, write_cryptedzkey_direct_to_db) {
     ASSERT_TRUE(wallet.EncryptWallet(strWalletPass));
     
     // adding a new key will fail as the wallet is locked
-    EXPECT_ANY_THROW(wallet.GenerateNewZKey());
+    EXPECT_ANY_THROW(wallet.GenerateNewSproutZKey());
     
     // unlock wallet and then add
     wallet.Unlock(strWalletPass);
-    auto address2 = wallet.GenerateNewZKey();
+    auto address2 = wallet.GenerateNewSproutZKey();
     ASSERT_NE(boost::get<libzcash::SproutPaymentAddress>(&address2), nullptr);
     auto paymentAddress2 = boost::get<libzcash::SproutPaymentAddress>(address2);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3166,7 +3166,7 @@ UniValue z_getnewaddress(const UniValue& params, bool fHelp)
     }
 
     if (addrType == ADDR_TYPE_SPROUT) {
-        return EncodePaymentAddress(pwalletMain->GenerateNewZKey());
+        return EncodePaymentAddress(pwalletMain->GenerateNewSproutZKey());
     } else if (addrType == ADDR_TYPE_SAPLING) {
         return EncodePaymentAddress(pwalletMain->GenerateNewSaplingZKey());
     } else {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -82,7 +82,7 @@ const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
 }
 
 // Generate a new spending key and return its public payment address
-libzcash::PaymentAddress CWallet::GenerateNewZKey()
+libzcash::PaymentAddress CWallet::GenerateNewSproutZKey()
 {
     AssertLockHeld(cs_wallet); // mapSproutZKeyMetadata
     // TODO: Add Sapling support
@@ -91,14 +91,14 @@ libzcash::PaymentAddress CWallet::GenerateNewZKey()
 
     // Check for collision, even though it is unlikely to ever occur
     if (CCryptoKeyStore::HaveSproutSpendingKey(addr))
-        throw std::runtime_error("CWallet::GenerateNewZKey(): Collision detected");
+        throw std::runtime_error("CWallet::GenerateNewSproutZKey(): Collision detected");
 
     // Create new metadata
     int64_t nCreationTime = GetTime();
     mapSproutZKeyMetadata[addr] = CKeyMetadata(nCreationTime);
 
     if (!AddSproutZKey(k))
-        throw std::runtime_error("CWallet::GenerateNewZKey(): AddSproutZKey failed");
+        throw std::runtime_error("CWallet::GenerateNewSproutZKey(): AddSproutZKey failed");
     return addr;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -82,10 +82,10 @@ const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
 }
 
 // Generate a new spending key and return its public payment address
-libzcash::PaymentAddress CWallet::GenerateNewSproutZKey()
+libzcash::SproutPaymentAddress CWallet::GenerateNewSproutZKey()
 {
     AssertLockHeld(cs_wallet); // mapSproutZKeyMetadata
-    // TODO: Add Sapling support
+
     auto k = SproutSpendingKey::random();
     auto addr = k.address();
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1042,10 +1042,10 @@ public:
     void GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const;
 
     /**
-      * ZKeys
+      * Sprout ZKeys
       */
-    //! Generates a new zaddr
-    libzcash::PaymentAddress GenerateNewSproutZKey();
+    //! Generates a new Sprout zaddr
+    libzcash::SproutPaymentAddress GenerateNewSproutZKey();
     //! Adds spending key to the store, and saves it to disk
     bool AddSproutZKey(const libzcash::SproutSpendingKey &key);
     //! Adds spending key to the store, without saving it to disk (used by LoadWallet)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1045,7 +1045,7 @@ public:
       * ZKeys
       */
     //! Generates a new zaddr
-    libzcash::PaymentAddress GenerateNewZKey();
+    libzcash::PaymentAddress GenerateNewSproutZKey();
     //! Adds spending key to the store, and saves it to disk
     bool AddSproutZKey(const libzcash::SproutSpendingKey &key);
     //! Adds spending key to the store, without saving it to disk (used by LoadWallet)


### PR DESCRIPTION
Closes https://github.com/zcash/zcash/issues/3577

When adding sapling support we had considered making the method `GenerateNewZKey` generic, but it ended up making more sense to add a second method `GenerateNewSaplingZKey` for sapling support.

This PR changes the name of `GenerateNewZKey` to `GenerateNewSproutZKey` and changes the return type from `libzcash::PaymentAddress` to `libzcash::SproutPaymentAddress` to make it more clear that this is what the method does.