### PR TITLE
Add stretch to list of suites in gitian linux descriptors

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -4,6 +4,7 @@ enable_cache: true
 distro: "debian"
 suites:
 - "jessie"
+- "stretch"
 architectures:
 - "amd64"
 packages:


### PR DESCRIPTION
We want to do reproducible builds for Debian stretch (9) in addition to Debian jessie (8).