### PR TITLE
Fixes #4013, added BitcoinABC as a disclosure partner

### DIFF
--- a/responsible_disclosure.md
+++ b/responsible_disclosure.md
@@ -51,8 +51,9 @@ We have set up agreements with the following neighboring projects to share vulne
 
 Specifically, we have agreed to engage in responsible disclosures for security issues affecting Zcash technology with the following contacts:
 
-- security@horizen.com via PGP
-- ca333@komodoplatform.com via PGP
+- Horizen security@horizen.com via PGP
+- Komodo ca333@komodoplatform.com via PGP
+- BitcoinABC https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/DISCLOSURE_POLICY.md
 
 ## Deviations from the Standard
 


### PR DESCRIPTION
I've tried to avoid using "partner" as a term in general because it's not accurate, but it's quicker to type. We intend to share any vulns we become aware of in our bitcoin code with at least BitcoinABC.