### PR TITLE
Remove --disable-libs flag from help output

### DIFF
--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -46,7 +46,7 @@ Usage:
 $0 --help
   Show this help message and exit.
 
-$0 [ --enable-lcov || --disable-tests ] [ --disable-mining ] [ --enable-proton ] [ --disable-libs ] [ MAKEARGS... ]
+$0 [ --enable-lcov || --disable-tests ] [ --disable-mining ] [ --enable-proton ] [ MAKEARGS... ]
   Build Zcash and most of its transitive dependencies from
   source. MAKEARGS are applied to both dependencies and Zcash itself.
 


### PR DESCRIPTION
The --disable-libs option was removed. This PR removes it from the output of `./zcutil/build.sh --help`.