### PR TITLE
Closes #3467. Add benchmarks for Sapling spends and outputs.

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2800,6 +2800,14 @@ UniValue zc_benchmark(const UniValue& params, bool fHelp)
             sample_times.push_back(benchmark_loadwallet());
         } else if (benchmarktype == "listunspent") {
             sample_times.push_back(benchmark_listunspent());
+        } else if (benchmarktype == "createsaplingspend") {
+            sample_times.push_back(benchmark_create_sapling_spend());
+        } else if (benchmarktype == "createsaplingoutput") {
+            sample_times.push_back(benchmark_create_sapling_output());
+        } else if (benchmarktype == "verifysaplingspend") {
+            sample_times.push_back(benchmark_verify_sapling_spend());
+        } else if (benchmarktype == "verifysaplingoutput") {
+            sample_times.push_back(benchmark_verify_sapling_output());
         } else {
             throw JSONRPCError(RPC_TYPE_ERROR, "Invalid benchmarktype");
         }

--- a/src/zcbenchmarks.h
+++ b/src/zcbenchmarks.h
@@ -19,5 +19,9 @@ extern double benchmark_connectblock_slow();
 extern double benchmark_sendtoaddress(CAmount amount);
 extern double benchmark_loadwallet();
 extern double benchmark_listunspent();
+extern double benchmark_create_sapling_spend();
+extern double benchmark_create_sapling_output();
+extern double benchmark_verify_sapling_spend();
+extern double benchmark_verify_sapling_output();
 
 #endif


### PR DESCRIPTION
Four new benchmarks are added to RPC zcbenchmark:
- createsaplingspend
- createsaplingoutput
- verifysaplingspend
- verifysaplingoutput