### PR TITLE
Save and restore current_path in TestingSetup constructor/destructor

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -93,6 +93,10 @@ TestingSetup::TestingSetup()
         bitdb.MakeMock();
         RegisterWalletRPCCommands(tableRPC);
 #endif
+
+        // Save current path, in case a test changes it
+        orig_current_path = boost::filesystem::current_path();
+
         ClearDatadirCache();
         pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
         boost::filesystem::create_directories(pathTemp);
@@ -131,6 +135,10 @@ TestingSetup::~TestingSetup()
         bitdb.Flush(true);
         bitdb.Reset();
 #endif
+
+        // Restore the previous current path so temporary directory can be deleted
+        boost::filesystem::current_path(orig_current_path);
+
         boost::filesystem::remove_all(pathTemp);
 }
 

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -30,6 +30,7 @@ struct JoinSplitTestingSetup: public BasicTestingSetup {
  */
 struct TestingSetup: public JoinSplitTestingSetup {
     CCoinsViewDB *pcoinsdbview;
+    boost::filesystem::path orig_current_path;
     boost::filesystem::path pathTemp;
     boost::thread_group threadGroup;
 


### PR DESCRIPTION
In issue https://github.com/zcash/zcash/issues/3653 , the affected tests change their current working directory to a temporary directory that is created in the TestingSetup constructor and deleted in the destructor. In Windows it seems to cause a problem when a process attempts to delete its current working directory.

This change fixes the issue by saving the path of the current working directory in the constructor, and restoring the working directory to that path in the destructor before deleting the temporary directory.