### PR TITLE
Report headers download

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6073,7 +6073,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         LOCK(cs_main);
 
         if (nCount == 0) {
-            // Nothing interesting. Stop asking this peers for more headers.
+            // Nothing interesting. Stop asking this peer for more headers.
             return true;
         }
 
@@ -6101,7 +6101,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             // Headers message had its maximum size; the peer may have more headers.
             // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
             // from there instead.
-            LogPrint("net", "more getheaders (%d) to end to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->id, pfrom->nStartingHeight);
+            LogPrint("net", "more getheaders (%d) to send to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->id, pfrom->nStartingHeight);
             pfrom->PushMessage("getheaders", chainActive.GetLocator(pindexLast), uint256());
         }
 

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -291,10 +291,17 @@ int printStats(bool mining)
            int downloadPercent = nSizeReindexed * 100 / nFullSizeToReindex;
            std::cout << "      " << _("Reindexing blocks") << " | " << DisplaySize(nSizeReindexed) << " / " << DisplaySize(nFullSizeToReindex) << " (" << downloadPercent << "%, " << height << " " << _("blocks") << ")" << std::endl;
        } else {
+           int nHeaders = currentHeadersHeight;
+           if (nHeaders < 0)
+               nHeaders = 0;
            int netheight = currentHeadersHeight == -1 || currentHeadersTime == 0 ?
                0 : EstimateNetHeight(params, currentHeadersHeight, currentHeadersTime);
+           if (netheight < nHeaders)
+               netheight = nHeaders;
+           if (netheight <= 0)
+               netheight = 1;
            int downloadPercent = height * 100 / netheight;
-           std::cout << "     " << _("Downloading blocks") << " | " << height << " / ~" << netheight << " (" << downloadPercent << "%)" << std::endl;
+           std::cout << "     " << _("Downloading blocks") << " | " << height << " (" << nHeaders << " " << _("headers") << ") / ~" << netheight << " (" << downloadPercent << "%)" << std::endl;
        }
     } else {
         std::cout << "           " << _("Block height") << " | " << height << std::endl;


### PR DESCRIPTION
With current compile-time defaults, a Zcash node prefetches up to 160 block headers per request without a limit on how far it can prefetch, but only up to 16 full blocks at a time. For this and other reasons, it can get very far ahead in headers prefetch (and PoW verification on those, so it's quite some processing too) over full blocks fetch (such as 10x ahead) during initial blocks download. Let's report to the user on how many headers the node has fetched, and let's also use this information as additional input on estimating the total number of blocks to fetch: it can't be less than the number of headers already fetched.

While at it, also fix typos in related code.