### PR TITLE
Fix potentially misleading test failures

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -355,11 +355,11 @@ def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants):
 
     return (txid, signresult["hex"], fee)
 
-def assert_equal(expected, actual, message = ""):
+def assert_equal(expected, actual, message=""):
     if expected != actual:
         if message:
-            message = "%s; " % message 
-        raise AssertionError("%sexpected: <%s> but was: <%s>" % (message, str(expected), str(actual)))
+            message = "; %s" % message 
+        raise AssertionError("(left == right)%s\n  left: <%s>\n right: <%s>" % (message, str(expected), str(actual)))
 
 def assert_true(condition, message = ""):
     if not condition:


### PR DESCRIPTION
This is in response to https://github.com/zcash/zcash/pull/3590#discussion_r224677644

Currently statements such as:

```assert_equal("Embarassment", "Embarrassment", "Misspelling detected")```

Will produce essentially the following error:
```
Assertion failed: Misspelling detected; expected: <Embarassment> but was: <Embarrassment>
  File "/home/eirik/Development/zcash/qa/rpc-tests/test_framework/test_framework.py", line 121, in main
    self.run_test()
  File "/home/eirik/Development/zcash/qa/rpc-tests/test_spelling.py", line 13, in run_test
```
Which is misleading because the item on the left is not what is actually expected.

This PR changes the assertion failure to be displayed as:
```
Assertion failed: (left == right); Misspelling detected
  left: <Embarassment>
 right: <Embarrassment>
  File "/home/eirik/Development/zcash/qa/rpc-tests/test_framework/test_framework.py", line 121, in main
    self.run_test()
  File "/home/eirik/Development/zcash/qa/rpc-tests/test_spelling.py", line 13, in run_test
```