### PR TITLE
update fixes gitian build runtime error

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -3,7 +3,7 @@ name: "zcash-2.0.4-rc1"
 enable_cache: true
 distro: "debian"
 suites:
-- "jessie"
+- "stretch"
 architectures:
 - "amd64"
 packages:


### PR DESCRIPTION
I had to update this parameter to get the https://github.com/zcash/zcash-gitian to successfully run and complete after 03/23/2019. 

This PR is in conjunction with https://github.com/zcash/zcash-gitian/pull/54

The change allows zcash-gitian to complete correctly at a commit that previously completed normally.