### PR TITLE
Remove unnecessary patch in bdb.mk

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -14,7 +14,6 @@ endef
 
 define $(package)_preprocess_cmds
   sed -i.old 's/WinIoCtl.h/winioctl.h/g' src/dbinc/win_db.h && \
-  sed -i.old 's/__atomic_compare_exchange\\(/__atomic_compare_exchange_db(/' src/dbinc/atomic.h && \
   sed -i.old 's/atomic_init/atomic_init_db/' src/dbinc/atomic.h src/mp/mp_region.c src/mp/mp_mvcc.c src/mp/mp_fget.c src/mutex/mut_method.c src/mutex/mut_tas.c
 endef
 


### PR DESCRIPTION
there is no "__atomic_compare_exchange" function in "src/dbinc/atomic.h".