### PR TITLE
update libsodium dl-path

### DIFF
--- a/depends/packages/libsodium.mk
+++ b/depends/packages/libsodium.mk
@@ -1,6 +1,6 @@
 package=libsodium
 $(package)_version=1.0.15
-$(package)_download_path=https://download.libsodium.org/libsodium/releases/
+$(package)_download_path=https://download.libsodium.org/libsodium/releases/old/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4
 $(package)_dependencies=


### PR DESCRIPTION
the 1.0.15 was moved to https://download.libsodium.org/libsodium/releases/old/ which results in DL from zcashs fallback repo