### PR TITLE
Return more information when building a transaction fails

### DIFF
--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -39,9 +39,7 @@ TEST(TransactionBuilder, Invoke)
     auto builder1 = TransactionBuilder(consensusParams, 1, &keystore);
     builder1.AddTransparentInput(COutPoint(), scriptPubKey, 50000);
     builder1.AddSaplingOutput(fvk_from.ovk, pk, 40000, {});
-    auto maybe_tx1 = builder1.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx1), true);
-    auto tx1 = maybe_tx1.get();
+    auto tx1 = builder1.Build().GetTxOrThrow();
 
     EXPECT_EQ(tx1.vin.size(), 1);
     EXPECT_EQ(tx1.vout.size(), 0);
@@ -74,9 +72,7 @@ TEST(TransactionBuilder, Invoke)
     ASSERT_FALSE(builder2.AddSaplingSpend(expsk, note, uint256(), witness));
 
     builder2.AddSaplingOutput(fvk.ovk, pk, 25000, {});
-    auto maybe_tx2 = builder2.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx2), true);
-    auto tx2 = maybe_tx2.get();
+    auto tx2 = builder2.Build().GetTxOrThrow();
 
     EXPECT_EQ(tx2.vin.size(), 0);
     EXPECT_EQ(tx2.vout.size(), 0);
@@ -157,22 +153,22 @@ TEST(TransactionBuilder, FailsWithNegativeChange)
     // 0.0005 z-ZEC out, 0.0001 t-ZEC fee
     auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingOutput(fvk.ovk, pk, 50000, {});
-    EXPECT_FALSE(static_cast<bool>(builder.Build()));
+    EXPECT_EQ("Change cannot be negative", builder.Build().GetError());
 
     // Fail if there is only a transparent output
     // 0.0005 t-ZEC out, 0.0001 t-ZEC fee
     builder = TransactionBuilder(consensusParams, 1, &keystore);
     EXPECT_TRUE(builder.AddTransparentOutput(taddr, 50000));
-    EXPECT_FALSE(static_cast<bool>(builder.Build()));
+    EXPECT_EQ("Change cannot be negative", builder.Build().GetError());
 
     // Fails if there is insufficient input
     // 0.0005 t-ZEC out, 0.0001 t-ZEC fee, 0.00059999 z-ZEC in
     EXPECT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
-    EXPECT_FALSE(static_cast<bool>(builder.Build()));
+    EXPECT_EQ("Change cannot be negative", builder.Build().GetError());
 
     // Succeeds if there is sufficient input
     builder.AddTransparentInput(COutPoint(), scriptPubKey, 1);
-    EXPECT_TRUE(static_cast<bool>(builder.Build()));
+    EXPECT_TRUE(builder.Build().IsTx());
 
     // Revert to default
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
@@ -216,7 +212,7 @@ TEST(TransactionBuilder, ChangeOutput)
     {
         auto builder = TransactionBuilder(consensusParams, 1, &keystore);
         builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000);
-        EXPECT_FALSE(static_cast<bool>(builder.Build()));
+        EXPECT_EQ("Could not determine change address", builder.Build().GetError());
     }
 
     // Change to the same address as the first Sapling spend
@@ -224,9 +220,7 @@ TEST(TransactionBuilder, ChangeOutput)
         auto builder = TransactionBuilder(consensusParams, 1, &keystore);
         builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000);
         ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
-        auto maybe_tx = builder.Build();
-        ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-        auto tx = maybe_tx.get();
+        auto tx = builder.Build().GetTxOrThrow();
 
         EXPECT_EQ(tx.vin.size(), 1);
         EXPECT_EQ(tx.vout.size(), 0);
@@ -241,9 +235,7 @@ TEST(TransactionBuilder, ChangeOutput)
         auto builder = TransactionBuilder(consensusParams, 1, &keystore);
         builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000);
         builder.SendChangeTo(zChangeAddr, fvkOut.ovk);
-        auto maybe_tx = builder.Build();
-        ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-        auto tx = maybe_tx.get();
+        auto tx = builder.Build().GetTxOrThrow();
 
         EXPECT_EQ(tx.vin.size(), 1);
         EXPECT_EQ(tx.vout.size(), 0);
@@ -258,9 +250,7 @@ TEST(TransactionBuilder, ChangeOutput)
         auto builder = TransactionBuilder(consensusParams, 1, &keystore);
         builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000);
         ASSERT_TRUE(builder.SendChangeTo(taddr));
-        auto maybe_tx = builder.Build();
-        ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-        auto tx = maybe_tx.get();
+        auto tx = builder.Build().GetTxOrThrow();
 
         EXPECT_EQ(tx.vin.size(), 1);
         EXPECT_EQ(tx.vout.size(), 1);
@@ -302,9 +292,7 @@ TEST(TransactionBuilder, SetFee)
         auto builder = TransactionBuilder(consensusParams, 1);
         ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
         builder.AddSaplingOutput(fvk.ovk, pk, 25000, {});
-        auto maybe_tx = builder.Build();
-        ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-        auto tx = maybe_tx.get();
+        auto tx = builder.Build().GetTxOrThrow();
 
         EXPECT_EQ(tx.vin.size(), 0);
         EXPECT_EQ(tx.vout.size(), 0);
@@ -320,9 +308,7 @@ TEST(TransactionBuilder, SetFee)
         ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
         builder.AddSaplingOutput(fvk.ovk, pk, 25000, {});
         builder.SetFee(20000);
-        auto maybe_tx = builder.Build();
-        ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-        auto tx = maybe_tx.get();
+        auto tx = builder.Build().GetTxOrThrow();
 
         EXPECT_EQ(tx.vin.size(), 0);
         EXPECT_EQ(tx.vout.size(), 0);

--- a/src/transaction_builder.h
+++ b/src/transaction_builder.h
@@ -52,6 +52,20 @@ struct TransparentInputInfo {
         CAmount value) : scriptPubKey(scriptPubKey), value(value) {}
 };
 
+class TransactionBuilderResult {
+private:
+    boost::optional<CTransaction> maybeTx;
+    boost::optional<std::string> maybeError;
+public:
+    TransactionBuilderResult() = delete;
+    TransactionBuilderResult(const CTransaction& tx);
+    TransactionBuilderResult(const std::string& error);
+    bool IsTx();
+    bool IsError();
+    CTransaction GetTxOrThrow();
+    std::string GetError();
+};
+
 class TransactionBuilder
 {
 private:
@@ -97,7 +111,7 @@ public:
 
     bool SendChangeTo(CTxDestination& changeAddr);
 
-    boost::optional<CTransaction> Build();
+    TransactionBuilderResult Build();
 };
 
 #endif /* TRANSACTION_BUILDER_H */

--- a/src/transaction_builder.h
+++ b/src/transaction_builder.h
@@ -88,9 +88,9 @@ public:
 
     void SetFee(CAmount fee);
 
-    // Returns false if the anchor does not match the anchor used by
+    // Throws if the anchor does not match the anchor used by
     // previously-added Sapling spends.
-    bool AddSaplingSpend(
+    void AddSaplingSpend(
         libzcash::SaplingExpandedSpendingKey expsk,
         libzcash::SaplingNote note,
         uint256 anchor,
@@ -105,11 +105,11 @@ public:
     // Assumes that the value correctly corresponds to the provided UTXO.
     void AddTransparentInput(COutPoint utxo, CScript scriptPubKey, CAmount value);
 
-    bool AddTransparentOutput(CTxDestination& to, CAmount value);
+    void AddTransparentOutput(CTxDestination& to, CAmount value);
 
     void SendChangeTo(libzcash::SaplingPaymentAddress changeAddr, uint256 ovk);
 
-    bool SendChangeTo(CTxDestination& changeAddr);
+    void SendChangeTo(CTxDestination& changeAddr);
 
     TransactionBuilderResult Build();
 };

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -375,11 +375,7 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
 
 
         // Build the transaction
-        auto maybe_tx = builder_.Build();
-        if (!maybe_tx) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Failed to build transaction.");
-        }
-        tx_ = maybe_tx.get();
+        tx_ = builder_.Build().GetTxOrThrow();
 
         // Send the transaction
         // TODO: Use CWallet::CommitTransaction instead of sendrawtransaction

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -338,13 +338,11 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
             if (!witnesses[i]) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "Missing witness for Sapling note");
             }
-            assert(builder_.AddSaplingSpend(expsks[i], saplingNotes[i], anchor, witnesses[i].get()));
+            builder_.AddSaplingSpend(expsks[i], saplingNotes[i], anchor, witnesses[i].get());
         }
 
         if (isToTaddr_) {
-            if (!builder_.AddTransparentOutput(toTaddr_, sendAmount)) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid output address, not a valid taddr.");
-            }
+            builder_.AddTransparentOutput(toTaddr_, sendAmount);
         } else {
             std::string zaddr = std::get<0>(recipient_);
             std::string memo = std::get<1>(recipient_);

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -475,11 +475,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
         }
 
         // Build the transaction
-        auto maybe_tx = builder_.Build();
-        if (!maybe_tx) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Failed to build transaction.");
-        }
-        tx_ = maybe_tx.get();
+        tx_ = builder_.Build().GetTxOrThrow();
 
         // Send the transaction
         // TODO: Use CWallet::CommitTransaction instead of sendrawtransaction

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -416,7 +416,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
             }
 
             CTxDestination changeAddr = vchPubKey.GetID();
-            assert(builder_.SendChangeTo(changeAddr));
+            builder_.SendChangeTo(changeAddr);
         }
 
         // Select Sapling notes
@@ -445,7 +445,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
             if (!witnesses[i]) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "Missing witness for Sapling note");
             }
-            assert(builder_.AddSaplingSpend(expsk, notes[i], anchor, witnesses[i].get()));
+            builder_.AddSaplingSpend(expsk, notes[i], anchor, witnesses[i].get());
         }
 
         // Add Sapling outputs
@@ -469,9 +469,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
             auto amount = std::get<1>(r);
 
             auto address = DecodeDestination(outputAddress);
-            if (!builder_.AddTransparentOutput(address, amount)) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid output address, not a valid taddr.");
-            }
+            builder_.AddTransparentOutput(address, amount);
         }
 
         // Build the transaction

--- a/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
+++ b/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
@@ -274,11 +274,7 @@ bool ShieldToAddress::operator()(const libzcash::SaplingPaymentAddress &zaddr) c
     m_op->builder_.SendChangeTo(zaddr, ovk);
 
     // Build the transaction
-    auto maybe_tx = m_op->builder_.Build();
-    if (!maybe_tx) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Failed to build transaction.");
-    }
-    m_op->tx_ = maybe_tx.get();
+    m_op->tx_ = m_op->builder_.Build().GetTxOrThrow();
 
     // Send the transaction
     // TODO: Use CWallet::CommitTransaction instead of sendrawtransaction

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -383,7 +383,7 @@ TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
     uint256 nullifier = nf.get();
 
     auto builder = TransactionBuilder(consensusParams, 1);
-    ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
+    builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(fvk.ovk, pk, 50000, {});
     builder.SetFee(0);
     auto tx = builder.Build().GetTxOrThrow();
@@ -501,7 +501,7 @@ TEST(WalletTests, FindMySaplingNotes) {
 
     // Generate transaction
     auto builder = TransactionBuilder(consensusParams, 1);
-    ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
+    builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(fvk.ovk, pk, 25000, {});
     auto tx = builder.Build().GetTxOrThrow();
 
@@ -639,7 +639,7 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
 
     // Generate tx to create output note B
     auto builder = TransactionBuilder(consensusParams, 1);
-    ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
+    builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(fvk.ovk, pk, 35000, {});
     auto tx = builder.Build().GetTxOrThrow();
     CWalletTx wtx {&wallet, tx};
@@ -693,13 +693,13 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
 
     // Create transaction to spend note B
     auto builder2 = TransactionBuilder(consensusParams, 2);
-    ASSERT_TRUE(builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness));
+    builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
     builder2.AddSaplingOutput(fvk.ovk, pk, 20000, {});
     auto tx2 = builder2.Build().GetTxOrThrow();
 
     // Create conflicting transaction which also spends note B
     auto builder3 = TransactionBuilder(consensusParams, 2);
-    ASSERT_TRUE(builder3.AddSaplingSpend(expsk, note2, anchor, spend_note_witness));
+    builder3.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
     builder3.AddSaplingOutput(fvk.ovk, pk, 19999, {});
     auto tx3 = builder3.Build().GetTxOrThrow();
 
@@ -798,7 +798,7 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
 
     // Generate transaction
     auto builder = TransactionBuilder(consensusParams, 1);
-    ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
+    builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(fvk.ovk, pk, 25000, {});
     auto tx = builder.Build().GetTxOrThrow();
 
@@ -893,7 +893,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
 
     // Generate transaction
     auto builder = TransactionBuilder(consensusParams, 1);
-    ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
+    builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(fvk.ovk, pk, 25000, {});
     auto tx = builder.Build().GetTxOrThrow();
 
@@ -1027,7 +1027,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
 
     // Generate transaction, which sends funds to note B
     auto builder = TransactionBuilder(consensusParams, 1);
-    ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
+    builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(fvk.ovk, pk, 25000, {});
     auto tx = builder.Build().GetTxOrThrow();
 
@@ -1097,7 +1097,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
 
     // Create transaction to spend note B
     auto builder2 = TransactionBuilder(consensusParams, 2);
-    ASSERT_TRUE(builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness));
+    builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
     builder2.AddSaplingOutput(fvk.ovk, pk, 12500, {});
     auto tx2 = builder2.Build().GetTxOrThrow();
     EXPECT_EQ(tx2.vin.size(), 0);
@@ -1725,7 +1725,7 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
 
     // Generate transaction
     auto builder = TransactionBuilder(consensusParams, 1);
-    ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
+    builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(fvk.ovk, pk2, 25000, {});
     auto tx = builder.Build().GetTxOrThrow();
 
@@ -1928,7 +1928,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     // Create a Sapling-only transaction
     // 0.0004 z-ZEC in, 0.00025 z-ZEC out, 0.0001 t-ZEC fee, 0.00005 z-ZEC change
     auto builder2 = TransactionBuilder(consensusParams, 2);
-    ASSERT_TRUE(builder2.AddSaplingSpend(expsk, note, anchor, witness));
+    builder2.AddSaplingSpend(expsk, note, anchor, witness);
     builder2.AddSaplingOutput(fvk.ovk, pk, 25000, {});
     auto tx2 = builder2.Build().GetTxOrThrow();
 

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -386,9 +386,7 @@ TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
     ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
     builder.AddSaplingOutput(fvk.ovk, pk, 50000, {});
     builder.SetFee(0);
-    auto maybe_tx = builder.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-    auto tx = maybe_tx.get();
+    auto tx = builder.Build().GetTxOrThrow();
 
     CWalletTx wtx {&wallet, tx};
 
@@ -505,9 +503,7 @@ TEST(WalletTests, FindMySaplingNotes) {
     auto builder = TransactionBuilder(consensusParams, 1);
     ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
     builder.AddSaplingOutput(fvk.ovk, pk, 25000, {});
-    auto maybe_tx = builder.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-    auto tx = maybe_tx.get();
+    auto tx = builder.Build().GetTxOrThrow();
 
     // No Sapling notes can be found in tx which does not belong to the wallet
     CWalletTx wtx {&wallet, tx};
@@ -645,9 +641,7 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
     auto builder = TransactionBuilder(consensusParams, 1);
     ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
     builder.AddSaplingOutput(fvk.ovk, pk, 35000, {});
-    auto maybe_tx = builder.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-    auto tx = maybe_tx.get();
+    auto tx = builder.Build().GetTxOrThrow();
     CWalletTx wtx {&wallet, tx};
 
     // Fake-mine the transaction
@@ -701,17 +695,13 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
     auto builder2 = TransactionBuilder(consensusParams, 2);
     ASSERT_TRUE(builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness));
     builder2.AddSaplingOutput(fvk.ovk, pk, 20000, {});
-    auto maybe_tx2 = builder2.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx2), true);
-    auto tx2 = maybe_tx2.get();
+    auto tx2 = builder2.Build().GetTxOrThrow();
 
     // Create conflicting transaction which also spends note B
     auto builder3 = TransactionBuilder(consensusParams, 2);
     ASSERT_TRUE(builder3.AddSaplingSpend(expsk, note2, anchor, spend_note_witness));
     builder3.AddSaplingOutput(fvk.ovk, pk, 19999, {});
-    auto maybe_tx3 = builder3.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx3), true);
-    auto tx3 = maybe_tx3.get();
+    auto tx3 = builder3.Build().GetTxOrThrow();
 
     CWalletTx wtx2 {&wallet, tx2};
     CWalletTx wtx3 {&wallet, tx3};
@@ -810,9 +800,7 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
     auto builder = TransactionBuilder(consensusParams, 1);
     ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
     builder.AddSaplingOutput(fvk.ovk, pk, 25000, {});
-    auto maybe_tx = builder.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-    auto tx = maybe_tx.get();
+    auto tx = builder.Build().GetTxOrThrow();
 
     CWalletTx wtx {&wallet, tx};
     ASSERT_TRUE(wallet.AddSaplingZKey(sk, pk));
@@ -907,9 +895,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     auto builder = TransactionBuilder(consensusParams, 1);
     ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
     builder.AddSaplingOutput(fvk.ovk, pk, 25000, {});
-    auto maybe_tx = builder.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-    auto tx = maybe_tx.get();
+    auto tx = builder.Build().GetTxOrThrow();
 
     CWalletTx wtx {&wallet, tx};
     ASSERT_TRUE(wallet.AddSaplingZKey(sk, pk));
@@ -1043,9 +1029,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     auto builder = TransactionBuilder(consensusParams, 1);
     ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
     builder.AddSaplingOutput(fvk.ovk, pk, 25000, {});
-    auto maybe_tx = builder.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-    auto tx = maybe_tx.get();
+    auto tx = builder.Build().GetTxOrThrow();
 
     CWalletTx wtx {&wallet, tx};
     ASSERT_TRUE(wallet.AddSaplingZKey(sk, pk));
@@ -1115,9 +1099,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     auto builder2 = TransactionBuilder(consensusParams, 2);
     ASSERT_TRUE(builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness));
     builder2.AddSaplingOutput(fvk.ovk, pk, 12500, {});
-    auto maybe_tx2 = builder2.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx2), true);
-    auto tx2 = maybe_tx2.get();
+    auto tx2 = builder2.Build().GetTxOrThrow();
     EXPECT_EQ(tx2.vin.size(), 0);
     EXPECT_EQ(tx2.vout.size(), 0);
     EXPECT_EQ(tx2.vjoinsplit.size(), 0);
@@ -1745,9 +1727,7 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
     auto builder = TransactionBuilder(consensusParams, 1);
     ASSERT_TRUE(builder.AddSaplingSpend(expsk, note, anchor, witness));
     builder.AddSaplingOutput(fvk.ovk, pk2, 25000, {});
-    auto maybe_tx = builder.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-    auto tx = maybe_tx.get();
+    auto tx = builder.Build().GetTxOrThrow();
 
     // Wallet contains fvk1 but not fvk2
     CWalletTx wtx {&wallet, tx};
@@ -1895,9 +1875,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     auto builder = TransactionBuilder(consensusParams, 1, &keystore);
     builder.AddTransparentInput(COutPoint(), scriptPubKey, 50000);
     builder.AddSaplingOutput(fvk.ovk, pk, 40000, {});
-    auto maybe_tx = builder.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx), true);
-    auto tx1 = maybe_tx.get();
+    auto tx1 = builder.Build().GetTxOrThrow();
 
     EXPECT_EQ(tx1.vin.size(), 1);
     EXPECT_EQ(tx1.vout.size(), 0);
@@ -1952,9 +1930,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     auto builder2 = TransactionBuilder(consensusParams, 2);
     ASSERT_TRUE(builder2.AddSaplingSpend(expsk, note, anchor, witness));
     builder2.AddSaplingOutput(fvk.ovk, pk, 25000, {});
-    auto maybe_tx2 = builder2.Build();
-    ASSERT_EQ(static_cast<bool>(maybe_tx2), true);
-    auto tx2 = maybe_tx2.get();
+    auto tx2 = builder2.Build().GetTxOrThrow();
 
     EXPECT_EQ(tx2.vin.size(), 0);
     EXPECT_EQ(tx2.vout.size(), 0);


### PR DESCRIPTION
This PR is intended to make it easier to diagnose what went wrong when building a transaction using `TransactionBuilder` fails.