### PR TITLE
Give a better error message for transaction expiry

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -871,7 +871,10 @@ bool ContextualCheckTransaction(
         if (IsExpiredTx(tx, nHeight)) {
             // Don't increase banscore if the transaction only just expired
             int expiredDosLevel = IsExpiredTx(tx, nHeight - 1) ? dosLevelConstricting : 0;
-            return state.DoS(expiredDosLevel, error("ContextualCheckTransaction(): transaction is expired"), REJECT_INVALID, "tx-overwinter-expired");
+            return state.DoS(
+                expiredDosLevel,
+                error("ContextualCheckTransaction(): transaction is expired. Resending when caught up with the blockchain, or manually setting the zcashd txexpirydelta parameter may help."),
+                REJECT_INVALID, "tx-overwinter-expired");
         }
     }
 


### PR DESCRIPTION
As mentioned in https://github.com/zcash/zcash/issues/3393, user gets an error when sending a tx while wallet not caught up. Here we give the user a better explanation of the possible error.