### PR TITLE
zmq: add flag to publish all checked blocks

### DIFF
--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -41,7 +41,7 @@ try:
             print '- RAW TX ('+sequence+') -'
             print binascii.hexlify(body)
         elif topic == "checkedblock":
-            print ' - CHECKED BLOCK ('+sequence+') -'
+            print '- CHECKED BLOCK ('+sequence+') -'
             print binascii.hexlify(body[:80])
 
 except KeyboardInterrupt:

--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -16,6 +16,7 @@ zmqSubSocket.setsockopt(zmq.SUBSCRIBE, "hashblock")
 zmqSubSocket.setsockopt(zmq.SUBSCRIBE, "hashtx")
 zmqSubSocket.setsockopt(zmq.SUBSCRIBE, "rawblock")
 zmqSubSocket.setsockopt(zmq.SUBSCRIBE, "rawtx")
+zmqSubSocket.setsockopt(zmq.SUBSCRIBE, "checkedblock")
 zmqSubSocket.connect("tcp://127.0.0.1:%i" % port)
 
 try:
@@ -39,6 +40,9 @@ try:
         elif topic == "rawtx":
             print '- RAW TX ('+sequence+') -'
             print binascii.hexlify(body)
+        elif topic == "checkedblock":
+            print ' - CHECKED BLOCK ('+sequence+') -'
+            print binascii.hexlify(body[:80])
 
 except KeyboardInterrupt:
     zmqContext.destroy()

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -16,6 +16,11 @@ bool CZMQAbstractNotifier::NotifyBlock(const CBlockIndex * /*CBlockIndex*/)
     return true;
 }
 
+bool CZMQAbstractNotifier::NotifyBlock(const CBlock &)
+{
+    return true;
+}
+
 bool CZMQAbstractNotifier::NotifyTransaction(const CTransaction &/*transaction*/)
 {
     return true;

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -33,6 +33,7 @@ public:
     virtual void Shutdown() = 0;
 
     virtual bool NotifyBlock(const CBlockIndex *pindex);
+    virtual bool NotifyBlock(const CBlock& pblock);
     virtual bool NotifyTransaction(const CTransaction &transaction);
 
 protected:

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -6,6 +6,7 @@
 #define BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
 
 #include "validationinterface.h"
+#include "consensus/validation.h"
 #include <string>
 #include <map>
 
@@ -26,6 +27,7 @@ protected:
     // CValidationInterface
     void SyncTransaction(const CTransaction &tx, const CBlock *pblock);
     void UpdatedBlockTip(const CBlockIndex *pindex);
+    void BlockChecked(const CBlock& block, const CValidationState& state);
 
 private:
     CZMQNotificationInterface();

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -12,6 +12,7 @@ static const char *MSG_HASHBLOCK = "hashblock";
 static const char *MSG_HASHTX    = "hashtx";
 static const char *MSG_RAWBLOCK  = "rawblock";
 static const char *MSG_RAWTX     = "rawtx";
+static const char *MSG_CHECKEDBLOCK = "checkedblock";
 
 // Internal function to send multipart message
 static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
@@ -177,6 +178,19 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
     }
 
     return SendMessage(MSG_RAWBLOCK, &(*ss.begin()), ss.size());
+}
+
+bool CZMQPublishCheckedBlockNotifier::NotifyBlock(const CBlock& block)
+{
+    LogPrint("zmq", "zmq: Publish checkedblock %s\n", block.GetHash().GetHex());
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    {
+        LOCK(cs_main);
+        ss << block;
+    }
+
+    return SendMessage(MSG_CHECKEDBLOCK, &(*ss.begin()), ss.size());
 }
 
 bool CZMQPublishRawTransactionNotifier::NotifyTransaction(const CTransaction &transaction)

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -52,4 +52,10 @@ public:
     bool NotifyTransaction(const CTransaction &transaction);
 };
 
+class CZMQPublishCheckedBlockNotifier : public CZMQAbstractPublishNotifier
+{
+public:
+    bool NotifyBlock(const CBlock &block);
+};
+
 #endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H


### PR DESCRIPTION
This change adds a hook for the BlockChecked signal to the zmq publisher. This is useful for light wallet daemon initialization (see https://github.com/zcash/zcash/issues/3638 for context, and [lightwalletd](https://github.com/zcash-hackworks/lightwalletd) for implementation).

The new flag is `-zmqpubcheckedblock=address`, in keeping with the established style.