### PR TITLE
Micro-benchmarking framework part 1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,11 @@ AC_ARG_ENABLE(tests,
     [use_tests=$enableval],
     [use_tests=yes])
 
+AC_ARG_ENABLE(bench,
+    AS_HELP_STRING([--enable-bench],[compile benchmarks (default is yes)]),
+    [use_bench=$enableval],
+    [use_bench=yes])
+
 AC_ARG_ENABLE([fuzz-main],
   [AS_HELP_STRING([--enable-fuzz-main],
   [Replace main() with a stub for fuzzing (default is no)])],
@@ -848,6 +853,7 @@ AM_CONDITIONAL([TARGET_WINDOWS], [test x$TARGET_OS = xwindows])
 AM_CONDITIONAL([ENABLE_WALLET],[test x$enable_wallet = xyes])
 AM_CONDITIONAL([ENABLE_MINING],[test x$enable_mining = xyes])
 AM_CONDITIONAL([ENABLE_TESTS],[test x$BUILD_TEST = xyes])
+AM_CONDITIONAL([ENABLE_BENCH],[test x$use_bench = xyes])
 AM_CONDITIONAL([USE_LCOV],[test x$use_lcov = xyes])
 AM_CONDITIONAL([GLIBC_BACK_COMPAT],[test x$use_glibc_compat = xyes])
 AM_CONDITIONAL([HARDEN],[test x$use_hardening = xyes])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,6 +78,7 @@ lib_LTLIBRARIES = $(LIBZCASH_CONSENSUS)
 bin_PROGRAMS =
 noinst_PROGRAMS =
 TESTS =
+BENCHMARKS =
 
 if BUILD_BITCOIND
   bin_PROGRAMS += zcashd
@@ -596,4 +597,8 @@ endif
 if ENABLE_TESTS
 include Makefile.test.include
 include Makefile.gtest.include
+endif
+
+if ENABLE_BENCH
+include Makefile.bench.include
 endif

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -7,7 +7,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/bench_bitcoin.cpp \
   bench/bench.cpp \
   bench/bench.h \
-  bench/MilliSleep.cpp
+  bench/Examples.cpp
 
 bench_bench_bitcoin_CPPFLAGS = $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_LDADD = \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -8,7 +8,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/bench.cpp \
   bench/bench.h \
   bench/Examples.cpp \
-  bench/rollingbloom.cpp
+  bench/rollingbloom.cpp \
+  bench/crypto_hash.cpp
 
 bench_bench_bitcoin_CPPFLAGS = $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_LDADD = \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -7,6 +7,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/bench_bitcoin.cpp \
   bench/bench.cpp \
   bench/bench.h \
+  bench/checkqueue.cpp \
   bench/Examples.cpp \
   bench/rollingbloom.cpp \
   bench/crypto_hash.cpp \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -10,7 +10,9 @@ bench_bench_bitcoin_SOURCES = \
   bench/Examples.cpp \
   bench/rollingbloom.cpp \
   bench/crypto_hash.cpp \
-  bench/base58.cpp
+  bench/base58.cpp \
+  bench/perf.cpp \
+  bench/perf.h
 
 bench_bench_bitcoin_CPPFLAGS = $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_LDADD = \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -16,7 +16,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/perf.h \
   bench/prevector_destructor.cpp
 
-bench_bench_bitcoin_CPPFLAGS = $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
+bench_bench_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
+bench_bench_bitcoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 bench_bench_bitcoin_LDADD = \
   $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_COMMON) \
@@ -37,7 +38,6 @@ endif
 
 bench_bench_bitcoin_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(LIBZCASH_LIBS)
 bench_bench_bitcoin_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
-
 
 CLEAN_BITCOIN_BENCH = bench/*.gcda bench/*.gcno
 

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -13,7 +13,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/crypto_hash.cpp \
   bench/base58.cpp \
   bench/perf.cpp \
-  bench/perf.h
+  bench/perf.h \
+  bench/prevector_destructor.cpp
 
 bench_bench_bitcoin_CPPFLAGS = $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_LDADD = \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -7,7 +7,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/bench_bitcoin.cpp \
   bench/bench.cpp \
   bench/bench.h \
-  bench/Examples.cpp
+  bench/Examples.cpp \
+  bench/rollingbloom.cpp
 
 bench_bench_bitcoin_CPPFLAGS = $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_LDADD = \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -1,0 +1,45 @@
+bin_PROGRAMS += bench/bench_bitcoin
+BENCH_SRCDIR = bench
+BENCH_BINARY = bench/bench_bitcoin$(EXEEXT)
+
+
+bench_bench_bitcoin_SOURCES = \
+  bench/bench_bitcoin.cpp \
+  bench/bench.cpp \
+  bench/bench.h \
+  bench/MilliSleep.cpp
+
+bench_bench_bitcoin_CPPFLAGS = $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
+bench_bench_bitcoin_LDADD = \
+  $(LIBBITCOIN_SERVER) \
+  $(LIBBITCOIN_COMMON) \
+  $(LIBBITCOIN_UNIVALUE) \
+  $(LIBBITCOIN_UTIL) \
+  $(LIBBITCOIN_CRYPTO) \
+  $(LIBLEVELDB) \
+  $(LIBMEMENV) \
+  $(LIBSECP256K1)
+
+if ENABLE_ZMQ
+bench_bench_bitcoin_LDADD += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
+endif
+
+if ENABLE_WALLET
+bench_bench_bitcoin_LDADD += $(LIBBITCOIN_WALLET)
+endif
+
+bench_bench_bitcoin_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(LIBZCASH_LIBS)
+bench_bench_bitcoin_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+
+
+CLEAN_BITCOIN_BENCH = bench/*.gcda bench/*.gcno
+
+CLEANFILES += $(CLEAN_BITCOIN_BENCH)
+
+bitcoin_bench: $(BENCH_BINARY)
+
+bench: $(BENCH_BINARY) FORCE
+	$(BENCH_BINARY)
+
+bitcoin_bench_clean : FORCE
+	rm -f $(CLEAN_BITCOIN_BENCH) $(bench_bench_bitcoin_OBJECTS) $(BENCH_BINARY)

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -9,7 +9,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/bench.h \
   bench/Examples.cpp \
   bench/rollingbloom.cpp \
-  bench/crypto_hash.cpp
+  bench/crypto_hash.cpp \
+  bench/base58.cpp
 
 bench_bench_bitcoin_CPPFLAGS = $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_LDADD = \

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -352,8 +352,8 @@ CAddrInfo CAddrMan::Select_(bool newOnly)
             int nKBucket = RandomInt(ADDRMAN_TRIED_BUCKET_COUNT);
             int nKBucketPos = RandomInt(ADDRMAN_BUCKET_SIZE);
             while (vvTried[nKBucket][nKBucketPos] == -1) {
-                nKBucket = (nKBucket + insecure_rand()) % ADDRMAN_TRIED_BUCKET_COUNT;
-                nKBucketPos = (nKBucketPos + insecure_rand()) % ADDRMAN_BUCKET_SIZE;
+                nKBucket = (nKBucket + insecure_rand.rand32()) % ADDRMAN_TRIED_BUCKET_COUNT;
+                nKBucketPos = (nKBucketPos + insecure_rand.rand32()) % ADDRMAN_BUCKET_SIZE;
                 if (i++ > kMaxRetries)
                     return CAddrInfo();
                 if (i % kRetriesBetweenSleep == 0 && !nKey.IsNull())
@@ -374,8 +374,8 @@ CAddrInfo CAddrMan::Select_(bool newOnly)
             int nUBucket = RandomInt(ADDRMAN_NEW_BUCKET_COUNT);
             int nUBucketPos = RandomInt(ADDRMAN_BUCKET_SIZE);
             while (vvNew[nUBucket][nUBucketPos] == -1) {
-                nUBucket = (nUBucket + insecure_rand()) % ADDRMAN_NEW_BUCKET_COUNT;
-                nUBucketPos = (nUBucketPos + insecure_rand()) % ADDRMAN_BUCKET_SIZE;
+                nUBucket = (nUBucket + insecure_rand.rand32()) % ADDRMAN_NEW_BUCKET_COUNT;
+                nUBucketPos = (nUBucketPos + insecure_rand.rand32()) % ADDRMAN_BUCKET_SIZE;
                 if (i++ > kMaxRetries)
                     return CAddrInfo();
                 if (i % kRetriesBetweenSleep == 0 && !nKey.IsNull())

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -203,6 +203,9 @@ protected:
     //! secret key to randomize bucket select with
     uint256 nKey;
 
+    //! Source of random numbers for randomization in inner loops
+    FastRandomContext insecure_rand;
+
     //! Find an entry.
     CAddrInfo* Find(const CNetAddr& addr, int *pnId = NULL);
 

--- a/src/bench/.gitignore
+++ b/src/bench/.gitignore
@@ -1,0 +1,1 @@
+bench_bitcoin

--- a/src/bench/Examples.cpp
+++ b/src/bench/Examples.cpp
@@ -6,6 +6,8 @@
 #include "main.h"
 #include "utiltime.h"
 
+// Sanity test: this should loop ten times, and
+// min/max/average should be close to 100ms.
 static void Sleep100ms(benchmark::State& state)
 {
     while (state.KeepRunning()) {
@@ -14,3 +16,19 @@ static void Sleep100ms(benchmark::State& state)
 }
 
 BENCHMARK(Sleep100ms);
+
+// Extremely fast-running benchmark:
+#include <math.h>
+
+volatile double sum = 0.0; // volatile, global so not optimized away
+
+static void Trig(benchmark::State& state)
+{
+    double d = 0.01;
+    while (state.KeepRunning()) {
+        sum += sin(d);
+        d += 0.000001;
+    }
+}
+
+BENCHMARK(Trig);

--- a/src/bench/MilliSleep.cpp
+++ b/src/bench/MilliSleep.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+#include "main.h"
+#include "utiltime.h"
+
+static void Sleep100ms(benchmark::State& state)
+{
+    while (state.KeepRunning()) {
+        MilliSleep(100);
+    }
+}
+
+BENCHMARK(Sleep100ms);

--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 the Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+
+#include "main.h"
+#include "base58.h"
+
+#include <vector>
+#include <string>
+
+
+static void Base58Encode(benchmark::State& state)
+{
+    unsigned char buff[32] = {
+        17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
+        227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
+        200, 24
+    };
+    unsigned char* b = buff;
+    while (state.KeepRunning()) {
+        EncodeBase58(b, b + 32);
+    }
+}
+
+
+static void Base58CheckEncode(benchmark::State& state)
+{
+    unsigned char buff[32] = {
+        17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
+        227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
+        200, 24
+    };
+    unsigned char* b = buff;
+    std::vector<unsigned char> vch;
+    vch.assign(b, b + 32);
+    while (state.KeepRunning()) {
+        EncodeBase58Check(vch);
+    }
+}
+
+
+static void Base58Decode(benchmark::State& state)
+{
+    const char* addr = "17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem";
+    std::vector<unsigned char> vch;
+    while (state.KeepRunning()) {
+        DecodeBase58(addr, vch);
+    }
+}
+
+
+BENCHMARK(Base58Encode);
+BENCHMARK(Base58CheckEncode);
+BENCHMARK(Base58Decode);

--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -7,34 +7,37 @@
 #include "main.h"
 #include "base58.h"
 
+#include <array>
 #include <vector>
 #include <string>
 
 
 static void Base58Encode(benchmark::State& state)
 {
-    unsigned char buff[32] = {
-        17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
-        227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
-        200, 24
+    static const std::array<unsigned char, 32> buff = {
+        {
+            17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
+            227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
+            200, 24
+        }
     };
-    unsigned char* b = buff;
     while (state.KeepRunning()) {
-        EncodeBase58(b, b + 32);
+        EncodeBase58(buff.begin(), buff.end());
     }
 }
 
 
 static void Base58CheckEncode(benchmark::State& state)
 {
-    unsigned char buff[32] = {
-        17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
-        227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
-        200, 24
+    static const std::array<unsigned char, 32> buff = {
+        {
+            17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
+            227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
+            200, 24
+        }
     };
-    unsigned char* b = buff;
     std::vector<unsigned char> vch;
-    vch.assign(b, b + 32);
+    vch.assign(buff.begin(), buff.end());
     while (state.KeepRunning()) {
         EncodeBase58Check(vch);
     }

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -64,8 +64,11 @@ bool State::KeepRunning()
           return true;
         }
         if (elapsed*16 < maxElapsed) {
-          countMask = ((countMask<<1)|1) & ((1LL<<60)-1);
-          countMaskInv = 1./(countMask+1);
+          uint64_t newCountMask = ((countMask<<1)|1) & ((1LL<<60)-1);
+          if ((count & newCountMask)==0) {
+              countMask = newCountMask;
+              countMaskInv = 1./(countMask+1);
+          }
         }
     }
     lastTime = now;

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -9,9 +9,7 @@
 #include <iomanip>
 #include <sys/time.h>
 
-using namespace benchmark;
-
-std::map<std::string, BenchFunction> BenchRunner::benchmarks;
+std::map<std::string, benchmark::BenchFunction> benchmark::BenchRunner::benchmarks;
 
 static double gettimedouble(void) {
     struct timeval tv;
@@ -19,29 +17,29 @@ static double gettimedouble(void) {
     return tv.tv_usec * 0.000001 + tv.tv_sec;
 }
 
-BenchRunner::BenchRunner(std::string name, BenchFunction func)
+benchmark::BenchRunner::BenchRunner(std::string name, benchmark::BenchFunction func)
 {
     benchmarks.insert(std::make_pair(name, func));
 }
 
 void
-BenchRunner::RunAll(double elapsedTimeForOne)
+benchmark::BenchRunner::RunAll(double elapsedTimeForOne)
 {
     perf_init();
     std::cout << "#Benchmark" << "," << "count" << "," << "min" << "," << "max" << "," << "average" << ","
               << "min_cycles" << "," << "max_cycles" << "," << "average_cycles" << "\n";
 
-    for (std::map<std::string,BenchFunction>::iterator it = benchmarks.begin();
+    for (std::map<std::string,benchmark::BenchFunction>::iterator it = benchmarks.begin();
          it != benchmarks.end(); ++it) {
 
         State state(it->first, elapsedTimeForOne);
-        BenchFunction& func = it->second;
+        benchmark::BenchFunction& func = it->second;
         func(state);
     }
     perf_fini();
 }
 
-bool State::KeepRunning()
+bool benchmark::State::KeepRunning()
 {
     if (count & countMask) {
       ++count;

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -9,7 +9,10 @@
 #include <iomanip>
 #include <sys/time.h>
 
-std::map<std::string, benchmark::BenchFunction> benchmark::BenchRunner::benchmarks;
+benchmark::BenchRunner::BenchmarkMap &benchmark::BenchRunner::benchmarks() {
+    static std::map<std::string, benchmark::BenchFunction> benchmarks_map;
+    return benchmarks_map;
+}
 
 static double gettimedouble(void) {
     struct timeval tv;
@@ -19,7 +22,7 @@ static double gettimedouble(void) {
 
 benchmark::BenchRunner::BenchRunner(std::string name, benchmark::BenchFunction func)
 {
-    benchmarks.insert(std::make_pair(name, func));
+    benchmarks().insert(std::make_pair(name, func));
 }
 
 void
@@ -29,12 +32,9 @@ benchmark::BenchRunner::RunAll(double elapsedTimeForOne)
     std::cout << "#Benchmark" << "," << "count" << "," << "min" << "," << "max" << "," << "average" << ","
               << "min_cycles" << "," << "max_cycles" << "," << "average_cycles" << "\n";
 
-    for (std::map<std::string,benchmark::BenchFunction>::iterator it = benchmarks.begin();
-         it != benchmarks.end(); ++it) {
-
-        State state(it->first, elapsedTimeForOne);
-        benchmark::BenchFunction& func = it->second;
-        func(state);
+    for (const auto &p: benchmarks()) {
+        State state(p.first, elapsedTimeForOne);
+        p.second(state);
     }
     perf_fini();
 }

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -23,6 +23,9 @@ void
 benchmark::BenchRunner::RunAll(benchmark::duration elapsedTimeForOne)
 {
     perf_init();
+    if (std::ratio_less_equal<benchmark::clock::period, std::micro>::value) {
+        std::cerr << "WARNING: Clock precision is worse than microsecond - benchmarks may be less accurate!\n";
+    }
     std::cout << "#Benchmark" << "," << "count" << "," << "min(ns)" << "," << "max(ns)" << "," << "average(ns)" << ","
               << "min_cycles" << "," << "max_cycles" << "," << "average_cycles" << "\n";
 

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -55,13 +55,13 @@ bool benchmark::State::KeepRunning()
     else {
         now = gettimedouble();
         double elapsed = now - lastTime;
-        double elapsedOne = elapsed * countMaskInv;
+        double elapsedOne = elapsed / (countMask + 1);
         if (elapsedOne < minTime) minTime = elapsedOne;
         if (elapsedOne > maxTime) maxTime = elapsedOne;
 
         // We only use relative values, so don't have to handle 64-bit wrap-around specially
         nowCycles = perf_cpucycles();
-        uint64_t elapsedOneCycles = (nowCycles - lastCycles) * countMaskInv;
+        uint64_t elapsedOneCycles = (nowCycles - lastCycles) / (countMask + 1);
         if (elapsedOneCycles < minCycles) minCycles = elapsedOneCycles;
         if (elapsedOneCycles > maxCycles) maxCycles = elapsedOneCycles;
 
@@ -69,7 +69,6 @@ bool benchmark::State::KeepRunning()
           // If the execution was much too fast (1/128th of maxElapsed), increase the count mask by 8x and restart timing.
           // The restart avoids including the overhead of this code in the measurement.
           countMask = ((countMask<<3)|7) & ((1LL<<60)-1);
-          countMaskInv = 1./(countMask+1);
           count = 0;
           minTime = std::numeric_limits<double>::max();
           maxTime = std::numeric_limits<double>::min();
@@ -81,7 +80,6 @@ bool benchmark::State::KeepRunning()
           uint64_t newCountMask = ((countMask<<1)|1) & ((1LL<<60)-1);
           if ((count & newCountMask)==0) {
               countMask = newCountMask;
-              countMaskInv = 1./(countMask+1);
           }
         }
     }

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -92,6 +92,8 @@ bool benchmark::State::KeepRunning()
 
     --count;
 
+    assert(count != 0 && "count == 0 => (now == 0 && beginTime == 0) => return above");
+
     // Output results
     double average = (now-beginTime)/count;
     int64_t averageCycles = (nowCycles-beginCycles)/count;

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -36,14 +36,22 @@ BenchRunner::RunAll(double elapsedTimeForOne)
 
 bool State::KeepRunning()
 {
-    double now = gettimedouble();
+    double now;
     if (count == 0) {
-        beginTime = now;
+        beginTime = now = gettimedouble();
     }
     else {
-        double elapsedOne = now - lastTime;
+        // timeCheckCount is used to avoid calling gettime most of the time,
+        // so benchmarks that run very quickly get consistent results.
+        if ((count+1)%timeCheckCount != 0) {
+            ++count;
+            return true; // keep going
+        }
+        now = gettimedouble();
+        double elapsedOne = (now - lastTime)/timeCheckCount;
         if (elapsedOne < minTime) minTime = elapsedOne;
         if (elapsedOne > maxTime) maxTime = elapsedOne;
+        if (elapsedOne*timeCheckCount < maxElapsed/16) timeCheckCount *= 2;
     }
     lastTime = now;
     ++count;

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -1,7 +1,9 @@
 // Copyright (c) 2015 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "bench.h"
+
 #include <iostream>
 #include <sys/time.h>
 

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -5,6 +5,7 @@
 #include "bench.h"
 #include "perf.h"
 
+#include <assert.h>
 #include <iostream>
 #include <iomanip>
 #include <sys/time.h>

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "bench.h"
+#include <iostream>
+#include <sys/time.h>
+
+using namespace benchmark;
+
+std::map<std::string, BenchFunction> BenchRunner::benchmarks;
+
+static double gettimedouble(void) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return tv.tv_usec * 0.000001 + tv.tv_sec;
+}
+
+BenchRunner::BenchRunner(std::string name, BenchFunction func)
+{
+    benchmarks.insert(std::make_pair(name, func));
+}
+
+void
+BenchRunner::RunAll(double elapsedTimeForOne)
+{
+    std::cout << "Benchmark" << "," << "count" << "," << "min" << "," << "max" << "," << "average" << "\n";
+
+    for (std::map<std::string,BenchFunction>::iterator it = benchmarks.begin();
+         it != benchmarks.end(); ++it) {
+
+        State state(it->first, elapsedTimeForOne);
+        BenchFunction& func = it->second;
+        func(state);
+    }
+}
+
+bool State::KeepRunning()
+{
+    double now = gettimedouble();
+    if (count == 0) {
+        beginTime = now;
+    }
+    else {
+        double elapsedOne = now - lastTime;
+        if (elapsedOne < minTime) minTime = elapsedOne;
+        if (elapsedOne > maxTime) maxTime = elapsedOne;
+    }
+    lastTime = now;
+    ++count;
+
+    if (now - beginTime < maxElapsed) return true; // Keep going
+
+    --count;
+
+    // Output results
+    double average = (now-beginTime)/count;
+    std::cout << name << "," << count << "," << minTime << "," << maxTime << "," << average << "\n";
+
+    return false;
+}

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -100,6 +100,7 @@ bool benchmark::State::KeepRunning()
     int64_t averageCycles = (nowCycles-beginCycles)/count;
     std::cout << std::fixed << std::setprecision(15) << name << "," << count << "," << minTime << "," << maxTime << "," << average << ","
               << minCycles << "," << maxCycles << "," << averageCycles << "\n";
+    std::cout.copyfmt(std::ios(nullptr));
 
     return false;
 }

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -8,17 +8,10 @@
 #include <assert.h>
 #include <iostream>
 #include <iomanip>
-#include <sys/time.h>
 
 benchmark::BenchRunner::BenchmarkMap &benchmark::BenchRunner::benchmarks() {
     static std::map<std::string, benchmark::BenchFunction> benchmarks_map;
     return benchmarks_map;
-}
-
-static double gettimedouble(void) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return tv.tv_usec * 0.000001 + tv.tv_sec;
 }
 
 benchmark::BenchRunner::BenchRunner(std::string name, benchmark::BenchFunction func)
@@ -27,10 +20,10 @@ benchmark::BenchRunner::BenchRunner(std::string name, benchmark::BenchFunction f
 }
 
 void
-benchmark::BenchRunner::RunAll(double elapsedTimeForOne)
+benchmark::BenchRunner::RunAll(benchmark::duration elapsedTimeForOne)
 {
     perf_init();
-    std::cout << "#Benchmark" << "," << "count" << "," << "min" << "," << "max" << "," << "average" << ","
+    std::cout << "#Benchmark" << "," << "count" << "," << "min(ns)" << "," << "max(ns)" << "," << "average(ns)" << ","
               << "min_cycles" << "," << "max_cycles" << "," << "average_cycles" << "\n";
 
     for (const auto &p: benchmarks()) {
@@ -46,16 +39,17 @@ bool benchmark::State::KeepRunning()
       ++count;
       return true;
     }
-    double now;
+    time_point now;
+
     uint64_t nowCycles;
     if (count == 0) {
-        lastTime = beginTime = now = gettimedouble();
+        lastTime = beginTime = now = clock::now();
         lastCycles = beginCycles = nowCycles = perf_cpucycles();
     }
     else {
-        now = gettimedouble();
-        double elapsed = now - lastTime;
-        double elapsedOne = elapsed / (countMask + 1);
+        now = clock::now();
+        auto elapsed = now - lastTime;
+        auto elapsedOne = elapsed / (countMask + 1);
         if (elapsedOne < minTime) minTime = elapsedOne;
         if (elapsedOne > maxTime) maxTime = elapsedOne;
 
@@ -70,8 +64,8 @@ bool benchmark::State::KeepRunning()
           // The restart avoids including the overhead of this code in the measurement.
           countMask = ((countMask<<3)|7) & ((1LL<<60)-1);
           count = 0;
-          minTime = std::numeric_limits<double>::max();
-          maxTime = std::numeric_limits<double>::min();
+          minTime = duration::max();
+          maxTime = duration::zero();
           minCycles = std::numeric_limits<uint64_t>::max();
           maxCycles = std::numeric_limits<uint64_t>::min();
           return true;
@@ -94,9 +88,13 @@ bool benchmark::State::KeepRunning()
     assert(count != 0 && "count == 0 => (now == 0 && beginTime == 0) => return above");
 
     // Output results
-    double average = (now-beginTime)/count;
+    // Duration casts are only necessary here because hardware with sub-nanosecond clocks
+    // will lose precision.
+    int64_t min_elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(minTime).count();
+    int64_t max_elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(maxTime).count();
+    int64_t avg_elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>((now-beginTime)/count).count();
     int64_t averageCycles = (nowCycles-beginCycles)/count;
-    std::cout << std::fixed << std::setprecision(15) << name << "," << count << "," << minTime << "," << maxTime << "," << average << ","
+    std::cout << std::fixed << std::setprecision(15) << name << "," << count << "," << min_elapsed << "," << max_elapsed << "," << avg_elapsed << ","
               << minCycles << "," << maxCycles << "," << averageCycles << "\n";
     std::cout.copyfmt(std::ios(nullptr));
 

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -63,7 +63,8 @@ namespace benchmark {
 
     class BenchRunner
     {
-        static std::map<std::string, BenchFunction> benchmarks;
+        typedef std::map<std::string, BenchFunction> BenchmarkMap;
+        static BenchmarkMap &benchmarks();
 
     public:
         BenchRunner(std::string name, BenchFunction func);

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -40,14 +40,15 @@ namespace benchmark {
         std::string name;
         double maxElapsed;
         double beginTime;
-        double lastTime, minTime, maxTime;
+        double lastTime, minTime, maxTime, countMaskInv;
         int64_t count;
-        int64_t timeCheckCount;
+        int64_t countMask;
     public:
         State(std::string _name, double _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
             minTime = std::numeric_limits<double>::max();
             maxTime = std::numeric_limits<double>::min();
-            timeCheckCount = 1;
+            countMask = 1;
+            countMaskInv = 1./(countMask + 1);
         }
         bool KeepRunning();
     };

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -41,12 +41,18 @@ namespace benchmark {
         double maxElapsed;
         double beginTime;
         double lastTime, minTime, maxTime, countMaskInv;
-        int64_t count;
-        int64_t countMask;
+        uint64_t count;
+        uint64_t countMask;
+        uint64_t beginCycles;
+        uint64_t lastCycles;
+        uint64_t minCycles;
+        uint64_t maxCycles;
     public:
         State(std::string _name, double _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
             minTime = std::numeric_limits<double>::max();
             maxTime = std::numeric_limits<double>::min();
+            minCycles = std::numeric_limits<uint64_t>::max();
+            maxCycles = std::numeric_limits<uint64_t>::min();
             countMask = 1;
             countMaskInv = 1./(countMask + 1);
         }

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -59,12 +59,17 @@ namespace benchmark {
         uint64_t minCycles;
         uint64_t maxCycles;
     public:
-        State(std::string _name, duration _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
-            minTime = duration::max();
-            maxTime = duration::zero();
-            minCycles = std::numeric_limits<uint64_t>::max();
-            maxCycles = std::numeric_limits<uint64_t>::min();
-            countMask = 1;
+        State(std::string _name, duration _maxElapsed) :
+            name(_name),
+            maxElapsed(_maxElapsed),
+            minTime(duration::max()),
+            maxTime(duration::zero()),
+            count(0),
+            countMask(1),
+            beginCycles(0),
+            lastCycles(0),
+            minCycles(std::numeric_limits<uint64_t>::max()),
+            maxCycles(std::numeric_limits<uint64_t>::min()) {
         }
         bool KeepRunning();
     };

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -37,13 +37,11 @@ BENCHMARK(CODE_TO_TIME);
  */
  
 namespace benchmark {
-    // On many systems, the high_resolution_clock offers no better resolution than the steady_clock.
-    // If that's the case, prefer the steady_clock.
+    // In case high_resolution_clock is steady, prefer that, otherwise use steady_clock.
     struct best_clock {
         using hi_res_clock = std::chrono::high_resolution_clock;
         using steady_clock = std::chrono::steady_clock;
-        static constexpr bool steady_is_high_res = std::ratio_less_equal<steady_clock::period, hi_res_clock::period>::value;
-        using type = std::conditional<steady_is_high_res, steady_clock, hi_res_clock>::type;
+        using type = std::conditional<hi_res_clock::is_steady, hi_res_clock, steady_clock>::type;
     };
     using clock = best_clock::type;
     using time_point = clock::time_point;

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -41,7 +41,7 @@ namespace benchmark {
         std::string name;
         double maxElapsed;
         double beginTime;
-        double lastTime, minTime, maxTime, countMaskInv;
+        double lastTime, minTime, maxTime;
         uint64_t count;
         uint64_t countMask;
         uint64_t beginCycles;
@@ -55,7 +55,6 @@ namespace benchmark {
             minCycles = std::numeric_limits<uint64_t>::max();
             maxCycles = std::numeric_limits<uint64_t>::min();
             countMask = 1;
-            countMaskInv = 1./(countMask + 1);
         }
         bool KeepRunning();
     };

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -1,8 +1,16 @@
 // Copyright (c) 2015 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#ifndef BITCOIN_BENCH_H
-#define BITCOIN_BENCH_H
+
+#ifndef BITCOIN_BENCH_BENCH_H
+#define BITCOIN_BENCH_BENCH_H
+
+#include <map>
+#include <string>
+
+#include <boost/function.hpp>
+#include <boost/preprocessor/cat.hpp>
+#include <boost/preprocessor/stringize.hpp>
 
 // Simple micro-benchmarking framework; API mostly matches a subset of the Google Benchmark
 // framework (see https://github.com/google/benchmark)
@@ -25,14 +33,7 @@ static void CODE_TO_TIME(benchmark::State& state)
 BENCHMARK(CODE_TO_TIME);
 
  */
-
-
-#include <boost/function.hpp>
-#include <boost/preprocessor/cat.hpp>
-#include <boost/preprocessor/stringize.hpp>
-#include <map>
-#include <string>
-
+ 
 namespace benchmark {
 
     class State {
@@ -68,4 +69,4 @@ namespace benchmark {
 #define BENCHMARK(n) \
     benchmark::BenchRunner BOOST_PP_CAT(bench_, BOOST_PP_CAT(__LINE__, n))(BOOST_PP_STRINGIZE(n), n);
 
-#endif // BITCOIN_BENCH_H
+#endif // BITCOIN_BENCH_BENCH_H

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -5,10 +5,11 @@
 #ifndef BITCOIN_BENCH_BENCH_H
 #define BITCOIN_BENCH_BENCH_H
 
+#include <functional>
+#include <limits>
 #include <map>
 #include <string>
 
-#include <boost/function.hpp>
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>
 
@@ -59,7 +60,7 @@ namespace benchmark {
         bool KeepRunning();
     };
 
-    typedef boost::function<void(State&)> BenchFunction;
+    typedef std::function<void(State&)> BenchFunction;
 
     class BenchRunner
     {

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -9,6 +9,7 @@
 #include <limits>
 #include <map>
 #include <string>
+#include <chrono>
 
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>
@@ -37,11 +38,15 @@ BENCHMARK(CODE_TO_TIME);
  
 namespace benchmark {
 
+    using clock = std::chrono::high_resolution_clock;
+    using time_point = clock::time_point;
+    using duration = clock::duration;
+
     class State {
         std::string name;
-        double maxElapsed;
-        double beginTime;
-        double lastTime, minTime, maxTime;
+        duration maxElapsed;
+        time_point beginTime, lastTime;
+        duration minTime, maxTime;
         uint64_t count;
         uint64_t countMask;
         uint64_t beginCycles;
@@ -49,9 +54,9 @@ namespace benchmark {
         uint64_t minCycles;
         uint64_t maxCycles;
     public:
-        State(std::string _name, double _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
-            minTime = std::numeric_limits<double>::max();
-            maxTime = std::numeric_limits<double>::min();
+        State(std::string _name, duration _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
+            minTime = duration::max();
+            maxTime = duration::zero();
             minCycles = std::numeric_limits<uint64_t>::max();
             maxCycles = std::numeric_limits<uint64_t>::min();
             countMask = 1;
@@ -69,7 +74,7 @@ namespace benchmark {
     public:
         BenchRunner(std::string name, BenchFunction func);
 
-        static void RunAll(double elapsedTimeForOne=1.0);
+        static void RunAll(duration elapsedTimeForOne = std::chrono::seconds(1));
     };
 }
 

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -37,8 +37,15 @@ BENCHMARK(CODE_TO_TIME);
  */
  
 namespace benchmark {
-
-    using clock = std::chrono::high_resolution_clock;
+    // On many systems, the high_resolution_clock offers no better resolution than the steady_clock.
+    // If that's the case, prefer the steady_clock.
+    struct best_clock {
+        using hi_res_clock = std::chrono::high_resolution_clock;
+        using steady_clock = std::chrono::steady_clock;
+        static constexpr bool steady_is_high_res = std::ratio_less_equal<steady_clock::period, hi_res_clock::period>::value;
+        using type = std::conditional<steady_is_high_res, steady_clock, hi_res_clock>::type;
+    };
+    using clock = best_clock::type;
     using time_point = clock::time_point;
     using duration = clock::duration;
 

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -41,10 +41,12 @@ namespace benchmark {
         double beginTime;
         double lastTime, minTime, maxTime;
         int64_t count;
+        int64_t timeCheckCount;
     public:
         State(std::string _name, double _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
             minTime = std::numeric_limits<double>::max();
             maxTime = std::numeric_limits<double>::min();
+            timeCheckCount = 1;
         }
         bool KeepRunning();
     };

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_BENCH_H
+#define BITCOIN_BENCH_H
+
+// Simple micro-benchmarking framework; API mostly matches a subset of the Google Benchmark
+// framework (see https://github.com/google/benchmark)
+// Wny not use the Google Benchmark framework? Because adding Yet Another Dependency
+// (that uses cmake as its build system and has lots of features we don't need) isn't
+// worth it.
+
+/*
+ * Usage:
+
+static void CODE_TO_TIME(benchmark::State& state)
+{
+    ... do any setup needed...
+    while (state.KeepRunning()) {
+       ... do stuff you want to time...
+    }
+    ... do any cleanup needed...
+}
+
+BENCHMARK(CODE_TO_TIME);
+
+ */
+
+
+#include <boost/function.hpp>
+#include <boost/preprocessor/cat.hpp>
+#include <boost/preprocessor/stringize.hpp>
+#include <map>
+#include <string>
+
+namespace benchmark {
+
+    class State {
+        std::string name;
+        double maxElapsed;
+        double beginTime;
+        double lastTime, minTime, maxTime;
+        int64_t count;
+    public:
+        State(std::string _name, double _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
+            minTime = std::numeric_limits<double>::max();
+            maxTime = std::numeric_limits<double>::min();
+        }
+        bool KeepRunning();
+    };
+
+    typedef boost::function<void(State&)> BenchFunction;
+
+    class BenchRunner
+    {
+        static std::map<std::string, BenchFunction> benchmarks;
+
+    public:
+        BenchRunner(std::string name, BenchFunction func);
+
+        static void RunAll(double elapsedTimeForOne=1.0);
+    };
+}
+
+// BENCHMARK(foo) expands to:  benchmark::BenchRunner bench_11foo("foo", foo);
+#define BENCHMARK(n) \
+    benchmark::BenchRunner BOOST_PP_CAT(bench_, BOOST_PP_CAT(__LINE__, n))(BOOST_PP_STRINGIZE(n), n);
+
+#endif // BITCOIN_BENCH_H

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+
+#include "key.h"
+#include "main.h"
+#include "util.h"
+
+int
+main(int argc, char** argv)
+{
+    ECC_Start();
+    SetupEnvironment();
+    fPrintToDebugLog = false; // don't want to write to debug.log file
+
+    benchmark::BenchRunner::RunAll();
+
+    ECC_Stop();
+}

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+#include "util.h"
+#include "main.h"
+#include "checkqueue.h"
+#include "prevector.h"
+#include <vector>
+#include <boost/thread/thread.hpp>
+#include "random.h"
+
+
+// This Benchmark tests the CheckQueue with the lightest
+// weight Checks, so it should make any lock contention
+// particularly visible
+static void CCheckQueueSpeed(benchmark::State& state)
+{
+    struct FakeJobNoWork {
+        bool operator()()
+        {
+            return true;
+        }
+        void swap(FakeJobNoWork& x){};
+    };
+    CCheckQueue<FakeJobNoWork> queue {128};
+    boost::thread_group tg;
+    for (auto x = 0; x < std::max(2, GetNumCores()); ++x) {
+       tg.create_thread([&]{queue.Thread();});
+    }
+    while (state.KeepRunning()) {
+        CCheckQueueControl<FakeJobNoWork> control(&queue);
+        // We can make vChecks out of the loop because calling Add doesn't
+        // change the size of the vector.
+        std::vector<FakeJobNoWork> vChecks;
+        vChecks.resize(30);
+
+        // We call Add a number of times to simulate the behavior of adding
+        // a block of transactions at once.
+        for (size_t j = 0; j < 101; ++j) {
+            control.Add(vChecks);
+        }
+        // control waits for completion by RAII, but
+        // it is done explicitly here for clarity
+        control.Wait();
+    }
+    tg.interrupt_all();
+    tg.join_all();
+}
+
+// This Benchmark tests the CheckQueue with a slightly realistic workload,
+// where checks all contain a prevector that is indirect 50% of the time
+// and there is a little bit of work done between calls to Add.
+static void CCheckQueueSpeedPrevectorJob(benchmark::State& state)
+{
+    struct PrevectorJob {
+        prevector<28, uint8_t> p;
+        PrevectorJob(){
+        }
+        PrevectorJob(FastRandomContext& insecure_rand){
+            p.resize(insecure_rand.rand32() % 56);
+        }
+        bool operator()()
+        {
+            return true;
+        }
+        void swap(PrevectorJob& x){p.swap(x.p);};
+    };
+    CCheckQueue<PrevectorJob> queue {128};
+    boost::thread_group tg;
+    for (auto x = 0; x < std::max(2, GetNumCores()); ++x) {
+       tg.create_thread([&]{queue.Thread();});
+    }
+    while (state.KeepRunning()) {
+        // Make insecure_rand here so that each iteration is identical.
+        FastRandomContext insecure_rand(true);
+        CCheckQueueControl<PrevectorJob> control(&queue);
+        for (size_t j = 0; j < 101; ++j) {
+            std::vector<PrevectorJob> vChecks;
+            vChecks.reserve(30);
+            for (auto x = 0; x < 30; ++x)
+                vChecks.emplace_back(insecure_rand);
+            control.Add(vChecks);
+        }
+        // control waits for completion by RAII, but
+        // it is done explicitly here for clarity
+        control.Wait();
+    }
+    tg.interrupt_all();
+    tg.join_all();
+}
+BENCHMARK(CCheckQueueSpeed);
+BENCHMARK(CCheckQueueSpeedPrevectorJob);

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <iostream>
+
+#include "bench.h"
+#include "bloom.h"
+#include "utiltime.h"
+#include "crypto/ripemd160.h"
+#include "crypto/sha1.h"
+#include "crypto/sha256.h"
+#include "crypto/sha512.h"
+
+/* Number of bytes to hash per iteration */
+static const uint64_t BUFFER_SIZE = 1000*1000;
+
+static void RIPEMD160(benchmark::State& state)
+{
+    uint8_t hash[CRIPEMD160::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CRIPEMD160().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+static void SHA1(benchmark::State& state)
+{
+    uint8_t hash[CSHA1::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CSHA1().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+static void SHA256(benchmark::State& state)
+{
+    uint8_t hash[CSHA256::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CSHA256().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+static void SHA512(benchmark::State& state)
+{
+    uint8_t hash[CSHA512::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CSHA512().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+BENCHMARK(RIPEMD160);
+BENCHMARK(SHA1);
+BENCHMARK(SHA256);
+BENCHMARK(SHA512);

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -51,7 +51,7 @@ static void SHA512(benchmark::State& state)
 static void FastRandom_32bit(benchmark::State& state)
 {
     FastRandomContext rng(true);
-    uint32_t x;
+    uint32_t x = 0;
     while (state.KeepRunning()) {
         for (int i = 0; i < 1000000; i++) {
             x += rng.rand32();
@@ -62,7 +62,7 @@ static void FastRandom_32bit(benchmark::State& state)
 static void FastRandom_1bit(benchmark::State& state)
 {
     FastRandomContext rng(true);
-    uint32_t x;
+    uint32_t x = 0;
     while (state.KeepRunning()) {
         for (int i = 0; i < 1000000; i++) {
             x += rng.randbool();

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -6,6 +6,7 @@
 
 #include "bench.h"
 #include "bloom.h"
+#include "random.h"
 #include "utiltime.h"
 #include "crypto/ripemd160.h"
 #include "crypto/sha1.h"
@@ -47,7 +48,32 @@ static void SHA512(benchmark::State& state)
         CSHA512().Write(begin_ptr(in), in.size()).Finalize(hash);
 }
 
+static void FastRandom_32bit(benchmark::State& state)
+{
+    FastRandomContext rng(true);
+    uint32_t x;
+    while (state.KeepRunning()) {
+        for (int i = 0; i < 1000000; i++) {
+            x += rng.rand32();
+        }
+    }
+}
+
+static void FastRandom_1bit(benchmark::State& state)
+{
+    FastRandomContext rng(true);
+    uint32_t x;
+    while (state.KeepRunning()) {
+        for (int i = 0; i < 1000000; i++) {
+            x += rng.randbool();
+        }
+    }
+}
+
 BENCHMARK(RIPEMD160);
 BENCHMARK(SHA1);
 BENCHMARK(SHA256);
 BENCHMARK(SHA512);
+
+BENCHMARK(FastRandom_32bit);
+BENCHMARK(FastRandom_1bit);

--- a/src/bench/perf.cpp
+++ b/src/bench/perf.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "perf.h"
+
+#if defined(__i386__) || defined(__x86_64__)
+
+/* These architectures support quering the cycle counter
+ * from user space, no need for any syscall overhead.
+ */
+void perf_init(void) { }
+void perf_fini(void) { }
+
+#elif defined(__linux__)
+
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <linux/perf_event.h>
+
+static int fd = -1;
+static struct perf_event_attr attr;
+
+void perf_init(void)
+{
+    attr.type = PERF_TYPE_HARDWARE;
+    attr.config = PERF_COUNT_HW_CPU_CYCLES;
+    fd = syscall(__NR_perf_event_open, &attr, 0, -1, -1, 0);
+}
+
+void perf_fini(void)
+{
+    if (fd != -1) {
+        close(fd);
+    }
+}
+
+uint64_t perf_cpucycles(void)
+{
+    uint64_t result = 0;
+    if (fd == -1 || read(fd, &result, sizeof(result)) < (ssize_t)sizeof(result)) {
+        return 0;
+    }
+    return result;
+}
+
+#else /* Unhandled platform */
+
+void perf_init(void) { }
+void perf_fini(void) { }
+uint64_t perf_cpucycles(void) { return 0; }
+
+#endif

--- a/src/bench/perf.h
+++ b/src/bench/perf.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/** Functions for measurement of CPU cycles */
+#ifndef H_PERF
+#define H_PERF
+
+#include <stdint.h>
+
+#if defined(__i386__)
+
+static inline uint64_t perf_cpucycles(void)
+{
+    uint64_t x;
+    __asm__ volatile (".byte 0x0f, 0x31" : "=A" (x));
+    return x;
+}
+
+#elif defined(__x86_64__)
+
+static inline uint64_t perf_cpucycles(void)
+{
+    uint32_t hi, lo;
+    __asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
+    return ((uint64_t)lo)|(((uint64_t)hi)<<32);
+}
+#else
+
+uint64_t perf_cpucycles(void);
+
+#endif
+
+void perf_init(void);
+void perf_fini(void);
+
+#endif // H_PERF

--- a/src/bench/prevector_destructor.cpp
+++ b/src/bench/prevector_destructor.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+#include "prevector.h"
+
+static void PrevectorDestructor(benchmark::State& state)
+{
+    while (state.KeepRunning()) {
+        for (auto x = 0; x < 1000; ++x) {
+            prevector<28, unsigned char> t0;
+            prevector<28, unsigned char> t1;
+            t0.resize(28);
+            t1.resize(29);
+        }
+    }
+}
+
+static void PrevectorClear(benchmark::State& state)
+{
+
+    while (state.KeepRunning()) {
+        for (auto x = 0; x < 1000; ++x) {
+            prevector<28, unsigned char> t0;
+            prevector<28, unsigned char> t1;
+            t0.resize(28);
+            t0.clear();
+            t1.resize(29);
+            t0.clear();
+        }
+    }
+}
+
+BENCHMARK(PrevectorDestructor);
+BENCHMARK(PrevectorClear);

--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <iostream>
+
+#include "bench.h"
+#include "bloom.h"
+#include "utiltime.h"
+
+static void RollingBloom(benchmark::State& state)
+{
+    CRollingBloomFilter filter(120000, 0.000001);
+    std::vector<unsigned char> data(32);
+    uint32_t count = 0;
+    uint32_t nEntriesPerGeneration = (120000 + 1) / 2;
+    uint32_t countnow = 0;
+    uint64_t match = 0;
+    while (state.KeepRunning()) {
+        count++;
+        data[0] = count;
+        data[1] = count >> 8;
+        data[2] = count >> 16;
+        data[3] = count >> 24;
+        if (countnow == nEntriesPerGeneration) {
+            int64_t b = GetTimeMicros();
+            filter.insert(data);
+            int64_t e = GetTimeMicros();
+            std::cout << "RollingBloom-refresh,1," << (e-b)*0.000001 << "," << (e-b)*0.000001 << "," << (e-b)*0.000001 << "\n";
+            countnow = 0;
+        } else {
+            filter.insert(data);
+        }
+        countnow++;
+        data[0] = count >> 24;
+        data[1] = count >> 16;
+        data[2] = count >> 8;
+        data[3] = count;
+        match += filter.contains(data);
+    }
+}
+
+BENCHMARK(RollingBloom);

--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -6,7 +6,6 @@
 
 #include "bench.h"
 #include "bloom.h"
-#include "utiltime.h"
 
 static void RollingBloom(benchmark::State& state)
 {
@@ -23,10 +22,10 @@ static void RollingBloom(benchmark::State& state)
         data[2] = count >> 16;
         data[3] = count >> 24;
         if (countnow == nEntriesPerGeneration) {
-            int64_t b = GetTimeMicros();
+            auto b = benchmark::clock::now();
             filter.insert(data);
-            int64_t e = GetTimeMicros();
-            std::cout << "RollingBloom-refresh,1," << (e-b)*0.000001 << "," << (e-b)*0.000001 << "," << (e-b)*0.000001 << "\n";
+            auto total = std::chrono::duration_cast<std::chrono::nanoseconds>(benchmark::clock::now() - b).count();
+            std::cout << "RollingBloom-refresh,1," << total << "," << total << "," << total << "\n";
             countnow = 0;
         } else {
             filter.insert(data);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5367,14 +5367,15 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             if (fListen && !IsInitialBlockDownload(chainparams))
             {
                 CAddress addr = GetLocalAddress(&pfrom->addr);
+                FastRandomContext insecure_rand;
                 if (addr.IsRoutable())
                 {
                     LogPrintf("ProcessMessages: advertizing address %s\n", addr.ToString());
-                    pfrom->PushAddress(addr);
+                    pfrom->PushAddress(addr, insecure_rand);
                 } else if (IsPeerAddrLocalGood(pfrom)) {
                     addr.SetIP(pfrom->addrLocal);
                     LogPrintf("ProcessMessages: advertizing address %s\n", addr.ToString());
-                    pfrom->PushAddress(addr);
+                    pfrom->PushAddress(addr, insecure_rand);
                 }
             }
 
@@ -5493,6 +5494,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     uint256 hashRand = ArithToUint256(UintToArith256(hashSalt) ^ (hashAddr<<32) ^ ((GetTime()+hashAddr)/(24*60*60)));
                     hashRand = Hash(BEGIN(hashRand), END(hashRand));
                     multimap<uint256, CNode*> mapMix;
+                    FastRandomContext insecure_rand;
                     BOOST_FOREACH(CNode* pnode, vNodes)
                     {
                         if (pnode->nVersion < CADDR_TIME_VERSION)
@@ -5505,7 +5507,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     }
                     int nRelayNodes = fReachable ? 2 : 1; // limited relaying of addresses outside our network(s)
                     for (multimap<uint256, CNode*>::iterator mi = mapMix.begin(); mi != mapMix.end() && nRelayNodes-- > 0; ++mi)
-                        ((*mi).second)->PushAddress(addr);
+                        ((*mi).second)->PushAddress(addr, insecure_rand);
                 }
             }
             // Do not store addresses outside our network
@@ -5927,8 +5929,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         pfrom->vAddrToSend.clear();
         vector<CAddress> vAddr = addrman.GetAddr();
+        FastRandomContext insecure_rand;
         BOOST_FOREACH(const CAddress &addr, vAddr)
-            pfrom->PushAddress(addr);
+            pfrom->PushAddress(addr, insecure_rand);
     }
 
 

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -117,4 +117,4 @@ static inline size_t DynamicUsage(const boost::unordered_map<X, Y, Z>& m)
 
 }
 
-#endif
+#endif // BITCOIN_MEMUSAGE_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -207,7 +207,8 @@ void AdvertizeLocal(CNode *pnode)
         if (addrLocal.IsRoutable())
         {
             LogPrintf("AdvertizeLocal: advertizing address %s\n", addrLocal.ToString());
-            pnode->PushAddress(addrLocal);
+            FastRandomContext insecure_rand;
+            pnode->PushAddress(addrLocal, insecure_rand);
         }
     }
 }

--- a/src/net.h
+++ b/src/net.h
@@ -401,14 +401,14 @@ public:
         addrKnown.insert(addr.GetKey());
     }
 
-    void PushAddress(const CAddress& addr)
+    void PushAddress(const CAddress& addr, FastRandomContext &insecure_rand)
     {
         // Known checking here is only to save space from duplicates.
         // SendMessages will filter it again for knowns that were added
         // after addresses were pushed.
         if (addr.IsValid() && !addrKnown.contains(addr.GetKey())) {
             if (vAddrToSend.size() >= MAX_ADDR_TO_SEND) {
-                vAddrToSend[insecure_rand() % vAddrToSend.size()] = addr;
+                vAddrToSend[insecure_rand.rand32() % vAddrToSend.size()] = addr;
             } else {
                 vAddrToSend.push_back(addr);
             }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -581,8 +581,8 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDe
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        static std::atomic_int counter;
+        random_auth.username = random_auth.password = strprintf("%i", counter++);
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     } else {

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -66,23 +66,21 @@ uint256 GetRandHash()
     return hash;
 }
 
-uint32_t insecure_rand_Rz = 11;
-uint32_t insecure_rand_Rw = 11;
-void seed_insecure_rand(bool fDeterministic)
+FastRandomContext::FastRandomContext(bool fDeterministic)
 {
     // The seed values have some unlikely fixed points which we avoid.
     if (fDeterministic) {
-        insecure_rand_Rz = insecure_rand_Rw = 11;
+        Rz = Rw = 11;
     } else {
         uint32_t tmp;
         do {
             GetRandBytes((unsigned char*)&tmp, 4);
         } while (tmp == 0 || tmp == 0x9068ffffU);
-        insecure_rand_Rz = tmp;
+        Rz = tmp;
         do {
             GetRandBytes((unsigned char*)&tmp, 4);
         } while (tmp == 0 || tmp == 0x464fffffU);
-        insecure_rand_Rw = tmp;
+        Rw = tmp;
     }
 }
 

--- a/src/random.h
+++ b/src/random.h
@@ -50,25 +50,22 @@ void MappedShuffle(RandomAccessIterator first,
 }
 
 /**
- * Seed insecure_rand using the random pool.
- * @param Deterministic Use a deterministic seed
+ * Fast randomness source. This is seeded once with secure random data, but
+ * is completely deterministic and insecure after that.
+ * This class is not thread-safe.
  */
-void seed_insecure_rand(bool fDeterministic = false);
+class FastRandomContext {
+public:
+    explicit FastRandomContext(bool fDeterministic=false);
 
-/**
- * MWC RNG of George Marsaglia
- * This is intended to be fast. It has a period of 2^59.3, though the
- * least significant 16 bits only have a period of about 2^30.1.
- *
- * @return random value
- */
-extern uint32_t insecure_rand_Rz;
-extern uint32_t insecure_rand_Rw;
-static inline uint32_t insecure_rand(void)
-{
-    insecure_rand_Rz = 36969 * (insecure_rand_Rz & 65535) + (insecure_rand_Rz >> 16);
-    insecure_rand_Rw = 18000 * (insecure_rand_Rw & 65535) + (insecure_rand_Rw >> 16);
-    return (insecure_rand_Rw << 16) + insecure_rand_Rz;
-}
+    uint32_t rand32() {
+        Rz = 36969 * (Rz & 65535) + (Rz >> 16);
+        Rw = 18000 * (Rw & 65535) + (Rw >> 16);
+        return (Rw << 16) + Rz;
+    }
+
+    uint32_t Rz;
+    uint32_t Rw;
+};
 
 #endif // BITCOIN_RANDOM_H

--- a/src/random.h
+++ b/src/random.h
@@ -64,6 +64,10 @@ public:
         return (Rw << 16) + Rz;
     }
 
+    bool randbool() {
+        return rand32() & 1;
+    }
+
     uint32_t Rz;
     uint32_t Rw;
 };

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -25,7 +25,7 @@ public:
     void MakeDeterministic()
     {
         nKey.SetNull();
-        seed_insecure_rand(true);
+        insecure_rand = FastRandomContext(true);
     }
 
     int RandomInt(int nMax)

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 #include "coins.h"
-#include "random.h"
+#include "test_random.h"
 #include "script/standard.h"
 #include "uint256.h"
 #include "utilstrencodings.h"

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -8,7 +8,7 @@
 #include "crypto/sha512.h"
 #include "crypto/hmac_sha256.h"
 #include "crypto/hmac_sha512.h"
-#include "random.h"
+#include "test_random.h"
 #include "utilstrencodings.h"
 #include "test/test_bitcoin.h"
 

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -8,7 +8,7 @@
 #include "uint256.h"
 #include "arith_uint256.h"
 #include "version.h"
-#include "random.h"
+#include "test_random.h"
 #include "test/test_bitcoin.h"
 
 #include <vector>

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <vector>
 #include "prevector.h"
-#include "random.h"
+#include "test_random.h"
 
 #include "serialize.h"
 #include "streams.h"
@@ -24,6 +24,7 @@ class prevector_tester {
     pretype pre_vector;
 
     typedef typename pretype::size_type Size;
+    FastRandomContext rand_cache;
 
     void test() {
         const pretype& const_pre_vector = pre_vector;
@@ -148,6 +149,11 @@ public:
     void shrink_to_fit() {
         pre_vector.shrink_to_fit();
         test();
+    }
+
+    prevector_tester() {
+        seed_insecure_rand();
+        rand_cache = insecure_rand_ctx;
     }
 };
 

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -35,8 +35,6 @@ static void MicroSleep(uint64_t n)
 
 BOOST_AUTO_TEST_CASE(manythreads)
 {
-    seed_insecure_rand(false);
-
     // Stress test: hundreds of microsecond-scheduled tasks,
     // serviced by 10 threads.
     //
@@ -51,7 +49,7 @@ BOOST_AUTO_TEST_CASE(manythreads)
 
     boost::mutex counterMutex[10];
     int counter[10] = { 0 };
-    boost::random::mt19937 rng(insecure_rand());
+    boost::random::mt19937 rng(42);
     boost::random::uniform_int_distribution<> zeroToNine(0, 9);
     boost::random::uniform_int_distribution<> randomMsec(-11, 1000);
     boost::random::uniform_int_distribution<> randomDelta(-1000, 1000);

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -6,7 +6,7 @@
 #include "consensus/validation.h"
 #include "data/sighash.json.h"
 #include "main.h"
-#include "random.h"
+#include "test_random.h"
 #include "script/interpreter.h"
 #include "script/script.h"
 #include "serialize.h"

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 #include "main.h"
-#include "random.h"
+#include "test_random.h"
 #include "util.h"
 #include "test/test_bitcoin.h"
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -33,6 +33,7 @@
 
 CClientUIInterface uiInterface; // Declared but not defined in ui_interface.h
 ZCJoinSplit *pzcashParams;
+FastRandomContext insecure_rand_ctx(true);
 
 extern bool fPrintToConsole;
 extern void noui_connect();

--- a/src/test/test_random.h
+++ b/src/test/test_random.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_RANDOM_H
+#define BITCOIN_TEST_RANDOM_H
+
+#include "random.h"
+
+extern FastRandomContext insecure_rand_ctx;
+
+static inline void seed_insecure_rand(bool fDeterministic = false)
+{
+    insecure_rand_ctx = FastRandomContext(fDeterministic);
+}
+
+static inline uint32_t insecure_rand(void)
+{
+    return insecure_rand_ctx.rand32();
+}
+
+#endif

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -6,7 +6,7 @@
 
 #include "clientversion.h"
 #include "primitives/transaction.h"
-#include "random.h"
+#include "test_random.h"
 #include "sync.h"
 #include "utilstrencodings.h"
 #include "utilmoneystr.h"

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -489,7 +489,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     if (nCheckFrequency == 0)
         return;
 
-    if (insecure_rand() >= nCheckFrequency)
+    if (GetRand(std::numeric_limits<uint32_t>::max()) >= nCheckFrequency)
         return;
 
     LogPrint("mempool", "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -13,6 +13,7 @@
 #include "mempool_limit.h"
 #include "primitives/transaction.h"
 #include "sync.h"
+#include "random.h"
 #include "addressindex.h"
 #include "spentindex.h"
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3022,7 +3022,7 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,uns
     vfBest.assign(vValue.size(), true);
     nBest = nTotalLower;
 
-    seed_insecure_rand();
+    FastRandomContext insecure_rand;
 
     for (int nRep = 0; nRep < iterations && nBest != nTargetValue; nRep++)
     {
@@ -3039,7 +3039,7 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,uns
                 //that the rng is fast. We do not use a constant random sequence,
                 //because there may be some privacy improvement by making
                 //the selection random.
-                if (nPass == 0 ? insecure_rand()&1 : !vfIncluded[i])
+                if (nPass == 0 ? insecure_rand.rand32()&1 : !vfIncluded[i])
                 {
                     nTotal += vValue[i].first;
                     vfIncluded[i] = true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3039,7 +3039,7 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,uns
                 //that the rng is fast. We do not use a constant random sequence,
                 //because there may be some privacy improvement by making
                 //the selection random.
-                if (nPass == 0 ? insecure_rand.rand32()&1 : !vfIncluded[i])
+                if (nPass == 0 ? insecure_rand.randbool() : !vfIncluded[i])
                 {
                     nTotal += vValue[i].first;
                     vfIncluded[i] = true;


### PR DESCRIPTION
Cherry-picked from the following upstream PRs:

- bitcoin/bitcoin#6733
- bitcoin/bitcoin#6770
- bitcoin/bitcoin#6892
  - Excluding changes to `src/policy/policy.h` which we don't have yet.
- bitcoin/bitcoin#7934
  - Just the benchmark, not the performance improvements.
- bitcoin/bitcoin#8039
- bitcoin/bitcoin#8107
- bitcoin/bitcoin#8115
- bitcoin/bitcoin#8914
  - Required resolving several merge conflicts in code that had been refactored upstream. The changes were simple enough that I decided it was okay to impose merge conflicts on pulling in those refactors later.
- bitcoin/bitcoin#9200
- bitcoin/bitcoin#9202
  - Adds support for measuring CPU cycles, which is later removed in an upstream PR after the refactor. I am including it to reduce future merge conflicts.
- bitcoin/bitcoin#9281
  - Only changes to `src/bench/bench.cpp`
- bitcoin/bitcoin#9498
- bitcoin/bitcoin#9712
- bitcoin/bitcoin#9547
- bitcoin/bitcoin#9505
  - Just the benchmark, not the performance improvements.
- bitcoin/bitcoin#9792
  - Just the benchmark, not the performance improvements.
- bitcoin/bitcoin#10272
- bitcoin/bitcoin#10395
  - Only changes to `src/bench/`
- bitcoin/bitcoin#10735
  - Only changes to `src/bench/base58.cpp`
- bitcoin/bitcoin#10963
- bitcoin/bitcoin#11303
  - Only the benchmark backend change.
- bitcoin/bitcoin#11562
- bitcoin/bitcoin#11646
- bitcoin/bitcoin#11654

This pulls in all changes to the micro-benchmark framework prior to December 2017, when it was rewritten. The rewrite depends on other upstream PRs we have not pulled in yet.

This does not pull in all benchmarks prior to December 2017. It leaves out benchmarks that either test code we do not have yet (except for the `FastRandomContext` refactor, which I decided to pull in), or would require rewrites to work with our changes to the codebase.