### PR TITLE
Adding hash for complete IPFS params

### DIFF
--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -13,8 +13,8 @@ SPROUT_VKEY_NAME='sprout-verifying.key'
 SAPLING_SPEND_NAME='sapling-spend.params'
 SAPLING_OUTPUT_NAME='sapling-output.params'
 SAPLING_SPROUT_GROTH16_NAME='sprout-groth16.params'
-SPROUT_URL="https://download.z.cash/downloads"
-SPROUT_IPFS="/ipfs/QmZKKx7Xup7LiAtFRhYsE1M7waXcv9ir9eCECyXAFGxhEo"
+DOWNLOAD_URL="https://download.z.cash/downloads"
+IPFS_HASH="/ipfs/QmXRHVGLQBiKwvNq7c2vPxAKz1zRVmMYbmt7G5TQss7tY7"
 
 SHA256CMD="$(command -v sha256sum || echo shasum)"
 SHA256ARGS="$(command -v sha256sum >/dev/null || echo '-a 256')"
@@ -38,7 +38,7 @@ function fetch_wget {
 
     cat <<EOF
 
-Retrieving (wget): $SPROUT_URL/$filename
+Retrieving (wget): $DOWNLOAD_URL/$filename
 EOF
 
     wget \
@@ -46,7 +46,7 @@ EOF
         --output-document="$dlname" \
         --continue \
         --retry-connrefused --waitretry=3 --timeout=30 \
-        "$SPROUT_URL/$filename"
+        "$DOWNLOAD_URL/$filename"
 }
 
 function fetch_ipfs {
@@ -59,10 +59,10 @@ function fetch_ipfs {
 
     cat <<EOF
 
-Retrieving (ipfs): $SPROUT_IPFS/$filename
+Retrieving (ipfs): $IPFS_HASH/$filename
 EOF
 
-    ipfs get --output "$dlname" "$SPROUT_IPFS/$filename"
+    ipfs get --output "$dlname" "$IPFS_HASH/$filename"
 }
 
 function fetch_curl {
@@ -75,13 +75,13 @@ function fetch_curl {
 
     cat <<EOF
 
-Retrieving (curl): $SPROUT_URL/$filename
+Retrieving (curl): $DOWNLOAD_URL/$filename
 EOF
 
     curl \
         --output "$dlname" \
         -# -L -C - \
-        "$SPROUT_URL/$filename"
+        "$DOWNLOAD_URL/$filename"
 
 }
 


### PR DESCRIPTION
This closes #3865. I added the Sapling parameters to IPFS and are available via `/ipfs/QmeHWxaqS87cJFjJHXQAz4D82yuSTWPLxv9WfL4fQSu4cc/`. You might just want to add this to the existing directory and close this but I renamed to something more generic in addition to changing the hash.

You can see the output of `./zcutil/fetch-params.sh` as a result of this PR:

```
gareth@gareth-pc ~/g/zcash> ./zcutil/fetch-params.sh
Zcash - fetch-params.sh

This script will fetch the Zcash zkSNARK parameters and verify their
integrity with sha256sum.

If they already exist locally, it will exit now and do nothing else.

Retrieving (ipfs): /ipfs/QmeHWxaqS87cJFjJHXQAz4D82yuSTWPLxv9WfL4fQSu4cc/sprout-proving.key
Saving file(s) to /home/gareth/.zcash-params/sprout-proving.key.dl
868.01 MiB / 868.01 MiB [==================================================================================================================================================] 100.00% 11s
Download successful!
/home/gareth/.zcash-params/sprout-proving.key.dl: OK
renamed '/home/gareth/.zcash-params/sprout-proving.key.dl' -> '/home/gareth/.zcash-params/sprout-proving.key'

Retrieving (ipfs): /ipfs/QmeHWxaqS87cJFjJHXQAz4D82yuSTWPLxv9WfL4fQSu4cc/sprout-verifying.key
Saving file(s) to /home/gareth/.zcash-params/sprout-verifying.key.dl
1.42 KiB / 1.42 KiB [=======================================================================================================================================================] 100.00% 0s
Download successful!
/home/gareth/.zcash-params/sprout-verifying.key.dl: OK
renamed '/home/gareth/.zcash-params/sprout-verifying.key.dl' -> '/home/gareth/.zcash-params/sprout-verifying.key'

Retrieving (ipfs): /ipfs/QmeHWxaqS87cJFjJHXQAz4D82yuSTWPLxv9WfL4fQSu4cc/sapling-spend.params
Saving file(s) to /home/gareth/.zcash-params/sapling-spend.params.dl
45.74 MiB / 45.74 MiB [=====================================================================================================================================================] 100.00% 0s
Download successful!
/home/gareth/.zcash-params/sapling-spend.params.dl: OK
renamed '/home/gareth/.zcash-params/sapling-spend.params.dl' -> '/home/gareth/.zcash-params/sapling-spend.params'

Retrieving (ipfs): /ipfs/QmeHWxaqS87cJFjJHXQAz4D82yuSTWPLxv9WfL4fQSu4cc/sapling-output.params
Saving file(s) to /home/gareth/.zcash-params/sapling-output.params.dl
3.43 MiB / 3.43 MiB [=======================================================================================================================================================] 100.00% 0s
Download successful!
/home/gareth/.zcash-params/sapling-output.params.dl: OK
renamed '/home/gareth/.zcash-params/sapling-output.params.dl' -> '/home/gareth/.zcash-params/sapling-output.params'

Retrieving (ipfs): /ipfs/QmeHWxaqS87cJFjJHXQAz4D82yuSTWPLxv9WfL4fQSu4cc/sprout-groth16.params
Saving file(s) to /home/gareth/.zcash-params/sprout-groth16.params.dl
691.91 MiB / 691.91 MiB [===================================================================================================================================================] 100.00% 7s
Download successful!
/home/gareth/.zcash-params/sprout-groth16.params.dl: OK
renamed '/home/gareth/.zcash-params/sprout-groth16.params.dl' -> '/home/gareth/.zcash-params/sprout-groth16.params'
```