### PR TITLE
Pass parameter paths as native strings to librustzcash

### DIFF
--- a/depends/packages/crate_aesni.mk
+++ b/depends/packages/crate_aesni.mk
@@ -1,9 +1,9 @@
 package=crate_aesni
 $(package)_crate_name=aesni
-$(package)_version=0.4.0
+$(package)_version=0.4.1
 $(package)_download_path=https://static.crates.io/crates/$($(package)_crate_name)
 $(package)_file_name=$($(package)_crate_name)-$($(package)_version).crate
-$(package)_sha256_hash=f2838c142db62c0c6aea0a24054c46d35488532fdaea0f51dbeba430f0985df5
+$(package)_sha256_hash=6810b7fb9f2bb4f76f05ac1c170b8dde285b6308955dc3afd89710268c958d9e
 $(package)_crate_versioned_name=$($(package)_crate_name)
 
 define $(package)_preprocess_cmds

--- a/depends/packages/crate_stream_cipher.mk
+++ b/depends/packages/crate_stream_cipher.mk
@@ -1,9 +1,9 @@
 package=crate_stream_cipher
 $(package)_crate_name=stream-cipher
-$(package)_version=0.1.0
+$(package)_version=0.1.1
 $(package)_download_path=https://static.crates.io/crates/$($(package)_crate_name)
 $(package)_file_name=$($(package)_crate_name)-$($(package)_version).crate
-$(package)_sha256_hash=ac49bc6cb2847200d18bfb738ce89448570f4aa1c34ac0348db6205ee69a0777
+$(package)_sha256_hash=30dc6118470d69ce0fdcf7e6f95e95853f7f4f72f80d835d4519577c323814ab
 $(package)_crate_versioned_name=$($(package)_crate_name)
 
 define $(package)_preprocess_cmds

--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -27,9 +27,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-  cd librustzcash && \
-  cargo build $($(package)_build_opts) && \
-  cd ..
+  cargo build --package librustzcash $($(package)_build_opts)
 endef
 
 define $(package)_stage_cmds

--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -3,10 +3,10 @@ $(package)_version=0.1
 $(package)_download_path=https://github.com/zcash/$(package)/archive/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=e9a488a8bbecf7fb237a32dadd65133211ef61616d44cf55609e029837a41004
-$(package)_git_commit=f5e5cb24e1bd756a02fc4a3fd2b824238ccd15ad
+$(package)_sha256_hash=d2f0d93876b490f9c20060d28dcad833eb85e0609163a1106f540153e1b459c9
+$(package)_git_commit=041671f6425563bdef43c7c907a8396da76f8f21
 $(package)_dependencies=rust $(rust_crates)
-$(package)_patches=cargo.config
+$(package)_patches=cargo.config 0001-Start-using-cargo-clippy-for-CI.patch remove-dev-dependencies.diff
 
 ifeq ($(host_os),mingw32)
 $(package)_library_file=target/x86_64-pc-windows-gnu/release/rustzcash.lib
@@ -20,17 +20,21 @@ $(package)_build_opts_mingw32=--target=x86_64-pc-windows-gnu
 endef
 
 define $(package)_preprocess_cmds
+  patch -p1 -d pairing < $($(package)_patch_dir)/0001-Start-using-cargo-clippy-for-CI.patch && \
+  patch -p1 < $($(package)_patch_dir)/remove-dev-dependencies.diff && \
   mkdir .cargo && \
   cat $($(package)_patch_dir)/cargo.config | sed 's|CRATE_REGISTRY|$(host_prefix)/$(CRATE_REGISTRY)|' > .cargo/config
 endef
 
 define $(package)_build_cmds
-  cargo build $($(package)_build_opts)
+  cd librustzcash && \
+  cargo build $($(package)_build_opts) && \
+  cd ..
 endef
 
 define $(package)_stage_cmds
   mkdir $($(package)_staging_dir)$(host_prefix)/lib/ && \
   mkdir $($(package)_staging_dir)$(host_prefix)/include/ && \
   cp $($(package)_library_file) $($(package)_staging_dir)$(host_prefix)/lib/ && \
-  cp include/librustzcash.h $($(package)_staging_dir)$(host_prefix)/include/
+  cp librustzcash/include/librustzcash.h $($(package)_staging_dir)$(host_prefix)/include/
 endef

--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -3,8 +3,8 @@ $(package)_version=0.1
 $(package)_download_path=https://github.com/zcash/$(package)/archive/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=d2f0d93876b490f9c20060d28dcad833eb85e0609163a1106f540153e1b459c9
-$(package)_git_commit=041671f6425563bdef43c7c907a8396da76f8f21
+$(package)_sha256_hash=9909ec59fa7a411c2071d6237b3363a0bc6e5e42358505cf64b7da0f58a7ff5a
+$(package)_git_commit=06da3b9ac8f278e5d4ae13088cf0a4c03d2c13f5
 $(package)_dependencies=rust $(rust_crates)
 $(package)_patches=cargo.config 0001-Start-using-cargo-clippy-for-CI.patch remove-dev-dependencies.diff
 

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -3,7 +3,6 @@ rust_crates := \
   crate_aesni \
   crate_aes_soft \
   crate_arrayvec \
-  crate_bellman \
   crate_bitflags \
   crate_bit_vec \
   crate_blake2_rfc \
@@ -27,15 +26,12 @@ rust_crates := \
   crate_num_integer \
   crate_num_traits \
   crate_opaque_debug \
-  crate_pairing \
   crate_rand \
-  crate_sapling_crypto \
   crate_stream_cipher \
   crate_typenum \
   crate_winapi_i686_pc_windows_gnu \
   crate_winapi \
-  crate_winapi_x86_64_pc_windows_gnu \
-  crate_zip32
+  crate_winapi_x86_64_pc_windows_gnu
 rust_packages := rust $(rust_crates) librustzcash
 proton_packages := proton
 zcash_packages := libgmp libsodium

--- a/depends/patches/librustzcash/0001-Start-using-cargo-clippy-for-CI.patch
+++ b/depends/patches/librustzcash/0001-Start-using-cargo-clippy-for-CI.patch
@@ -1,0 +1,42 @@
+From cc5b83510277632852af67d896a27e0cb40f342b Mon Sep 17 00:00:00 2001
+From: Sean Bowe <ewillbefull@gmail.com>
+Date: Wed, 4 Jul 2018 12:45:08 -0600
+Subject: [PATCH 1/2] Start using cargo-clippy for CI.
+
+---
+ src/lib.rs | 21 ++++++++++-----------
+ 1 file changed, 10 insertions(+), 11 deletions(-)
+
+diff --git a/src/lib.rs b/src/lib.rs
+index fefdae3..c3640c4 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,15 +1,14 @@
+ // `clippy` is a code linting tool for improving code quality by catching
+-// common mistakes or strange code patterns. If the `clippy` feature is
+-// provided, it is enabled and all compiler warnings are prohibited.
+-#![cfg_attr(feature = "clippy", deny(warnings))]
+-#![cfg_attr(feature = "clippy", feature(plugin))]
+-#![cfg_attr(feature = "clippy", plugin(clippy))]
+-#![cfg_attr(feature = "clippy", allow(inline_always))]
+-#![cfg_attr(feature = "clippy", allow(too_many_arguments))]
+-#![cfg_attr(feature = "clippy", allow(unreadable_literal))]
+-#![cfg_attr(feature = "clippy", allow(many_single_char_names))]
+-#![cfg_attr(feature = "clippy", allow(new_without_default_derive))]
+-#![cfg_attr(feature = "clippy", allow(write_literal))]
++// common mistakes or strange code patterns. If the `cargo-clippy` feature
++// is provided, all compiler warnings are prohibited.
++#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
++#![cfg_attr(feature = "cargo-clippy", allow(inline_always))]
++#![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
++#![cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
++#![cfg_attr(feature = "cargo-clippy", allow(many_single_char_names))]
++#![cfg_attr(feature = "cargo-clippy", allow(new_without_default_derive))]
++#![cfg_attr(feature = "cargo-clippy", allow(write_literal))]
++
+ // Force public structures to implement Debug
+ #![deny(missing_debug_implementations)]
+ 
+-- 
+2.17.1
+

--- a/depends/patches/librustzcash/remove-dev-dependencies.diff
+++ b/depends/patches/librustzcash/remove-dev-dependencies.diff
@@ -1,0 +1,630 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index bc740bb..3c6c94b 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -28,22 +28,6 @@ dependencies = [
+  "stream-cipher 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+-[[package]]
+-name = "aho-corasick"
+-version = "0.6.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "ansi_term"
+-version = "0.11.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+ [[package]]
+ name = "arrayvec"
+ version = "0.4.7"
+@@ -52,27 +36,6 @@ dependencies = [
+  "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+-[[package]]
+-name = "backtrace"
+-version = "0.3.9"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "backtrace-sys"
+-version = "0.1.24"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "cc 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+ [[package]]
+ name = "bellman"
+ version = "0.1.0"
+@@ -92,11 +55,6 @@ name = "bit-vec"
+ version = "0.4.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+-[[package]]
+-name = "bitflags"
+-version = "0.9.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+ [[package]]
+ name = "bitflags"
+ version = "1.0.1"
+@@ -130,61 +88,6 @@ name = "byteorder"
+ version = "1.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+-[[package]]
+-name = "cargo_metadata"
+-version = "0.5.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "cc"
+-version = "1.0.22"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "cfg-if"
+-version = "0.1.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "clippy"
+-version = "0.0.200"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "clippy_lints 0.0.200 (registry+https://github.com/rust-lang/crates.io-index)",
+- "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "clippy_lints"
+-version = "0.0.200"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "cargo_metadata 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+- "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+- "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+ [[package]]
+ name = "constant_time_eq"
+ version = "0.1.3"
+@@ -203,19 +106,6 @@ dependencies = [
+  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+-[[package]]
+-name = "either"
+-version = "1.5.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "error-chain"
+-version = "0.11.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+ [[package]]
+ name = "fpe"
+ version = "0.1.0"
+@@ -256,11 +146,6 @@ dependencies = [
+  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+-[[package]]
+-name = "gcc"
+-version = "0.3.54"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+ [[package]]
+ name = "generic-array"
+ version = "0.9.0"
+@@ -269,59 +154,6 @@ dependencies = [
+  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+-[[package]]
+-name = "getopts"
+-version = "0.2.18"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "hex-literal"
+-version = "0.1.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "hex-literal-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "proc-macro-hack 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "hex-literal-impl"
+-version = "0.1.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "proc-macro-hack 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "idna"
+-version = "0.1.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "if_chain"
+-version = "0.1.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "itertools"
+-version = "0.7.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "itoa"
+-version = "0.4.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+ [[package]]
+ name = "lazy_static"
+ version = "1.0.0"
+@@ -347,19 +179,6 @@ dependencies = [
+  "zip32 0.0.0",
+ ]
+ 
+-[[package]]
+-name = "matches"
+-version = "0.1.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "memchr"
+-version = "2.0.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+ [[package]]
+ name = "nodrop"
+ version = "0.1.12"
+@@ -405,65 +224,6 @@ name = "pairing"
+ version = "0.14.2"
+ dependencies = [
+  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "clippy 0.0.200 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "percent-encoding"
+-version = "1.0.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "proc-macro-hack"
+-version = "0.4.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "proc-macro-hack-impl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "proc-macro-hack-impl"
+-version = "0.4.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "proc-macro2"
+-version = "0.4.14"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "pulldown-cmark"
+-version = "0.1.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "quine-mc_cluskey"
+-version = "0.2.4"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "quote"
+-version = "0.6.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "proc-macro2 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "rand"
+-version = "0.3.22"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -477,66 +237,6 @@ dependencies = [
+  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+-[[package]]
+-name = "redox_syscall"
+-version = "0.1.40"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "regex"
+-version = "1.0.4"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "regex-syntax"
+-version = "0.6.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "rust-crypto"
+-version = "0.2.36"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+- "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "rustc-demangle"
+-version = "0.1.9"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "rustc-serialize"
+-version = "0.3.24"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "rustc_version"
+-version = "0.2.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "ryu"
+-version = "0.2.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+ [[package]]
+ name = "sapling-crypto"
+ version = "0.0.1"
+@@ -545,49 +245,8 @@ dependencies = [
+  "blake2-rfc 0.2.18 (git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9)",
+  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pairing 0.14.2",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "semver"
+-version = "0.9.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "semver-parser"
+-version = "0.7.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "serde"
+-version = "1.0.75"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "serde_derive"
+-version = "1.0.75"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "proc-macro2 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "serde_json"
+-version = "1.0.26"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -598,90 +257,11 @@ dependencies = [
+  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+-[[package]]
+-name = "syn"
+-version = "0.14.9"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "proc-macro2 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "thread_local"
+-version = "0.3.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "time"
+-version = "0.1.40"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "toml"
+-version = "0.4.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+ [[package]]
+ name = "typenum"
+ version = "1.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+-[[package]]
+-name = "ucd-util"
+-version = "0.1.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "unicode-bidi"
+-version = "0.3.4"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "unicode-normalization"
+-version = "0.1.7"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "unicode-width"
+-version = "0.1.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "unicode-xid"
+-version = "0.1.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[[package]]
+-name = "url"
+-version = "1.7.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "utf8-ranges"
+-version = "1.0.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+ [[package]]
+ name = "winapi"
+ version = "0.3.4"
+@@ -730,87 +310,33 @@ dependencies = [
+ "checksum aes 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6fb1737cdc8da3db76e90ca817a194249a38fcb500c2e6ecec39b29448aa873"
+ "checksum aes-soft 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67cc03b0a090a05cb01e96998a01905d7ceedce1bc23b756c0bb7faa0682ccb1"
+ "checksum aesni 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6810b7fb9f2bb4f76f05ac1c170b8dde285b6308955dc3afd89710268c958d9e"
+-"checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
+-"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+ "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
+-"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
+-"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
+ "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+-"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+ "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+ "checksum blake2-rfc 0.2.18 (git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9)" = "<none>"
+ "checksum block-cipher-trait 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "370424437b9459f3dfd68428ed9376ddfe03d8b70ede29cc533b3557df186ab4"
+ "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
+ "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
+-"checksum cargo_metadata 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1efca0b863ca03ed4c109fb1c55e0bc4bbeb221d3e103d86251046b06a526bd0"
+-"checksum cc 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "4a6007c146fdd28d4512a794b07ffe9d8e89e6bf86e2e0c4ddff2e1fb54a0007"
+-"checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
+-"checksum clippy 0.0.200 (registry+https://github.com/rust-lang/crates.io-index)" = "927a1f79af10deb103df108347f23c6b7fa1731c953d6fb24d68be1748a0993f"
+-"checksum clippy_lints 0.0.200 (registry+https://github.com/rust-lang/crates.io-index)" = "d2432663f6bdb90255dcf9df5ca504f99b575bb471281591138f62f9d31f863b"
+ "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
+ "checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
+ "checksum digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "00a49051fef47a72c9623101b19bd71924a45cca838826caae3eaa4d00772603"
+-"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+-"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+ "checksum fpe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce3371c82bfbd984f624cab093f55e7336f5a6e589f8518e1258f54f011b89ad"
+ "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+ "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+ "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
+ "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+-"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+ "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+-"checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
+-"checksum hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4da5f0e01bd8a71a224a4eedecaacfcabda388dbb7a80faf04d3514287572d95"
+-"checksum hex-literal-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1d340b6514f232f6db1bd16db65302a5278a04fef9ce867cb932e7e5fa21130a"
+-"checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+-"checksum if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4bac95d9aa0624e7b78187d6fb8ab012b41d9f6f54b1bcb61e61c4845f8357ec"
+-"checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
+-"checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
+ "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+ "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+-"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+-"checksum memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a3b4142ab8738a78c51896f704f83c11df047ff1bda9a92a661aa6361552d93d"
+ "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
+ "checksum num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3eceac7784c5dc97c2d6edf30259b4e153e6e2b42b3c85e9a6e9f45d06caef6e"
+ "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+ "checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
+ "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
+ "checksum opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d620c9c26834b34f039489ac0dfdb12c7ac15ccaf818350a64c9b5334a452ad7"
+-"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+-"checksum proc-macro-hack 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ba8d4f9257b85eb6cdf13f055cea3190520aab1409ca2ab43493ea4820c25f0"
+-"checksum proc-macro-hack-impl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5cb6f960ad471404618e9817c0e5d10b1ae74cfdf01fab89ea0641fe7fb2892"
+-"checksum proc-macro2 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b331c6ad3411474cd55540398dc7ad89fc41488e64ec71fdecc9c9b86de96fb0"
+-"checksum pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fdf85cda6cadfae5428a54661d431330b312bc767ddbc57adbedc24da66e32"
+-"checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
+-"checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
+-"checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
+ "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+-"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+-"checksum regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "67d0301b0c6804eca7e3c275119d0b01ff3b7ab9258a65709e608a66312a1025"
+-"checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
+-"checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
+-"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
+-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+-"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+-"checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
+-"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+-"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+-"checksum serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)" = "22d340507cea0b7e6632900a176101fea959c7065d93ba555072da90aaaafc87"
+-"checksum serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)" = "234fc8b737737b148ccd625175fc6390f5e4dacfdaa543cb93a3430d984a9119"
+-"checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
+ "checksum stream-cipher 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "30dc6118470d69ce0fdcf7e6f95e95853f7f4f72f80d835d4519577c323814ab"
+-"checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
+-"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+-"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
+-"checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
+ "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+-"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+-"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+-"checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
+-"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+-"checksum url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a321979c09843d272956e73700d12c4e7d3d92b2ee112b31548aef0d4efc5a6"
+-"checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
+ "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+ "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+ "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+diff --git a/pairing/Cargo.toml b/pairing/Cargo.toml
+index 98725aa..dedce80 100644
+--- a/pairing/Cargo.toml
++++ b/pairing/Cargo.toml
+@@ -14,7 +14,6 @@ repository = "https://github.com/ebfull/pairing"
+ [dependencies]
+ rand = "0.4"
+ byteorder = "1"
+-clippy = { version = "0.0.200", optional = true }
+ 
+ [features]
+ unstable-features = ["expose-arith"]
+diff --git a/sapling-crypto/Cargo.toml b/sapling-crypto/Cargo.toml
+index 6e802f2..33e21bf 100644
+--- a/sapling-crypto/Cargo.toml
++++ b/sapling-crypto/Cargo.toml
+@@ -22,10 +22,6 @@ byteorder = "1"
+ git = "https://github.com/gtank/blake2-rfc"
+ rev = "7a5b5fc99ae483a0043db7547fb79a6fa44b88a9"
+ 
+-[dev-dependencies]
+-hex-literal = "0.1"
+-rust-crypto = "0.2"
+-
+ [features]
+ default = ["u128-support"]
+ u128-support = ["pairing/u128-support"]

--- a/src/gtest/main.cpp
+++ b/src/gtest/main.cpp
@@ -34,19 +34,25 @@ int main(int argc, char **argv) {
   boost::filesystem::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
   boost::filesystem::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
 
-  std::string sapling_spend_str = sapling_spend.string();
-  std::string sapling_output_str = sapling_output.string();
-  std::string sprout_groth16_str = sprout_groth16.string();
+    static_assert(
+        sizeof(boost::filesystem::path::value_type) == sizeof(codeunit),
+        "librustzcash not configured correctly");
+    auto sapling_spend_str = sapling_spend.native();
+    auto sapling_output_str = sapling_output.native();
+    auto sprout_groth16_str = sprout_groth16.native();
 
-  librustzcash_init_zksnark_params(
-      sapling_spend_str.c_str(),
-      "8270785a1a0d0bc77196f000ee6d221c9c9894f55307bd9357c3f0105d31ca63991ab91324160d8f53e2bbd3c2633a6eb8bdf5205d822e7f3f73edac51b2b70c",
-      sapling_output_str.c_str(),
-      "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028",
-      sprout_groth16_str.c_str(),
-      "e9b238411bd6c0ec4791e9d04245ec350c9c5744f5610dfcce4365d5ca49dfefd5054e371842b3f88fa1b9d7e8e075249b3ebabd167fa8b0f3161292d36c180a"
-  );
-  
+    librustzcash_init_zksnark_params(
+        reinterpret_cast<const codeunit*>(sapling_spend_str.c_str()),
+        sapling_spend_str.length(),
+        "8270785a1a0d0bc77196f000ee6d221c9c9894f55307bd9357c3f0105d31ca63991ab91324160d8f53e2bbd3c2633a6eb8bdf5205d822e7f3f73edac51b2b70c",
+        reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
+        sapling_output_str.length(),
+        "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028",
+        reinterpret_cast<const codeunit*>(sprout_groth16_str.c_str()),
+        sprout_groth16_str.length(),
+        "e9b238411bd6c0ec4791e9d04245ec350c9c5744f5610dfcce4365d5ca49dfefd5054e371842b3f88fa1b9d7e8e075249b3ebabd167fa8b0f3161292d36c180a"
+    );
+
   testing::InitGoogleMock(&argc, argv);
   
   auto ret = RUN_ALL_TESTS();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -718,21 +718,27 @@ static void ZC_LoadParams(
     elapsed = float(tv_end.tv_sec-tv_start.tv_sec) + (tv_end.tv_usec-tv_start.tv_usec)/float(1000000);
     LogPrintf("Loaded verifying key in %fs seconds.\n", elapsed);
 
-    std::string sapling_spend_str = sapling_spend.string();
-    std::string sapling_output_str = sapling_output.string();
-    std::string sprout_groth16_str = sprout_groth16.string();
+    static_assert(
+        sizeof(boost::filesystem::path::value_type) == sizeof(codeunit),
+        "librustzcash not configured correctly");
+    auto sapling_spend_str = sapling_spend.native();
+    auto sapling_output_str = sapling_output.native();
+    auto sprout_groth16_str = sprout_groth16.native();
 
-    LogPrintf("Loading Sapling (Spend) parameters from %s\n", sapling_spend_str.c_str());
-    LogPrintf("Loading Sapling (Output) parameters from %s\n", sapling_output_str.c_str());
-    LogPrintf("Loading Sapling (Sprout Groth16) parameters from %s\n", sprout_groth16_str.c_str());
+    LogPrintf("Loading Sapling (Spend) parameters from %s\n", sapling_spend.string().c_str());
+    LogPrintf("Loading Sapling (Output) parameters from %s\n", sapling_output.string().c_str());
+    LogPrintf("Loading Sapling (Sprout Groth16) parameters from %s\n", sprout_groth16.string().c_str());
     gettimeofday(&tv_start, 0);
 
     librustzcash_init_zksnark_params(
-        sapling_spend_str.c_str(),
+        reinterpret_cast<const codeunit*>(sapling_spend_str.c_str()),
+        sapling_spend_str.length(),
         "8270785a1a0d0bc77196f000ee6d221c9c9894f55307bd9357c3f0105d31ca63991ab91324160d8f53e2bbd3c2633a6eb8bdf5205d822e7f3f73edac51b2b70c",
-        sapling_output_str.c_str(),
+        reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
+        sapling_output_str.length(),
         "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028",
-        sprout_groth16_str.c_str(),
+        reinterpret_cast<const codeunit*>(sprout_groth16_str.c_str()),
+        sprout_groth16_str.length(),
         "e9b238411bd6c0ec4791e9d04245ec350c9c5744f5610dfcce4365d5ca49dfefd5054e371842b3f88fa1b9d7e8e075249b3ebabd167fa8b0f3161292d36c180a"
     );
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -45,16 +45,22 @@ JoinSplitTestingSetup::JoinSplitTestingSetup()
     boost::filesystem::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
     boost::filesystem::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
 
-    std::string sapling_spend_str = sapling_spend.string();
-    std::string sapling_output_str = sapling_output.string();
-    std::string sprout_groth16_str = sprout_groth16.string();
+    static_assert(
+        sizeof(boost::filesystem::path::value_type) == sizeof(codeunit),
+        "librustzcash not configured correctly");
+    auto sapling_spend_str = sapling_spend.native();
+    auto sapling_output_str = sapling_output.native();
+    auto sprout_groth16_str = sprout_groth16.native();
 
     librustzcash_init_zksnark_params(
-        sapling_spend_str.c_str(),
+        reinterpret_cast<const codeunit*>(sapling_spend_str.c_str()),
+        sapling_spend_str.length(),
         "8270785a1a0d0bc77196f000ee6d221c9c9894f55307bd9357c3f0105d31ca63991ab91324160d8f53e2bbd3c2633a6eb8bdf5205d822e7f3f73edac51b2b70c",
-        sapling_output_str.c_str(),
+        reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
+        sapling_output_str.length(),
         "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028",
-        sprout_groth16_str.c_str(),
+        reinterpret_cast<const codeunit*>(sprout_groth16_str.c_str()),
+        sprout_groth16_str.length(),
         "e9b238411bd6c0ec4791e9d04245ec350c9c5744f5610dfcce4365d5ca49dfefd5054e371842b3f88fa1b9d7e8e075249b3ebabd167fa8b0f3161292d36c180a"
     );
 }


### PR DESCRIPTION
Fixes a user-reported crash when starting on Windows with a Cyrillic non-UTF-8 locale.