### PR TITLE
Don't use the deprecated proton::url

### DIFF
--- a/src/amqp/amqpconfig.h
+++ b/src/amqp/amqpconfig.h
@@ -24,7 +24,6 @@
 #include <proton/tracker.hpp>
 #include <proton/transport.hpp>
 #include <proton/types.hpp>
-#include <proton/url.hpp>
 #endif
 
 #include "primitives/block.h"


### PR DESCRIPTION
Don't use the deprecated proton::url