### PR TITLE
initialize pCurrentParams in TransactionBuilder tests

### DIFF
--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -95,6 +95,7 @@ TEST(TransactionBuilder, Invoke)
 
 TEST(TransactionBuilder, ThrowsOnTransparentInputWithoutKeyStore)
 {
+    SelectParams(CBaseChainParams::REGTEST);
     auto consensusParams = Params().GetConsensus();
 
     auto builder = TransactionBuilder(consensusParams, 1);
@@ -103,6 +104,7 @@ TEST(TransactionBuilder, ThrowsOnTransparentInputWithoutKeyStore)
 
 TEST(TransactionBuilder, RejectsInvalidTransparentOutput)
 {
+    SelectParams(CBaseChainParams::REGTEST);
     auto consensusParams = Params().GetConsensus();
 
     // Default CTxDestination type is an invalid address
@@ -113,6 +115,7 @@ TEST(TransactionBuilder, RejectsInvalidTransparentOutput)
 
 TEST(TransactionBuilder, RejectsInvalidTransparentChangeAddress)
 {
+    SelectParams(CBaseChainParams::REGTEST);
     auto consensusParams = Params().GetConsensus();
 
     // Default CTxDestination type is an invalid address


### PR DESCRIPTION
In issue https://github.com/zcash/zcash/issues/3715 the failing tests were calling Params(), which includes an assertion that pCurrentParams is not null, without first calling SelectParams(), which will set that pointer. All the other tests in the same test case (which don't fail in the manner described in #3715 ) start out by calling `SelectParams(CBaseChainParams::REGTEST);`.

This change adds an identical call to the affected tests, getting past the failed assertion  in Params() on pCurrentParams.

Here is a GitLab pipeline showing output from these tests run in isolation before this change:
https://gitlab.com/charlieok/zcash/pipelines/38304730

...and here is one with the same set of tests after this change:
https://gitlab.com/charlieok/zcash/pipelines/38307556