### PR TITLE
Activate turnstile on mainnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -193,6 +193,14 @@ public:
                             //   total number of tx / (checkpoint block height / (24 * 24))
         };
 
+        // Hardcoded fallback value for the Sprout shielded value pool balance
+        // for nodes that have not reindexed since the introduction of monitoring
+        // in #2795.
+        nSproutValuePoolCheckpointHeight = 520633;
+        nSproutValuePoolCheckpointBalance = 22145062442933;
+        fZIP209Enabled = true;
+        hashSproutValuePoolCheckpointBlock = uint256S("0000000000c7b46b6bc04b4cbf87d8bb08722aebd51232619b214f7273f8460e");
+
         // Founders reward script expects a vector of 2-of-3 multisig addresses
         vFoundersRewardAddress = {
             "t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd", /* main-index: 0*/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3451,17 +3451,12 @@ void FallbackSproutValuePoolBalance(
     const CChainParams& chainparams
 )
 {
-    // We might not want to enable the checkpointing for mainnet
-    // yet.
     if (!chainparams.ZIP209Enabled()) {
         return;
     }
 
     // When developer option -developersetpoolsizezero is enabled, we don't need a fallback balance.
-    if ((chainparams.NetworkIDString() == "test" || chainparams.NetworkIDString() == "regtest") &&
-        fExperimentalMode &&
-        mapArgs.count("-developersetpoolsizezero"))
-    {
+    if (fExperimentalMode && mapArgs.count("-developersetpoolsizezero")) {
         return;
     }
 
@@ -4252,13 +4247,10 @@ bool static LoadBlockIndexDB()
             // Fall back to hardcoded Sprout value pool balance
             FallbackSproutValuePoolBalance(pindex, chainparams);
 
-            // If developer option -developersetpoolsizezero has been enabled on testnet or in regtest mode,
+            // If developer option -developersetpoolsizezero has been enabled,
             // override and set the in-memory size of shielded pools to zero.  An unshielding transaction
             // can then be used to trigger and test the handling of turnstile violations.
-            if ((chainparams.NetworkIDString() == "test" || chainparams.NetworkIDString() == "regtest") &&
-                fExperimentalMode &&
-                mapArgs.count("-developersetpoolsizezero"))
-            {
+            if (fExperimentalMode && mapArgs.count("-developersetpoolsizezero")) {
                 pindex->nChainSproutValue = 0;
                 pindex->nChainSaplingValue = 0;
             }


### PR DESCRIPTION
This PR enables [ZIP209](https://github.com/zcash/zips/blob/master/zip-0209.rst) support on mainnet, to mark blocks as invalid if they would lead to a turnstile violation in the Sprout or Sapling value pools.  

To test this PR, I performed the following manual tests:

1. Used RPC call `getblock` to verify the fallback Sprout value.
2. Individually changed the fallback Sprout block hash, block height and chain value, recompiling and relaunching the node, verifying that each individual change resulted in an error.  When the block hash and block height are incorrect, an error is logged to debug.log `FallbackSproutValuePoolBalance(): fallback block hash is incorrect`.  An incorrect chain value results in node termination with error: `void FallbackSproutValuePoolBalance(CBlockIndex*, const CChainParams&): Assertion '*pindex->nChainSproutValue == chainparams.SproutValuePoolCheckpointBalance()' failed.`
3. Ran the `Smoke Testing` described in PR #3885, on mainnet.
4. Launched zcashd with experimental feature `-developersetpoolsizezero` to manually trigger a turnstile violation in both Sprout and Sapling shielded pools.  The Sprout turnstile violation occurred after launch, due to chance, when the next incoming block 520786 contained a Sprout unshielding transaction. The Sapling turnstile violation was triggered after creating a Sapling unshielding transaction.