### PR TITLE
Closes #3329. Send alert to put non-Sapling nodes into safe mode.

### DIFF
--- a/src/sendalert.cpp
+++ b/src/sendalert.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 The Zcash developers
+// Copyright (c) 2016-2018 The Zcash developers
 // Original code from: https://gist.github.com/laanwj/0e689cfa37b52bcbbb44
 
 /*
@@ -72,13 +72,15 @@ void ThreadSendAlert()
     CAlert alert;
     alert.nRelayUntil   = GetTime() + 15 * 60;
     alert.nExpiration   = GetTime() + 10 * 365 * 24 * 60 * 60;
-    alert.nID           = 1005;  // use https://github.com/zcash/zcash/wiki/specification#assigned-numbers to keep track of alert IDs
-    alert.nCancel       = 1004;  // cancels previous messages up to this ID number
+    alert.nID           = 1006;  // use https://github.com/zcash/zcash/wiki/specification#assigned-numbers to keep track of alert IDs
+    alert.nCancel       = 1005;  // cancels previous messages up to this ID number
 
     // These versions are protocol versions
     // 170002 : 1.0.0
+    // 170006 : 1.1.2
+    // 170007 : 2.0.0
     alert.nMinVer       = 170002;
-    alert.nMaxVer       = 170004;
+    alert.nMaxVer       = 170006;
 
     //
     // main.cpp:
@@ -88,7 +90,7 @@ void ThreadSendAlert()
     //  4000 or higher will put the RPC into safe mode
     alert.nPriority     = 4000;
     alert.strComment    = "";
-    alert.strStatusBar  = "Your client is out of date and incompatible with the Overwinter network upgrade. Please update to a recent version of Zcash (1.1.0 or later).";
+    alert.strStatusBar  = "Your client is out of date and incompatible with the Sapling network upgrade. Please update to a recent version of Zcash (2.0.1 or later).";
     alert.strRPCError   = alert.strStatusBar;
 
     // Set specific client version/versions here. If setSubVer is empty, no filtering on subver is done:


### PR DESCRIPTION
The alert targets nodes running protocol version <= 170006.
Sapling compatible nodes run protocol version >= 170007.