### PR TITLE
init: Fix new HD seed generation for previously-encrypted wallets

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1645,8 +1645,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
         if (!pwalletMain->HaveHDSeed())
         {
-            // generate a new HD seed
-            pwalletMain->GenerateNewSeed();
+            // We can't set the new HD seed until the wallet is decrypted.
+            // https://github.com/zcash/zcash/issues/3607
+            if (!pwalletMain->IsCrypted()) {
+                // generate a new HD seed
+                pwalletMain->GenerateNewSeed();
+            }
         }
 
         if (fFirstRun)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -499,8 +499,14 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase)
                 return false;
             if (!crypter.Decrypt(pMasterKey.second.vchCryptedKey, vMasterKey))
                 continue; // try another master key
-            if (CCryptoKeyStore::Unlock(vMasterKey))
+            if (CCryptoKeyStore::Unlock(vMasterKey)) {
+                // Now that the wallet is decrypted, ensure we have an HD seed.
+                // https://github.com/zcash/zcash/issues/3607
+                if (!this->HaveHDSeed()) {
+                    this->GenerateNewSeed();
+                }
                 return true;
+            }
         }
     }
     return false;


### PR DESCRIPTION
Closes #3607.

How to verify (with `zcashd` flags `-testnet -wallet=wallet.3607.dat -experimentalfeatures -developerencryptwallet`):
- Start `zcashd` 2.0.0, encrypt the wallet, and stop the node.
- Start `zcashd` 2.0.1+ (before this branch), and see that it crashes during startup.
- Start `zcashd` built from this branch, and see that it does not crash during startup. Unlock the wallet, then stop.
- Start `zcashd` 2.0.1+ (before this branch), and see that it no longer crashes during startup.