### PR TITLE
add curl to package list for gitian lxc container

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -7,6 +7,7 @@ suites:
 architectures:
 - "amd64"
 packages:
+- "curl"
 - "autoconf"
 - "automake"
 - "bsdmainutils"


### PR DESCRIPTION
This PR fixes the issue we are seeing in the gitian builder: 
https://github.com/zcash/zcash-gitian/issues/64

The base lxc image no longer contains curl by default so it must be installed.