### PR TITLE
Fixes issue #3504

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -32,7 +32,7 @@ Run `zcashd --version` to find out
 - Disk Type (HD/SDD):
 - Linux kernel version (uname -a):
 - Compiler version (gcc --version):
-- Linker version (ld --version):
+- Linker version (ld -v):
 - Assembler version (as --version):
 
 ### Any extra information that might be useful in the debugging process.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -31,7 +31,9 @@ Run `zcashd --version` to find out
 - Disk size:
 - Disk Type (HD/SDD):
 - Linux kernel version (uname -a):
-- Compiler version (gcc -version):
+- Compiler version (gcc --version):
+- Linker version (ld --version):
+- Assembler version (as --version):
 
 ### Any extra information that might be useful in the debugging process.
 This includes the relevant contents of `~/.zcash/debug.log`. You can paste raw text, attach the file directly in the issue or link to the text via a pastebin type site.


### PR DESCRIPTION
Changes the command to obtain the GCC version in the GitHub issue template to `gcc --version`, and adds a couple other useful commands.
