### PR TITLE
PoW-only verification mode for Initial block sync

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -343,6 +343,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-dbcache=<n>", strprintf(_("Set database cache size in megabytes (%d to %d, default: %d)"), nMinDbCache, nMaxDbCache, nDefaultDbCache));
     strUsage += HelpMessageOpt("-debuglogfile=<file>", strprintf(_("Specify location of debug log file: this can be an absolute path or a path relative to the data directory (default: %s)"), DEFAULT_DEBUGLOGFILE));
     strUsage += HelpMessageOpt("-exportdir=<dir>", _("Specify directory to be used when exporting data"));
+    strUsage += HelpMessageOpt("-ibdskiptxverification", _("Skip Tx verification during initial block download"));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file on startup"));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
     strUsage += HelpMessageOpt("-par=<n>", strprintf(_("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)"),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4058,6 +4058,11 @@ bool CheckBlock(const CBlock& block, CValidationState& state,
             return state.DoS(100, error("CheckBlock(): more than one coinbase"),
                              REJECT_INVALID, "bad-cb-multiple");
 
+    // If this is initial block download and "ibdskiptxverification" is set, we'll skip verifying the transactions
+    if (IsInitialBlockDownload(chainparams) && GetBoolArg("-ibdskiptxverification", false)) {
+        return true;
+    }
+
     // Check transactions
     BOOST_FOREACH(const CTransaction& tx, block.vtx)
         if (!CheckTransaction(tx, state, verifier))
@@ -4148,24 +4153,6 @@ bool ContextualCheckBlock(
     const int nHeight = pindexPrev == NULL ? 0 : pindexPrev->nHeight + 1;
     const Consensus::Params& consensusParams = chainparams.GetConsensus();
 
-    // Check that all transactions are finalized
-    BOOST_FOREACH(const CTransaction& tx, block.vtx) {
-
-        // Check transaction contextually against consensus rules at block height
-        if (!ContextualCheckTransaction(tx, state, chainparams, nHeight, true)) {
-            return false; // Failure reason has been set in validation state object
-        }
-
-        int nLockTimeFlags = 0;
-        int64_t nLockTimeCutoff = (nLockTimeFlags & LOCKTIME_MEDIAN_TIME_PAST)
-                                ? pindexPrev->GetMedianTimePast()
-                                : block.GetBlockTime();
-        if (!IsFinalTx(tx, nHeight, nLockTimeCutoff)) {
-            return state.DoS(10, error("%s: contains a non-final transaction", __func__),
-                             REJECT_INVALID, "bad-txns-nonfinal");
-        }
-    }
-
     // Enforce BIP 34 rule that the coinbase starts with serialized block height.
     // In Zcash this has been enforced since launch, except that the genesis
     // block didn't include the height in the coinbase (see Zcash protocol spec
@@ -4206,6 +4193,32 @@ bool ContextualCheckBlock(
         if (!found) {
             return state.DoS(100, error("%s: founders reward missing", __func__),
                              REJECT_INVALID, "cb-no-founders-reward");
+        }
+    }
+
+    // If this is initial block download and "ibdskiptxverification" is set, we'll skip verifying the transactions
+    if (IsInitialBlockDownload(chainparams) && GetBoolArg("-ibdskiptxverification", false)) {
+        // If checkpoints are enabled, then skip verification only upto the last checkpoint.
+        if (fCheckpointsEnabled && nHeight < Checkpoints::GetTotalBlocksEstimate(chainparams.Checkpoints())) {
+            return true;
+        }
+    }
+
+    // Check that all transactions are finalized
+    BOOST_FOREACH(const CTransaction& tx, block.vtx) {
+
+        // Check transaction contextually against consensus rules at block height
+        if (!ContextualCheckTransaction(tx, state, chainparams, nHeight, true)) {
+            return false; // Failure reason has been set in validation state object
+        }
+
+        int nLockTimeFlags = 0;
+        int64_t nLockTimeCutoff = (nLockTimeFlags & LOCKTIME_MEDIAN_TIME_PAST)
+                                ? pindexPrev->GetMedianTimePast()
+                                : block.GetBlockTime();
+        if (!IsFinalTx(tx, nHeight, nLockTimeCutoff)) {
+            return state.DoS(10, error("%s: contains a non-final transaction", __func__),
+                             REJECT_INVALID, "bad-txns-nonfinal");
         }
     }
 


### PR DESCRIPTION
For new users that don't have a wallet, a pow-only sync mode that skips verifying every transaction signature to speed up initial block sync. Since the new user doesn't have any addresses, they are OK skipping verification and getting a faster sync instead. 

With my experiments, syncing mainnet is about ~25% - 33% faster with this flag. 