### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie AS builder
+FROM debian:latest AS builder
 
 ENV ZCASH_URL=https://github.com/zcash/zcash.git \
     ZCASH_CONF=/home/zcash/.zcash/zcash.conf
@@ -23,7 +23,7 @@ RUN ./zcutil/build.sh -j$(nproc)
 WORKDIR /src/zcash/src
 RUN /usr/bin/install -c zcash-tx zcashd zcash-cli zcash-gtest ../zcutil/fetch-params.sh -t /usr/bin/
 
-FROM debian:jessie
+FROM debian:latest
 
 ENV ZCASH_CONF=/home/zcash/.zcash/zcash.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie AS builder
 ENV ZCASH_URL=https://github.com/zcash/zcash.git \
     ZCASH_CONF=/home/zcash/.zcash/zcash.conf
 
-ARG TAG
+ARG VERSION=master
 
 RUN apt-get update
 
@@ -17,7 +17,7 @@ WORKDIR /src
 RUN git clone ${ZCASH_URL}
 
 WORKDIR /src/zcash
-RUN git checkout $TAG
+RUN git checkout $VERSION
 RUN ./zcutil/build.sh -j$(nproc)
 
 WORKDIR /src/zcash/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM debian:jessie AS builder
+
+ENV ZCASH_URL=https://github.com/zcash/zcash.git \
+    ZCASH_CONF=/home/zcash/.zcash/zcash.conf
+
+ARG TAG
+
+RUN apt-get update
+
+RUN apt-get -qqy install --no-install-recommends build-essential \
+    automake ncurses-dev libcurl4-openssl-dev libssl-dev libgtest-dev \
+    make autoconf automake libtool git apt-utils pkg-config libc6-dev \
+    libcurl3-dev libudev-dev m4 g++-multilib unzip git python zlib1g-dev \
+    wget ca-certificates pwgen bsdmainutils curl
+
+WORKDIR /src
+RUN git clone ${ZCASH_URL}
+
+WORKDIR /src/zcash
+RUN git checkout $TAG
+RUN ./zcutil/build.sh -j$(nproc)
+
+WORKDIR /src/zcash/src
+RUN /usr/bin/install -c zcash-tx zcashd zcash-cli zcash-gtest ../zcutil/fetch-params.sh -t /usr/bin/
+
+FROM debian:jessie
+
+ENV ZCASH_CONF=/home/zcash/.zcash/zcash.conf
+
+RUN apt-get update
+
+RUN apt-get install -y libgomp1 wget curl
+
+RUN apt-get clean all -y
+
+COPY --from=builder /usr/bin/zcash-cli /usr/bin/zcashd /usr/bin/fetch-params.sh /usr/bin/
+
+RUN adduser --uid 1000 --system zcash && \
+    mkdir -p /home/zcash/.zcash/ && \
+    mkdir -p /home/zcash/.zcash-params/ && \
+    chown -R zcash /home/zcash && \
+    echo "Success"
+
+USER zcash
+RUN echo "rpcuser=zcash" > ${ZCASH_CONF} && \
+        echo "rpcpassword=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo ''`" >> ${ZCASH_CONF} && \
+        echo "addnode=mainnet.z.cash" >> ${ZCASH_CONF} && \
+        echo "Success"
+
+VOLUME ["/home/zcash/.zcash"]

--- a/doc/docker-usage.md
+++ b/doc/docker-usage.md
@@ -1,0 +1,45 @@
+# Build a zcashd node from multi-container Docker build
+
+If no VERSION is exported the Dockerfile will apply the default value `master` and build current master.
+
+```
+#in the root of the zcash source directory:
+export VERSION=v2.0.3
+docker build --build-arg VERSION -t zcash/zcash:$VERSION --memory-swap -1 .
+```
+
+# Create docker volumes and populate the `zcash-params` volume
+```
+docker volume create mainnet-params
+
+docker run --rm -itd \
+--mount source=mainnet-params,destination=/home/zcash/.zcash-params \
+zcash/zcash:latest bash -c "fetch-params.sh"
+```
+
+# Create docker volume to persist the blockchain database and state 
+```
+docker volume create mainnet-chain
+```
+
+# Start a container and background it. Optionally mount in a configuration file or wallet
+```
+CUR_PATH=`PWD`
+
+docker run -itd \
+--name zcash \
+--mount source=mainnet-chain,destination=/home/zcash/.zcash \
+--mount source=mainnet-params,destination=/home/zcash/.zcash-params \
+-v $CUR_PATH/mainnet.daemon.conf:/home/zcash/.zcash/zcash.conf \
+zcash/zcash:latest
+```
+
+# Start the node
+```
+docker exec -itd zcash bash -c "zcashd"
+```
+
+# Query the node
+```
+docker exec -it zcash zcash-cli getinfo
+```

--- a/doc/docker-usage.md
+++ b/doc/docker-usage.md
@@ -30,7 +30,7 @@ docker run -itd \
 --name zcash \
 --mount source=mainnet-chain,destination=/home/zcash/.zcash \
 --mount source=mainnet-params,destination=/home/zcash/.zcash-params \
--v $CUR_PATH/mainnet.daemon.conf:/home/zcash/.zcash/zcash.conf \
+--mount type=bind,source="$(pwd)"/custom-mainnet.conf,destination=/home/zcash/.zcash/zcash.conf \
 zcash/zcash:latest
 ```
 


### PR DESCRIPTION
I just wanted to move along the conversation for the right way to add a usable Dockerfile.

(Also I want to add it such that the container can be automatically built and pushed to docker hub.)

There are some other good patterns out there for docker builds. i.e. @madars https://github.com/madars/zcash-docker/blob/master/Dockerfiled

However his build is from an Alpine image and includes a patch which I think diverges a little too much from master. He includes the man pages which I could be easily convinced to add but I think the help built into the command line tools is sufficient.

I like this build because it uses a multi container build strategy to build the project from source and then copies it into a smaller container for runtime. It also uses the base debian images which most closely follows the primary build pattern for zcashd from source.

This is similar to #2303 but I feel like it is a little bit more updated and has a bit fewer lines. I have been using this image daily for quiet some time. It is also used in conjunction with the lightwalletd server and code that has been developed with @boltlabs-inc.

I think if anything the documentation will require more editing to help with how one uses this Docker image effectively. 