### PR TITLE
Update RPC test_framework to allow execution on Windows with Python 2.7

### DIFF
--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -47,6 +47,8 @@ try:
 except ImportError:
     import urlparse
 
+import os
+
 USER_AGENT = "AuthServiceProxy/0.1"
 
 HTTP_TIMEOUT = 600
@@ -55,7 +57,11 @@ log = logging.getLogger("BitcoinRPC")
 
 class JSONRPCException(Exception):
     def __init__(self, rpc_error):
-        Exception.__init__(self)
+        try:
+            errmsg = '%(message)s (%(code)i)' % rpc_error
+        except (KeyError, TypeError):
+            errmsg = ''
+        Exception.__init__(self, errmsg)
         self.error = rpc_error
 
 
@@ -87,16 +93,33 @@ class AuthServiceProxy(object):
         authpair = user + b':' + passwd
         self.__auth_header = b'Basic ' + base64.b64encode(authpair)
 
+        self.timeout = timeout
+        self._set_conn(connection)
+        
+        #if connection:
+            # Callables re-use the connection of the original proxy
+        #    self.__conn = connection
+        #elif self.__url.scheme == 'https':
+        #    self.__conn = httplib.HTTPSConnection(self.__url.hostname, port,
+        #                                          None, None, False,
+        #                                          timeout)
+        #else:
+        #    self.__conn = httplib.HTTPConnection(self.__url.hostname, port,
+        #                                         False, timeout)
+
+    def _set_conn(self, connection=None):
+        port = 80 if self.__url.port is None else self.__url.port
         if connection:
             # Callables re-use the connection of the original proxy
             self.__conn = connection
+            self.timeout = connection.timeout
         elif self.__url.scheme == 'https':
             self.__conn = httplib.HTTPSConnection(self.__url.hostname, port,
                                                   None, None, False,
-                                                  timeout)
+                                                  self.timeout)
         else:
-            self.__conn = httplib.HTTPConnection(self.__url.hostname, port,
-                                                 False, timeout)
+             self.__conn = httplib.HTTPConnection(self.__url.hostname, port,
+                                                 False, self.timeout)
 
     def __getattr__(self, name):
         if name.startswith('__') and name.endswith('__'):
@@ -115,6 +138,11 @@ class AuthServiceProxy(object):
                    'User-Agent': USER_AGENT,
                    'Authorization': self.__auth_header,
                    'Content-type': 'application/json'}
+        if os.name == 'nt':
+            # Windows somehow does not like to re-use connections
+            # TODO: Find out why the connection would disconnect occasionally and make it reusable on Windows
+            self._set_conn()
+
         try:
             self.__conn.request(method, path, postdata, headers)
             return self._get_response()
@@ -135,12 +163,12 @@ class AuthServiceProxy(object):
         AuthServiceProxy.__id_count += 1
 
         log.debug("-%s-> %s %s"%(AuthServiceProxy.__id_count, self.__service_name,
-                                 json.dumps(args, default=EncodeDecimal)))
+                                 json.dumps(args, default=EncodeDecimal)))                      
         postdata = json.dumps({'version': '1.1',
                                'method': self.__service_name,
                                'params': args,
-                               'id': AuthServiceProxy.__id_count}, default=EncodeDecimal)
-        response = self._request('POST', self.__url.path, postdata)
+                               'id': AuthServiceProxy.__id_count}, default=EncodeDecimal, ensure_ascii=self.ensure_ascii)
+        response = self._request('POST', self.__url.path, postdata.encode('utf-8'))
         if response['error'] is not None:
             raise JSONRPCException(response['error'])
         elif 'result' not in response:

--- a/qa/rpc-tests/test_framework/blockstore.py
+++ b/qa/rpc-tests/test_framework/blockstore.py
@@ -7,11 +7,11 @@ from mininode import CBlock, CBlockHeader, CBlockLocator, CTransaction, msg_bloc
 
 import sys
 import cStringIO
-import dbm
+import anydbm
 
 class BlockStore(object):
     def __init__(self, datadir):
-        self.blockDB = dbm.open(datadir + "/blocks", 'c')
+        self.blockDB = anydbm.open(datadir + "/blocks", 'c')
         self.currentBlock = 0L
 
     def close(self):
@@ -96,7 +96,7 @@ class BlockStore(object):
 
 class TxStore(object):
     def __init__(self, datadir):
-        self.txDB = dbm.open(datadir + "/transactions", 'c')
+        self.txDB = anydbm.open(datadir + "/transactions", 'c')
 
     def close(self):
         self.txDB.close()

--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -6,7 +6,6 @@
 # Linux network utilities
 import sys
 import socket
-import fcntl
 import struct
 import array
 import os
@@ -88,6 +87,7 @@ def all_interfaces():
     '''
     Return all interfaces that are up
     '''
+    import fcntl #linux only
     is_64bits = sys.maxsize > 2**32
     struct_size = 40 if is_64bits else 32
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -131,6 +131,9 @@ class BitcoinTestFramework(object):
         except Exception as e:
             print("Unexpected exception caught during testing: "+str(e))
             traceback.print_tb(sys.exc_info()[2])
+        except KeyboardInterrupt as e:
+            print("Keyboard Interrupt: "+str(e))
+
 
         if not self.options.noshutdown:
             print("Stopping nodes")
@@ -140,7 +143,7 @@ class BitcoinTestFramework(object):
             print("Note: bitcoinds were not stopped and may still be running")
 
         if not self.options.nocleanup and not self.options.noshutdown:
-            print("Cleaning up")
+            print("Cleaning up {} on exit".format(self.options.tmpdir))
             shutil.rmtree(self.options.tmpdir)
 
         if success:

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -91,9 +91,18 @@ def initialize_chain(test_dir):
     4 wallets.
     bitcoind and bitcoin-cli must be in search path.
     """
-
-    if not os.path.isdir(os.path.join("cache", "node0")):
-        devnull = open("/dev/null", "w+")
+    
+    if (not os.path.isdir(os.path.join("cache","node0"))
+        or not os.path.isdir(os.path.join("cache","node1")) 
+        or not os.path.isdir(os.path.join("cache","node2")) 
+        or not os.path.isdir(os.path.join("cache","node3"))):
+        
+        #find and delete old cache directories if any exist
+        for i in range(4):
+            if os.path.isdir(os.path.join("cache","node"+str(i))): 
+                shutil.rmtree(os.path.join("cache","node"+str(i)))
+                
+        devnull = open(os.devnull, "w+")
         # Create cache directories, run bitcoinds:
         for i in range(4):
             datadir=initialize_datadir("cache", i)
@@ -185,7 +194,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     args = [ binary, "-datadir="+datadir, "-keypool=1", "-discover=0", "-rest" ]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
-    devnull = open("/dev/null", "w+")
+    devnull = open(os.devnull, "w+")
     if os.getenv("PYTHON_DEBUG", ""):
         print "start_node: bitcoind started, calling bitcoin-cli -rpcwait getblockcount"
     subprocess.check_call([ os.getenv("BITCOINCLI", "bitcoin-cli"), "-datadir="+datadir] +


### PR DESCRIPTION
Using https://github.com/zcash/zcash/pull/3780, this allows a user to run the RPC stack in a native Windows environment. Once reviewed/approved, this will serve as the Python2.7 snapshot so we can begin updating the entire RPC stack to Python3+ conventions. 