### PR TITLE
[WIP] Add the ability to run dependency tests to the depends system

### DIFF
--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -30,6 +30,10 @@ define $(package)_build_cmds
   cargo build --package librustzcash $($(package)_build_opts)
 endef
 
+define $(package)_test_cmds
+  cargo test $($(package)_build_opts)
+endef
+
 define $(package)_stage_cmds
   mkdir $($(package)_staging_dir)$(host_prefix)/lib/ && \
   mkdir $($(package)_staging_dir)$(host_prefix)/include/ && \


### PR DESCRIPTION
I did this because I mistakenly thought we didn't have automated CI for the rust crates and it would be easier to do this than to add CI everywhere, but we actually have CI: Travis-CI is turned on for `librustzcash` and that ends up testing a copy of `sapling-crypto`, etc. I don't expect we'll merge this but I'm posting it in case we ever want to run a dependency's test during the build.

Usage: `cd depends; make TESTED=_tested`.

As it is, it won't work, because `sapling-crypto` requires additional dependencies to run its tests.