### PR TITLE
Add a call to SetupNetworking in BasicTestingSetup

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -75,6 +75,7 @@ BasicTestingSetup::BasicTestingSetup()
     assert(init_and_check_sodium() != -1);
     ECC_Start();
     SetupEnvironment();
+    SetupNetworking();
     fPrintToDebugLog = false; // don't want to write to debug.log file
     fCheckBlockIndex = true;
     SelectParams(CBaseChainParams::MAIN);


### PR DESCRIPTION
In issue https://github.com/zcash/zcash/issues/3668 , the error code returned by `getaddrinfo_a` (10093) is `WSANOTINITIALISED`:

> Successful WSAStartup not yet performed.  Either the application has not called WSAStartup or WSAStartup  failed. The application may be accessing a socket that the current  active task does not own (that is, trying to share a socket between  tasks), or WSACleanup has been called too many times.

https://docs.microsoft.com/en-us/windows/desktop/winsock/windows-sockets-error-codes-2

`WSAStartup` is called from the `SetupNetworking` function in `util.cpp`, but `SetupNetworking` was not being called during test setup. This pull request adds that call.

Here is a gitlab pipeline running tests in the `test_bitcoin.exe` executable before this change:
https://gitlab.com/charlieok/zcash/pipelines/36483478

...and here is the same set of tests run after this change:
https://gitlab.com/charlieok/zcash/pipelines/36485098