### PR TITLE
Don't allow Sprout-to-Sapling migration when syncing during IBD or after wake from sleep.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -581,7 +581,13 @@ void CWallet::ChainTip(const CBlockIndex *pindex,
 {
     if (added) {
         ChainTipAdded(pindex, pblock, sproutTree, saplingTree);
-        RunSaplingMigration(pindex->nHeight);
+        // Prevent migration transactions from being created when node is syncing after launch,
+        // and also when node wakes up from suspension/hibernation and incoming blocks are old.
+        if (!IsInitialBlockDownload() &&
+            pblock->GetBlockTime() > GetAdjustedTime() - 3 * 60 * 60)
+        {
+            RunSaplingMigration(pindex->nHeight);
+        }
     } else {
         DecrementNoteWitnesses(pindex);
         UpdateSaplingNullifierNoteMapForBlock(pblock);


### PR DESCRIPTION
Prevent migration transactions from being created in response to incoming blocks when a node launches and syncs (the initial block download phase) and when a node wakes from sleep/hibernation and starts syncing old blocks rapidly.