### PR TITLE
WIP:  Allow sync independent commands to run in warm up

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -429,17 +429,18 @@ std::string JSONRPCExecBatch(const UniValue& vReq)
 
 UniValue CRPCTable::execute(const std::string &strMethod, const UniValue &params) const
 {
-    // Return immediately if in warmup
-    {
-        LOCK(cs_rpcWarmup);
-        if (fRPCInWarmup)
-            throw JSONRPCError(RPC_IN_WARMUP, rpcWarmupStatus);
-    }
-
     // Find method
     const CRPCCommand *pcmd = tableRPC[strMethod];
     if (!pcmd)
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found");
+
+    // Return if in warmup
+    {
+        LOCK(cs_rpcWarmup);
+        if (fRPCInWarmup && pcmd->name != "z_listaddresses")
+            throw JSONRPCError(RPC_IN_WARMUP, rpcWarmupStatus);
+    }
+
 
     g_rpcSignals.PreCommand(*pcmd);
 


### PR DESCRIPTION
Because some commands do not require synchronization
with the state of the blockchain, they should be runnable
before the scanning phase of node
initialization has completed.  This commit makes
this true for one exemplar "z_listaddresses".

This PR is not intended for merge.   I am hoping to learn about the CI infrastructure by opening this PR.  At a minimum other pre-sync commands should be added, and tests should be added before this PR is ready to merge.

Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.
* [ ] Relevant documentation for this PR has to be completed and reviewed by the documentation team (@ioptio, @mdr0id, or @Eirik0) before the PR can be merged
* [ ] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release

As a note, all buildbot tests need to be passing and all appropriate code reviews need to be done before this PR can be merged
