### PR TITLE
Make clean before making when building

### DIFF
--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -104,4 +104,5 @@ ld -v
 HOST="$HOST" BUILD="$BUILD" NO_PROTON="$PROTON_ARG" "$MAKE" "$@" -C ./depends/ V=1
 ./autogen.sh
 CONFIG_SITE="$PWD/depends/$HOST/share/config.site" ./configure "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" "$PROTON_ARG" $CONFIGURE_FLAGS CXXFLAGS='-g'
+"$MAKE" clean
 "$MAKE" "$@" V=1


### PR DESCRIPTION
Closes #3625 

This adds a call to `make clean` to the `build.sh` script to address issues such as #3624.