### PR TITLE
Reject blocks that violate turnstile

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -353,6 +353,12 @@ public:
             715          //   total number of tx / (checkpoint block height / (24 * 24))
         };
 
+        // Hardcoded fallback value for the Sprout shielded value pool balance
+        // for nodes that have not reindexed since the introduction of monitoring
+        // in #2795.
+        nSproutValuePoolCheckpointHeight = 440329;
+        nSproutValuePoolCheckpointBalance = 40000029096803;
+
         // Founders reward script expects a vector of 2-of-3 multisig addresses
         vFoundersRewardAddress = {
             "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi", "t2N9PH9Wk9xjqYg9iin1Ua3aekJqfAtE543", "t2NGQjYMQhFndDHguvUw4wZdNdsssA6K7x2", "t2ENg7hHVqqs9JwU5cgjvSbxnT2a9USNfhy",

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -358,7 +358,7 @@ public:
         // in #2795.
         nSproutValuePoolCheckpointHeight = 440329;
         nSproutValuePoolCheckpointBalance = 40000029096803;
-        fSproutValuePoolCheckpointEnabled = true;
+        fZIP209Enabled = true;
         hashSproutValuePoolCheckpointBlock = uint256S("000a95d08ba5dcbabe881fc6471d11807bcca7df5f1795c99f3ec4580db4279b");
 
         // Founders reward script expects a vector of 2-of-3 multisig addresses
@@ -479,7 +479,7 @@ public:
         // regtest.
         nSproutValuePoolCheckpointHeight = 0;
         nSproutValuePoolCheckpointBalance = 0;
-        fSproutValuePoolCheckpointEnabled = true;
+        fZIP209Enabled = true;
         hashSproutValuePoolCheckpointBlock = consensus.hashGenesisBlock;
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -359,6 +359,7 @@ public:
         nSproutValuePoolCheckpointHeight = 440329;
         nSproutValuePoolCheckpointBalance = 40000029096803;
         fSproutValuePoolCheckpointEnabled = true;
+        hashSproutValuePoolCheckpointBlock = uint256S("000a95d08ba5dcbabe881fc6471d11807bcca7df5f1795c99f3ec4580db4279b");
 
         // Founders reward script expects a vector of 2-of-3 multisig addresses
         vFoundersRewardAddress = {
@@ -476,7 +477,10 @@ public:
 
         // Enable Sprout shielded value pool checkpointing on
         // regtest.
+        nSproutValuePoolCheckpointHeight = 0;
+        nSproutValuePoolCheckpointBalance = 0;
         fSproutValuePoolCheckpointEnabled = true;
+        hashSproutValuePoolCheckpointBlock = consensus.hashGenesisBlock;
     }
 
     void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -358,6 +358,7 @@ public:
         // in #2795.
         nSproutValuePoolCheckpointHeight = 440329;
         nSproutValuePoolCheckpointBalance = 40000029096803;
+        fSproutValuePoolCheckpointEnabled = true;
 
         // Founders reward script expects a vector of 2-of-3 multisig addresses
         vFoundersRewardAddress = {
@@ -472,6 +473,10 @@ public:
         // Founders reward script expects a vector of 2-of-3 multisig addresses
         vFoundersRewardAddress = { "t2FwcEhFdNXuFMv1tcYwaBJtYVtMj8b1uTg" };
         assert(vFoundersRewardAddress.size() <= consensus.GetLastFoundersRewardBlockHeight());
+
+        // Enable Sprout shielded value pool checkpointing on
+        // regtest.
+        fSproutValuePoolCheckpointEnabled = true;
     }
 
     void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -474,13 +474,6 @@ public:
         // Founders reward script expects a vector of 2-of-3 multisig addresses
         vFoundersRewardAddress = { "t2FwcEhFdNXuFMv1tcYwaBJtYVtMj8b1uTg" };
         assert(vFoundersRewardAddress.size() <= consensus.GetLastFoundersRewardBlockHeight());
-
-        // Enable Sprout shielded value pool checkpointing on
-        // regtest.
-        nSproutValuePoolCheckpointHeight = 0;
-        nSproutValuePoolCheckpointBalance = 0;
-        fZIP209Enabled = true;
-        hashSproutValuePoolCheckpointBlock = consensus.hashGenesisBlock;
     }
 
     void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight)

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -72,6 +72,7 @@ public:
 
     CAmount SproutValuePoolCheckpointHeight() const { return nSproutValuePoolCheckpointHeight; }
     CAmount SproutValuePoolCheckpointBalance() const { return nSproutValuePoolCheckpointBalance; }
+    uint256 SproutValuePoolCheckpointBlockHash() const { return hashSproutValuePoolCheckpointBlock; }
     bool SproutValuePoolCheckpointEnabled() const { return fSproutValuePoolCheckpointEnabled; }
 
     const CBlock& GenesisBlock() const { return genesis; }
@@ -132,6 +133,7 @@ protected:
 
     CAmount nSproutValuePoolCheckpointHeight = 0;
     CAmount nSproutValuePoolCheckpointBalance = 0;
+    uint256 hashSproutValuePoolCheckpointBlock;
     bool fSproutValuePoolCheckpointEnabled = false;
 };
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -73,7 +73,7 @@ public:
     CAmount SproutValuePoolCheckpointHeight() const { return nSproutValuePoolCheckpointHeight; }
     CAmount SproutValuePoolCheckpointBalance() const { return nSproutValuePoolCheckpointBalance; }
     uint256 SproutValuePoolCheckpointBlockHash() const { return hashSproutValuePoolCheckpointBlock; }
-    bool SproutValuePoolCheckpointEnabled() const { return fSproutValuePoolCheckpointEnabled; }
+    bool ZIP209Enabled() const { return fZIP209Enabled; }
 
     const CBlock& GenesisBlock() const { return genesis; }
     /** Make miner wait to have peers to avoid wasting work */
@@ -134,7 +134,7 @@ protected:
     CAmount nSproutValuePoolCheckpointHeight = 0;
     CAmount nSproutValuePoolCheckpointBalance = 0;
     uint256 hashSproutValuePoolCheckpointBlock;
-    bool fSproutValuePoolCheckpointEnabled = false;
+    bool fZIP209Enabled = false;
 };
 
 /**

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -72,6 +72,7 @@ public:
 
     CAmount SproutValuePoolCheckpointHeight() const { return nSproutValuePoolCheckpointHeight; }
     CAmount SproutValuePoolCheckpointBalance() const { return nSproutValuePoolCheckpointBalance; }
+    bool SproutValuePoolCheckpointEnabled() const { return fSproutValuePoolCheckpointEnabled; }
 
     const CBlock& GenesisBlock() const { return genesis; }
     /** Make miner wait to have peers to avoid wasting work */
@@ -131,6 +132,7 @@ protected:
 
     CAmount nSproutValuePoolCheckpointHeight = 0;
     CAmount nSproutValuePoolCheckpointBalance = 0;
+    bool fSproutValuePoolCheckpointEnabled = false;
 };
 
 /**

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -70,6 +70,9 @@ public:
     const std::vector<unsigned char>& AlertKey() const { return vAlertPubKey; }
     int GetDefaultPort() const { return nDefaultPort; }
 
+    CAmount SproutValuePoolCheckpointHeight() const { return nSproutValuePoolCheckpointHeight; }
+    CAmount SproutValuePoolCheckpointBalance() const { return nSproutValuePoolCheckpointBalance; }
+
     const CBlock& GenesisBlock() const { return genesis; }
     /** Make miner wait to have peers to avoid wasting work */
     bool MiningRequiresPeers() const { return fMiningRequiresPeers; }
@@ -125,6 +128,9 @@ protected:
     bool fTestnetToBeDeprecatedFieldRPC = false;
     CCheckpointData checkpointData;
     std::vector<std::string> vFoundersRewardAddress;
+
+    CAmount nSproutValuePoolCheckpointHeight = 0;
+    CAmount nSproutValuePoolCheckpointBalance = 0;
 };
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3365,7 +3365,6 @@ void FallbackSproutValuePoolBalance(
 bool ReceivedBlockTransactions(const CBlock &block, CValidationState& state, CBlockIndex *pindexNew, const CDiskBlockPos& pos)
 {
     const CChainParams& chainparams = Params();
-
     pindexNew->nTx = block.vtx.size();
     pindexNew->nChainTx = 0;
     CAmount sproutValue = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4092,7 +4092,6 @@ bool static LoadBlockIndexDB()
                     } else {
                         pindex->nChainSproutValue = boost::none;
                     }
-
                     if (pindex->pprev->nChainSaplingValue) {
                         pindex->nChainSaplingValue = *pindex->pprev->nChainSaplingValue + pindex->nSaplingValue;
                     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2452,7 +2452,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     // Reject a block that results in a negative shielded value pool balance.
-    if (Params().SproutValuePoolCheckpointEnabled()) {
+    if (chainparams.SproutValuePoolCheckpointEnabled()) {
         // Sprout
         //
         // We can expect nChainSproutValue to be valid after the hardcoded

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2469,10 +2469,14 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         //
         // If we've reached ConnectBlock, we have all transactions of
         // parents and can expect nChainSaplingValue not to be boost::none.
-        assert(pindex->nChainSaplingValue != boost::none);
-        if (*pindex->nChainSaplingValue < 0) {
-            return state.DoS(100, error("ConnectBlock(): turnstile violation in Sapling shielded value pool"),
-                         REJECT_INVALID, "turnstile-violation-sapling-shielded-pool");
+        // However, the miner and mining RPCs may not have populated this
+        // value and will call `TestBlockValidity`. So, we act
+        // conditionally.
+        if (pindex->nChainSaplingValue) {
+            if (*pindex->nChainSaplingValue < 0) {
+                return state.DoS(100, error("ConnectBlock(): turnstile violation in Sapling shielded value pool"),
+                             REJECT_INVALID, "turnstile-violation-sapling-shielded-pool");
+            }
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2452,7 +2452,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     // Reject a block that results in a negative shielded value pool balance.
-    if (chainparams.SproutValuePoolCheckpointEnabled()) {
+    if (chainparams.ZIP209Enabled()) {
         // Sprout
         //
         // We can expect nChainSproutValue to be valid after the hardcoded
@@ -3328,7 +3328,7 @@ void FallbackSproutValuePoolBalance(
 {
     // We might not want to enable the checkpointing for mainnet
     // yet.
-    if (!chainparams.SproutValuePoolCheckpointEnabled()) {
+    if (!chainparams.ZIP209Enabled()) {
         return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3296,9 +3296,34 @@ CBlockIndex* AddToBlockIndex(const CBlockHeader& block)
     return pindexNew;
 }
 
+void FallbackSproutValuePoolBalance(
+    CBlockIndex *pindex,
+    const CChainParams& chainparams
+)
+{
+    // Check if the height of this block matches the checkpoint
+    if (pindex->nHeight == chainparams.SproutValuePoolCheckpointHeight()) {
+        // Are we monitoring the Sprout pool?
+        if (!pindex->nChainSproutValue) {
+            // Apparently not. Introduce the hardcoded value.
+            pindex->nChainSproutValue = chainparams.SproutValuePoolCheckpointBalance();
+        } else {
+            // Apparently we have been. So, we should expect the current
+            // value to match the hardcoded one.
+            assert(*pindex->nChainSproutValue == chainparams.SproutValuePoolCheckpointBalance());
+            // And we should expect non-none for the delta stored in the block index here,
+            // or the checkpoint is too early.
+            assert(pindex->nSproutValue != boost::none);
+        }
+    }
+}
+
 /** Mark a block as having its data received and checked (up to BLOCK_VALID_TRANSACTIONS). */
 bool ReceivedBlockTransactions(const CBlock &block, CValidationState& state, CBlockIndex *pindexNew, const CDiskBlockPos& pos)
 {
+    const CChainParams& chainparams = Params();
+    bool this_is_testnet = chainparams.NetworkIDString() == "test";
+
     pindexNew->nTx = block.vtx.size();
     pindexNew->nChainTx = 0;
     CAmount sproutValue = 0;
@@ -3351,6 +3376,13 @@ bool ReceivedBlockTransactions(const CBlock &block, CValidationState& state, CBl
                 pindex->nChainSproutValue = pindex->nSproutValue;
                 pindex->nChainSaplingValue = pindex->nSaplingValue;
             }
+
+            // Fall back to hardcoded Sprout value pool balance if we're on
+            // testnet.
+            if (this_is_testnet) {
+                FallbackSproutValuePoolBalance(pindex, chainparams);
+            }
+
             {
                 LOCK(cs_nBlockSequenceId);
                 pindex->nSequenceId = nBlockSequenceId++;
@@ -4003,6 +4035,8 @@ CBlockIndex * InsertBlockIndex(uint256 hash)
 bool static LoadBlockIndexDB()
 {
     const CChainParams& chainparams = Params();
+    bool this_is_testnet = chainparams.NetworkIDString() == "test";
+
     if (!pblocktree->LoadBlockIndexGuts())
         return false;
 
@@ -4032,6 +4066,7 @@ bool static LoadBlockIndexDB()
                     } else {
                         pindex->nChainSproutValue = boost::none;
                     }
+
                     if (pindex->pprev->nChainSaplingValue) {
                         pindex->nChainSaplingValue = *pindex->pprev->nChainSaplingValue + pindex->nSaplingValue;
                     } else {
@@ -4047,6 +4082,12 @@ bool static LoadBlockIndexDB()
                 pindex->nChainTx = pindex->nTx;
                 pindex->nChainSproutValue = pindex->nSproutValue;
                 pindex->nChainSaplingValue = pindex->nSaplingValue;
+            }
+
+            // Fall back to hardcoded Sprout value pool balance if we're on
+            // testnet.
+            if (this_is_testnet) {
+                FallbackSproutValuePoolBalance(pindex, chainparams);
             }
         }
         // Construct in-memory chain of branch IDs.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -337,7 +337,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
                 CAmount sproutValueDummy = sproutValue;
                 CAmount saplingValueDummy = saplingValue;
 
-                sproutValueDummy += -tx.valueBalance;
+                saplingValueDummy += -tx.valueBalance;
 
                 for (auto js : tx.vjoinsplit) {
                     sproutValueDummy += js.vpub_old;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -109,7 +109,6 @@ void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, 
 CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
 {
     const CChainParams& chainparams = Params();
-
     // Create new block
     std::unique_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
     if(!pblocktemplate.get())
@@ -260,7 +259,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
         CAmount sproutValue = 0;
         CAmount saplingValue = 0;
         bool monitoring_pool_balances = true;
-        if (chainparams.SproutValuePoolCheckpointEnabled()) {
+        if (chainparams.ZIP209Enabled()) {
             if (pindexPrev->nChainSproutValue) {
                 sproutValue = *pindexPrev->nChainSproutValue;
             } else {
@@ -328,7 +327,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             if (!ContextualCheckInputs(tx, state, view, true, MANDATORY_SCRIPT_VERIFY_FLAGS, true, txdata, Params().GetConsensus(), consensusBranchId))
                 continue;
 
-            if (chainparams.SproutValuePoolCheckpointEnabled() && monitoring_pool_balances) {
+            if (chainparams.ZIP209Enabled() && monitoring_pool_balances) {
                 // Does this transaction lead to a turnstile violation?
 
                 CAmount sproutValueDummy = sproutValue;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -342,11 +342,11 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
                 }
 
                 if (sproutValueDummy < 0) {
-                    LogPrintf("CreateNewBlock(): tx %s appears to violate Sprout turnstile", tx.GetHash().ToString());
+                    LogPrintf("CreateNewBlock(): tx %s appears to violate Sprout turnstile\n", tx.GetHash().ToString());
                     continue;
                 }
                 if (saplingValueDummy < 0) {
-                    LogPrintf("CreateNewBlock(): tx %s appears to violate Sapling turnstile", tx.GetHash().ToString());
+                    LogPrintf("CreateNewBlock(): tx %s appears to violate Sapling turnstile\n", tx.GetHash().ToString());
                     continue;
                 }
 


### PR DESCRIPTION
This is an implementation of a consensus rule which marks blocks as invalid if they would lead to a turnstile violation in the Sprout or Shielded value pools. The motivations and deployment details can be found in the [accompanying ZIP draft](https://github.com/zcash/zips/pull/210).

**This PR only introduces the rule for testnet at the moment.**

We achieve the institution of this rule in three ways:

1. Nodes prior to #2795 did not record the "delta" in the Sprout value pool balance as part of the on-disk block index. This was a long time ago, though, and all nodes that are consensus-compatible with the network today have been recording this value for newer blocks. However, the value is absent from older block indexes unless the node has reindexed or synchronized from scratch in the time since. We shouldn't need to require nodes to reindex in order to enforce this consensus rule. We avoid this problem by falling back on a hardcoded Sprout shielded value pool balance in a very recent block.
2. If during `ConnectBlock` we observe that the resulting shielded value pool balance of Sprout or Sapling is negative, we reject the block.
3. During the miner's block assembly process the miner will skip over transactions if adding them to the assembled block might violate the turnstile, since the resulting block would be invalid. This means that theoretical transactions violating the turnstile would still be relayed in the network (and made available in users' memory pools) and so a turnstile violation would have some visibility outside of block relay.

## Smoke Testing

It's really tricky to test the behavior that automatically falls back to hardcoded shielded value pool balances in our architecture because it's very testnet-specific and node-version-specific. However, we can do some smoke tests to see that everything is working.

I modified the serialization of `CDiskBlockIndex` to serialize `boost::none` for `nSproutValue`

```
if ((s.GetType() & SER_DISK) && (nVersion >= SPROUT_VALUE_VERSION)) {
    boost::optional<CAmount> nSproutValueFake = boost::none;
    READWRITE(nSproutValueFake);
}
```

and then began a reindex of my node which I interruped around height 130k on testnet. I then restored the original serialization and resumed the reindex; I have thus _roughly_ simulated a older node "upgrading" to a newer node that records the deltas when processing new blocks. My node showed pool monitoring was disabled, as expected, for Sprout. I confirmed that some blocks following the reindex had nonzero Sprout `valueDelta` from `getblock`, as expected. I finished the reindex, restarted the node, and confirmed that the serialization worked for newer blocks but not older blocks by querying `getblock`, simply as a reassurance.

Finally, I introduced the code in this PR and reloaded the node. The desired behavior (that the chain began to be "monitored" again) worked, and the values were consistent with the hardcoded constant. I then made a payment to a Sprout z-addr from the transparent pool and the pool value increased as expected, as reported by `getblockchaininfo`. I reindexed the node again to exercise the remaining logic and check for turnstile violations throughout the history of testnet; there were none.