### PR TITLE
WIP: Migrate tests from py2 to py3

### DIFF
--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -1,7 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #
 # Test addressindex generation and fetching for insightexplorer
 # 
@@ -12,10 +13,10 @@
 #   getaddressdeltas
 #   getaddressutxos
 #   getaddressmempool
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+#
 
 from test_framework.test_framework import BitcoinTestFramework
+
 
 from test_framework.util import (
     assert_equal,
@@ -40,7 +41,7 @@ from test_framework.mininode import (
     CTxIn, CTxOut, COutPoint,
 )
 
-from binascii import hexlify
+from binascii import hexlify, unhexlify
 
 
 class AddressIndexTest(BitcoinTestFramework):
@@ -252,7 +253,7 @@ class AddressIndexTest(BitcoinTestFramework):
 
         # Ensure the change from that transaction appears
         tx = self.nodes[0].getrawtransaction(txid, 1)
-        change_vout = filter(lambda v: v['valueZat'] != 3 * COIN, tx['vout'])
+        change_vout = [v for v in tx['vout'] if v['valueZat'] != 3 * COIN]
         change = change_vout[0]['scriptPubKey']['addresses'][0]
         bal = self.nodes[2].getaddressbalance(change)
         assert(bal['received'] > 0)
@@ -323,7 +324,7 @@ class AddressIndexTest(BitcoinTestFramework):
         # so for comparison, remove the 4 (and -4 for output) from the
         # deltas list
         deltas = self.nodes[1].getaddressdeltas({'addresses': [addr1]})
-        deltas = filter(lambda d: abs(d['satoshis']) != 4 * COIN, deltas)
+        deltas = [d for d in deltas if abs(d['satoshis']) != 4 * COIN]
         assert_equal(len(utxos), len(deltas))
         for i in range(len(utxos)):
             assert_equal(utxos[i]['address'],   addr1)
@@ -334,13 +335,13 @@ class AddressIndexTest(BitcoinTestFramework):
         # Check that outputs with the same address in the same tx return one txid
         # (can't use createrawtransaction() as it combines duplicate addresses)
         addr = "t2LMJ6Arw9UWBMWvfUr2QLHM4Xd9w53FftS"
-        addressHash = "97643ce74b188f4fb6bbbb285e067a969041caf2".decode('hex')
+        addressHash = unhexlify("97643ce74b188f4fb6bbbb285e067a969041caf2")
         scriptPubKey = CScript([OP_HASH160, addressHash, OP_EQUAL])
         # Add an unrecognized script type to vout[], a legal script that pays,
         # but won't modify the addressindex (since the address can't be extracted).
         # (This extra output has no effect on the rest of the test.)
         scriptUnknown = CScript([OP_HASH160, OP_DUP, OP_DROP, addressHash, OP_EQUAL])
-        unspent = filter(lambda u: u['amount'] >= 4, self.nodes[0].listunspent())
+        unspent = [u for u in self.nodes[0].listunspent() if u['amount'] >= 4]
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(int(unspent[0]['txid'], 16), unspent[0]['vout']))]
         tx.vout = [

--- a/qa/rpc-tests/bip65-cltv-p2p.py
+++ b/qa/rpc-tests/bip65-cltv-p2p.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import start_nodes
@@ -13,7 +13,7 @@ from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager
 from test_framework.script import CScript, OP_1NEGATE, OP_NOP2, OP_DROP
 from binascii import unhexlify
-import cStringIO
+import io
 
 
 '''
@@ -38,10 +38,10 @@ class BIP65Test(ComparisonTestFramework):
         self.is_network_split = False
 
     def run_test(self):
-        test = TestManager(self, self.options.tmpdir)
-        test.add_all_connections(self.nodes)
+        test_manager = TestManager(self, self.options.tmpdir)
+        test_manager.add_all_connections(self.nodes)
         NetworkThread().start() # Start up network handling in another thread
-        test.run()
+        test_manager.run()
 
     def create_transaction(self, node, coinbase, to_address, amount):
         from_txid = node.getblock(coinbase)['tx'][0]
@@ -50,7 +50,7 @@ class BIP65Test(ComparisonTestFramework):
         rawtx = node.createrawtransaction(inputs, outputs)
         signresult = node.signrawtransaction(rawtx)
         tx = CTransaction()
-        f = cStringIO.StringIO(unhexlify(signresult['hex']))
+        f = io.BytesIO(unhexlify(signresult['hex']))
         tx.deserialize(f)
         return tx
 
@@ -67,8 +67,8 @@ class BIP65Test(ComparisonTestFramework):
         self.coinbase_blocks = self.nodes[0].generate(1)
         self.nodes[0].generate(100)
         hashTip = self.nodes[0].getbestblockhash()
-        hashFinalSaplingRoot = int("0x" + self.nodes[0].getblock(hashTip)['finalsaplingroot'] + "L", 0)
-        self.tip = int ("0x" + hashTip + "L", 0)
+        hashFinalSaplingRoot = int("0x" + self.nodes[0].getblock(hashTip)['finalsaplingroot'], 0)
+        self.tip = int ("0x" + hashTip, 0)
         self.nodeaddress = self.nodes[0].getnewaddress()
 
         '''Check that the rules are enforced.'''

--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import start_nodes
@@ -13,7 +13,7 @@ from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager
 from test_framework.script import CScript
 from binascii import unhexlify
-import cStringIO
+import io
 
 
 '''
@@ -49,7 +49,7 @@ class BIP66Test(ComparisonTestFramework):
         rawtx = node.createrawtransaction(inputs, outputs)
         signresult = node.signrawtransaction(rawtx)
         tx = CTransaction()
-        f = cStringIO.StringIO(unhexlify(signresult['hex']))
+        f = io.BytesIO(unhexlify(signresult['hex']))
         tx.deserialize(f)
         return tx
 
@@ -74,8 +74,8 @@ class BIP66Test(ComparisonTestFramework):
         self.coinbase_blocks = self.nodes[0].generate(1)
         self.nodes[0].generate(100)
         hashTip = self.nodes[0].getbestblockhash()
-        hashFinalSaplingRoot = int("0x" + self.nodes[0].getblock(hashTip)['finalsaplingroot'] + "L", 0)
-        self.tip = int ("0x" + hashTip + "L", 0)
+        hashFinalSaplingRoot = int("0x" + self.nodes[0].getblock(hashTip)['finalsaplingroot'], 0)
+        self.tip = int ("0x" + hashTip, 0)
         self.nodeaddress = self.nodes[0].getnewaddress()
 
         '''Check that the rules are enforced.'''

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -8,7 +8,7 @@
 # rpc/blockchain.cpp.
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 import decimal
 
@@ -42,13 +42,13 @@ class BlockchainTest(BitcoinTestFramework):
         node = self.nodes[0]
         res = node.gettxoutsetinfo()
 
-        assert_equal(res[u'total_amount'], decimal.Decimal('2181.25000000')) # 150*12.5 + 49*6.25
-        assert_equal(res[u'transactions'], 200)
-        assert_equal(res[u'height'], 200)
-        assert_equal(res[u'txouts'], 349) # 150*2 + 49
-        assert_equal(res[u'bytes_serialized'], 14951), # 32*199 + 48*90 + 49*60 + 27*49
-        assert_equal(len(res[u'bestblock']), 64)
-        assert_equal(len(res[u'hash_serialized']), 64)
+        assert_equal(res['total_amount'], decimal.Decimal('2181.25000000')) # 150*12.5 + 49*6.25
+        assert_equal(res['transactions'], 200)
+        assert_equal(res['height'], 200)
+        assert_equal(res['txouts'], 349) # 150*2 + 49
+        assert_equal(res['bytes_serialized'], 14951), # 32*199 + 48*90 + 49*60 + 27*49
+        assert_equal(len(res['bestblock']), 64)
+        assert_equal(len(res['hash_serialized']), 64)
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/decodescript.py
+++ b/qa/rpc-tests/decodescript.py
@@ -1,16 +1,16 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes
 from test_framework.mininode import CTransaction
 from binascii import hexlify, unhexlify
-from cStringIO import StringIO
+from io import BytesIO
 
 
 class DecodeScriptTest(BitcoinTestFramework):
@@ -25,27 +25,27 @@ class DecodeScriptTest(BitcoinTestFramework):
         self.is_network_split = False
 
     def decodescript_script_sig(self):
-        signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
-        push_signature = '48' + signature
-        public_key = '03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
-        push_public_key = '21' + public_key
+        signature = b'304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
+        push_signature = b'48' + signature
+        public_key = b'03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
+        push_public_key = b'21' + public_key
 
         # below are test cases for all of the standard transaction types
 
         # 1) P2PK scriptSig
         # the scriptSig of a public key scriptPubKey simply pushes a signature onto the stack
         rpc_result = self.nodes[0].decodescript(push_signature)
-        assert_equal(signature, rpc_result['asm'])
+        assert_equal(str(signature)[2:].rstrip("'"), rpc_result['asm'])
 
         # 2) P2PKH scriptSig
         rpc_result = self.nodes[0].decodescript(push_signature + push_public_key)
-        assert_equal(signature + ' ' + public_key, rpc_result['asm'])
+        assert_equal(str(signature + b' ' + public_key)[2:].rstrip("'"), rpc_result['asm'])
 
         # 3) multisig scriptSig
         # this also tests the leading portion of a P2SH multisig scriptSig
         # OP_0 <A sig> <B sig>
-        rpc_result = self.nodes[0].decodescript('00' + push_signature + push_signature)
-        assert_equal('0 ' + signature + ' ' + signature, rpc_result['asm'])
+        rpc_result = self.nodes[0].decodescript(b'00' + push_signature + push_signature)
+        assert_equal(str(b'0 ' + signature + b' ' + signature)[2:].rstrip("'"), rpc_result['asm'])
 
         # 4) P2SH scriptSig
         # an empty P2SH redeemScript is valid and makes for a very simple test case.
@@ -58,45 +58,45 @@ class DecodeScriptTest(BitcoinTestFramework):
         # thus, no test case for that standard transaction type is here.
 
     def decodescript_script_pub_key(self):
-        public_key = '03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
-        push_public_key = '21' + public_key
-        public_key_hash = '11695b6cd891484c2d49ec5aa738ec2b2f897777'
-        push_public_key_hash = '14' + public_key_hash
+        public_key = b'03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
+        push_public_key = b'21' + public_key
+        public_key_hash = b'11695b6cd891484c2d49ec5aa738ec2b2f897777'
+        push_public_key_hash = b'14' + public_key_hash
 
         # below are test cases for all of the standard transaction types
 
         # 1) P2PK scriptPubKey
         # <pubkey> OP_CHECKSIG
-        rpc_result = self.nodes[0].decodescript(push_public_key + 'ac')
-        assert_equal(public_key + ' OP_CHECKSIG', rpc_result['asm'])
+        rpc_result = self.nodes[0].decodescript(push_public_key + b'ac')
+        assert_equal(str(public_key + b' OP_CHECKSIG')[2:].rstrip("'"), rpc_result['asm'])
 
         # 2) P2PKH scriptPubKey
         # OP_DUP OP_HASH160 <PubKeyHash> OP_EQUALVERIFY OP_CHECKSIG
-        rpc_result = self.nodes[0].decodescript('76a9' + push_public_key_hash + '88ac')
-        assert_equal('OP_DUP OP_HASH160 ' + public_key_hash + ' OP_EQUALVERIFY OP_CHECKSIG', rpc_result['asm'])
+        rpc_result = self.nodes[0].decodescript(b'76a9' + push_public_key_hash + b'88ac')
+        assert_equal(str(b'OP_DUP OP_HASH160 ' + public_key_hash + b' OP_EQUALVERIFY OP_CHECKSIG')[2:].rstrip("'"), rpc_result['asm'])
 
         # 3) multisig scriptPubKey
         # <m> <A pubkey> <B pubkey> <C pubkey> <n> OP_CHECKMULTISIG
         # just imagine that the pub keys used below are different.
         # for our purposes here it does not matter that they are the same even though it is unrealistic.
-        rpc_result = self.nodes[0].decodescript('52' + push_public_key + push_public_key + push_public_key + '53ae')
-        assert_equal('2 ' + public_key + ' ' + public_key + ' ' + public_key +  ' 3 OP_CHECKMULTISIG', rpc_result['asm'])
+        rpc_result = self.nodes[0].decodescript(b'52' + push_public_key + push_public_key + push_public_key + b'53ae')
+        assert_equal(str(b'2 ' + public_key + b' ' + public_key + b' ' + public_key +  b' 3 OP_CHECKMULTISIG')[2:].rstrip("'"), rpc_result['asm'])
 
         # 4) P2SH scriptPubKey
         # OP_HASH160 <Hash160(redeemScript)> OP_EQUAL.
         # push_public_key_hash here should actually be the hash of a redeem script.
         # but this works the same for purposes of this test.
-        rpc_result = self.nodes[0].decodescript('a9' + push_public_key_hash + '87')
-        assert_equal('OP_HASH160 ' + public_key_hash + ' OP_EQUAL', rpc_result['asm'])
+        rpc_result = self.nodes[0].decodescript(b'a9' + push_public_key_hash + b'87')
+        assert_equal(str(b'OP_HASH160 ' + public_key_hash + b' OP_EQUAL')[2:].rstrip("'"), rpc_result['asm'])
 
         # 5) null data scriptPubKey
         # use a signature look-alike here to make sure that we do not decode random data as a signature.
         # this matters if/when signature sighash decoding comes along.
         # would want to make sure that no such decoding takes place in this case.
-        signature_imposter = '48304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
+        signature_imposter = b'48304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
         # OP_RETURN <data>
-        rpc_result = self.nodes[0].decodescript('6a' + signature_imposter)
-        assert_equal('OP_RETURN ' + signature_imposter[2:], rpc_result['asm'])
+        rpc_result = self.nodes[0].decodescript(b'6a' + signature_imposter)
+        assert_equal(str(b'OP_RETURN ' + signature_imposter[2:])[2:].rstrip("'"), rpc_result['asm'])
 
         # 6) a CLTV redeem script. redeem scripts are in-effect scriptPubKey scripts, so adding a test here.
         # OP_NOP2 is also known as OP_CHECKLOCKTIMEVERIFY.
@@ -111,8 +111,8 @@ class DecodeScriptTest(BitcoinTestFramework):
         # <sender-pubkey> OP_CHECKSIG
         #
         # lock until block 500,000
-        rpc_result = self.nodes[0].decodescript('63' + push_public_key + 'ad670320a107b17568' + push_public_key + 'ac')
-        assert_equal('OP_IF ' + public_key + ' OP_CHECKSIGVERIFY OP_ELSE 500000 OP_NOP2 OP_DROP OP_ENDIF ' + public_key + ' OP_CHECKSIG', rpc_result['asm'])
+        rpc_result = self.nodes[0].decodescript(b'63' + push_public_key + b'ad670320a107b17568' + push_public_key + b'ac')
+        assert_equal(str(b'OP_IF ' + public_key + b' OP_CHECKSIGVERIFY OP_ELSE 500000 OP_NOP2 OP_DROP OP_ENDIF ' + public_key + b' OP_CHECKSIG')[2:].rstrip("'"), rpc_result['asm'])
 
     def decoderawtransaction_asm_sighashtype(self):
         """Tests decoding scripts via RPC command "decoderawtransaction".
@@ -121,32 +121,32 @@ class DecodeScriptTest(BitcoinTestFramework):
         """
 
         # this test case uses a random plain vanilla mainnet transaction with a single P2PKH input and output
-        tx = '0100000001696a20784a2c70143f634e95227dbdfdf0ecd51647052e70854512235f5986ca010000008a47304402207174775824bec6c2700023309a168231ec80b82c6069282f5133e6f11cbb04460220570edc55c7c5da2ca687ebd0372d3546ebc3f810516a002350cac72dfe192dfb014104d3f898e6487787910a690410b7a917ef198905c27fb9d3b0a42da12aceae0544fc7088d239d9a48f2828a15a09e84043001f27cc80d162cb95404e1210161536ffffffff0100e1f505000000001976a914eb6c6e0cdb2d256a32d97b8df1fc75d1920d9bca88ac00000000'
+        tx = b'0100000001696a20784a2c70143f634e95227dbdfdf0ecd51647052e70854512235f5986ca010000008a47304402207174775824bec6c2700023309a168231ec80b82c6069282f5133e6f11cbb04460220570edc55c7c5da2ca687ebd0372d3546ebc3f810516a002350cac72dfe192dfb014104d3f898e6487787910a690410b7a917ef198905c27fb9d3b0a42da12aceae0544fc7088d239d9a48f2828a15a09e84043001f27cc80d162cb95404e1210161536ffffffff0100e1f505000000001976a914eb6c6e0cdb2d256a32d97b8df1fc75d1920d9bca88ac00000000'
         rpc_result = self.nodes[0].decoderawtransaction(tx)
         assert_equal('304402207174775824bec6c2700023309a168231ec80b82c6069282f5133e6f11cbb04460220570edc55c7c5da2ca687ebd0372d3546ebc3f810516a002350cac72dfe192dfb[ALL] 04d3f898e6487787910a690410b7a917ef198905c27fb9d3b0a42da12aceae0544fc7088d239d9a48f2828a15a09e84043001f27cc80d162cb95404e1210161536', rpc_result['vin'][0]['scriptSig']['asm'])
 
         # this test case uses a mainnet transaction that has a P2SH input and both P2PKH and P2SH outputs.
         # it's from James D'Angelo's awesome introductory videos about multisig: https://www.youtube.com/watch?v=zIbUSaZBJgU and https://www.youtube.com/watch?v=OSA1pwlaypc
         # verify that we have not altered scriptPubKey decoding.
-        tx = '01000000018d1f5635abd06e2c7e2ddf58dc85b3de111e4ad6e0ab51bb0dcf5e84126d927300000000fdfe0000483045022100ae3b4e589dfc9d48cb82d41008dc5fa6a86f94d5c54f9935531924602730ab8002202f88cf464414c4ed9fa11b773c5ee944f66e9b05cc1e51d97abc22ce098937ea01483045022100b44883be035600e9328a01b66c7d8439b74db64187e76b99a68f7893b701d5380220225bf286493e4c4adcf928c40f785422572eb232f84a0b83b0dea823c3a19c75014c695221020743d44be989540d27b1b4bbbcfd17721c337cb6bc9af20eb8a32520b393532f2102c0120a1dda9e51a938d39ddd9fe0ebc45ea97e1d27a7cbd671d5431416d3dd87210213820eb3d5f509d7438c9eeecb4157b2f595105e7cd564b3cdbb9ead3da41eed53aeffffffff02611e0000000000001976a914dc863734a218bfe83ef770ee9d41a27f824a6e5688acee2a02000000000017a9142a5edea39971049a540474c6a99edf0aa4074c588700000000'
+        tx = b'01000000018d1f5635abd06e2c7e2ddf58dc85b3de111e4ad6e0ab51bb0dcf5e84126d927300000000fdfe0000483045022100ae3b4e589dfc9d48cb82d41008dc5fa6a86f94d5c54f9935531924602730ab8002202f88cf464414c4ed9fa11b773c5ee944f66e9b05cc1e51d97abc22ce098937ea01483045022100b44883be035600e9328a01b66c7d8439b74db64187e76b99a68f7893b701d5380220225bf286493e4c4adcf928c40f785422572eb232f84a0b83b0dea823c3a19c75014c695221020743d44be989540d27b1b4bbbcfd17721c337cb6bc9af20eb8a32520b393532f2102c0120a1dda9e51a938d39ddd9fe0ebc45ea97e1d27a7cbd671d5431416d3dd87210213820eb3d5f509d7438c9eeecb4157b2f595105e7cd564b3cdbb9ead3da41eed53aeffffffff02611e0000000000001976a914dc863734a218bfe83ef770ee9d41a27f824a6e5688acee2a02000000000017a9142a5edea39971049a540474c6a99edf0aa4074c588700000000'
         rpc_result = self.nodes[0].decoderawtransaction(tx)
         assert_equal('8e3730608c3b0bb5df54f09076e196bc292a8e39a78e73b44b6ba08c78f5cbb0', rpc_result['txid'])
         assert_equal('0 3045022100ae3b4e589dfc9d48cb82d41008dc5fa6a86f94d5c54f9935531924602730ab8002202f88cf464414c4ed9fa11b773c5ee944f66e9b05cc1e51d97abc22ce098937ea[ALL] 3045022100b44883be035600e9328a01b66c7d8439b74db64187e76b99a68f7893b701d5380220225bf286493e4c4adcf928c40f785422572eb232f84a0b83b0dea823c3a19c75[ALL] 5221020743d44be989540d27b1b4bbbcfd17721c337cb6bc9af20eb8a32520b393532f2102c0120a1dda9e51a938d39ddd9fe0ebc45ea97e1d27a7cbd671d5431416d3dd87210213820eb3d5f509d7438c9eeecb4157b2f595105e7cd564b3cdbb9ead3da41eed53ae', rpc_result['vin'][0]['scriptSig']['asm'])
-        assert_equal('OP_DUP OP_HASH160 dc863734a218bfe83ef770ee9d41a27f824a6e56 OP_EQUALVERIFY OP_CHECKSIG', rpc_result['vout'][0]['scriptPubKey']['asm'])
-        assert_equal('OP_HASH160 2a5edea39971049a540474c6a99edf0aa4074c58 OP_EQUAL', rpc_result['vout'][1]['scriptPubKey']['asm'])
+        assert_equal(str(b'OP_DUP OP_HASH160 dc863734a218bfe83ef770ee9d41a27f824a6e56 OP_EQUALVERIFY OP_CHECKSIG')[2:].rstrip("'"), rpc_result['vout'][0]['scriptPubKey']['asm'])
+        assert_equal(str(b'OP_HASH160 2a5edea39971049a540474c6a99edf0aa4074c58 OP_EQUAL')[2:].rstrip("'"), rpc_result['vout'][1]['scriptPubKey']['asm'])
         txSave = CTransaction()
-        txSave.deserialize(StringIO(unhexlify(tx)))
+        txSave.deserialize(BytesIO(unhexlify(tx)))
 
         # make sure that a specifically crafted op_return value will not pass all the IsDERSignature checks and then get decoded as a sighash type
-        tx = '01000000015ded05872fdbda629c7d3d02b194763ce3b9b1535ea884e3c8e765d42e316724020000006b48304502204c10d4064885c42638cbff3585915b322de33762598321145ba033fc796971e2022100bb153ad3baa8b757e30a2175bd32852d2e1cb9080f84d7e32fcdfd667934ef1b012103163c0ff73511ea1743fb5b98384a2ff09dd06949488028fd819f4d83f56264efffffffff0200000000000000000b6a0930060201000201000180380100000000001976a9141cabd296e753837c086da7a45a6c2fe0d49d7b7b88ac00000000'
+        tx = b'01000000015ded05872fdbda629c7d3d02b194763ce3b9b1535ea884e3c8e765d42e316724020000006b48304502204c10d4064885c42638cbff3585915b322de33762598321145ba033fc796971e2022100bb153ad3baa8b757e30a2175bd32852d2e1cb9080f84d7e32fcdfd667934ef1b012103163c0ff73511ea1743fb5b98384a2ff09dd06949488028fd819f4d83f56264efffffffff0200000000000000000b6a0930060201000201000180380100000000001976a9141cabd296e753837c086da7a45a6c2fe0d49d7b7b88ac00000000'
         rpc_result = self.nodes[0].decoderawtransaction(tx)
-        assert_equal('OP_RETURN 300602010002010001', rpc_result['vout'][0]['scriptPubKey']['asm'])
+        assert_equal(str(b'OP_RETURN 300602010002010001')[2:].rstrip("'"), rpc_result['vout'][0]['scriptPubKey']['asm'])
 
         # verify that we have not altered scriptPubKey processing even of a specially crafted P2PKH pubkeyhash and P2SH redeem script hash that is made to pass the der signature checks
-        tx = '01000000018d1f5635abd06e2c7e2ddf58dc85b3de111e4ad6e0ab51bb0dcf5e84126d927300000000fdfe0000483045022100ae3b4e589dfc9d48cb82d41008dc5fa6a86f94d5c54f9935531924602730ab8002202f88cf464414c4ed9fa11b773c5ee944f66e9b05cc1e51d97abc22ce098937ea01483045022100b44883be035600e9328a01b66c7d8439b74db64187e76b99a68f7893b701d5380220225bf286493e4c4adcf928c40f785422572eb232f84a0b83b0dea823c3a19c75014c695221020743d44be989540d27b1b4bbbcfd17721c337cb6bc9af20eb8a32520b393532f2102c0120a1dda9e51a938d39ddd9fe0ebc45ea97e1d27a7cbd671d5431416d3dd87210213820eb3d5f509d7438c9eeecb4157b2f595105e7cd564b3cdbb9ead3da41eed53aeffffffff02611e0000000000001976a914301102070101010101010102060101010101010188acee2a02000000000017a91430110207010101010101010206010101010101018700000000'
+        tx = b'01000000018d1f5635abd06e2c7e2ddf58dc85b3de111e4ad6e0ab51bb0dcf5e84126d927300000000fdfe0000483045022100ae3b4e589dfc9d48cb82d41008dc5fa6a86f94d5c54f9935531924602730ab8002202f88cf464414c4ed9fa11b773c5ee944f66e9b05cc1e51d97abc22ce098937ea01483045022100b44883be035600e9328a01b66c7d8439b74db64187e76b99a68f7893b701d5380220225bf286493e4c4adcf928c40f785422572eb232f84a0b83b0dea823c3a19c75014c695221020743d44be989540d27b1b4bbbcfd17721c337cb6bc9af20eb8a32520b393532f2102c0120a1dda9e51a938d39ddd9fe0ebc45ea97e1d27a7cbd671d5431416d3dd87210213820eb3d5f509d7438c9eeecb4157b2f595105e7cd564b3cdbb9ead3da41eed53aeffffffff02611e0000000000001976a914301102070101010101010102060101010101010188acee2a02000000000017a91430110207010101010101010206010101010101018700000000'
         rpc_result = self.nodes[0].decoderawtransaction(tx)
-        assert_equal('OP_DUP OP_HASH160 3011020701010101010101020601010101010101 OP_EQUALVERIFY OP_CHECKSIG', rpc_result['vout'][0]['scriptPubKey']['asm'])
-        assert_equal('OP_HASH160 3011020701010101010101020601010101010101 OP_EQUAL', rpc_result['vout'][1]['scriptPubKey']['asm'])
+        assert_equal(str(b'OP_DUP OP_HASH160 3011020701010101010101020601010101010101 OP_EQUALVERIFY OP_CHECKSIG')[2:].rstrip("'"), rpc_result['vout'][0]['scriptPubKey']['asm'])
+        assert_equal(str(b'OP_HASH160 3011020701010101010101020601010101010101 OP_EQUAL')[2:].rstrip("'"), rpc_result['vout'][1]['scriptPubKey']['asm'])
 
         # some more full transaction tests of varying specific scriptSigs. used instead of
         # tests in decodescript_script_sig because the decodescript RPC is specifically
@@ -154,32 +154,31 @@ class DecodeScriptTest(BitcoinTestFramework):
         push_signature = hexlify(txSave.vin[0].scriptSig)[2:(0x48*2+4)]
         signature = push_signature[2:]
         der_signature = signature[:-2]
-        signature_sighash_decoded = der_signature + '[ALL]'
-        signature_2 = der_signature + '82'
-        push_signature_2 = '48' + signature_2
-        signature_2_sighash_decoded = der_signature + '[NONE|ANYONECANPAY]'
+        signature_sighash_decoded = der_signature + b'[ALL]'
+        signature_2 = der_signature + b'82'
+        push_signature_2 = b'48' + signature_2
+        signature_2_sighash_decoded = der_signature + b'[NONE|ANYONECANPAY]'
 
         # 1) P2PK scriptSig
         txSave.vin[0].scriptSig = unhexlify(push_signature)
         rpc_result = self.nodes[0].decoderawtransaction(hexlify(txSave.serialize()))
-        assert_equal(signature_sighash_decoded, rpc_result['vin'][0]['scriptSig']['asm'])
+        assert_equal(str(signature_sighash_decoded)[2:].rstrip("'"), rpc_result['vin'][0]['scriptSig']['asm'])
 
         # make sure that the sighash decodes come out correctly for a more complex / lesser used case.
         txSave.vin[0].scriptSig = unhexlify(push_signature_2)
         rpc_result = self.nodes[0].decoderawtransaction(hexlify(txSave.serialize()))
-        assert_equal(signature_2_sighash_decoded, rpc_result['vin'][0]['scriptSig']['asm'])
+        assert_equal(str(signature_2_sighash_decoded)[2:].rstrip("'"), rpc_result['vin'][0]['scriptSig']['asm'])
 
         # 2) multisig scriptSig
-        txSave.vin[0].scriptSig = unhexlify('00' + push_signature + push_signature_2)
+        txSave.vin[0].scriptSig = unhexlify(b'00' + push_signature + push_signature_2)
         rpc_result = self.nodes[0].decoderawtransaction(hexlify(txSave.serialize()))
-        assert_equal('0 ' + signature_sighash_decoded + ' ' + signature_2_sighash_decoded, rpc_result['vin'][0]['scriptSig']['asm'])
+        assert_equal(str(b'0 ' + signature_sighash_decoded + b' ' + signature_2_sighash_decoded)[2:].rstrip("'"), rpc_result['vin'][0]['scriptSig']['asm'])
 
         # 3) test a scriptSig that contains more than push operations.
         # in fact, it contains an OP_RETURN with data specially crafted to cause improper decode if the code does not catch it.
-        txSave.vin[0].scriptSig = unhexlify('6a143011020701010101010101020601010101010101')
+        txSave.vin[0].scriptSig = unhexlify(b'6a143011020701010101010101020601010101010101')
         rpc_result = self.nodes[0].decoderawtransaction(hexlify(txSave.serialize()))
-        print(hexlify('636174'))
-        assert_equal('OP_RETURN 3011020701010101010101020601010101010101', rpc_result['vin'][0]['scriptSig']['asm'])
+        assert_equal(str(b'OP_RETURN 3011020701010101010101020601010101010101')[2:].rstrip("'"), rpc_result['vin'][0]['scriptSig']['asm'])
 
     def run_test(self):
         self.decodescript_script_sig()

--- a/qa/rpc-tests/disablewallet.py
+++ b/qa/rpc-tests/disablewallet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,7 +7,7 @@
 # Exercise API with -disablewallet.
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import initialize_chain_clean, start_nodes

--- a/qa/rpc-tests/finalsaplingroot.py
+++ b/qa/rpc-tests/finalsaplingroot.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -30,6 +30,8 @@ class FinalSaplingRootTest(BitcoinTestFramework):
 
     def setup_network(self, split=False):
         self.nodes = start_nodes(4, self.options.tmpdir, extra_args=[[
+            '-nuparams=5ba81b19:100', # Overwinter
+            '-nuparams=76b809bb:200', # Sapling
             '-txindex'                # Avoid JSONRPC error: No information available about transaction
             ]] * 4 )
         connect_nodes_bi(self.nodes,0,1)
@@ -40,6 +42,7 @@ class FinalSaplingRootTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
+        # Activate Overwinter and Sapling
         self.nodes[0].generate(200)
         self.sync_all()
 
@@ -49,7 +52,7 @@ class FinalSaplingRootTest(BitcoinTestFramework):
 
         # Verify all generated blocks contain the empty root of the Sapling tree.
         blockcount = self.nodes[0].getblockcount()
-        for height in xrange(1, blockcount + 1):
+        for height in range(1, blockcount + 1):
             blk = self.nodes[0].getblock(str(height))
             assert_equal(blk["finalsaplingroot"], SAPLING_TREE_EMPTY_ROOT)
 

--- a/qa/rpc-tests/forknotify.py
+++ b/qa/rpc-tests/forknotify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,7 +7,7 @@
 # Test -alertnotify 
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import start_node, connect_nodes

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -33,8 +33,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        print "Mining blocks..."
-        feeTolerance = Decimal(0.00000002) #if the fee's positive delta is higher than this value tests will fail, neg. delta always fail the tests
+        print("Mining blocks...")
+        feeTolerance = Decimal("0.00000002") #if the fee's positive delta is higher than this value tests will fail, neg. delta always fail the tests
 
         self.nodes[2].generate(1)
         self.sync_all()
@@ -155,9 +155,8 @@ class RawTransactionsTest(BitcoinTestFramework):
                 break;
 
         assert_equal(utx!=False, True)
-
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
-        outputs = { self.nodes[0].getnewaddress() : Decimal(5.0) - fee - feeTolerance }
+        outputs = { self.nodes[0].getnewaddress() : Decimal("5.0") - fee - feeTolerance }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
@@ -204,7 +203,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         matchingOuts = 0
         for i, out in enumerate(dec_tx['vout']):
             totalOut += out['value']
-            if outputs.has_key(out['scriptPubKey']['addresses'][0]):
+            if out['scriptPubKey']['addresses'][0] in outputs:
                 matchingOuts+=1
             else:
                 assert_equal(i, rawtxfund['changepos'])
@@ -244,7 +243,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         matchingOuts = 0
         for out in dec_tx['vout']:
             totalOut += out['value']
-            if outputs.has_key(out['scriptPubKey']['addresses'][0]):
+            if out['scriptPubKey']['addresses'][0] in outputs:
                 matchingOuts+=1
 
         assert_equal(matchingOuts, 1)
@@ -286,7 +285,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         matchingOuts = 0
         for out in dec_tx['vout']:
             totalOut += out['value']
-            if outputs.has_key(out['scriptPubKey']['addresses'][0]):
+            if out['scriptPubKey']['addresses'][0] in outputs:
                 matchingOuts+=1
 
         assert_equal(matchingOuts, 2)
@@ -304,7 +303,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         errorString = ""
         try:
             rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
 
         assert_equal("Insufficient" in errorString, True);

--- a/qa/rpc-tests/getblocktemplate.py
+++ b/qa/rpc-tests/getblocktemplate.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2016 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, connect_nodes_bi, \

--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import AuthServiceProxy
@@ -20,12 +20,12 @@ def check_array_result(object_array, to_match, expected):
     num_matched = 0
     for item in object_array:
         all_match = True
-        for key,value in to_match.items():
+        for key,value in list(to_match.items()):
             if item[key] != value:
                 all_match = False
         if not all_match:
             continue
-        for key,value in expected.items():
+        for key,value in list(expected.items()):
             if item[key] != value:
                 raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
             num_matched = num_matched+1
@@ -53,7 +53,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
     '''
 
     def run_test(self):
-        print "Warning: this test will take about 70 seconds in the best case. Be patient."
+        print("Warning: this test will take about 70 seconds in the best case. Be patient.")
         self.nodes[0].generate(10)
         templat = self.nodes[0].getblocktemplate()
         longpollid = templat['longpollid']

--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -22,12 +22,12 @@ def check_array_result(object_array, to_match, expected):
     num_matched = 0
     for item in object_array:
         all_match = True
-        for key,value in to_match.items():
+        for key,value in list(to_match.items()):
             if item[key] != value:
                 all_match = False
         if not all_match:
             continue
-        for key,value in expected.items():
+        for key,value in list(expected.items()):
             if item[key] != value:
                 raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
             num_matched = num_matched+1

--- a/qa/rpc-tests/getchaintips.py
+++ b/qa/rpc-tests/getchaintips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,7 +7,7 @@
 # on chains of different lengths, and join the network together again.
 # This gives us two tips, verify that it works.
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal

--- a/qa/rpc-tests/getrawtransaction_insight.py
+++ b/qa/rpc-tests/getrawtransaction_insight.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2019 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -65,7 +65,7 @@ class GetrawtransactionTest(BitcoinTestFramework):
         tx_a = self.nodes[2].getrawtransaction(txid_a, 1)
 
         # txid_b is not yet confirmed, so height is invalid (-1)
-        vout = filter(lambda o: o['value'] == 2, tx_a['vout'])
+        vout = list(filter(lambda o: o['value'] == 2, tx_a['vout']))
         assert_equal(vout[0]['spentTxId'], txid_b)
         assert_equal(vout[0]['spentIndex'], 0)
         assert_equal(vout[0]['spentHeight'], -1)
@@ -84,7 +84,7 @@ class GetrawtransactionTest(BitcoinTestFramework):
         assert_equal(tx_a['vin'][0]['value'], 10) # coinbase
         assert_equal(tx_a['vin'][0]['valueSat'], 10*COIN)
         # we want the non-change (payment) output
-        vout = filter(lambda o: o['value'] == 2, tx_a['vout'])
+        vout = list(filter(lambda o: o['value'] == 2, tx_a['vout']))
         assert_equal(vout[0]['spentTxId'], txid_b)
         assert_equal(vout[0]['spentIndex'], 0)
         assert_equal(vout[0]['spentHeight'], 107)

--- a/qa/rpc-tests/hardforkdetection.py
+++ b/qa/rpc-tests/hardforkdetection.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Test hard fork detection
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -31,7 +31,7 @@ class HardForkDetectionTest(BitcoinTestFramework):
         errorString = ""
         try:
             self.nodes[0].getbalance()
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
 
         assert_equal("Safe mode:" in errorString, True)

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,21 +7,15 @@
 # Test rpc http basics
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, start_nodes
 
 import base64
 
-try:
-    import http.client as httplib
-except ImportError:
-    import httplib
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import http
+import urllib.parse as urlparse
 
 class HTTPBasicsTest (BitcoinTestFramework):
     def setup_nodes(self):
@@ -34,70 +28,70 @@ class HTTPBasicsTest (BitcoinTestFramework):
         #################################################
         url = urlparse.urlparse(self.nodes[0].url)
         authpair = url.username + ':' + url.password
-        headers = {"Authorization": "Basic " + base64.b64encode(authpair)}
+        headers = {"Authorization": "Basic " + str(base64.b64encode(bytes(authpair, encoding="utf-8")))[1:].strip("'")}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True)
+        assert_equal(b'"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) # according to http/1.1 connection must still be open!
 
         # send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out2 = conn.getresponse().read()
-        assert_equal('"error":null' in out2, True) # must also response with a correct json-rpc message
+        assert_equal(b'"error":null' in out2, True) # must also response with a correct json-rpc message
         assert_equal(conn.sock!=None, True) # according to http/1.1 connection must still be open!
         conn.close()
 
         # same should be if we add keep-alive because this should be the std. behaviour
-        headers = {"Authorization": "Basic " + base64.b64encode(authpair), "Connection": "keep-alive"}
+        headers = {"Authorization": "Basic " + str(base64.b64encode(bytes(authpair, encoding="utf-8")))[1:].strip("'"), "Connection": "keep-alive"}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True)
+        assert_equal(b'"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) # according to http/1.1 connection must still be open!
 
         # send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out2 = conn.getresponse().read()
-        assert_equal('"error":null' in out2, True) # must also response with a correct json-rpc message
+        assert_equal(b'"error":null' in out2, True) # must also response with a correct json-rpc message
         assert_equal(conn.sock!=None, True) # according to http/1.1 connection must still be open!
         conn.close()
 
         # now do the same with "Connection: close"
-        headers = {"Authorization": "Basic " + base64.b64encode(authpair), "Connection":"close"}
+        headers = {"Authorization": "Basic " + str(base64.b64encode(bytes(authpair, encoding="utf-8")))[1:].strip("'"), "Connection":"close"}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True)
+        assert_equal(b'"error":null' in out1, True)
         assert_equal(conn.sock!=None, False) # now the connection must be closed after the response
 
         # node1 (2nd node) is running with disabled keep-alive option
         urlNode1 = urlparse.urlparse(self.nodes[1].url)
         authpair = urlNode1.username + ':' + urlNode1.password
-        headers = {"Authorization": "Basic " + base64.b64encode(authpair)}
+        headers = {"Authorization": "Basic " + str(base64.b64encode(bytes(authpair, encoding="utf-8")))[1:].strip("'")}
 
-        conn = httplib.HTTPConnection(urlNode1.hostname, urlNode1.port)
+        conn = http.client.HTTPConnection(urlNode1.hostname, urlNode1.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True)
+        assert_equal(b'"error":null' in out1, True)
 
         # node2 (third node) is running with standard keep-alive parameters which means keep-alive is on
         urlNode2 = urlparse.urlparse(self.nodes[2].url)
         authpair = urlNode2.username + ':' + urlNode2.password
-        headers = {"Authorization": "Basic " + base64.b64encode(authpair)}
+        headers = {"Authorization": "Basic " + str(base64.b64encode(bytes(authpair, encoding="utf-8")))[1:].strip("'")}
 
-        conn = httplib.HTTPConnection(urlNode2.hostname, urlNode2.port)
+        conn = http.client.HTTPConnection(urlNode2.hostname, urlNode2.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True)
+        assert_equal(b'"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) # connection must be closed because bitcoind should use keep-alive by default
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/invalidateblock.py
+++ b/qa/rpc-tests/invalidateblock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,7 +7,7 @@
 # Test InvalidateBlock code
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import initialize_chain_clean, start_node, \
@@ -28,46 +28,46 @@ class InvalidateTest(BitcoinTestFramework):
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
 
     def run_test(self):
-        print "Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:"
-        print "Mine 4 blocks on Node 0"
+        print("Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:")
+        print("Mine 4 blocks on Node 0")
         self.nodes[0].generate(4)
         assert(self.nodes[0].getblockcount() == 4)
         besthash = self.nodes[0].getbestblockhash()
 
-        print "Mine competing 6 blocks on Node 1"
+        print("Mine competing 6 blocks on Node 1")
         self.nodes[1].generate(6)
         assert(self.nodes[1].getblockcount() == 6)
 
-        print "Connect nodes to force a reorg"
+        print("Connect nodes to force a reorg")
         connect_nodes_bi(self.nodes,0,1)
         sync_blocks(self.nodes[0:2])
         assert(self.nodes[0].getblockcount() == 6)
         badhash = self.nodes[1].getblockhash(2)
 
-        print "Invalidate block 2 on node 0 and verify we reorg to node 0's original chain"
+        print("Invalidate block 2 on node 0 and verify we reorg to node 0's original chain")
         self.nodes[0].invalidateblock(badhash)
         newheight = self.nodes[0].getblockcount()
         newhash = self.nodes[0].getbestblockhash()
         if (newheight != 4 or newhash != besthash):
             raise AssertionError("Wrong tip for node0, hash %s, height %d"%(newhash,newheight))
 
-        print "\nMake sure we won't reorg to a lower work chain:"
+        print("\nMake sure we won't reorg to a lower work chain:")
         connect_nodes_bi(self.nodes,1,2)
-        print "Sync node 2 to node 1 so both have 6 blocks"
+        print("Sync node 2 to node 1 so both have 6 blocks")
         sync_blocks(self.nodes[1:3])
         assert(self.nodes[2].getblockcount() == 6)
-        print "Invalidate block 5 on node 1 so its tip is now at 4"
+        print("Invalidate block 5 on node 1 so its tip is now at 4")
         self.nodes[1].invalidateblock(self.nodes[1].getblockhash(5))
         assert(self.nodes[1].getblockcount() == 4)
-        print "Invalidate block 3 on node 2, so its tip is now 2"
+        print("Invalidate block 3 on node 2, so its tip is now 2")
         self.nodes[2].invalidateblock(self.nodes[2].getblockhash(3))
         assert(self.nodes[2].getblockcount() == 2)
-        print "..and then mine a block"
+        print("..and then mine a block")
         self.nodes[2].generate(1)
-        print "Verify all nodes are at the right height"
+        print("Verify all nodes are at the right height")
         time.sleep(5)
-        for i in xrange(3):
-            print i,self.nodes[i].getblockcount()
+        for i in range(3):
+            print(i,self.nodes[i].getblockcount())
         assert(self.nodes[2].getblockcount() == 3)
         assert(self.nodes[0].getblockcount() == 4)
         node1height = self.nodes[1].getblockcount()

--- a/qa/rpc-tests/invalidblockrequest.py
+++ b/qa/rpc-tests/invalidblockrequest.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import assert_equal
@@ -60,7 +60,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         Now we need that block to mature so we can spend the coinbase.
         '''
         test = TestInstance(sync_every_block=False)
-        for i in xrange(100):
+        for i in range(100):
             block = create_block(self.tip, create_coinbase(), self.block_time)
             block.solve()
             self.tip = block.sha256

--- a/qa/rpc-tests/key_import_export.py
+++ b/qa/rpc-tests/key_import_export.py
@@ -1,15 +1,16 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from decimal import Decimal
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_greater_than, start_nodes, initialize_chain_clean, connect_nodes_bi
 
 import logging
+from functools import reduce
 
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 
@@ -40,11 +41,8 @@ class KeyImportExportTest (BitcoinTestFramework):
 
         def verify_utxos(node, amounts):
             utxos = node.listunspent(1, 10**9, [addr])
-
-            def cmp_confirmations_high_to_low(a, b):
-                return cmp(b["confirmations"], a["confirmations"])
-
-            utxos.sort(cmp_confirmations_high_to_low)
+            utxos.sort(key=lambda x: x["confirmations"])
+            utxos.reverse()
 
             try:
                 assert_equal(amounts, [utxo["amount"] for utxo in utxos])
@@ -66,7 +64,7 @@ class KeyImportExportTest (BitcoinTestFramework):
         verify_utxos(charlie, [])
 
         # the amounts of each txn embodied which generates a single UTXO:
-        amounts = map(Decimal, ['2.3', '3.7', '0.1', '0.5', '1.0', '0.19'])
+        amounts = list(map(Decimal, ['2.3', '3.7', '0.1', '0.5', '1.0', '0.19']))
 
         # Internal test consistency assertion:
         assert_greater_than(

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,7 +7,7 @@
 
 # Add python-bitcoinrpc to module search path:
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import check_json_precision, initialize_chain, \
@@ -28,12 +28,12 @@ def check_array_result(object_array, to_match, expected):
     num_matched = 0
     for item in object_array:
         all_match = True
-        for key,value in to_match.items():
+        for key,value in list(to_match.items()):
             if item[key] != value:
                 all_match = False
         if not all_match:
             continue
-        for key,value in expected.items():
+        for key,value in list(expected.items()):
             if item[key] != value:
                 raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
             num_matched = num_matched+1
@@ -51,7 +51,7 @@ def run_test(nodes, tmpdir):
     try:
         addr = nodes[0].getnewaddress()
         raise AssertionError('Keypool should be exhausted after one address')
-    except JSONRPCException,e:
+    except JSONRPCException as e:
         assert(e.error['code']==-12)
 
     # put three new keys in the keypool
@@ -71,7 +71,7 @@ def run_test(nodes, tmpdir):
     try:
         addr = nodes[0].getrawchangeaddress()
         raise AssertionError('Keypool should be exhausted after three addresses')
-    except JSONRPCException,e:
+    except JSONRPCException as e:
         assert(e.error['code']==-12)
 
 

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 # Exercise the listtransactions API
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 
@@ -20,12 +20,12 @@ def check_array_result(object_array, to_match, expected):
     num_matched = 0
     for item in object_array:
         all_match = True
-        for key,value in to_match.items():
+        for key,value in list(to_match.items()):
             if item[key] != value:
                 all_match = False
         if not all_match:
             continue
-        for key,value in expected.items():
+        for key,value in list(expected.items()):
             if item[key] != value:
                 raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
             num_matched = num_matched+1

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.mininode import NodeConn, NodeConnCB, NetworkThread, \
     EarlyDisconnectError, CInv, msg_inv, mininode_lock
@@ -75,9 +75,9 @@ class TestManager(NodeConnCB):
                             raise AssertionError("Error, test failed: block %064x requested more than once" % key)
                 if total_requests > MAX_REQUESTS:
                     raise AssertionError("Error, too many blocks (%d) requested" % total_requests)
-                print "Round %d: success (total requests: %d)" % (count, total_requests)
+                print("Round %d: success (total requests: %d)" % (count, total_requests))
         except AssertionError as e:
-            print "TEST FAILED: ", e.args
+            print("TEST FAILED: ", e.args)
 
         self.disconnectOkay = True
         self.connection.disconnect_node()
@@ -90,7 +90,7 @@ class MaxBlocksInFlightTest(BitcoinTestFramework):
                           help="Binary to test max block requests behavior")
 
     def setup_chain(self):
-        print "Initializing test directory "+self.options.tmpdir
+        print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 1)
 
     def setup_network(self):

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (

--- a/qa/rpc-tests/mempool_nu_activation.py
+++ b/qa/rpc-tests/mempool_nu_activation.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -31,7 +30,7 @@ class MempoolUpgradeActivationTest(BitcoinTestFramework):
         self.sync_all
 
     def setup_chain(self):
-        print "Initializing test directory "+self.options.tmpdir
+        print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 2)
 
     def run_test(self):
@@ -48,7 +47,7 @@ class MempoolUpgradeActivationTest(BitcoinTestFramework):
         node0_zaddr = self.nodes[0].z_getnewaddress('sapling')
         recipients = [{'address': node0_zaddr, 'amount': Decimal('10')}]
         myopid = self.nodes[1].z_sendmany(node1_taddr, recipients, 1, Decimal('0'))
-        print wait_and_assert_operationid_status(self.nodes[1], myopid)
+        print(wait_and_assert_operationid_status(self.nodes[1], myopid))
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -8,7 +8,7 @@
 # that spend (directly or indirectly) coinbase transactions.
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -8,7 +8,7 @@
 # the blockchain is re-organized.
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, start_node

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -13,7 +13,7 @@
 # but less mature coinbase spends are NOT.
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException

--- a/qa/rpc-tests/mempool_tx_expiry.py
+++ b/qa/rpc-tests/mempool_tx_expiry.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -6,8 +6,6 @@
 #
 # Test proper expiry for transactions >= version 4
 #
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
@@ -37,7 +35,7 @@ class MempoolTxExpiryTest(BitcoinTestFramework):
         bob = self.nodes[2].getnewaddress()
         z_bob = self.nodes[2].z_getnewaddress('sapling')
 
-        print "Splitting network..."
+        print("Splitting network...")
         self.split_network()
 
         # Test dependent txs
@@ -46,7 +44,7 @@ class MempoolTxExpiryTest(BitcoinTestFramework):
         assert_equal(firstTxInfo["version"], 4)
         assert_equal(firstTxInfo["overwintered"], True)
         assert("expiryheight" in firstTxInfo)
-        print "First tx expiry height:", firstTxInfo['expiryheight']
+        print("First tx expiry height:", firstTxInfo['expiryheight'])
         # Mine first transaction
         self.nodes[0].generate(1)
         for outpoint in firstTxInfo['vout']:
@@ -60,19 +58,19 @@ class MempoolTxExpiryTest(BitcoinTestFramework):
         assert(rawTxSigned['complete'])
         secondTx = self.nodes[0].sendrawtransaction(rawTxSigned['hex'])
         secondTxInfo = self.nodes[0].getrawtransaction(secondTx, 1)
-        print "Second tx expiry height:", secondTxInfo['expiryheight']
+        print("Second tx expiry height:", secondTxInfo['expiryheight'])
         # Mine second, dependent transaction
         self.nodes[0].generate(1)
-        print "Mine %d competing blocks on Node 2..." % (2 + TX_EXPIRY_DELTA)
+        print("Mine %d competing blocks on Node 2..." % (2 + TX_EXPIRY_DELTA))
         blocks = self.nodes[2].generate(2 + TX_EXPIRY_DELTA)
-        print "Connect nodes to force a reorg"
+        print("Connect nodes to force a reorg")
         connect_nodes_bi(self.nodes,0,2)
         self.is_network_split = False
-        print "Syncing blocks"
+        print("Syncing blocks")
         sync_blocks(self.nodes)
-        print "Ensure that both txs are dropped from mempool of node 0"
-        print "Blockheight node 0:", self.nodes[0].getblockchaininfo()['blocks']
-        print "Blockheight node 2:", self.nodes[2].getblockchaininfo()['blocks']
+        print("Ensure that both txs are dropped from mempool of node 0")
+        print("Blockheight node 0:", self.nodes[0].getblockchaininfo()['blocks'])
+        print("Blockheight node 2:", self.nodes[2].getblockchaininfo()['blocks'])
         assert_equal(set(self.nodes[0].getrawmempool()), set())
         assert_equal(set(self.nodes[2].getrawmempool()), set())
 
@@ -84,10 +82,10 @@ class MempoolTxExpiryTest(BitcoinTestFramework):
 
         # Get balance on node 0
         bal = self.nodes[0].z_gettotalbalance()
-        print "Balance before zsend, after shielding 10: ", bal
+        print("Balance before zsend, after shielding 10: ", bal)
         assert_equal(Decimal(bal["private"]), Decimal("9.9999"))
 
-        print "Splitting network..."
+        print("Splitting network...")
         self.split_network()
 
         # Create transactions
@@ -103,148 +101,148 @@ class MempoolTxExpiryTest(BitcoinTestFramework):
         assert_equal(rawtx["version"], 4)
         assert_equal(rawtx["overwintered"], True)
         assert_equal(rawtx["expiryheight"], blockheight + 1 + TX_EXPIRY_DELTA)
-        print "Blockheight at persist_transparent & persist_shielded creation:", self.nodes[0].getblockchaininfo()['blocks']
-        print "Expiryheight of persist_transparent:", rawtx['expiryheight']
+        print("Blockheight at persist_transparent & persist_shielded creation:", self.nodes[0].getblockchaininfo()['blocks'])
+        print("Expiryheight of persist_transparent:", rawtx['expiryheight'])
         # Verify shielded transaction is version 4 intended for Sapling branch
         rawtx = self.nodes[0].getrawtransaction(persist_shielded, 1)
-        print "Expiryheight of persist_shielded", rawtx['expiryheight']
+        print("Expiryheight of persist_shielded", rawtx['expiryheight'])
         assert_equal(rawtx["version"], 4)
         assert_equal(rawtx["overwintered"], True)
         assert_equal(rawtx["expiryheight"], blockheight + 1 + TX_EXPIRY_DELTA)
 
-        print "\n Blockheight advances to less than expiry block height. After reorg, txs should persist in mempool"
+        print("\n Blockheight advances to less than expiry block height. After reorg, txs should persist in mempool")
         assert(persist_transparent in self.nodes[0].getrawmempool())
         assert(persist_shielded in self.nodes[0].getrawmempool())
         assert_equal(set(self.nodes[2].getrawmempool()), set())
-        print "mempool node 0:", self.nodes[0].getrawmempool()
-        print "mempool node 2:", self.nodes[2].getrawmempool()
+        print("mempool node 0:", self.nodes[0].getrawmempool())
+        print("mempool node 2:", self.nodes[2].getrawmempool())
         bal = self.nodes[0].z_gettotalbalance()
-        print "Printing balance before persist_shielded & persist_transparent are initially mined from mempool", bal
+        print("Printing balance before persist_shielded & persist_transparent are initially mined from mempool", bal)
         # Txs are mined on node 0; will later be rolled back
         self.nodes[0].generate(1)
-        print "Node 0 generated 1 block"
-        print "Node 0 height:", self.nodes[0].getblockchaininfo()['blocks']
-        print "Node 2 height:", self.nodes[2].getblockchaininfo()['blocks']
+        print("Node 0 generated 1 block")
+        print("Node 0 height:", self.nodes[0].getblockchaininfo()['blocks'])
+        print("Node 2 height:", self.nodes[2].getblockchaininfo()['blocks'])
         bal = self.nodes[0].z_gettotalbalance()
-        print "Printing balance after persist_shielded & persist_transparent are mined:", bal
+        print("Printing balance after persist_shielded & persist_transparent are mined:", bal)
         assert_equal(set(self.nodes[0].getrawmempool()), set())
 
-        print "Mine 2 competing blocks on Node 2..."
+        print("Mine 2 competing blocks on Node 2...")
         blocks = self.nodes[2].generate(2)
         for block in blocks:
             blk = self.nodes[2].getblock(block)
-            print "Height: {0}, Mined block txs: {1}".format(blk["height"], blk["tx"])
-        print "Connect nodes to force a reorg"
+            print("Height: {0}, Mined block txs: {1}".format(blk["height"], blk["tx"]))
+        print("Connect nodes to force a reorg")
         connect_nodes_bi(self.nodes,0,2)
         self.is_network_split = False
 
-        print "Syncing blocks"
+        print("Syncing blocks")
         sync_blocks(self.nodes)
 
-        print "Ensure that txs are back in mempool of node 0"
-        print "Blockheight node 0:", self.nodes[0].getblockchaininfo()['blocks']
-        print "Blockheight node 2:", self.nodes[2].getblockchaininfo()['blocks']
-        print "mempool node 0: ", self.nodes[0].getrawmempool()
-        print "mempool node 2: ", self.nodes[2].getrawmempool()
+        print("Ensure that txs are back in mempool of node 0")
+        print("Blockheight node 0:", self.nodes[0].getblockchaininfo()['blocks'])
+        print("Blockheight node 2:", self.nodes[2].getblockchaininfo()['blocks'])
+        print("mempool node 0: ", self.nodes[0].getrawmempool())
+        print("mempool node 2: ", self.nodes[2].getrawmempool())
         assert(persist_transparent in self.nodes[0].getrawmempool())
         assert(persist_shielded in self.nodes[0].getrawmempool())
         bal = self.nodes[0].z_gettotalbalance()
         # Mine txs to get them out of the way of mempool sync in split_network()
-        print "Generating another block on node 0 to clear txs from mempool"
+        print("Generating another block on node 0 to clear txs from mempool")
         self.nodes[0].generate(1)
         assert_equal(set(self.nodes[0].getrawmempool()), set())
         sync_blocks(self.nodes)
 
-        print "Splitting network..."
+        print("Splitting network...")
         self.split_network()
 
-        print "\n Blockheight advances to equal expiry block height. After reorg, txs should persist in mempool"
+        print("\n Blockheight advances to equal expiry block height. After reorg, txs should persist in mempool")
         myopid = self.nodes[0].z_sendmany(z_alice, recipients)
         persist_shielded_2 = wait_and_assert_operationid_status(self.nodes[0], myopid)
         persist_transparent_2 = self.nodes[0].sendtoaddress(bob, 0.01)
         rawtx_trans = self.nodes[0].getrawtransaction(persist_transparent_2, 1)
         rawtx_shield = self.nodes[0].getrawtransaction(persist_shielded_2, 1)
-        print "Blockheight node 0 at persist_transparent_2 creation:", self.nodes[0].getblockchaininfo()['blocks']
-        print "Blockheight node 2 at persist_transparent_2 creation:", self.nodes[2].getblockchaininfo()['blocks']
-        print "Expiryheight of persist_transparent_2:", rawtx_trans['expiryheight']
-        print "Expiryheight of persist_shielded_2:", rawtx_shield['expiryheight']
+        print("Blockheight node 0 at persist_transparent_2 creation:", self.nodes[0].getblockchaininfo()['blocks'])
+        print("Blockheight node 2 at persist_transparent_2 creation:", self.nodes[2].getblockchaininfo()['blocks'])
+        print("Expiryheight of persist_transparent_2:", rawtx_trans['expiryheight'])
+        print("Expiryheight of persist_shielded_2:", rawtx_shield['expiryheight'])
         blocks = self.nodes[2].generate(4)
         for block in blocks:
             blk = self.nodes[2].getblock(block)
-            print "Height: {0}, Mined block txs: {1}".format(blk["height"], blk["tx"])
-        print "Connect nodes to force a reorg"
+            print("Height: {0}, Mined block txs: {1}".format(blk["height"], blk["tx"]))
+        print("Connect nodes to force a reorg")
         connect_nodes_bi(self.nodes, 0, 2)
         self.is_network_split = False
         sync_blocks(self.nodes)
-        print "Ensure that persist_transparent_2 & persist_shielded_2 are in mempool at expiry block height"
-        print "Blockheight node 0:", self.nodes[0].getblockchaininfo()['blocks']
-        print "Blockheight node 2:", self.nodes[2].getblockchaininfo()['blocks']
-        print "mempool node 0: ", self.nodes[0].getrawmempool()
-        print "mempool node 2: ", self.nodes[2].getrawmempool()
+        print("Ensure that persist_transparent_2 & persist_shielded_2 are in mempool at expiry block height")
+        print("Blockheight node 0:", self.nodes[0].getblockchaininfo()['blocks'])
+        print("Blockheight node 2:", self.nodes[2].getblockchaininfo()['blocks'])
+        print("mempool node 0: ", self.nodes[0].getrawmempool())
+        print("mempool node 2: ", self.nodes[2].getrawmempool())
         assert(persist_transparent_2 in self.nodes[0].getrawmempool())
         assert(persist_shielded_2 in self.nodes[0].getrawmempool())
         # Mine persist txs to get them out of the way of mempool sync in split_network()
         self.nodes[0].generate(1)
         assert_equal(set(self.nodes[0].getrawmempool()), set())
         sync_blocks(self.nodes)
-        print "Balance after persist_shielded_2 is mined to remove from mempool: ", self.nodes[0].z_gettotalbalance()
+        print("Balance after persist_shielded_2 is mined to remove from mempool: ", self.nodes[0].z_gettotalbalance())
 
-        print "Splitting network..."
+        print("Splitting network...")
         self.split_network()
 
-        print "\n Blockheight advances to greater than expiry block height. After reorg, txs should expire from mempool"
-        print "Balance before expire_shielded is sent: ", self.nodes[0].z_gettotalbalance()
+        print("\n Blockheight advances to greater than expiry block height. After reorg, txs should expire from mempool")
+        print("Balance before expire_shielded is sent: ", self.nodes[0].z_gettotalbalance())
         myopid = self.nodes[0].z_sendmany(z_alice, recipients)
         expire_shielded = wait_and_assert_operationid_status(self.nodes[0], myopid)
         expire_transparent = self.nodes[0].sendtoaddress(bob, 0.01)
-        print "Blockheight node 0 at expire_transparent creation:", self.nodes[0].getblockchaininfo()['blocks']
-        print "Blockheight node 2 at expire_shielded creation:", self.nodes[2].getblockchaininfo()['blocks']
-        print "Expiryheight of expire_transparent:", self.nodes[0].getrawtransaction(expire_transparent, 1)['expiryheight']
-        print "Expiryheight of expire_shielded:", self.nodes[0].getrawtransaction(expire_shielded, 1)['expiryheight']
+        print("Blockheight node 0 at expire_transparent creation:", self.nodes[0].getblockchaininfo()['blocks'])
+        print("Blockheight node 2 at expire_shielded creation:", self.nodes[2].getblockchaininfo()['blocks'])
+        print("Expiryheight of expire_transparent:", self.nodes[0].getrawtransaction(expire_transparent, 1)['expiryheight'])
+        print("Expiryheight of expire_shielded:", self.nodes[0].getrawtransaction(expire_shielded, 1)['expiryheight'])
         assert(expire_transparent in self.nodes[0].getrawmempool())
         assert(expire_shielded in self.nodes[0].getrawmempool())
         blocks = self.nodes[2].generate(1 + TX_EXPIRY_DELTA + 1)
         for block in blocks:
             blk = self.nodes[2].getblock(block)
-            print "Height: {0}, Mined block txs: {1}".format(blk["height"], blk["tx"])
-        print "Connect nodes to force a reorg"
+            print("Height: {0}, Mined block txs: {1}".format(blk["height"], blk["tx"]))
+        print("Connect nodes to force a reorg")
         connect_nodes_bi(self.nodes, 0, 2)
         self.is_network_split = False
         sync_blocks(self.nodes)
-        print "Ensure that expire_transparent & expire_shielded are not in mempool after expiry block height"
-        print "mempool node 0: ", self.nodes[0].getrawmempool()
-        print "mempool node 2: ", self.nodes[2].getrawmempool()
+        print("Ensure that expire_transparent & expire_shielded are not in mempool after expiry block height")
+        print("mempool node 0: ", self.nodes[0].getrawmempool())
+        print("mempool node 2: ", self.nodes[2].getrawmempool())
         assert_equal(set(self.nodes[0].getrawmempool()), set())
-        print "Ensure balance of node 0 is correct"
+        print("Ensure balance of node 0 is correct")
         bal = self.nodes[0].z_gettotalbalance()
-        print "Balance after expire_shielded has expired: ", bal
+        print("Balance after expire_shielded has expired: ", bal)
         assert_equal(Decimal(bal["private"]), Decimal("7.9999"))
 
-        print "Splitting network..."
+        print("Splitting network...")
         self.split_network()
 
-        print "\n Blockheight advances to just before expiring soon threshold.  Txs should be rejected from entering mempool."
-        print "Balance before expire_shielded is sent: ", self.nodes[0].z_gettotalbalance()
+        print("\n Blockheight advances to just before expiring soon threshold.  Txs should be rejected from entering mempool.")
+        print("Balance before expire_shielded is sent: ", self.nodes[0].z_gettotalbalance())
         myopid = self.nodes[0].z_sendmany(z_alice, recipients)
         expire_shielded = wait_and_assert_operationid_status(self.nodes[0], myopid)
         expire_transparent = self.nodes[0].sendtoaddress(bob, 0.01)
-        print "Blockheight node 0 at expire_transparent creation:", self.nodes[0].getblockchaininfo()['blocks']
-        print "Blockheight node 2 at expire_shielded creation:", self.nodes[2].getblockchaininfo()['blocks']
-        print "Expiryheight of expire_transparent:", self.nodes[0].getrawtransaction(expire_transparent, 1)['expiryheight']
-        print "Expiryheight of expire_shielded:", self.nodes[0].getrawtransaction(expire_shielded, 1)['expiryheight']
+        print("Blockheight node 0 at expire_transparent creation:", self.nodes[0].getblockchaininfo()['blocks'])
+        print("Blockheight node 2 at expire_shielded creation:", self.nodes[2].getblockchaininfo()['blocks'])
+        print("Expiryheight of expire_transparent:", self.nodes[0].getrawtransaction(expire_transparent, 1)['expiryheight'])
+        print("Expiryheight of expire_shielded:", self.nodes[0].getrawtransaction(expire_shielded, 1)['expiryheight'])
         assert(expire_transparent in self.nodes[0].getrawmempool())
         assert(expire_shielded in self.nodes[0].getrawmempool())
         blocks = self.nodes[2].generate(1 + TX_EXPIRY_DELTA - TX_EXPIRING_SOON_THRESHOLD - 1)
         for block in blocks:
             blk = self.nodes[2].getblock(block)
-            print "Height: {0}, Mined block txs: {1}".format(blk["height"], blk["tx"])
-        print "Connect nodes to force a reorg"
+            print("Height: {0}, Mined block txs: {1}".format(blk["height"], blk["tx"]))
+        print("Connect nodes to force a reorg")
         connect_nodes_bi(self.nodes, 0, 2)
         self.is_network_split = False
         sync_blocks(self.nodes)
-        print "Ensure that expire_transparent & expire_shielded are in node 0 mempool but not node 2 mempool"
-        print "mempool node 0: ", self.nodes[0].getrawmempool()
-        print "mempool node 2: ", self.nodes[2].getrawmempool()
+        print("Ensure that expire_transparent & expire_shielded are in node 0 mempool but not node 2 mempool")
+        print("mempool node 0: ", self.nodes[0].getrawmempool())
+        print("mempool node 2: ", self.nodes[2].getrawmempool())
         assert(expire_transparent in self.nodes[0].getrawmempool())
         assert(expire_shielded in self.nodes[0].getrawmempool())
         assert(expire_transparent not in self.nodes[2].getrawmempool())

--- a/qa/rpc-tests/mergetoaddress_helper.py
+++ b/qa/rpc-tests/mergetoaddress_helper.py
@@ -56,7 +56,7 @@ class MergeToAddressHelper:
         test.sync_all()
 
     def run_test(self, test):
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         test.nodes[0].generate(1)
         do_not_shield_taddr = test.nodes[0].getnewaddress()

--- a/qa/rpc-tests/mergetoaddress_mixednotes.py
+++ b/qa/rpc-tests/mergetoaddress_mixednotes.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from decimal import Decimal
 from test_framework.test_framework import BitcoinTestFramework
@@ -21,7 +21,7 @@ class MergeToAddressMixedNotes(BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, 4)
 
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(102)
         self.sync_all()
 

--- a/qa/rpc-tests/mergetoaddress_sapling.py
+++ b/qa/rpc-tests/mergetoaddress_sapling.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from mergetoaddress_helper import MergeToAddressHelper

--- a/qa/rpc-tests/mergetoaddress_sprout.py
+++ b/qa/rpc-tests/mergetoaddress_sprout.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from mergetoaddress_helper import MergeToAddressHelper

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,7 +7,7 @@
 # Test merkleblock fetch/validation
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 import string
 from test_framework.test_framework import BitcoinTestFramework
@@ -38,7 +38,7 @@ class MerkleBlockTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(105)
         self.sync_all()
 

--- a/qa/rpc-tests/multi_rpc.py
+++ b/qa/rpc-tests/multi_rpc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -16,14 +16,8 @@ from test_framework.util import (
 import base64
 import os
 
-try:
-    import http.client as httplib
-except ImportError:
-    import httplib
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import http.client as httplib
+import urllib.parse as urlparse
 
 class HTTPBasicsTest (BitcoinTestFramework):
     def setup_nodes(self):
@@ -47,18 +41,18 @@ class HTTPBasicsTest (BitcoinTestFramework):
         url = urlparse.urlparse(self.nodes[0].url)
 
         #Old authpair
-        authpair = url.username + ':' + url.password
+        authpair = url.username.encode() + b':' + url.password.encode()
 
         #New authpair generated via share/rpcuser tool
         #rpcauth = "rpcauth=rt:93648e835a54c573682c2eb19f882535$7681e9c5b74bdd85e78166031d2058e1069b3ed7ed967c93fc63abba06f31144"
-        password = "cA773lm788buwYe4g4WT+05pKyNruVKjQ25x3n0DQcM="
+        password = b"cA773lm788buwYe4g4WT+05pKyNruVKjQ25x3n0DQcM="
 
         #Second authpair with different username
         #rpcauth2 = "rpcauth=rt2:f8607b1a88861fac29dfccf9b52ff9f$ff36a0c23c8c62b4846112e50fa888416e94c17bfd4c42f88fd8f55ec6a3137e"
-        password2 = "8/F3uMDw4KSEbw96U3CA1C4X05dkHDN2BPFjTgZW4KI="
-        authpairnew = "rt:"+password
+        password2 = b"8/F3uMDw4KSEbw96U3CA1C4X05dkHDN2BPFjTgZW4KI="
+        authpairnew = b"rt:"+password
 
-        headers = {"Authorization": "Basic " + base64.b64encode(authpair)}
+        headers = {"Authorization": b"Basic " + base64.b64encode(authpair)}
 
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -68,7 +62,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.close()
         
         #Use new authpair to confirm both work
-        headers = {"Authorization": "Basic " + base64.b64encode(authpairnew)}
+        headers = {"Authorization": b"Basic " + base64.b64encode(authpairnew)}
 
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -78,8 +72,8 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.close()
 
         #Wrong login name with rt's password
-        authpairnew = "rtwrong:"+password
-        headers = {"Authorization": "Basic " + base64.b64encode(authpairnew)}
+        authpairnew = b"rtwrong:"+password
+        headers = {"Authorization": b"Basic " + base64.b64encode(authpairnew)}
 
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -89,8 +83,8 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.close()
 
         #Wrong password for rt
-        authpairnew = "rt:"+password+"wrong"
-        headers = {"Authorization": "Basic " + base64.b64encode(authpairnew)}
+        authpairnew = b"rt:"+password+b"wrong"
+        headers = {"Authorization": b"Basic " + base64.b64encode(authpairnew)}
 
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -100,8 +94,8 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.close()
 
         #Correct for rt2
-        authpairnew = "rt2:"+password2
-        headers = {"Authorization": "Basic " + base64.b64encode(authpairnew)}
+        authpairnew = b"rt2:"+password2
+        headers = {"Authorization": b"Basic " + base64.b64encode(authpairnew)}
 
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -111,8 +105,8 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.close()
 
         #Wrong password for rt2
-        authpairnew = "rt2:"+password2+"wrong"
-        headers = {"Authorization": "Basic " + base64.b64encode(authpairnew)}
+        authpairnew = b"rt2:" + password2 + b"wrong"
+        headers = {"Authorization": b"Basic " + base64.b64encode(authpairnew)}
 
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()

--- a/qa/rpc-tests/nodehandling.py
+++ b/qa/rpc-tests/nodehandling.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,17 +7,14 @@
 # Test node handling
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, connect_nodes_bi, p2p_port
 
 import time
 
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import urllib
 
 class NodeHandlingTest (BitcoinTestFramework):
     def run_test(self):
@@ -51,7 +48,7 @@ class NodeHandlingTest (BitcoinTestFramework):
         ###########################
         # RPC disconnectnode test #
         ###########################
-        url = urlparse.urlparse(self.nodes[1].url)
+        url = urllib.parse.urlparse(self.nodes[1].url)
         self.nodes[0].disconnectnode(url.hostname+":"+str(p2p_port(1)))
         time.sleep(2) #disconnecting a node needs a little bit of time
         for node in self.nodes[0].getpeerinfo():

--- a/qa/rpc-tests/p2p-acceptblock.py
+++ b/qa/rpc-tests/p2p-acceptblock.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.mininode import CBlockHeader, CInv, NodeConn, NodeConnCB, \
     NetworkThread, msg_block, msg_headers, msg_inv, msg_ping, msg_pong, \
@@ -159,7 +159,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         # This should be accepted.
         blocks_h2 = []  # the height 2 blocks on each node's chain
         block_time = time.time() + 1
-        for i in xrange(2):
+        for i in range(2):
             blocks_h2.append(create_block(tips[i], create_coinbase(), block_time))
             blocks_h2[i].solve()
             block_time += 1
@@ -169,11 +169,11 @@ class AcceptBlockTest(BitcoinTestFramework):
         [ x.sync_with_ping() for x in [test_node, white_node] ]
         assert_equal(self.nodes[0].getblockcount(), 2)
         assert_equal(self.nodes[1].getblockcount(), 2)
-        print "First height 2 block accepted by both nodes"
+        print("First height 2 block accepted by both nodes")
 
         # 3. Send another block that builds on the original tip.
         blocks_h2f = []  # Blocks at height 2 that fork off the main chain
-        for i in xrange(2):
+        for i in range(2):
             blocks_h2f.append(create_block(tips[i], create_coinbase(), blocks_h2[i].nTime+1))
             blocks_h2f[i].solve()
         test_node.send_message(msg_block(blocks_h2f[0]))
@@ -188,11 +188,11 @@ class AcceptBlockTest(BitcoinTestFramework):
             if x['hash'] == blocks_h2f[1].hash:
                 assert_equal(x['status'], "valid-headers")
 
-        print "Second height 2 block accepted only from whitelisted peer"
+        print("Second height 2 block accepted only from whitelisted peer")
 
         # 4. Now send another block that builds on the forking chain.
         blocks_h3 = []
-        for i in xrange(2):
+        for i in range(2):
             blocks_h3.append(create_block(blocks_h2f[i].sha256, create_coinbase(), blocks_h2f[i].nTime+1))
             blocks_h3[i].solve()
         test_node.send_message(msg_block(blocks_h3[0]))
@@ -208,13 +208,13 @@ class AcceptBlockTest(BitcoinTestFramework):
         # But this block should be accepted by node0 since it has more work.
         try:
             self.nodes[0].getblock(blocks_h3[0].hash)
-            print "Unrequested more-work block accepted from non-whitelisted peer"
+            print("Unrequested more-work block accepted from non-whitelisted peer")
         except:
             raise AssertionError("Unrequested more work block was not processed")
 
         # Node1 should have accepted and reorged.
         assert_equal(self.nodes[1].getblockcount(), 3)
-        print "Successfully reorged to length 3 chain from whitelisted peer"
+        print("Successfully reorged to length 3 chain from whitelisted peer")
 
         # 4b. Now mine 288 more blocks and deliver; all should be processed but
         # the last (height-too-high) on node0.  Node1 should process the tip if
@@ -222,8 +222,8 @@ class AcceptBlockTest(BitcoinTestFramework):
         tips = blocks_h3
         headers_message = msg_headers()
         all_blocks = []   # node0's blocks
-        for j in xrange(2):
-            for i in xrange(288):
+        for j in range(2):
+            for i in range(288):
                 next_block = create_block(tips[j].sha256, create_coinbase(), tips[j].nTime+1)
                 next_block.solve()
                 if j==0:
@@ -241,7 +241,7 @@ class AcceptBlockTest(BitcoinTestFramework):
                     raise AssertionError("Unrequested block too far-ahead should have been ignored")
             except:
                 if x == all_blocks[287]:
-                    print "Unrequested block too far-ahead not processed"
+                    print("Unrequested block too far-ahead not processed")
                 else:
                     raise AssertionError("Unrequested block with more work should have been accepted")
 
@@ -251,7 +251,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         try:
             white_node.sync_with_ping()
             self.nodes[1].getblock(tips[1].hash)
-            print "Unrequested block far ahead of tip accepted from whitelisted peer"
+            print("Unrequested block far ahead of tip accepted from whitelisted peer")
         except:
             raise AssertionError("Unrequested block from whitelisted peer not accepted")
 
@@ -267,7 +267,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         # a getdata request for this block.
         test_node.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 2)
-        print "Unrequested block that would complete more-work chain was ignored"
+        print("Unrequested block that would complete more-work chain was ignored")
 
         # 6. Try to get node to request the missing block.
         # Poke the node with an inv for block at height 3 and see if that
@@ -283,14 +283,14 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # Check that the getdata includes the right block
         assert_equal(getdata.inv[0].hash, blocks_h2f[0].sha256)
-        print "Inv at tip triggered getdata for unprocessed block"
+        print("Inv at tip triggered getdata for unprocessed block")
 
         # 7. Send the missing block for the third time (now it is requested)
         test_node.send_message(msg_block(blocks_h2f[0]))
 
         test_node.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 290)
-        print "Successfully reorged to longer chain from non-whitelisted peer"
+        print("Successfully reorged to longer chain from non-whitelisted peer")
 
         [ c.disconnect_node() for c in connections ]
 

--- a/qa/rpc-tests/p2p_node_bloom.py
+++ b/qa/rpc-tests/p2p_node_bloom.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.mininode import NodeConn, NodeConnCB, NetworkThread, \
     msg_filteradd, msg_filterclear, mininode_lock, SAPLING_PROTO_VERSION
@@ -48,7 +48,7 @@ class TestNode(NodeConnCB):
 class NodeBloomTest(BitcoinTestFramework):
 
     def setup_chain(self):
-        print "Initializing test directory "+self.options.tmpdir
+        print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 2)
 
     def setup_network(self):

--- a/qa/rpc-tests/p2p_nu_peer_management.py
+++ b/qa/rpc-tests/p2p_nu_peer_management.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.mininode import (
     NodeConn,
@@ -54,7 +54,7 @@ class TestManager(NodeConnCB):
 class NUPeerManagementTest(BitcoinTestFramework):
 
     def setup_chain(self):
-        print "Initializing test directory "+self.options.tmpdir
+        print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 1)
 
     def setup_network(self):
@@ -70,7 +70,7 @@ class NUPeerManagementTest(BitcoinTestFramework):
 
         # Launch Sprout, Overwinter, and Sapling mininodes
         nodes = []
-        for x in xrange(10):
+        for x in range(10):
             nodes.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0],
                 test, "regtest", SPROUT_PROTO_VERSION))
             nodes.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0],

--- a/qa/rpc-tests/p2p_txexpiringsoon.py
+++ b/qa/rpc-tests/p2p_txexpiringsoon.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+from binascii import unhexlify
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.mininode import NodeConn, NetworkThread, CInv, \
@@ -19,7 +19,7 @@ from binascii import hexlify
 class TxExpiringSoonTest(BitcoinTestFramework):
 
     def setup_chain(self):
-        print "Initializing test directory " + self.options.tmpdir
+        print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 3)
 
     def setup_network(self):
@@ -122,8 +122,8 @@ class TxExpiringSoonTest(BitcoinTestFramework):
         tx2 = self.send_transaction(testnode0, coinbase_blocks[1], node_address, 204)
 
         # tx2 is not expiring soon
-        assert_equal([tx2.hash], self.nodes[0].getrawmempool())
-        assert_equal([tx2.hash], self.nodes[1].getrawmempool())
+        assert_equal(tx2.hash, self.nodes[0].getrawmempool()[0])
+        assert_equal(tx2.hash, self.nodes[1].getrawmempool()[0])
         # node 2 is isolated
         assert_equal([], self.nodes[2].getrawmempool())
 
@@ -159,8 +159,8 @@ class TxExpiringSoonTest(BitcoinTestFramework):
         assert_equal(self.nodes[2].getblockcount(), 201)
 
         # Verify contents of mempool
-        assert_equal([tx2.hash], self.nodes[0].getrawmempool())
-        assert_equal([tx2.hash], self.nodes[1].getrawmempool())
+        assert_equal(tx2.hash, self.nodes[0].getrawmempool()[0])
+        assert_equal(tx2.hash, self.nodes[1].getrawmempool()[0])
         assert_equal([], self.nodes[2].getrawmempool())
 
         # Confirm tx2 cannot be submitted to a mempool because it is expiring soon.

--- a/qa/rpc-tests/p2p_txexpiry_dos.py
+++ b/qa/rpc-tests/p2p_txexpiry_dos.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.mininode import NodeConn, NetworkThread, \
     msg_tx, SAPLING_PROTO_VERSION
@@ -18,7 +18,7 @@ import time
 class TxExpiryDoSTest(BitcoinTestFramework):
 
     def setup_chain(self):
-        print "Initializing test directory " + self.options.tmpdir
+        print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 1)
 
     def setup_network(self):

--- a/qa/rpc-tests/paymentdisclosure.py
+++ b/qa/rpc-tests/paymentdisclosure.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -34,7 +34,7 @@ class PaymentDisclosureTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         self.nodes[0].generate(4)
         self.sync_all()

--- a/qa/rpc-tests/prioritisetransaction.py
+++ b/qa/rpc-tests/prioritisetransaction.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
@@ -31,7 +31,7 @@ class PrioritiseTransactionTest (BitcoinTestFramework):
     def run_test (self):
         # tx priority is calculated: priority = sum(input_value_in_base_units * input_age)/size_in_bytes
 
-        print "Mining 11kb blocks..."
+        print("Mining 11kb blocks...")
         self.nodes[0].generate(501)
 
         base_fee = self.nodes[0].getnetworkinfo()['relayfee']

--- a/qa/rpc-tests/proton_test.py
+++ b/qa/rpc-tests/proton_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -12,8 +12,6 @@
 #   To install:
 #     pip install python-qpid-proton
 #
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, bytes_to_hex_str, \
@@ -37,7 +35,7 @@ class Server(MessagingHandler):
         self.txidseq = -1
 
     def on_start(self, event):
-        print "Proton listening on:", self.url
+        print("Proton listening on:", self.url)
         self.container = event.container
         self.acceptor = event.container.listen(self.url)
 
@@ -73,6 +71,7 @@ class ProtonTest (BitcoinTestFramework):
 
         # Launch proton server in background thread
         # It terminates after receiving numblocks * 2 messages (one for coinbase, one for block)
+        print("Do we get here?")
         self.server = Server("127.0.0.1:%i" % self.port, self.numblocks * 2)
         self.container = Container(self.server)
         self.t1 = threading.Thread(target=self.container.run)
@@ -87,13 +86,15 @@ class ProtonTest (BitcoinTestFramework):
             ])
 
     def run_test(self):
+        print("self.numblocks is: %s" % self.numblocks)
         self.sync_all()
         baseheight = self.nodes[0].getblockcount()    # 200 blocks already mined
 
         # generate some blocks
-        self.nodes[0].generate(self.numblocks/2)
+        self.nodes[0].generate(self.numblocks//2)
         self.sync_all()
-        self.nodes[1].generate(self.numblocks/2)
+        self.nodes[1].generate(self.numblocks//2)
+        print("About to run self.sync_all()")
         self.sync_all()
 
         # wait for server to finish
@@ -106,7 +107,7 @@ class ProtonTest (BitcoinTestFramework):
         assert_equal(len(self.server.txids), self.numblocks)
 
         # verify that each block has the correct coinbase txid
-        for i in xrange(0, self.numblocks):
+        for i in range(0, self.numblocks):
             height = baseheight + i + 1
             blockhash = self.nodes[0].getblockhash(height)
             assert_equal(blockhash, self.server.blockhashes[i])

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 import socket
 import os
@@ -58,7 +57,7 @@ class ProxyTest(BitcoinTestFramework):
             self.conf3.unauth = True
             self.conf3.auth = True
         else:
-            print "Warning: testing without local IPv6 support"
+            print("Warning: testing without local IPv6 support")
 
         self.serv1 = Socks5Server(self.conf1)
         self.serv1.start()
@@ -89,7 +88,7 @@ class ProxyTest(BitcoinTestFramework):
         assert(isinstance(cmd, Socks5Command))
         # Note: bitcoind's SOCKS5 implementation only sends atyp DOMAINNAME, even if connecting directly to IPv4/IPv6
         assert_equal(cmd.atyp, AddressType.DOMAINNAME)
-        assert_equal(cmd.addr, "15.61.23.23")
+        assert_equal(cmd.addr, str(bytearray(b"15.61.23.23")))
         assert_equal(cmd.port, 1234)
         if not auth:
             assert_equal(cmd.username, None)
@@ -116,7 +115,7 @@ class ProxyTest(BitcoinTestFramework):
             cmd = proxies[2].queue.get()
             assert(isinstance(cmd, Socks5Command))
             assert_equal(cmd.atyp, AddressType.DOMAINNAME)
-            assert_equal(cmd.addr, "bitcoinostk4e4re.onion")
+            assert_equal(cmd.addr, str(bytearray(b"bitcoinostk4e4re.onion")))
             assert_equal(cmd.port, 8333)
             if not auth:
                 assert_equal(cmd.username, None)
@@ -128,7 +127,7 @@ class ProxyTest(BitcoinTestFramework):
         cmd = proxies[3].queue.get()
         assert(isinstance(cmd, Socks5Command))
         assert_equal(cmd.atyp, AddressType.DOMAINNAME)
-        assert_equal(cmd.addr, "node.noumenon")
+        assert_equal(cmd.addr, str(bytearray("node.noumenon", encoding="utf-8")))
         assert_equal(cmd.port, 8333)
         if not auth:
             assert_equal(cmd.username, None)

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -11,7 +11,7 @@
 # This test takes 30 mins or more (up to 2 hours)
 # ********
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -35,11 +35,11 @@ class PruneTest(BitcoinTestFramework):
 
         # create one script_pubkey
         script_pubkey = "6a4d0200" #OP_RETURN OP_PUSH2 512 bytes
-        for i in xrange (512):
+        for i in range (512):
             script_pubkey = script_pubkey + "01"
         # concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
         self.txouts = "81"
-        for k in xrange(128):
+        for k in range(128):
             # add txout value
             self.txouts = self.txouts + "0000000000000000"
             # add length of script_pubkey
@@ -81,7 +81,7 @@ class PruneTest(BitcoinTestFramework):
         sync_blocks(self.nodes[0:2])
         self.nodes[0].generate(150)
         # Then mine enough full blocks to create more than 550MB of data
-        for i in xrange(645):
+        for i in range(645):
             self.mine_full_block(self.nodes[0], self.address[0])
 
         sync_blocks(self.nodes[0:3])
@@ -89,11 +89,11 @@ class PruneTest(BitcoinTestFramework):
     def test_height_min(self):
         if not os.path.isfile(self.prunedir+"blk00000.dat"):
             raise AssertionError("blk00000.dat is missing, pruning too early")
-        print "Success"
-        print "Though we're already using more than 550MB, current usage:", calc_usage(self.prunedir)
-        print "Mining 25 more blocks should cause the first block file to be pruned"
+        print("Success")
+        print("Though we're already using more than 550MB, current usage:", calc_usage(self.prunedir))
+        print("Mining 25 more blocks should cause the first block file to be pruned")
         # Pruning doesn't run until we're allocating another chunk, 20 full blocks past the height cutoff will ensure this
-        for i in xrange(25):
+        for i in range(25):
             self.mine_full_block(self.nodes[0],self.address[0])
 
         waitstart = time.time()
@@ -102,17 +102,17 @@ class PruneTest(BitcoinTestFramework):
             if time.time() - waitstart > 10:
                 raise AssertionError("blk00000.dat not pruned when it should be")
 
-        print "Success"
+        print("Success")
         usage = calc_usage(self.prunedir)
-        print "Usage should be below target:", usage
+        print("Usage should be below target:", usage)
         if (usage > 550):
             raise AssertionError("Pruning target not being met")
 
     def create_chain_with_staleblocks(self):
         # Create stale blocks in manageable sized chunks
-        print "Mine 24 (stale) blocks on Node 1, followed by 25 (main chain) block reorg from Node 0, for 12 rounds"
+        print("Mine 24 (stale) blocks on Node 1, followed by 25 (main chain) block reorg from Node 0, for 12 rounds")
 
-        for j in xrange(12):
+        for j in range(12):
             # Disconnect node 0 so it can mine a longer reorg chain without knowing about node 1's soon-to-be-stale chain
             # Node 2 stays connected, so it hears about the stale blocks and then reorg's when node0 reconnects
             # Stopping node 0 also clears its mempool, so it doesn't have node1's transactions to accidentally mine
@@ -120,7 +120,7 @@ class PruneTest(BitcoinTestFramework):
             self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=999000", "-checkblocks=5"], timewait=900)
             # Mine 24 blocks in node 1
             self.utxo = self.nodes[1].listunspent()
-            for i in xrange(24):
+            for i in range(24):
                 if j == 0:
                     self.mine_full_block(self.nodes[1],self.address[1])
                 else:
@@ -128,7 +128,7 @@ class PruneTest(BitcoinTestFramework):
 
             # Reorg back with 25 block chain from node 0
             self.utxo = self.nodes[0].listunspent()
-            for i in xrange(25): 
+            for i in range(25): 
                 self.mine_full_block(self.nodes[0],self.address[0])
 
             # Create connections in the order so both nodes can see the reorg at the same time
@@ -136,7 +136,7 @@ class PruneTest(BitcoinTestFramework):
             connect_nodes(self.nodes[2], 0)
             sync_blocks(self.nodes[0:3])
 
-        print "Usage can be over target because of high stale rate:", calc_usage(self.prunedir)
+        print("Usage can be over target because of high stale rate:", calc_usage(self.prunedir))
 
     def reorg_test(self):
         # Node 1 will mine a 300 block chain starting 287 blocks back from Node 0 and Node 2's tip
@@ -147,11 +147,11 @@ class PruneTest(BitcoinTestFramework):
         self.nodes[1]=start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
 
         height = self.nodes[1].getblockcount()
-        print "Current block height:", height
+        print("Current block height:", height)
 
         invalidheight = height-287
         badhash = self.nodes[1].getblockhash(invalidheight)
-        print "Invalidating block at height:",invalidheight,badhash
+        print("Invalidating block at height:",invalidheight,badhash)
         self.nodes[1].invalidateblock(badhash)
 
         # We've now switched to our previously mined-24 block fork on node 1, but thats not what we want
@@ -163,29 +163,29 @@ class PruneTest(BitcoinTestFramework):
             curhash = self.nodes[1].getblockhash(invalidheight - 1)
 
         assert(self.nodes[1].getblockcount() == invalidheight - 1)
-        print "New best height", self.nodes[1].getblockcount()
+        print("New best height", self.nodes[1].getblockcount())
 
         # Reboot node1 to clear those giant tx's from mempool
         stop_node(self.nodes[1],1)
         self.nodes[1]=start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
 
-        print "Generating new longer chain of 300 more blocks"
+        print("Generating new longer chain of 300 more blocks")
         self.nodes[1].generate(300)
 
-        print "Reconnect nodes"
+        print("Reconnect nodes")
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[2], 1)
         sync_blocks(self.nodes[0:3])
 
-        print "Verify height on node 2:",self.nodes[2].getblockcount()
-        print "Usage possibly still high bc of stale blocks in block files:", calc_usage(self.prunedir)
+        print("Verify height on node 2:",self.nodes[2].getblockcount())
+        print("Usage possibly still high bc of stale blocks in block files:", calc_usage(self.prunedir))
 
-        print "Mine 220 more blocks so we have requisite history (some blocks will be big and cause pruning of previous chain)"
+        print("Mine 220 more blocks so we have requisite history (some blocks will be big and cause pruning of previous chain)")
         self.nodes[0].generate(220) #node 0 has many large tx's in its mempool from the disconnects
         sync_blocks(self.nodes[0:3])
 
         usage = calc_usage(self.prunedir)
-        print "Usage should be below target:", usage
+        print("Usage should be below target:", usage)
         if (usage > 550):
             raise AssertionError("Pruning target not being met")
 
@@ -197,7 +197,7 @@ class PruneTest(BitcoinTestFramework):
             self.nodes[2].getblock(self.forkhash)
             raise AssertionError("Old block wasn't pruned so can't test redownload")
         except JSONRPCException:
-            print "Will need to redownload block",self.forkheight
+            print("Will need to redownload block",self.forkheight)
 
         # Verify that we have enough history to reorg back to the fork point
         # Although this is more than 288 blocks, because this chain was written more recently
@@ -221,14 +221,14 @@ class PruneTest(BitcoinTestFramework):
         # At this point node 2 is within 288 blocks of the fork point so it will preserve its ability to reorg
         if self.nodes[2].getblockcount() < self.mainchainheight:
             blocks_to_mine = first_reorg_height + 1 - self.mainchainheight
-            print "Rewind node 0 to prev main chain to mine longer chain to trigger redownload. Blocks needed:", blocks_to_mine
+            print("Rewind node 0 to prev main chain to mine longer chain to trigger redownload. Blocks needed:", blocks_to_mine)
             self.nodes[0].invalidateblock(curchainhash)
             assert(self.nodes[0].getblockcount() == self.mainchainheight)
             assert(self.nodes[0].getbestblockhash() == self.mainchainhash2)
             goalbesthash = self.nodes[0].generate(blocks_to_mine)[-1]
             goalbestheight = first_reorg_height + 1
 
-        print "Verify node 2 reorged back to the main chain, some blocks of which it had to redownload"
+        print("Verify node 2 reorged back to the main chain, some blocks of which it had to redownload")
         waitstart = time.time()
         while self.nodes[2].getblockcount() < goalbestheight:
             time.sleep(0.1)
@@ -241,7 +241,7 @@ class PruneTest(BitcoinTestFramework):
     def mine_full_block(self, node, address):
         # Want to create a full block
         # We'll generate a 66k transaction below, and 14 of them is close to the 1MB block limit
-        for j in xrange(14):
+        for j in range(14):
             if len(self.utxo) < 14:
                 self.utxo = node.listunspent()
             inputs=[]
@@ -265,8 +265,8 @@ class PruneTest(BitcoinTestFramework):
 
 
     def run_test(self):
-        print "Warning! This test requires 4GB of disk space and takes over 30 mins (up to 2 hours)"
-        print "Mining a big blockchain of 995 blocks"
+        print("Warning! This test requires 4GB of disk space and takes over 30 mins (up to 2 hours)")
+        print("Mining a big blockchain of 995 blocks")
         self.create_big_chain()
         # Chain diagram key:
         # *   blocks on main chain
@@ -277,12 +277,12 @@ class PruneTest(BitcoinTestFramework):
         # Start by mining a simple chain that all nodes have
         # N0=N1=N2 **...*(995)
 
-        print "Check that we haven't started pruning yet because we're below PruneAfterHeight"
+        print("Check that we haven't started pruning yet because we're below PruneAfterHeight")
         self.test_height_min()
         # Extend this chain past the PruneAfterHeight
         # N0=N1=N2 **...*(1020)
 
-        print "Check that we'll exceed disk space target if we have a very high stale block rate"
+        print("Check that we'll exceed disk space target if we have a very high stale block rate")
         self.create_chain_with_staleblocks()
         # Disconnect N0
         # And mine a 24 block chain on N1 and a separate 25 block chain on N0
@@ -306,7 +306,7 @@ class PruneTest(BitcoinTestFramework):
         self.mainchainheight = self.nodes[2].getblockcount()   #1320
         self.mainchainhash2 = self.nodes[2].getblockhash(self.mainchainheight)
 
-        print "Check that we can survive a 288 block reorg still"
+        print("Check that we can survive a 288 block reorg still")
         (self.forkheight,self.forkhash) = self.reorg_test() #(1033, )
         # Now create a 288 block reorg by mining a longer chain on N1
         # First disconnect N1
@@ -339,7 +339,7 @@ class PruneTest(BitcoinTestFramework):
         #                                 \
         #                                  *...**(1320)
 
-        print "Test that we can rerequest a block we previously pruned if needed for a reorg"
+        print("Test that we can rerequest a block we previously pruned if needed for a reorg")
         self.reorg_back()
         # Verify that N2 still has block 1033 on current chain (@), but not on main chain (*)
         # Invalidate 1033 on current chain (@) on N2 and we should be able to reorg to
@@ -359,7 +359,7 @@ class PruneTest(BitcoinTestFramework):
         #
         # N1 doesn't change because 1033 on main chain (*) is invalid
 
-        print "Done"
+        print("Done")
 
 if __name__ == '__main__':
     PruneTest().main()

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -8,7 +8,7 @@
 # that spend (directly or indirectly) coinbase transactions.
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -65,7 +65,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         errorString = ""
         try:
             rawtx   = self.nodes[2].sendrawtransaction(rawtx['hex'])
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
 
         assert_equal("Missing inputs" in errorString, True);

--- a/qa/rpc-tests/receivedby.py
+++ b/qa/rpc-tests/receivedby.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 # Exercise the listreceivedbyaddress API
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 
@@ -18,7 +18,7 @@ def get_sub_array_from_array(object_array, to_match):
     '''
     for item in object_array:
         all_match = True
-        for key,value in to_match.items():
+        for key,value in list(to_match.items()):
             if item[key] != value:
                 all_match = False
         if not all_match:
@@ -38,12 +38,12 @@ def check_array_result(object_array, to_match, expected, should_not_find = False
     num_matched = 0
     for item in object_array:
         all_match = True
-        for key,value in to_match.items():
+        for key,value in list(to_match.items()):
             if item[key] != value:
                 all_match = False
         if not all_match:
             continue
-        for key,value in expected.items():
+        for key,value in list(expected.items()):
             if item[key] != value:
                 raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
             num_matched = num_matched+1

--- a/qa/rpc-tests/regtest_signrawtransaction.py
+++ b/qa/rpc-tests/regtest_signrawtransaction.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import wait_and_assert_operationid_status

--- a/qa/rpc-tests/reindex.py
+++ b/qa/rpc-tests/reindex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,7 +7,7 @@
 # Test -reindex with CheckBlockIndex
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
@@ -31,7 +31,7 @@ class ReindexTest(BitcoinTestFramework):
         wait_bitcoinds()
         self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug", "-reindex", "-checkblockindex=1"])
         assert_equal(self.nodes[0].getblockcount(), 3)
-        print "Success"
+        print("Success")
 
 if __name__ == '__main__':
     ReindexTest().main()

--- a/qa/rpc-tests/reorg_limit.py
+++ b/qa/rpc-tests/reorg_limit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,7 +7,7 @@
 # Test reorg limit
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -19,7 +19,7 @@ from time import sleep
 
 def check_stopped(i, timeout=10):
     stopped = False
-    for x in xrange(1, timeout):
+    for x in range(1, timeout):
         ret = check_node(i)
         if ret is None:
             sleep(1)
@@ -36,39 +36,39 @@ class ReorgLimitTest(BitcoinTestFramework):
 
         self.split_network()
 
-        print "Test the maximum-allowed reorg:"
-        print "Mine 99 blocks on Node 0"
+        print("Test the maximum-allowed reorg:")
+        print("Mine 99 blocks on Node 0")
         self.nodes[0].generate(99)
         assert(self.nodes[0].getblockcount() == 299)
         assert(self.nodes[2].getblockcount() == 200)
 
-        print "Mine competing 100 blocks on Node 2"
+        print("Mine competing 100 blocks on Node 2")
         self.nodes[2].generate(100)
         assert(self.nodes[0].getblockcount() == 299)
         assert(self.nodes[2].getblockcount() == 300)
 
-        print "Connect nodes to force a reorg"
+        print("Connect nodes to force a reorg")
         connect_nodes_bi(self.nodes, 0, 2)
         self.is_network_split = False
         sync_blocks(self.nodes)
 
-        print "Check Node 0 is still running and on the correct chain"
+        print("Check Node 0 is still running and on the correct chain")
         assert(self.nodes[0].getblockcount() == 300)
 
         self.split_network()
 
-        print "Test the minimum-rejected reorg:"
-        print "Mine 100 blocks on Node 0"
+        print("Test the minimum-rejected reorg:")
+        print("Mine 100 blocks on Node 0")
         self.nodes[0].generate(100)
         assert(self.nodes[0].getblockcount() == 400)
         assert(self.nodes[2].getblockcount() == 300)
 
-        print "Mine competing 101 blocks on Node 2"
+        print("Mine competing 101 blocks on Node 2")
         self.nodes[2].generate(101)
         assert(self.nodes[0].getblockcount() == 400)
         assert(self.nodes[2].getblockcount() == 401)
 
-        print "Sync nodes to force a reorg"
+        print("Sync nodes to force a reorg")
         connect_nodes_bi(self.nodes, 0, 2)
         self.is_network_split = False
         # sync_blocks uses RPC calls to wait for nodes to be synced, so don't
@@ -76,7 +76,7 @@ class ReorgLimitTest(BitcoinTestFramework):
         # when Node 0 stops. Instead, we explicitly check for the process itself
         # to stop.
 
-        print "Check Node 0 is no longer running"
+        print("Check Node 0 is no longer running")
         assert(check_stopped(0))
 
         # Dummy stop to enable the test to tear down

--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,8 +7,6 @@
 # Test REST interface
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
-
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_greater_than, \
     initialize_chain_clean, start_nodes, connect_nodes_bi
@@ -16,17 +14,11 @@ from test_framework.util import assert_equal, assert_greater_than, \
 import struct
 import binascii
 import json
-import StringIO
+import io
 from decimal import Decimal
 
-try:
-    import http.client as httplib
-except ImportError:
-    import httplib
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import http.client
+import urllib.parse
 
 def deser_uint256(f):
     r = 0
@@ -37,17 +29,17 @@ def deser_uint256(f):
 
 # allows simple http get calls
 def http_get_call(host, port, path, response_object = 0):
-    conn = httplib.HTTPConnection(host, port)
+    conn = http.client.HTTPConnection(host, port)
     conn.request('GET', path)
 
     if response_object:
         return conn.getresponse()
 
-    return conn.getresponse().read()
+    return conn.getresponse().read().decode("utf-8")
 
 # allows simple http post calls with a request body
 def http_post_call(host, port, path, requestdata = '', response_object = 0):
-    conn = httplib.HTTPConnection(host, port)
+    conn = http.client.HTTPConnection(host, port)
     conn.request('POST', path, requestdata)
 
     if response_object:
@@ -71,8 +63,8 @@ class RESTTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        url = urlparse.urlparse(self.nodes[0].url)
-        print "Mining blocks..."
+        url = urllib.parse.urlparse(self.nodes[0].url)
+        print("Mining blocks...")
 
         self.nodes[0].generate(1)
         self.sync_all()
@@ -151,11 +143,11 @@ class RESTTest (BitcoinTestFramework):
         binaryRequest += struct.pack("i", 0);
 
         bin_response = http_post_call(url.hostname, url.port, '/rest/getutxos'+self.FORMAT_SEPARATOR+'bin', binaryRequest)
-        output = StringIO.StringIO()
+        output = io.BytesIO()
         output.write(bin_response)
         output.seek(0)
         chainHeight = struct.unpack("i", output.read(4))[0]
-        hashFromBinResponse = hex(deser_uint256(output))[2:].zfill(65).rstrip("L")
+        hashFromBinResponse = str(hex(deser_uint256(output)))[2:].zfill(64)
 
         assert_equal(bb_hash, hashFromBinResponse) # check if getutxo's chaintip during calculation was fine
         assert_equal(chainHeight, 102) # chain height must be 102
@@ -247,7 +239,7 @@ class RESTTest (BitcoinTestFramework):
         assert_equal(response_hex.status, 200)
         assert_greater_than(int(response_hex.getheader('content-length')), 354)
         response_hex_str = response_hex.read()
-        assert_equal(response_str.encode("hex")[0:354], response_hex_str[0:354])
+        assert_equal(bytes(response_str).hex()[:354].encode(), response_hex_str[:354])
 
         # compare with hex block header
         response_header_hex = http_get_call(url.hostname, url.port, '/rest/headers/1/'+bb_hash+self.FORMAT_SEPARATOR+"hex", True)
@@ -255,7 +247,7 @@ class RESTTest (BitcoinTestFramework):
         assert_greater_than(int(response_header_hex.getheader('content-length')), 354)
         response_header_hex_str = response_header_hex.read()
         assert_equal(response_hex_str[0:354], response_header_hex_str[0:354])
-        assert_equal(response_header_str.encode("hex")[0:354], response_header_hex_str[0:354])
+        assert_equal(bytes(response_header_str).hex()[0:354].encode(), response_header_hex_str[0:354])
 
         # check json format
         block_json_string = http_get_call(url.hostname, url.port, '/rest/block/'+bb_hash+self.FORMAT_SEPARATOR+'json')
@@ -265,7 +257,7 @@ class RESTTest (BitcoinTestFramework):
         # compare with json block header
         response_header_json = http_get_call(url.hostname, url.port, '/rest/headers/1/'+bb_hash+self.FORMAT_SEPARATOR+"json", True)
         assert_equal(response_header_json.status, 200)
-        response_header_json_str = response_header_json.read()
+        response_header_json_str = response_header_json.read().decode('utf-8')
         json_obj = json.loads(response_header_json_str, parse_float=Decimal)
         assert_equal(len(json_obj), 1) # ensure that there is one header in the json response
         assert_equal(json_obj[0]['hash'], bb_hash) # request/response hash should be the same
@@ -289,7 +281,7 @@ class RESTTest (BitcoinTestFramework):
         self.sync_all()
         response_header_json = http_get_call(url.hostname, url.port, '/rest/headers/5/'+bb_hash+self.FORMAT_SEPARATOR+"json", True)
         assert_equal(response_header_json.status, 200)
-        response_header_json_str = response_header_json.read()
+        response_header_json_str = response_header_json.read().decode("utf-8")
         json_obj = json.loads(response_header_json_str)
         assert_equal(len(json_obj), 5) # now we should have 5 header objects
 

--- a/qa/rpc-tests/rewind_index.py
+++ b/qa/rpc-tests/rewind_index.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \

--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -6,8 +6,6 @@
 # Test for -rpcbind, as well as -rpcallowip and -rpcconnect
 
 # Dependency: python-bitcoinrpc
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.util import assert_equal, check_json_precision, \
     initialize_chain, start_nodes, stop_nodes, wait_bitcoinds, \

--- a/qa/rpc-tests/script_test.py
+++ b/qa/rpc-tests/script_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -19,7 +19,7 @@ that flag, we use a block time before the switchover date).
 NOTE: This test is very slow and may take more than 40 minutes to run.
 '''
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.comptool import TestInstance, TestManager
@@ -83,7 +83,7 @@ def ParseScriptFlags(flag_string):
         if x in flag_map:
             flags |= flag_map[x]
         else:
-            print "Error: unrecognized script flag: ", x
+            print("Error: unrecognized script flag: ", x)
     return flags
 
 '''
@@ -107,7 +107,7 @@ def ParseScript(json_script):
                 parsed_script += CScriptNum(int(x, 0))
         elif x.startswith("0x"):
             # Raw hex data, inserted NOT pushed onto stack:
-            for i in xrange(2, len(x), 2):
+            for i in range(2, len(x), 2):
                 parsed_script = CScript(bytes(parsed_script) + bytes(chr(int(x[i:i+2],16))))
         elif x.startswith("'") and x.endswith("'") and len(x) >= 2:
             # Single-quoted string, pushed as data.
@@ -118,7 +118,7 @@ def ParseScript(json_script):
             if tryopname in OPCODES_BY_NAME:
                 parsed_script += CScriptOp(OPCODES_BY_NAME["OP_" + x])
             else:
-                print "ParseScript: error parsing '%s'" % x
+                print("ParseScript: error parsing '%s'" % x)
                 return ""
     return parsed_script
             
@@ -177,7 +177,7 @@ class ScriptTest(ComparisonTestFramework):
         self.tip = block.sha256
         test.blocks_and_transactions = [[block, True]]
 
-        for i in xrange(100):
+        for i in range(100):
             block = create_block(self.tip, create_coinbase(), self.block_time)
             self.block_time += 1
             block.solve()
@@ -211,7 +211,7 @@ class ScriptTest(ComparisonTestFramework):
         Build out to 100 blocks total, maturing the coinbase.
         '''
         test = TestInstance(objects=[], sync_every_block=False, sync_every_tx=False)
-        for i in xrange(100):
+        for i in range(100):
             b = create_block(self.tip, create_coinbase(), self.block_time)
             b.solve()
             test.blocks_and_transactions.append([b, True])
@@ -243,7 +243,7 @@ class ScriptTest(ComparisonTestFramework):
             else:
                 self.block_time = 1333230000 + counter # Before the BIP16 switchover
 
-            print "Script test: [%s]" % script_test
+            print("Script test: [%s]" % script_test)
 
             yield self.generate_test_instance(scriptpubkey, scriptsig)
             counter += 1

--- a/qa/rpc-tests/shorter_block_times.py
+++ b/qa/rpc-tests/shorter_block_times.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from decimal import Decimal
 from test_framework.test_framework import BitcoinTestFramework
@@ -27,7 +25,7 @@ class ShorterBlockTimes(BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, 4)
 
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(101)
         self.sync_all()
 
@@ -47,7 +45,7 @@ class ShorterBlockTimes(BitcoinTestFramework):
 
         self.nodes[0].generate(2)
         self.sync_all()
-        print "Mining last pre-Blossom blocks"
+        print("Mining last pre-Blossom blocks")
         # Activate blossom
         self.nodes[1].generate(1)
         self.sync_all()
@@ -55,7 +53,7 @@ class ShorterBlockTimes(BitcoinTestFramework):
         assert_equal(10, Decimal(self.nodes[1].getwalletinfo()['immature_balance']))
 
         # After blossom activation the block reward will be halved
-        print "Mining first Blossom block"
+        print("Mining first Blossom block")
         self.nodes[1].generate(1)
         self.sync_all()
         # Check that we received an additional Blossom mining reward

--- a/qa/rpc-tests/signrawtransaction_offline.py
+++ b/qa/rpc-tests/signrawtransaction_offline.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_true, initialize_chain_clean, start_node
@@ -9,7 +9,7 @@ from test_framework.authproxy import JSONRPCException
 class SignOfflineTest (BitcoinTestFramework):
     # Setup Methods
     def setup_chain(self):
-        print "Initializing test directory " + self.options.tmpdir
+        print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 2)
 
     def setup_network(self):
@@ -19,7 +19,7 @@ class SignOfflineTest (BitcoinTestFramework):
 
     # Tests
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(101)
 
         offline_node = start_node(1, self.options.tmpdir, ["-maxconnections=0", "-nuparams=2bb40e60:10"])

--- a/qa/rpc-tests/signrawtransactions.py
+++ b/qa/rpc-tests/signrawtransactions.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
@@ -38,8 +38,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
 
         outputs = {'tmJXomn8fhYy3AFqDEteifjHRMUdKtBuTGM': 0.1}
 
-        # Also test setting an expiry height of 0.
-        rawTx = self.nodes[0].createrawtransaction(inputs, outputs, 0, 0)
+        rawTx = self.nodes[0].createrawtransaction(inputs, outputs)
         rawTxSigned = self.nodes[0].signrawtransaction(rawTx, inputs, privKeys)
 
         # 1) The transaction has a complete set of signatures

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,7 +7,7 @@
 # Test fee estimation code
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import start_node, connect_nodes, \
@@ -114,7 +114,7 @@ def check_estimates(node, fees_seen, max_invalid, print_estimates = True):
         print([str(all_estimates[e-1]) for e in [1,2,3,6,15,25]])
     delta = 1.0e-6 # account for rounding error
     last_e = max(fees_seen)
-    for e in filter(lambda x: x >= 0, all_estimates):
+    for e in [x for x in all_estimates if x >= 0]:
         # Estimates should be within the bounds of what transactions fees actually were:
         if float(e)+delta < min(fees_seen) or float(e)-delta > max(fees_seen):
             raise AssertionError("Estimated fee (%f) out of range (%f,%f)"

--- a/qa/rpc-tests/spentindex.py
+++ b/qa/rpc-tests/spentindex.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 #
 # Test spentindex generation and fetching for insightexplorer
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -81,7 +80,7 @@ class SpentIndexTest(BitcoinTestFramework):
         assert_equal(tx1['vin'][0]['value'], 10)  # coinbase
         assert_equal(tx1['vin'][0]['valueSat'], 10*COIN)
         # we want the non-change (payment) output
-        vout = filter(lambda o: o['value'] == 2, tx1['vout'])
+        vout = [o for o in tx1['vout'] if o['value'] == 2]
         n = vout[0]['n']
         assert_equal(vout[0]['spentTxId'], txid2)
         assert_equal(vout[0]['spentIndex'], 0)
@@ -111,7 +110,7 @@ class SpentIndexTest(BitcoinTestFramework):
         try:
             self.nodes[1].getspentinfo({'txid': txid2, 'index': 0})
             fail('getspentinfo should have thrown an exception')
-        except JSONRPCException, e:
+        except JSONRPCException as e:
             assert_equal(e.error['message'], "Unable to get spent info")
 
         block_hash_next = self.nodes[0].generate(1)
@@ -146,7 +145,7 @@ class SpentIndexTest(BitcoinTestFramework):
 
         assert_equal(len(to_a_tx['outputs']), 2)
         # find the nonchange output, which is the payment to addr1
-        out = filter(lambda o: o['satoshis'] == 2*COIN, to_a_tx['outputs'])
+        out = [o for o in to_a_tx['outputs'] if o['satoshis'] == 2*COIN]
         assert_equal(len(out), 1)
         assert_equal(out[0]['address'], addr1)
 
@@ -178,7 +177,7 @@ class SpentIndexTest(BitcoinTestFramework):
 
         assert_equal(len(to_b_tx['outputs']), 2)
         # find the nonchange output, which is the payment to addr2
-        out = filter(lambda o: o['satoshis'] == 1*COIN, to_b_tx['outputs'])
+        out = [o for o in to_b_tx['outputs'] if o['satoshis'] == 1*COIN]
         assert_equal(len(out), 1)
         assert_equal(out[0]['address'], addr2)
 

--- a/qa/rpc-tests/sprout_sapling_migration.py
+++ b/qa/rpc-tests/sprout_sapling_migration.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from decimal import Decimal
 from test_framework.test_framework import BitcoinTestFramework
@@ -52,7 +52,10 @@ def check_migration_status(node, destination_address, migration_state):
 
 class SproutSaplingMigration(BitcoinTestFramework):
     def setup_nodes(self):
+        # Activate overwinter/sapling on all nodes
         extra_args = [[
+            '-nuparams=5ba81b19:100',  # Overwinter
+            '-nuparams=76b809bb:100',  # Sapling
         ]] * 4
         # Add migration parameters to nodes[0]
         extra_args[0] = extra_args[0] + [
@@ -60,8 +63,8 @@ class SproutSaplingMigration(BitcoinTestFramework):
             '-migrationdestaddress=' + SAPLING_ADDR,
             '-debug=zrpcunsafe'
         ]
-        assert_equal(3, len(extra_args[0]))
-        assert_equal(0, len(extra_args[1]))
+        assert_equal(5, len(extra_args[0]))
+        assert_equal(2, len(extra_args[1]))
         return start_nodes(4, self.options.tmpdir, extra_args)
 
     def setup_chain(self):
@@ -101,7 +104,7 @@ class SproutSaplingMigration(BitcoinTestFramework):
         assert_equal(target_height, result['target_height'])
         assert_equal(1, result['result']['num_tx_created'])
         assert_equal(1, len(result['result']['migration_txids']))
-        assert_true(result['result']['amount_migrated'] > Decimal('0'))
+        assert_true(Decimal(result['result']['amount_migrated']) > Decimal('0'))
 
         assert_equal(0, len(node.getrawmempool()), "mempool size at 495 % 500")
 

--- a/qa/rpc-tests/test_framework/bignum.py
+++ b/qa/rpc-tests/test_framework/bignum.py
@@ -10,7 +10,7 @@
 
 """Bignum routines"""
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 import struct
 

--- a/qa/rpc-tests/test_framework/blockstore.py
+++ b/qa/rpc-tests/test_framework/blockstore.py
@@ -3,16 +3,16 @@
 #             and for constructing a getheaders message
 #
 
-from mininode import CBlock, CBlockHeader, CBlockLocator, CTransaction, msg_block, msg_headers, msg_tx
+from .mininode import CBlock, CBlockHeader, CBlockLocator, CTransaction, msg_block, msg_headers, msg_tx
 
 import sys
-import cStringIO
-import dbm
+import io
+import dbm.ndbm
 
 class BlockStore(object):
     def __init__(self, datadir):
-        self.blockDB = dbm.open(datadir + "/blocks", 'c')
-        self.currentBlock = 0L
+        self.blockDB = dbm.ndbm.open(datadir + "/blocks", 'c')
+        self.currentBlock = 0
 
     def close(self):
         self.blockDB.close()
@@ -23,7 +23,7 @@ class BlockStore(object):
             serialized_block = self.blockDB[repr(blockhash)]
         except KeyError:
             return None
-        f = cStringIO.StringIO(serialized_block)
+        f = io.BytesIO(serialized_block)
         ret = CBlock()
         ret.deserialize(f)
         ret.calc_sha256()
@@ -62,7 +62,7 @@ class BlockStore(object):
         try:
             self.blockDB[repr(block.sha256)] = bytes(block.serialize())
         except TypeError as e:
-            print "Unexpected error: ", sys.exc_info()[0], e.args
+            print("Unexpected error: ", sys.exc_info()[0], e.args)
         self.currentBlock = block.sha256
 
     def get_blocks(self, inv):
@@ -96,7 +96,7 @@ class BlockStore(object):
 
 class TxStore(object):
     def __init__(self, datadir):
-        self.txDB = dbm.open(datadir + "/transactions", 'c')
+        self.txDB = dbm.ndbm.open(datadir + "/transactions", 'c')
 
     def close(self):
         self.txDB.close()
@@ -107,7 +107,7 @@ class TxStore(object):
             serialized_tx = self.txDB[repr(txhash)]
         except KeyError:
             return None
-        f = cStringIO.StringIO(serialized_tx)
+        f = io.BytesIO(serialized_tx)
         ret = CTransaction()
         ret.deserialize(f)
         ret.calc_sha256()
@@ -118,7 +118,7 @@ class TxStore(object):
         try:
             self.txDB[repr(tx.sha256)] = bytes(tx.serialize())
         except TypeError as e:
-            print "Unexpected error: ", sys.exc_info()[0], e.args
+            print("Unexpected error: ", sys.exc_info()[0], e.args)
 
     def get_transactions(self, inv):
         responses = []

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -4,8 +4,8 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 #
 
-from mininode import CBlock, CTransaction, CTxIn, CTxOut, COutPoint
-from script import CScript, OP_0, OP_EQUAL, OP_HASH160
+from .mininode import CBlock, CTransaction, CTxIn, CTxOut, COutPoint
+from .script import CScript, OP_0, OP_EQUAL, OP_HASH160
 
 # Create a block (with regtest difficulty)
 def create_block(hashprev, coinbase, nTime=None, nBits=None, hashFinalSaplingRoot=None):
@@ -54,11 +54,11 @@ def create_coinbase(heightAdjust = 0):
     coinbaseoutput.nValue = int(12.5*100000000)
     halvings = int((counter+heightAdjust)/150) # regtest
     coinbaseoutput.nValue >>= halvings
-    coinbaseoutput.scriptPubKey = ""
+    coinbaseoutput.scriptPubKey = b""
     coinbase.vout = [ coinbaseoutput ]
     if halvings == 0: # regtest
         froutput = CTxOut()
-        froutput.nValue = coinbaseoutput.nValue / 5
+        froutput.nValue = coinbaseoutput.nValue // 5
         # regtest
         fraddr = bytearray([0x67, 0x08, 0xe6, 0x67, 0x0d, 0xb0, 0xb9, 0x50,
                             0xda, 0xc6, 0x80, 0x31, 0x02, 0x5c, 0xc5, 0xb6,

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -1,13 +1,13 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 #
 
-from mininode import CBlock, CTransaction, CInv, NodeConn, NodeConnCB, \
+from .mininode import CBlock, CTransaction, CInv, NodeConn, NodeConnCB, \
     msg_inv, msg_getheaders, msg_ping, msg_mempool, mininode_lock, MAX_INV_SZ
-from blockstore import BlockStore, TxStore
-from util import p2p_port
+from .blockstore import BlockStore, TxStore
+from .util import p2p_port
 
 import time
 
@@ -161,7 +161,9 @@ class TestManager(object):
             # Create a p2p connection to each node
             test_node = TestNode(self.block_store, self.tx_store)
             self.test_nodes.append(test_node)
-            self.connections.append(NodeConn('127.0.0.1', p2p_port(i), nodes[i], test_node))
+            p2p_port_i = p2p_port(i)
+            NC = NodeConn('127.0.0.1', p2p_port_i, nodes[i], test_node)
+            self.connections.append(NC)
             # Make sure the TestNode (callback class) has a reference to its
             # associated NodeConn
             test_node.add_connection(self.connections[-1])
@@ -335,7 +337,7 @@ class TestManager(object):
                 if (not self.check_mempool(tx.sha256, tx_outcome)):
                     raise AssertionError("Mempool test failed at test %d" % test_number)
 
-            print "Test %d: PASS" % test_number, [ c.rpc.getblockcount() for c in self.connections ]
+            print("Test %d: PASS" % test_number, [ c.rpc.getblockcount() for c in self.connections ])
             test_number += 1
 
         [ c.disconnect_node() for c in self.connections ]

--- a/qa/rpc-tests/test_framework/equihash.py
+++ b/qa/rpc-tests/test_framework/equihash.py
@@ -1,5 +1,6 @@
 from operator import itemgetter
 import struct
+from functools import reduce
 
 DEBUG = False
 VERBOSE = False
@@ -12,8 +13,8 @@ def expand_array(inp, out_len, bit_len, byte_pad=0):
     assert bit_len >= 8 and word_size >= 7+bit_len
     bit_len_mask = (1<<bit_len)-1
 
-    out_width = (bit_len+7)/8 + byte_pad
-    assert out_len == 8*out_width*len(inp)/bit_len
+    out_width = (bit_len+7)//8 + byte_pad
+    assert out_len == 8*out_width*len(inp)//bit_len
     out = bytearray(out_len)
 
     bit_len_mask = (1 << bit_len) - 1
@@ -24,7 +25,7 @@ def expand_array(inp, out_len, bit_len, byte_pad=0):
     acc_value = 0;
 
     j = 0
-    for i in xrange(len(inp)):
+    for i in range(len(inp)):
         acc_value = ((acc_value << 8) & word_mask) | inp[i]
         acc_bits += 8
 
@@ -32,7 +33,7 @@ def expand_array(inp, out_len, bit_len, byte_pad=0):
         # output element.
         if acc_bits >= bit_len:
             acc_bits -= bit_len
-            for x in xrange(byte_pad, out_width):
+            for x in range(byte_pad, out_width):
                 out[j+x] = (
                     # Big-endian
                     acc_value >> (acc_bits+(8*(out_width-x-1)))
@@ -47,8 +48,8 @@ def expand_array(inp, out_len, bit_len, byte_pad=0):
 def compress_array(inp, out_len, bit_len, byte_pad=0):
     assert bit_len >= 8 and word_size >= 7+bit_len
 
-    in_width = (bit_len+7)/8 + byte_pad
-    assert out_len == bit_len*len(inp)/(8*in_width)
+    in_width = (bit_len+7)//8 + byte_pad
+    assert out_len == bit_len*len(inp)//(8*in_width)
     out = bytearray(out_len)
 
     bit_len_mask = (1 << bit_len) - 1
@@ -59,12 +60,12 @@ def compress_array(inp, out_len, bit_len, byte_pad=0):
     acc_value = 0;
 
     j = 0
-    for i in xrange(out_len):
+    for i in range(out_len):
         # When we have fewer than 8 bits left in the accumulator, read the next
         # input element.
         if acc_bits < 8:
             acc_value = ((acc_value << bit_len) & word_mask) | inp[j]
-            for x in xrange(byte_pad, in_width):
+            for x in range(byte_pad, in_width):
                 acc_value = acc_value | (
                     (
                         # Apply bit_len_mask across byte boundaries
@@ -80,19 +81,19 @@ def compress_array(inp, out_len, bit_len, byte_pad=0):
 
 def get_indices_from_minimal(minimal, bit_len):
     eh_index_size = 4
-    assert (bit_len+7)/8 <= eh_index_size
-    len_indices = 8*eh_index_size*len(minimal)/bit_len
-    byte_pad = eh_index_size - (bit_len+7)/8
+    assert (bit_len+7)//8 <= eh_index_size
+    len_indices = 8*eh_index_size*len(minimal)//bit_len
+    byte_pad = eh_index_size - (bit_len+7)//8
     expanded = expand_array(minimal, len_indices, bit_len, byte_pad)
     return [struct.unpack('>I', expanded[i:i+4])[0] for i in range(0, len_indices, eh_index_size)]
 
 def get_minimal_from_indices(indices, bit_len):
     eh_index_size = 4
-    assert (bit_len+7)/8 <= eh_index_size
+    assert (bit_len+7)//8 <= eh_index_size
     len_indices = len(indices)*eh_index_size
-    min_len = bit_len*len_indices/(8*eh_index_size)
-    byte_pad = eh_index_size - (bit_len+7)/8
-    byte_indices = bytearray(''.join([struct.pack('>I', i) for i in indices]))
+    min_len = bit_len*len_indices//(8*eh_index_size)
+    byte_pad = eh_index_size - (bit_len+7)//8
+    byte_indices = bytearray(b''.join([struct.pack('>I', i) for i in indices]))
     return compress_array(byte_indices, min_len, bit_len, byte_pad)
 
 
@@ -114,7 +115,7 @@ def count_zeroes(h):
     return (h+'1').index('1')
 
 def has_collision(ha, hb, i, l):
-    res = [ha[j] == hb[j] for j in range((i-1)*l/8, i*l/8)]
+    res = [ha[j] == hb[j] for j in range((i-1)*l//8, i*l//8)]
     return reduce(lambda x, y: x and y, res)
 
 def distinct_indices(a, b):
@@ -130,39 +131,39 @@ def xor(ha, hb):
 def gbp_basic(digest, n, k):
     '''Implementation of Basic Wagner's algorithm for the GBP.'''
     validate_params(n, k)
-    collision_length = n/(k+1)
+    collision_length = n//(k+1)
     hash_length = (k+1)*((collision_length+7)//8)
-    indices_per_hash_output = 512/n
+    indices_per_hash_output = 512//n
 
     # 1) Generate first list
-    if DEBUG: print 'Generating first list'
+    if DEBUG: print('Generating first list')
     X = []
-    tmp_hash = ''
+    tmp_hash = b''
     for i in range(0, 2**(collision_length+1)):
         r = i % indices_per_hash_output
         if r == 0:
             # X_i = H(I||V||x_i)
             curr_digest = digest.copy()
-            hash_xi(curr_digest, i/indices_per_hash_output)
+            hash_xi(curr_digest, i//indices_per_hash_output)
             tmp_hash = curr_digest.digest()
         X.append((
-            expand_array(bytearray(tmp_hash[r*n/8:(r+1)*n/8]),
+            expand_array(bytearray(tmp_hash[r*n//8:(r+1)*n//8]),
                          hash_length, collision_length),
             (i,)
         ))
 
     # 3) Repeat step 2 until 2n/(k+1) bits remain
     for i in range(1, k):
-        if DEBUG: print 'Round %d:' % i
+        if DEBUG: print('Round %d:' % i)
 
         # 2a) Sort the list
-        if DEBUG: print '- Sorting list'
+        if DEBUG: print('- Sorting list')
         X.sort(key=itemgetter(0))
         if DEBUG and VERBOSE:
             for Xi in X[-32:]:
-                print '%s %s' % (print_hash(Xi[0]), Xi[1])
+                print('%s %s' % (print_hash(Xi[0]), Xi[1]))
 
-        if DEBUG: print '- Finding collisions'
+        if DEBUG: print('- Finding collisions')
         Xc = []
         while len(X) > 0:
             # 2b) Find next set of unordered pairs with collisions on first n/(k+1) bits
@@ -192,13 +193,13 @@ def gbp_basic(digest, n, k):
 
     # k+1) Find a collision on last 2n(k+1) bits
     if DEBUG:
-        print 'Final round:'
-        print '- Sorting list'
+        print('Final round:')
+        print('- Sorting list')
     X.sort(key=itemgetter(0))
     if DEBUG and VERBOSE:
         for Xi in X[-32:]:
-            print '%s %s' % (print_hash(Xi[0]), Xi[1])
-    if DEBUG: print '- Finding collisions'
+            print('%s %s' % (print_hash(Xi[0]), Xi[1]))
+    if DEBUG: print('- Finding collisions')
     solns = []
     while len(X) > 0:
         j = 1
@@ -213,9 +214,9 @@ def gbp_basic(digest, n, k):
                 res = xor(X[-1-l][0], X[-1-m][0])
                 if count_zeroes(res) == 8*hash_length and distinct_indices(X[-1-l][1], X[-1-m][1]):
                     if DEBUG and VERBOSE:
-                        print 'Found solution:'
-                        print '- %s %s' % (print_hash(X[-1-l][0]), X[-1-l][1])
-                        print '- %s %s' % (print_hash(X[-1-m][0]), X[-1-m][1])
+                        print('Found solution:')
+                        print('- %s %s' % (print_hash(X[-1-l][0]), X[-1-l][1]))
+                        print('- %s %s' % (print_hash(X[-1-m][0]), X[-1-m][1]))
                     if X[-1-l][1][0] < X[-1-m][1][0]:
                         solns.append(list(X[-1-l][1] + X[-1-m][1]))
                     else:
@@ -229,14 +230,14 @@ def gbp_basic(digest, n, k):
 
 def gbp_validate(digest, minimal, n, k):
     validate_params(n, k)
-    collision_length = n/(k+1)
+    collision_length = n//(k+1)
     hash_length = (k+1)*((collision_length+7)//8)
-    indices_per_hash_output = 512/n
+    indices_per_hash_output = 512//n
     solution_width = (1 << k)*(collision_length+1)//8
 
     if len(minimal) != solution_width:
-        print 'Invalid solution length: %d (expected %d)' % \
-            (len(minimal), solution_width)
+        print('Invalid solution length: %d (expected %d)' % \
+            (len(minimal), solution_width))
         return False
 
     X = []
@@ -244,10 +245,10 @@ def gbp_validate(digest, minimal, n, k):
         r = i % indices_per_hash_output
         # X_i = H(I||V||x_i)
         curr_digest = digest.copy()
-        hash_xi(curr_digest, i/indices_per_hash_output)
+        hash_xi(curr_digest, i//indices_per_hash_output)
         tmp_hash = curr_digest.digest()
         X.append((
-            expand_array(bytearray(tmp_hash[r*n/8:(r+1)*n/8]),
+            expand_array(bytearray(tmp_hash[r*n//8:(r+1)*n//8]),
                          hash_length, collision_length),
             (i,)
         ))
@@ -256,23 +257,23 @@ def gbp_validate(digest, minimal, n, k):
         Xc = []
         for i in range(0, len(X), 2):
             if not has_collision(X[i][0], X[i+1][0], r, collision_length):
-                print 'Invalid solution: invalid collision length between StepRows'
+                print('Invalid solution: invalid collision length between StepRows')
                 return False
             if X[i+1][1][0] < X[i][1][0]:
-                print 'Invalid solution: Index tree incorrectly ordered'
+                print('Invalid solution: Index tree incorrectly ordered')
                 return False
             if not distinct_indices(X[i][1], X[i+1][1]):
-                print 'Invalid solution: duplicate indices'
+                print('Invalid solution: duplicate indices')
                 return False
             Xc.append((xor(X[i][0], X[i+1][0]), X[i][1] + X[i+1][1]))
         X = Xc
 
     if len(X) != 1:
-        print 'Invalid solution: incorrect length after end of rounds: %d' % len(X)
+        print('Invalid solution: incorrect length after end of rounds: %d' % len(X))
         return False
 
     if count_zeroes(X[0][0]) != 8*hash_length:
-        print 'Invalid solution: incorrect number of zeroes: %d' % count_zeroes(X[0][0])
+        print('Invalid solution: incorrect number of zeroes: %d' % count_zeroes(X[0][0]))
         return False
 
     return True

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -20,11 +20,12 @@
 import struct
 import socket
 import asyncore
-import binascii
 import time
 import sys
 import random
-import cStringIO
+from binascii import hexlify, unhexlify
+from io import BytesIO
+from codecs import encode
 import hashlib
 from threading import RLock
 from threading import Thread
@@ -39,13 +40,14 @@ from .equihash import (
     zcash_person,
 )
 
+
 BIP0031_VERSION = 60000
 SPROUT_PROTO_VERSION = 170002  # past bip-31 for ping/pong
 OVERWINTER_PROTO_VERSION = 170003
 SAPLING_PROTO_VERSION = 170006
 BLOSSOM_PROTO_VERSION = 170008
 
-MY_SUBVERSION = "/python-mininode-tester:0.0.1/"
+MY_SUBVERSION = b"/python-mininode-tester:0.0.1/"
 
 SPROUT_VERSION_GROUP_ID = 0x00000000
 OVERWINTER_VERSION_GROUP_ID = 0x03C48270
@@ -94,44 +96,42 @@ def deser_string(f):
         nit = struct.unpack("<Q", f.read(8))[0]
     return f.read(nit)
 
-
 def ser_string(s):
     if len(s) < 253:
-        return chr(len(s)) + s
+        return struct.pack("B", len(s)) + s
     elif len(s) < 0x10000:
-        return chr(253) + struct.pack("<H", len(s)) + s
-    elif len(s) < 0x100000000L:
-        return chr(254) + struct.pack("<I", len(s)) + s
-    return chr(255) + struct.pack("<Q", len(s)) + s
-
+        return struct.pack("<BH", 253, len(s)) + s
+    elif len(s) < 0x100000000:
+        return struct.pack("<BI", 254, len(s)) + s
+    return struct.pack("<BQ", 255, len(s)) + s
 
 def deser_uint256(f):
-    r = 0L
-    for i in xrange(8):
+    r = 0
+    for i in range(8):
         t = struct.unpack("<I", f.read(4))[0]
         r += t << (i * 32)
     return r
 
 
 def ser_uint256(u):
-    rs = ""
-    for i in xrange(8):
-        rs += struct.pack("<I", u & 0xFFFFFFFFL)
+    rs = b""
+    for i in range(8):
+        rs += struct.pack("<I", u & 0xFFFFFFFF)
         u >>= 32
     return rs
 
 
 def uint256_from_str(s):
-    r = 0L
+    r = 0
     t = struct.unpack("<IIIIIIII", s[:32])
-    for i in xrange(8):
+    for i in range(8):
         r += t[i] << (i * 32)
     return r
 
 
 def uint256_from_compact(c):
     nbytes = (c >> 24) & 0xFF
-    v = (c & 0xFFFFFFL) << (8 * (nbytes - 3))
+    v = (c & 0xFFFFFF) << (8 * (nbytes - 3))
     return v
 
 
@@ -144,7 +144,7 @@ def deser_vector(f, c):
     elif nit == 255:
         nit = struct.unpack("<Q", f.read(8))[0]
     r = []
-    for i in xrange(nit):
+    for i in range(nit):
         t = c()
         t.deserialize(f)
         r.append(t)
@@ -152,15 +152,15 @@ def deser_vector(f, c):
 
 
 def ser_vector(l):
-    r = ""
+    r = b""
     if len(l) < 253:
-        r = chr(len(l))
+        r = struct.pack("B", len(l))
     elif len(l) < 0x10000:
-        r = chr(253) + struct.pack("<H", len(l))
-    elif len(l) < 0x100000000L:
-        r = chr(254) + struct.pack("<I", len(l))
+        r = struct.pack("<BH", 253, len(l))
+    elif len(l) < 0x100000000:
+        r = struct.pack("<BI", 254, len(l))
     else:
-        r = chr(255) + struct.pack("<Q", len(l))
+        r = struct.pack("<BQ", 255, len(l))
     for i in l:
         r += i.serialize()
     return r
@@ -175,22 +175,22 @@ def deser_uint256_vector(f):
     elif nit == 255:
         nit = struct.unpack("<Q", f.read(8))[0]
     r = []
-    for i in xrange(nit):
+    for i in range(nit):
         t = deser_uint256(f)
         r.append(t)
     return r
 
 
 def ser_uint256_vector(l):
-    r = ""
+    r = b""
     if len(l) < 253:
-        r = chr(len(l))
+        r = struct.pack("B", len(l))
     elif len(l) < 0x10000:
-        r = chr(253) + struct.pack("<H", len(l))
-    elif len(l) < 0x100000000L:
-        r = chr(254) + struct.pack("<I", len(l))
+        r = struct.pack("<BH", 253, len(l))
+    elif len(l) < 0x100000000:
+        r = struct.pack("<BI", 254, len(l))
     else:
-        r = chr(255) + struct.pack("<Q", len(l))
+        r = struct.pack("<BQ", 255, len(l))
     for i in l:
         r += ser_uint256(i)
     return r
@@ -205,22 +205,22 @@ def deser_string_vector(f):
     elif nit == 255:
         nit = struct.unpack("<Q", f.read(8))[0]
     r = []
-    for i in xrange(nit):
+    for i in range(nit):
         t = deser_string(f)
         r.append(t)
     return r
 
 
 def ser_string_vector(l):
-    r = ""
+    r = b""
     if len(l) < 253:
-        r = chr(len(l))
+        r = struct.pack("B", len(l))
     elif len(l) < 0x10000:
-        r = chr(253) + struct.pack("<H", len(l))
-    elif len(l) < 0x100000000L:
-        r = chr(254) + struct.pack("<I", len(l))
+        r = struct.pack("<BH", 253, len(l))
+    elif len(l) < 0x100000000:
+        r = struct.pack("<BI", 254, len(l))
     else:
-        r = chr(255) + struct.pack("<Q", len(l))
+        r = struct.pack("<BQ", 255, len(l))
     for sv in l:
         r += ser_string(sv)
     return r
@@ -235,26 +235,25 @@ def deser_int_vector(f):
     elif nit == 255:
         nit = struct.unpack("<Q", f.read(8))[0]
     r = []
-    for i in xrange(nit):
+    for i in range(nit):
         t = struct.unpack("<i", f.read(4))[0]
         r.append(t)
     return r
 
 
 def ser_int_vector(l):
-    r = ""
+    r = b""
     if len(l) < 253:
-        r = chr(len(l))
+        r = struct.pack("B", len(l))
     elif len(l) < 0x10000:
-        r = chr(253) + struct.pack("<H", len(l))
-    elif len(l) < 0x100000000L:
-        r = chr(254) + struct.pack("<I", len(l))
+        r = struct.pack("<BH", 253, len(l))
+    elif len(l) < 0x100000000:
+        r = struct.pack("<BI", 254, len(l))
     else:
-        r = chr(255) + struct.pack("<Q", len(l))
+        r = struct.pack("<BQ", 255, len(l))
     for i in l:
         r += struct.pack("<i", i)
     return r
-
 
 def deser_char_vector(f):
     nit = struct.unpack("<B", f.read(1))[0]
@@ -265,33 +264,32 @@ def deser_char_vector(f):
     elif nit == 255:
         nit = struct.unpack("<Q", f.read(8))[0]
     r = []
-    for i in xrange(nit):
+    for i in range(nit):
         t = struct.unpack("<B", f.read(1))[0]
         r.append(t)
     return r
 
 
 def ser_char_vector(l):
-    r = ""
+    r = b""
     if len(l) < 253:
-        r = chr(len(l))
+        r = struct.pack("B", len(l))
     elif len(l) < 0x10000:
-        r = chr(253) + struct.pack("<H", len(l))
-    elif len(l) < 0x100000000L:
-        r = chr(254) + struct.pack("<I", len(l))
+        r = struct.pack("<BH", 253, len(l))
+    elif len(l) < 0x100000000:
+        r = struct.pack("<BI", 254, len(l))
     else:
-        r = chr(255) + struct.pack("<Q", len(l))
+        r = struct.pack("<BQ", 255, len(l))
     for i in l:
-        r += chr(i)
+        r += struct.pack("B", i)
     return r
-
 
 # Objects that map to bitcoind objects, which can be serialized/deserialized
 
 class CAddress(object):
     def __init__(self):
         self.nServices = 1
-        self.pchReserved = "\x00" * 10 + "\xff" * 2
+        self.pchReserved = b"\x00" * 10 + b"\xff" * 2
         self.ip = "0.0.0.0"
         self.port = 0
 
@@ -302,7 +300,7 @@ class CAddress(object):
         self.port = struct.unpack(">H", f.read(2))[0]
 
     def serialize(self):
-        r = ""
+        r = b""
         r += struct.pack("<Q", self.nServices)
         r += self.pchReserved
         r += socket.inet_aton(self.ip)
@@ -316,11 +314,11 @@ class CAddress(object):
 
 class CInv(object):
     typemap = {
-        0: "Error",
-        1: "TX",
-        2: "Block"}
+        0: b"Error",
+        1: b"TX",
+        2: b"Block"}
 
-    def __init__(self, t=0, h=0L):
+    def __init__(self, t=0, h=0):
         self.type = t
         self.hash = h
 
@@ -329,7 +327,7 @@ class CInv(object):
         self.hash = deser_uint256(f)
 
     def serialize(self):
-        r = ""
+        r = b""
         r += struct.pack("<i", self.type)
         r += ser_uint256(self.hash)
         return r
@@ -349,14 +347,14 @@ class CBlockLocator(object):
         self.vHave = deser_uint256_vector(f)
 
     def serialize(self):
-        r = ""
+        r = b""
         r += struct.pack("<i", self.nVersion)
         r += ser_uint256_vector(self.vHave)
         return r
 
     def __repr__(self):
         return "CBlockLocator(nVersion=%i vHave=%r)" \
-            % (self.nVersion, self.vHave)
+            % (self.nVersion, repr(self.vHave))
 
 
 class SpendDescription(object):
@@ -377,7 +375,7 @@ class SpendDescription(object):
         self.spendAuthSig = f.read(64)
 
     def serialize(self):
-        r = ""
+        r = b""
         r += ser_uint256(self.cv)
         r += ser_uint256(self.anchor)
         r += ser_uint256(self.nullifier)
@@ -409,7 +407,7 @@ class OutputDescription(object):
         self.zkproof = f.read(192)
 
     def serialize(self):
-        r = ""
+        r = b""
         r += ser_uint256(self.cv)
         r += ser_uint256(self.cmu)
         r += ser_uint256(self.ephemeralKey)
@@ -464,7 +462,7 @@ class ZCProof(object):
             return chr(G1_PREFIX_MASK | p['y_lsb']) + p['x']
         def ser_g2(self, p):
             return chr(G2_PREFIX_MASK | p['y_gt']) + p['x']
-        r = ""
+        r = b""
         r += ser_g1(self.g_A)
         r += ser_g1(self.g_A_prime)
         r += ser_g2(self.g_B)
@@ -548,7 +546,7 @@ class JSDescription(object):
             self.ciphertexts.append(f.read(ZC_NOTECIPHERTEXT_SIZE))
 
     def serialize(self):
-        r = ""
+        r = b""
         r += struct.pack("<q", self.vpub_old)
         r += struct.pack("<q", self.vpub_new)
         r += ser_uint256(self.anchor)
@@ -570,7 +568,6 @@ class JSDescription(object):
             % (self.vpub_old, self.vpub_new, self.anchor,
                self.onetimePubKey, self.randomSeed, self.proof)
 
-
 class COutPoint(object):
     def __init__(self, hash=0, n=0):
         self.hash = hash
@@ -581,7 +578,7 @@ class COutPoint(object):
         self.n = struct.unpack("<I", f.read(4))[0]
 
     def serialize(self):
-        r = ""
+        r = b""
         r += ser_uint256(self.hash)
         r += struct.pack("<I", self.n)
         return r
@@ -591,7 +588,7 @@ class COutPoint(object):
 
 
 class CTxIn(object):
-    def __init__(self, outpoint=None, scriptSig="", nSequence=0):
+    def __init__(self, outpoint=None, scriptSig=b"", nSequence=0):
         if outpoint is None:
             self.prevout = COutPoint()
         else:
@@ -606,20 +603,20 @@ class CTxIn(object):
         self.nSequence = struct.unpack("<I", f.read(4))[0]
 
     def serialize(self):
-        r = ""
+        r = b""
         r += self.prevout.serialize()
         r += ser_string(self.scriptSig)
         r += struct.pack("<I", self.nSequence)
         return r
 
     def __repr__(self):
-        return "CTxIn(prevout=%r scriptSig=%s nSequence=%i)" \
-            % (self.prevout, binascii.hexlify(self.scriptSig),
+        return "CTxIn(prevout=%s scriptSig=%s nSequence=%i)" \
+            % (self.prevout, hexlify(self.scriptSig),
                self.nSequence)
 
 
 class CTxOut(object):
-    def __init__(self, nValue=0, scriptPubKey=""):
+    def __init__(self, nValue=0, scriptPubKey=b""):
         self.nValue = nValue
         self.scriptPubKey = scriptPubKey
 
@@ -628,7 +625,7 @@ class CTxOut(object):
         self.scriptPubKey = deser_string(f)
 
     def serialize(self):
-        r = ""
+        r = b""
         r += struct.pack("<q", self.nValue)
         r += ser_string(self.scriptPubKey)
         return r
@@ -636,7 +633,7 @@ class CTxOut(object):
     def __repr__(self):
         return "CTxOut(nValue=%i.%08i scriptPubKey=%s)" \
             % (self.nValue // 100000000, self.nValue % 100000000,
-               binascii.hexlify(self.scriptPubKey))
+               hexlify(self.scriptPubKey))
 
 
 class CTransaction(object):
@@ -722,7 +719,7 @@ class CTransaction(object):
                        self.nVersionGroupId == SAPLING_VERSION_GROUP_ID and
                        self.nVersion == 4)
 
-        r = ""
+        r = b""
         r += struct.pack("<I", header)
         if self.fOverwintered:
             r += struct.pack("<I", self.nVersionGroupId)
@@ -749,14 +746,15 @@ class CTransaction(object):
         self.calc_sha256()
 
     def calc_sha256(self):
+        serialized = self.serialize()
         if self.sha256 is None:
-            self.sha256 = uint256_from_str(hash256(self.serialize()))
-        self.hash = hash256(self.serialize())[::-1].encode('hex_codec')
+            self.sha256 = uint256_from_str(hash256(serialized))
+        self.hash = hash256(self.serialize())[::-1].hex()
 
     def is_valid(self):
         self.calc_sha256()
         for tout in self.vout:
-            if tout.nValue < 0 or tout.nValue > 21000000L * 100000000L:
+            if tout.nValue < 0 or tout.nValue > 21000000 * 100000000:
                 return False
         return True
 
@@ -820,7 +818,7 @@ class CBlockHeader(object):
         self.hash = None
 
     def serialize(self):
-        r = ""
+        r = b""
         r += struct.pack("<i", self.nVersion)
         r += ser_uint256(self.hashPrevBlock)
         r += ser_uint256(self.hashMerkleRoot)
@@ -833,7 +831,7 @@ class CBlockHeader(object):
 
     def calc_sha256(self):
         if self.sha256 is None:
-            r = ""
+            r = b""
             r += struct.pack("<i", self.nVersion)
             r += ser_uint256(self.hashPrevBlock)
             r += ser_uint256(self.hashMerkleRoot)
@@ -843,7 +841,7 @@ class CBlockHeader(object):
             r += ser_uint256(self.nNonce)
             r += ser_char_vector(self.nSolution)
             self.sha256 = uint256_from_str(hash256(r))
-            self.hash = hash256(r)[::-1].encode('hex_codec')
+            self.hash = hash256(r)[::-1].hex()
 
     def rehash(self):
         self.sha256 = None
@@ -866,7 +864,7 @@ class CBlock(CBlockHeader):
         self.vtx = deser_vector(f, CTransaction)
 
     def serialize(self):
-        r = ""
+        r = b""
         r += super(CBlock, self).serialize()
         r += ser_vector(self.vtx)
         return r
@@ -878,7 +876,7 @@ class CBlock(CBlockHeader):
             hashes.append(ser_uint256(tx.sha256))
         while len(hashes) > 1:
             newhashes = []
-            for i in xrange(0, len(hashes), 2):
+            for i in range(0, len(hashes), 2):
                 i2 = min(i+1, len(hashes)-1)
                 newhashes.append(hash256(hashes[i] + hashes[i2]))
             hashes = newhashes
@@ -886,7 +884,7 @@ class CBlock(CBlockHeader):
 
     def is_valid(self, n=48, k=5):
         # H(I||...
-        digest = blake2b(digest_size=(512/n)*n/8, person=zcash_person(n, k))
+        digest = blake2b(digest_size=(512//n)*n//8, person=zcash_person(n, k))
         digest.update(super(CBlock, self).serialize()[:108])
         hash_nonce(digest, self.nNonce)
         if not gbp_validate(self.nSolution, digest, n, k):
@@ -905,7 +903,7 @@ class CBlock(CBlockHeader):
     def solve(self, n=48, k=5):
         target = uint256_from_compact(self.nBits)
         # H(I||...
-        digest = blake2b(digest_size=(512/n)*n/8, person=zcash_person(n, k))
+        digest = blake2b(digest_size=(512//n)*n//8, person=zcash_person(n, k))
         digest.update(super(CBlock, self).serialize()[:108])
         self.nNonce = 0
         while True:
@@ -941,9 +939,9 @@ class CUnsignedAlert(object):
         self.nMaxVer = 0
         self.setSubVer = []
         self.nPriority = 0
-        self.strComment = ""
-        self.strStatusBar = ""
-        self.strReserved = ""
+        self.strComment = b""
+        self.strStatusBar = b""
+        self.strReserved = b""
 
     def deserialize(self, f):
         self.nVersion = struct.unpack("<i", f.read(4))[0]
@@ -961,7 +959,7 @@ class CUnsignedAlert(object):
         self.strReserved = deser_string(f)
 
     def serialize(self):
-        r = ""
+        r = b""
         r += struct.pack("<i", self.nVersion)
         r += struct.pack("<q", self.nRelayUntil)
         r += struct.pack("<q", self.nExpiration)
@@ -986,15 +984,15 @@ class CUnsignedAlert(object):
 
 class CAlert(object):
     def __init__(self):
-        self.vchMsg = ""
-        self.vchSig = ""
+        self.vchMsg = b""
+        self.vchSig = b""
 
     def deserialize(self, f):
         self.vchMsg = deser_string(f)
         self.vchSig = deser_string(f)
 
     def serialize(self):
-        r = ""
+        r = b""
         r += ser_string(self.vchMsg)
         r += ser_string(self.vchSig)
         return r
@@ -1006,12 +1004,12 @@ class CAlert(object):
 
 # Objects that correspond to messages on the wire
 class msg_version(object):
-    command = "version"
+    command = b"version"
 
     def __init__(self, protocol_version=SPROUT_PROTO_VERSION):
         self.nVersion = protocol_version
         self.nServices = 1
-        self.nTime = time.time()
+        self.nTime = int(time.time())
         self.addrTo = CAddress()
         self.addrFrom = CAddress()
         self.nNonce = random.getrandbits(64)
@@ -1042,7 +1040,7 @@ class msg_version(object):
             self.nStartingHeight = None
 
     def serialize(self):
-        r = ""
+        r = b""
         r += struct.pack("<i", self.nVersion)
         r += struct.pack("<Q", self.nServices)
         r += struct.pack("<q", self.nTime)
@@ -1054,14 +1052,14 @@ class msg_version(object):
         return r
 
     def __repr__(self):
-        return 'msg_version(nVersion=%i nServices=%i nTime=%s addrTo=%r addrFrom=%r nNonce=0x%016X strSubVer=%s nStartingHeight=%i)' \
+        return 'msg_version(nVersion=%i nServices=%i nTime=%s addrTo=%s addrFrom=%s nNonce=0x%016X strSubVer=%s nStartingHeight=%i)' \
             % (self.nVersion, self.nServices, time.ctime(self.nTime),
                self.addrTo, self.addrFrom, self.nNonce,
                self.strSubVer, self.nStartingHeight)
 
 
 class msg_verack(object):
-    command = "verack"
+    command = b"verack"
 
     def __init__(self):
         pass
@@ -1070,14 +1068,14 @@ class msg_verack(object):
         pass
 
     def serialize(self):
-        return ""
+        return b""
 
     def __repr__(self):
         return "msg_verack()"
 
 
 class msg_addr(object):
-    command = "addr"
+    command = b"addr"
 
     def __init__(self):
         self.addrs = []
@@ -1093,7 +1091,7 @@ class msg_addr(object):
 
 
 class msg_alert(object):
-    command = "alert"
+    command = b"alert"
 
     def __init__(self):
         self.alert = CAlert()
@@ -1103,16 +1101,16 @@ class msg_alert(object):
         self.alert.deserialize(f)
 
     def serialize(self):
-        r = ""
+        r = b""
         r += self.alert.serialize()
         return r
 
     def __repr__(self):
-        return "msg_alert(alert=%r)" % (self.alert,)
+        return "msg_alert(alert=%s)" % (repr(self.alert), )
 
 
 class msg_inv(object):
-    command = "inv"
+    command = b"inv"
 
     def __init__(self, inv=None):
         if inv is None:
@@ -1127,14 +1125,14 @@ class msg_inv(object):
         return ser_vector(self.inv)
 
     def __repr__(self):
-        return "msg_inv(inv=%r)" % (self.inv,)
+        return "msg_inv(inv=%s)" % (repr(self.inv))
 
 
 class msg_getdata(object):
-    command = "getdata"
+    command = b"getdata"
 
-    def __init__(self):
-        self.inv = []
+    def __init__(self, inv=None):
+        self.inv = inv if inv != None else []
 
     def deserialize(self, f):
         self.inv = deser_vector(f, CInv)
@@ -1143,11 +1141,11 @@ class msg_getdata(object):
         return ser_vector(self.inv)
 
     def __repr__(self):
-        return "msg_getdata(inv=%r)" % (self.inv,)
+        return "msg_getdata(inv=%s)" % (repr(self.inv))
 
 
 class msg_notfound(object):
-    command = "notfound"
+    command = b"notfound"
 
     def __init__(self):
         self.inv = []
@@ -1163,11 +1161,11 @@ class msg_notfound(object):
 
 
 class msg_getblocks(object):
-    command = "getblocks"
+    command = b"getblocks"
 
     def __init__(self):
         self.locator = CBlockLocator()
-        self.hashstop = 0L
+        self.hashstop = 0
 
     def deserialize(self, f):
         self.locator = CBlockLocator()
@@ -1175,18 +1173,18 @@ class msg_getblocks(object):
         self.hashstop = deser_uint256(f)
 
     def serialize(self):
-        r = ""
+        r = b""
         r += self.locator.serialize()
         r += ser_uint256(self.hashstop)
         return r
 
     def __repr__(self):
-        return "msg_getblocks(locator=%r hashstop=%064x)" \
-            % (self.locator, self.hashstop)
+        return "msg_getblocks(locator=%s hashstop=%064x)" \
+            % (repr(self.locator), self.hashstop)
 
 
 class msg_tx(object):
-    command = "tx"
+    command = b"tx"
 
     def __init__(self, tx=CTransaction()):
         self.tx = tx
@@ -1198,11 +1196,11 @@ class msg_tx(object):
         return self.tx.serialize()
 
     def __repr__(self):
-        return "msg_tx(tx=%r)" % (self.tx,)
+        return "msg_tx(tx=%s)" % (repr(self.tx))
 
 
 class msg_block(object):
-    command = "block"
+    command = b"block"
 
     def __init__(self, block=None):
         if block is None:
@@ -1217,11 +1215,11 @@ class msg_block(object):
         return self.block.serialize()
 
     def __repr__(self):
-        return "msg_block(block=%r)" % (self.block,)
+        return "msg_block(block=%s)" % (repr(self.block))
 
 
 class msg_getaddr(object):
-    command = "getaddr"
+    command = b"getaddr"
 
     def __init__(self):
         pass
@@ -1230,14 +1228,14 @@ class msg_getaddr(object):
         pass
 
     def serialize(self):
-        return ""
+        return b""
 
     def __repr__(self):
         return "msg_getaddr()"
 
 
 class msg_ping_prebip31(object):
-    command = "ping"
+    command = b"ping"
 
     def __init__(self):
         pass
@@ -1246,23 +1244,23 @@ class msg_ping_prebip31(object):
         pass
 
     def serialize(self):
-        return ""
+        return b""
 
     def __repr__(self):
         return "msg_ping() (pre-bip31)"
 
 
 class msg_ping(object):
-    command = "ping"
+    command = b"ping"
 
-    def __init__(self, nonce=0L):
+    def __init__(self, nonce=0):
         self.nonce = nonce
 
     def deserialize(self, f):
         self.nonce = struct.unpack("<Q", f.read(8))[0]
 
     def serialize(self):
-        r = ""
+        r = b""
         r += struct.pack("<Q", self.nonce)
         return r
 
@@ -1271,16 +1269,16 @@ class msg_ping(object):
 
 
 class msg_pong(object):
-    command = "pong"
+    command = b"pong"
 
-    def __init__(self, nonce=0L):
+    def __init__(self, nonce=0):
         self.nonce = nonce
 
     def deserialize(self, f):
         self.nonce = struct.unpack("<Q", f.read(8))[0]
 
     def serialize(self):
-        r = ""
+        r = b""
         r += struct.pack("<Q", self.nonce)
         return r
 
@@ -1289,7 +1287,7 @@ class msg_pong(object):
 
 
 class msg_mempool(object):
-    command = "mempool"
+    command = b"mempool"
 
     def __init__(self):
         pass
@@ -1298,7 +1296,7 @@ class msg_mempool(object):
         pass
 
     def serialize(self):
-        return ""
+        return b""
 
     def __repr__(self):
         return "msg_mempool()"
@@ -1309,11 +1307,11 @@ class msg_mempool(object):
 # vector of hashes
 # hash_stop (hash of last desired block header, 0 to get as many as possible)
 class msg_getheaders(object):
-    command = "getheaders"
+    command = b"getheaders"
 
     def __init__(self):
         self.locator = CBlockLocator()
-        self.hashstop = 0L
+        self.hashstop = 0
 
     def deserialize(self, f):
         self.locator = CBlockLocator()
@@ -1321,20 +1319,20 @@ class msg_getheaders(object):
         self.hashstop = deser_uint256(f)
 
     def serialize(self):
-        r = ""
+        r = b""
         r += self.locator.serialize()
         r += ser_uint256(self.hashstop)
         return r
 
     def __repr__(self):
-        return "msg_getheaders(locator=%r, stop=%064x)" \
-            % (self.locator, self.hashstop)
+        return "msg_getheaders(locator=%s, stop=%064x)" \
+            % (repr(self.locator), self.hashstop)
 
 
 # headers message has
 # <count> <vector of block headers>
 class msg_headers(object):
-    command = "headers"
+    command = b"headers"
 
     def __init__(self):
         self.headers = []
@@ -1350,30 +1348,33 @@ class msg_headers(object):
         return ser_vector(blocks)
 
     def __repr__(self):
-        return "msg_headers(headers=%r)" % (self.headers,)
+        return "msg_headers(headers=%s)" % repr(self.headers)
 
 
 class msg_reject(object):
-    command = "reject"
+    command = b"reject"
+    REJECT_MALFORMED = 1
 
     def __init__(self):
-        self.message = ""
-        self.code = ""
-        self.reason = ""
-        self.data = 0L
+        self.message = b""
+        self.code = 0
+        self.reason = b""
+        self.data = 0
 
     def deserialize(self, f):
         self.message = deser_string(f)
         self.code = struct.unpack("<B", f.read(1))[0]
         self.reason = deser_string(f)
-        if (self.message == "block" or self.message == "tx"):
+        if (self.code != self.REJECT_MALFORMED and
+                (self.message == b"block" or self.message == b"tx")):
             self.data = deser_uint256(f)
 
     def serialize(self):
         r = ser_string(self.message)
         r += struct.pack("<B", self.code)
         r += ser_string(self.reason)
-        if (self.message == "block" or self.message == "tx"):
+        if (self.code != self.REJECT_MALFORMED and
+                (self.message == b"block" or self.message == b"tx")):
             r += ser_uint256(self.data)
         return r
 
@@ -1383,10 +1384,10 @@ class msg_reject(object):
 
 
 class msg_filteradd(object):
-    command = "filteradd"
+    command = b"filteradd"
 
     def __init__(self):
-        self.data = ""
+        self.data = b""
 
     def deserialize(self, f):
         self.data = deser_string(f)
@@ -1399,7 +1400,7 @@ class msg_filteradd(object):
 
 
 class msg_filterclear(object):
-    command = "filterclear"
+    command = b"filterclear"
 
     def __init__(self):
         pass
@@ -1408,7 +1409,7 @@ class msg_filterclear(object):
         pass
 
     def serialize(self):
-        return ""
+        return b""
 
     def __repr__(self):
         return "msg_filterclear()"
@@ -1424,23 +1425,23 @@ class NodeConnCB(object):
     # which associates the derived classes' functions to incoming messages
     def create_callback_map(self):
         self.cbmap = {
-            "version": self.on_version,
-            "verack": self.on_verack,
-            "addr": self.on_addr,
-            "alert": self.on_alert,
-            "inv": self.on_inv,
-            "getdata": self.on_getdata,
-            "notfound": self.on_notfound,
-            "getblocks": self.on_getblocks,
-            "tx": self.on_tx,
-            "block": self.on_block,
-            "getaddr": self.on_getaddr,
-            "ping": self.on_ping,
-            "pong": self.on_pong,
-            "headers": self.on_headers,
-            "getheaders": self.on_getheaders,
-            "reject": self.on_reject,
-            "mempool": self.on_mempool
+            b"version": self.on_version,
+            b"verack": self.on_verack,
+            b"addr": self.on_addr,
+            b"alert": self.on_alert,
+            b"inv": self.on_inv,
+            b"getdata": self.on_getdata,
+            b"notfound": self.on_notfound,
+            b"getblocks": self.on_getblocks,
+            b"tx": self.on_tx,
+            b"block": self.on_block,
+            b"getaddr": self.on_getaddr,
+            b"ping": self.on_ping,
+            b"pong": self.on_pong,
+            b"headers": self.on_headers,
+            b"getheaders": self.on_getheaders,
+            b"reject": self.on_reject,
+            b"mempool": self.on_mempool
         }
 
     def deliver(self, conn, message):
@@ -1448,8 +1449,8 @@ class NodeConnCB(object):
             try:
                 self.cbmap[message.command](conn, message)
             except:
-                print "ERROR delivering %r (%s)" % (message,
-                                                    sys.exc_info()[0])
+                print("ERROR delivering %r (%s)" % (message,
+                                                    sys.exc_info()[0]))
 
     def on_version(self, conn, message):
         if message.nVersion >= 209:
@@ -1493,28 +1494,28 @@ class NodeConnCB(object):
 # This class provides an interface for a p2p connection to a specified node
 class NodeConn(asyncore.dispatcher):
     messagemap = {
-        "version": msg_version,
-        "verack": msg_verack,
-        "addr": msg_addr,
-        "alert": msg_alert,
-        "inv": msg_inv,
-        "getdata": msg_getdata,
-        "notfound": msg_notfound,
-        "getblocks": msg_getblocks,
-        "tx": msg_tx,
-        "block": msg_block,
-        "getaddr": msg_getaddr,
-        "ping": msg_ping,
-        "pong": msg_pong,
-        "headers": msg_headers,
-        "getheaders": msg_getheaders,
-        "reject": msg_reject,
-        "mempool": msg_mempool
+        b"version": msg_version,
+        b"verack": msg_verack,
+        b"addr": msg_addr,
+        b"alert": msg_alert,
+        b"inv": msg_inv,
+        b"getdata": msg_getdata,
+        b"notfound": msg_notfound,
+        b"getblocks": msg_getblocks,
+        b"tx": msg_tx,
+        b"block": msg_block,
+        b"getaddr": msg_getaddr,
+        b"ping": msg_ping,
+        b"pong": msg_pong,
+        b"headers": msg_headers,
+        b"getheaders": msg_getheaders,
+        b"reject": msg_reject,
+        b"mempool": msg_mempool
     }
     MAGIC_BYTES = {
-        "mainnet": "\x24\xe9\x27\x64",   # mainnet
-        "testnet3": "\xfa\x1a\xf9\xbf",  # testnet3
-        "regtest": "\xaa\xe8\x3f\x5f"    # regtest
+        "mainnet": b"\x24\xe9\x27\x64",   # mainnet
+        "testnet3": b"\xfa\x1a\xf9\xbf",  # testnet3
+        "regtest": b"\xaa\xe8\x3f\x5f"    # regtest
     }
 
     def __init__(self, dstaddr, dstport, rpc, callback, net="regtest", protocol_version=SAPLING_PROTO_VERSION):
@@ -1523,8 +1524,8 @@ class NodeConn(asyncore.dispatcher):
         self.dstaddr = dstaddr
         self.dstport = dstport
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.sendbuf = ""
-        self.recvbuf = ""
+        self.sendbuf = b""
+        self.recvbuf = b""
         self.ver_send = 209
         self.ver_recv = 209
         self.last_sent = 0
@@ -1540,8 +1541,8 @@ class NodeConn(asyncore.dispatcher):
         vt.addrFrom.ip = "0.0.0.0"
         vt.addrFrom.port = 0
         self.send_message(vt, True)
-        print 'MiniNode: Connecting to Bitcoin Node IP # ' + dstaddr + ':' \
-            + str(dstport) + ' using version ' + str(protocol_version)
+        print('MiniNode: Connecting to Bitcoin Node IP # ' + dstaddr + ':' \
+            + str(dstport) + ' using version ' + str(protocol_version))
 
         try:
             self.connect((dstaddr, dstport))
@@ -1554,14 +1555,14 @@ class NodeConn(asyncore.dispatcher):
 
     def handle_connect(self):
         self.show_debug_msg("MiniNode: Connected & Listening: \n")
-        self.state = "connected"
+        self.state = b"connected"
 
     def handle_close(self):
         self.show_debug_msg("MiniNode: Closing Connection to %s:%d... "
                             % (self.dstaddr, self.dstport))
-        self.state = "closed"
-        self.recvbuf = ""
-        self.sendbuf = ""
+        self.state = b"closed"
+        self.recvbuf = b""
+        self.sendbuf = b""
         try:
             self.close()
         except:
@@ -1603,7 +1604,7 @@ class NodeConn(asyncore.dispatcher):
             if self.ver_recv < 209:
                 if len(self.recvbuf) < 4 + 12 + 4:
                     return
-                command = self.recvbuf[4:4+12].split("\x00", 1)[0]
+                command = self.recvbuf[4:4+12].split(b"\x00", 1)[0]
                 msglen = struct.unpack("<i", self.recvbuf[4+12:4+12+4])[0]
                 checksum = None
                 if len(self.recvbuf) < 4 + 12 + 4 + msglen:
@@ -1613,7 +1614,7 @@ class NodeConn(asyncore.dispatcher):
             else:
                 if len(self.recvbuf) < 4 + 12 + 4 + 4:
                     return
-                command = self.recvbuf[4:4+12].split("\x00", 1)[0]
+                command = self.recvbuf[4:4+12].split(b"\x00", 1)[0]
                 msglen = struct.unpack("<i", self.recvbuf[4+12:4+12+4])[0]
                 checksum = self.recvbuf[4+12+4:4+12+4+4]
                 if len(self.recvbuf) < 4 + 12 + 4 + 4 + msglen:
@@ -1625,22 +1626,23 @@ class NodeConn(asyncore.dispatcher):
                     raise ValueError("got bad checksum %r" % (self.recvbuf,))
                 self.recvbuf = self.recvbuf[4+12+4+4+msglen:]
             if command in self.messagemap:
-                f = cStringIO.StringIO(msg)
+                f = BytesIO(msg)
                 t = self.messagemap[command]()
                 t.deserialize(f)
                 self.got_message(t)
             else:
-                self.show_debug_msg("Unknown command: '%s' %r" % (command, msg))
+                self.show_debug_msg("Unknown command: '" + command + "' " +
+                                        repr(msg))
 
     def send_message(self, message, pushbuf=False):
-        if self.state != "connected" and not pushbuf:
+        if self.state != b"connected" and not pushbuf:
             return
-        self.show_debug_msg("Send %r" % (message,))
+        self.show_debug_msg("Send %s" % repr(message))
         command = message.command
         data = message.serialize()
         tmsg = self.MAGIC_BYTES[self.network]
         tmsg += command
-        tmsg += "\x00" * (12 - len(command))
+        tmsg += b"\x00" * (12 - len(command))
         tmsg += struct.pack("<I", len(data))
         if self.ver_send >= 209:
             th = sha256(data)
@@ -1652,12 +1654,12 @@ class NodeConn(asyncore.dispatcher):
             self.last_sent = time.time()
 
     def got_message(self, message):
-        if message.command == "version":
+        if message.command == b"version":
             if message.nVersion <= BIP0031_VERSION:
-                self.messagemap['ping'] = msg_ping_prebip31
+                self.messagemap[b'ping'] = msg_ping_prebip31
         if self.last_sent + 30 * 60 < time.time():
-            self.send_message(self.messagemap['ping']())
-        self.show_debug_msg("Recv %r" % (message,))
+            self.send_message(self.messagemap[b'ping']())
+        self.show_debug_msg("Recv %s" % repr(message))
         self.cb.deliver(self, message)
 
     def disconnect_node(self):

--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -45,7 +45,7 @@ def _convert_ip_port(array):
     # convert host from mangled-per-four-bytes form as used by kernel
     host = binascii.unhexlify(host)
     host_out = ''
-    for x in range(0, len(host)/4):
+    for x in range(0, len(host) // 4):
         (val,) = struct.unpack('=I', host[x*4:(x+1)*4])
         host_out += '%08x' % val
 
@@ -94,7 +94,7 @@ def all_interfaces():
     max_possible = 8 # initial value
     while True:
         bytes = max_possible * struct_size
-        names = array.array('B', '\0' * bytes)
+        names = array.array('B', b'\0' * bytes)
         outbytes = struct.unpack('iL', fcntl.ioctl(
             s.fileno(),
             0x8912,  # SIOCGIFCONF
@@ -105,7 +105,7 @@ def all_interfaces():
         else:
             break
     namestr = names.tostring()
-    return [(namestr[i:i+16].split('\0', 1)[0],
+    return [(namestr[i:i+16].split(b'\0', 1)[0],
              socket.inet_ntoa(namestr[i+20:i+24]))
             for i in range(0, outbytes, struct_size)]
 
@@ -136,7 +136,7 @@ def addr_to_hex(addr):
         addr = sub[0] + ([0] * nullbytes) + sub[1]
     else:
         raise ValueError('Could not parse address %s' % addr)
-    return binascii.hexlify(bytearray(addr))
+    return binascii.hexlify(bytearray(addr)).decode('ascii')
 
 def test_ipv6_local():
     '''

--- a/qa/rpc-tests/test_framework/script.py
+++ b/qa/rpc-tests/test_framework/script.py
@@ -12,7 +12,7 @@
 Functionality to build scripts, as well as SignatureHash().
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 from test_framework.mininode import CTransaction, CTxOut, hash256
 
@@ -658,7 +658,7 @@ class CScript(bytes):
                 other = bchr(CScriptOp(OP_0))
             else:
                 other = CScriptNum.encode(other)
-        elif isinstance(other, (int, long)):
+        elif isinstance(other, int):
             if 0 <= other <= 16:
                 other = bytes(bchr(CScriptOp.encode_op_n(other)))
             elif other == -1:
@@ -691,8 +691,6 @@ class CScript(bytes):
             def coerce_iterable(iterable):
                 for instance in iterable:
                     yield cls.__coerce_instance(instance)
-            # Annoyingly on both python2 and python3 bytes.join() always
-            # returns a bytes instance even when subclassed.
             return super(CScript, cls).__new__(cls, b''.join(coerce_iterable(value)))
 
     def raw_iter(self):

--- a/qa/rpc-tests/test_framework/socks5.py
+++ b/qa/rpc-tests/test_framework/socks5.py
@@ -4,8 +4,8 @@
 '''
 Dummy Socks5 server for testing.
 '''
-from __future__ import print_function, division, unicode_literals
-import socket, threading, Queue
+
+import socket, threading, queue
 import traceback, sys
 
 ### Protocol constants
@@ -117,7 +117,7 @@ class Socks5Connection(object):
             self.serv.queue.put(cmdin)
             print('Proxy: ', cmdin)
             # Fall through to disconnect
-        except Exception,e:
+        except Exception as e:
             traceback.print_exc(file=sys.stderr)
             self.serv.queue.put(e)
         finally:
@@ -132,7 +132,7 @@ class Socks5Server(object):
         self.s.listen(5)
         self.running = False
         self.thread = None
-        self.queue = Queue.Queue() # report connections and exceptions to client
+        self.queue = queue.Queue() # report connections and exceptions to client
 
     def run(self):
         while self.running:

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -13,8 +13,8 @@ import shutil
 import tempfile
 import traceback
 
-from authproxy import JSONRPCException
-from util import assert_equal, check_json_precision, \
+from .authproxy import JSONRPCException
+from .util import assert_equal, check_json_precision, \
     initialize_chain, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, stop_nodes, \
     sync_blocks, sync_mempools, wait_bitcoinds
@@ -126,7 +126,7 @@ class BitcoinTestFramework(object):
             print("JSONRPC error: "+e.error['message'])
             traceback.print_tb(sys.exc_info()[2])
         except AssertionError as e:
-            print("Assertion failed: "+e.message)
+            print(f"Assertion failed: {e}")
             traceback.print_tb(sys.exc_info()[2])
         except Exception as e:
             print("Unexpected exception caught during testing: "+str(e))
@@ -172,7 +172,7 @@ class ComparisonTestFramework(BitcoinTestFramework):
                           help="bitcoind binary to use for reference nodes (if any)")
 
     def setup_chain(self):
-        print "Initializing test directory "+self.options.tmpdir
+        print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     def setup_network(self):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -21,7 +21,7 @@ import subprocess
 import time
 import re
 
-from authproxy import AuthServiceProxy
+from .authproxy import AuthServiceProxy
 
 PRE_BLOSSOM_BLOCK_TARGET_SPACING = 150
 POST_BLOSSOM_BLOCK_TARGET_SPACING = 75
@@ -69,7 +69,7 @@ def sync_blocks(rpc_connections, wait=1):
 def sync_mempools(rpc_connections, wait=1):
     """
     Wait until everybody has the same transactions in their memory
-    pools, and has notified all internal listeners of them
+    pools
     """
     while True:
         pool = set(rpc_connections[0].getrawmempool())
@@ -78,14 +78,6 @@ def sync_mempools(rpc_connections, wait=1):
             if set(rpc_connections[i].getrawmempool()) == pool:
                 num_match = num_match+1
         if num_match == len(rpc_connections):
-            break
-        time.sleep(wait)
-
-    # Now that the mempools are in sync, wait for the internal
-    # notifications to finish
-    while True:
-        notified = [ x.getmempoolinfo()['fullyNotified'] for x in rpc_connections ]
-        if notified == [ True ] * len(notified):
             break
         time.sleep(wait)
 
@@ -128,16 +120,20 @@ def initialize_chain(test_dir):
     # default). Therefore, if the logic between the completion of any two
     # adjacent calls to `generate` within a test takes longer than 2.5 minutes,
     # the excess will subtract from the slack.
-    if os.path.isdir(os.path.join("cache", "node0")):
-        if os.stat("cache").st_mtime + (60 * 60) < time.time():
-            print("initialize_chain(): Removing stale cache")
-            shutil.rmtree("cache")
+    if (os.path.isdir("cache") and
+        (os.stat("cache").st_mtime + (60 * 60) < time.time()
+         or not os.path.isdir(os.path.join("cache","node0"))
+         or not os.path.isdir(os.path.join("cache","node1"))
+         or not os.path.isdir(os.path.join("cache","node2"))
+         or not os.path.isdir(os.path.join("cache","node3")))):
+        print("initialize_chain(): Removing stale or incomplete cache")
+        shutil.rmtree("cache")
 
     if not os.path.isdir(os.path.join("cache", "node0")):
         devnull = open("/dev/null", "w+")
         # Create cache directories, run bitcoinds:
         for i in range(4):
-            datadir=initialize_datadir("cache", i)
+            datadir = initialize_datadir("cache", i)
             args = [ os.getenv("BITCOIND", "bitcoind"), "-keypool=1", "-datadir="+datadir, "-discover=0" ]
             args.extend([
                 '-nuparams=5ba81b19:1', # Overwinter
@@ -147,11 +143,11 @@ def initialize_chain(test_dir):
                 args.append("-connect=127.0.0.1:"+str(p2p_port(0)))
             bitcoind_processes[i] = subprocess.Popen(args)
             if os.getenv("PYTHON_DEBUG", ""):
-                print "initialize_chain: bitcoind started, calling bitcoin-cli -rpcwait getblockcount"
+                print("initialize_chain: bitcoind started, calling bitcoin-cli -rpcwait getblockcount")
             subprocess.check_call([ os.getenv("BITCOINCLI", "bitcoin-cli"), "-datadir="+datadir,
                                     "-rpcwait", "getblockcount"], stdout=devnull)
             if os.getenv("PYTHON_DEBUG", ""):
-                print "initialize_chain: bitcoin-cli -rpcwait getblockcount completed"
+                print("initialize_chain: bitcoin-cli -rpcwait getblockcount completed")
         devnull.close()
         rpcs = []
         for i in range(4):
@@ -239,12 +235,12 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     bitcoind_processes[i] = subprocess.Popen(args)
     devnull = open("/dev/null", "w+")
     if os.getenv("PYTHON_DEBUG", ""):
-        print "start_node: bitcoind started, calling bitcoin-cli -rpcwait getblockcount"
+        print("start_node: bitcoind started, calling bitcoin-cli -rpcwait getblockcount")
     subprocess.check_call([ os.getenv("BITCOINCLI", "bitcoin-cli"), "-datadir="+datadir] +
                           _rpchost_to_args(rpchost)  +
                           ["-rpcwait", "getblockcount"], stdout=devnull)
     if os.getenv("PYTHON_DEBUG", ""):
-        print "start_node: calling bitcoin-cli -rpcwait getblockcount returned"
+        print("start_node: calling bitcoin-cli -rpcwait getblockcount returned")
     devnull.close()
     url = "http://rt:rt@%s:%d" % (rpchost or '127.0.0.1', rpc_port(i))
     if timewait is not None:
@@ -285,7 +281,7 @@ def set_node_times(nodes, t):
 
 def wait_bitcoinds():
     # Wait for all bitcoinds to cleanly exit
-    for bitcoind in bitcoind_processes.values():
+    for bitcoind in list(bitcoind_processes.values()):
         bitcoind.wait()
     bitcoind_processes.clear()
 
@@ -442,7 +438,7 @@ def fail(message=""):
 def wait_and_assert_operationid_status_result(node, myopid, in_status='success', in_errormsg=None, timeout=300):
     print('waiting for async operation {}'.format(myopid))
     result = None
-    for _ in xrange(1, timeout):
+    for _ in range(1, timeout):
         results = node.z_getoperationresult([myopid])
         if len(results) > 0:
             result = results[0]

--- a/qa/rpc-tests/test_framework/wallet_shieldcoinbase.py
+++ b/qa/rpc-tests/test_framework/wallet_shieldcoinbase.py
@@ -1,15 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, initialize_chain_clean, \
+from .test_framework import BitcoinTestFramework
+from .authproxy import JSONRPCException
+from .util import assert_equal, initialize_chain_clean, \
     start_node, connect_nodes_bi, sync_blocks, sync_mempools, \
-    wait_and_assert_operationid_status, get_coinbase_address
+    wait_and_assert_operationid_status, get_coinbase_address, fail
 
 from decimal import Decimal
 
@@ -35,7 +34,7 @@ class WalletShieldCoinbaseTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         self.nodes[0].generate(1)
         self.nodes[0].generate(4)
@@ -64,44 +63,44 @@ class WalletShieldCoinbaseTest (BitcoinTestFramework):
         self.nodes[2].importaddress(mytaddr)
         try:
             self.nodes[2].z_shieldcoinbase(mytaddr, myzaddr)
-        except JSONRPCException,e:
-            errorString = e.error['message']
-        assert_equal("Could not find any coinbase funds to shield" in errorString, True)
+            fail("Expected JSONRPCException not raised!")
+        except JSONRPCException as e:
+            assert_equal("Could not find any coinbase funds to shield" in e.error['message'], True)
 
         # Shielding will fail because fee is negative
         try:
             self.nodes[0].z_shieldcoinbase("*", myzaddr, -1)
-        except JSONRPCException,e:
-            errorString = e.error['message']
-        assert_equal("Amount out of range" in errorString, True)
+            fail("Expected JSONRPCException not raised!")
+        except JSONRPCException as e:
+            assert_equal("Amount out of range" in e.error['message'], True)
 
         # Shielding will fail because fee is larger than MAX_MONEY
         try:
             self.nodes[0].z_shieldcoinbase("*", myzaddr, Decimal('21000000.00000001'))
-        except JSONRPCException,e:
-            errorString = e.error['message']
-        assert_equal("Amount out of range" in errorString, True)
+            fail("Expected JSONRPCException not raised!")
+        except JSONRPCException as e:
+            assert_equal("Amount out of range" in e.error['message'], True)
 
         # Shielding will fail because fee is larger than sum of utxos
         try:
             self.nodes[0].z_shieldcoinbase("*", myzaddr, 999)
-        except JSONRPCException,e:
-            errorString = e.error['message']
-        assert_equal("Insufficient coinbase funds" in errorString, True)
+            fail("Expected JSONRPCException not raised!")
+        except JSONRPCException as e:
+            assert_equal("Insufficient coinbase funds" in e.error['message'], True)
 
         # Shielding will fail because limit parameter must be at least 0
         try:
             self.nodes[0].z_shieldcoinbase("*", myzaddr, Decimal('0.001'), -1)
-        except JSONRPCException,e:
-            errorString = e.error['message']
-        assert_equal("Limit on maximum number of utxos cannot be negative" in errorString, True)
+            fail("Expected JSONRPCException not raised!")
+        except JSONRPCException as e:
+            assert_equal("Limit on maximum number of utxos cannot be negative" in e.error['message'], True)
 
         # Shielding will fail because limit parameter is absurdly large
         try:
             self.nodes[0].z_shieldcoinbase("*", myzaddr, Decimal('0.001'), 99999999999999)
-        except JSONRPCException,e:
-            errorString = e.error['message']
-        assert_equal("JSON integer out of range" in errorString, True)
+            fail("Expected JSONRPCException not raised!")
+        except JSONRPCException as e:
+            assert_equal("JSON integer out of range" in e.error['message'], True)
 
         # Shield coinbase utxos from node 0 of value 40, standard fee of 0.00010000
         result = self.nodes[0].z_shieldcoinbase(mytaddr, myzaddr)

--- a/qa/rpc-tests/timestampindex.py
+++ b/qa/rpc-tests/timestampindex.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 #
 # Test timestampindex generation and fetching for insightexplorer
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 import time
 
@@ -41,7 +39,7 @@ class TimestampIndexTest(BitcoinTestFramework):
 
     def run_test(self):
         blockhashes = []
-        print "Mining blocks..."
+        print("Mining blocks...")
         for _ in range(8):
             blockhashes.extend(self.nodes[0].generate(1))
             time.sleep(1)
@@ -79,7 +77,7 @@ class TimestampIndexTest(BitcoinTestFramework):
             firsttime+10+1, firsttime,
             {'logicalTimes': True})
         ltimes = [r['logicalts'] for r in results]
-        assert_equal(ltimes, range(firsttime, firsttime+10))
+        assert_equal(ltimes, list(range(firsttime, firsttime+10)))
 
         # there's also a flag to exclude orphaned blocks; results should
         # be the same in this test

--- a/qa/rpc-tests/turnstile.py
+++ b/qa/rpc-tests/turnstile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -26,7 +26,7 @@
 # 7. Verify zcashd rejected the block
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -40,6 +40,8 @@ from test_framework.util import (
 )
 from decimal import Decimal
 
+NUPARAMS_ARGS = ['-nuparams=5ba81b19:100', # Overwinter
+                 '-nuparams=76b809bb:101'] # Sapling
 TURNSTILE_ARGS = ['-experimentalfeatures',
                   '-developersetpoolsizezero']
 
@@ -50,7 +52,8 @@ class TurnstileTest (BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, 3)
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir)
+        self.nodes = start_nodes(3, self.options.tmpdir,
+            extra_args=[NUPARAMS_ARGS] * 3)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         self.is_network_split=False
@@ -67,7 +70,7 @@ class TurnstileTest (BitcoinTestFramework):
 
     # Helper method to start a single node with extra args and sync to the network
     def start_and_sync_node(self, index, args=[]):
-        self.nodes[index] = start_node(index, self.options.tmpdir, extra_args=args)
+        self.nodes[index] = start_node(index, self.options.tmpdir, extra_args=NUPARAMS_ARGS + args)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/qa/rpc-tests/tx_expiry_helper.py
+++ b/qa/rpc-tests/tx_expiry_helper.py
@@ -9,7 +9,7 @@ from test_framework.mininode import CTransaction, NodeConnCB, mininode_lock, msg
     msg_pong
 from test_framework.util import fail
 
-import cStringIO
+import io
 import time
 
 from binascii import hexlify, unhexlify
@@ -86,13 +86,13 @@ def create_transaction(node, coinbase, to_address, amount, expiry_height):
     tx = CTransaction()
 
     # Set the expiry height
-    f = cStringIO.StringIO(unhexlify(rawtx))
+    f = io.BytesIO(unhexlify(rawtx))
     tx.deserialize(f)
     tx.nExpiryHeight = expiry_height
     rawtx = hexlify(tx.serialize())
 
     signresult = node.signrawtransaction(rawtx)
-    f = cStringIO.StringIO(unhexlify(signresult['hex']))
+    f = io.BytesIO(unhexlify(signresult['hex']))
     tx.deserialize(f)
     tx.rehash()
     return tx

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -7,7 +7,7 @@
 # Test proper accounting with malleable transactions
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, connect_nodes, \

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -29,7 +28,7 @@ class WalletTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         self.nodes[0].generate(4)
         self.sync_all()
@@ -106,7 +105,7 @@ class WalletTest (BitcoinTestFramework):
         signed_tx = self.nodes[2].signrawtransaction(raw_tx)
         try:
             self.nodes[2].sendrawtransaction(signed_tx["hex"])
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert("absurdly high fees" in errorString)
         assert("900000000 > 10000000" in errorString)
@@ -291,10 +290,10 @@ class WalletTest (BitcoinTestFramework):
         num_z_recipients = 2100
         amount_per_recipient = Decimal('0.00000001')
         errorString = ''
-        for i in xrange(0,num_t_recipients):
+        for i in range(0,num_t_recipients):
             newtaddr = self.nodes[2].getnewaddress()
             recipients.append({"address":newtaddr, "amount":amount_per_recipient})
-        for i in xrange(0,num_z_recipients):
+        for i in range(0,num_z_recipients):
             newzaddr = self.nodes[2].z_getnewaddress('sprout')
             recipients.append({"address":newzaddr, "amount":amount_per_recipient})
 
@@ -309,7 +308,7 @@ class WalletTest (BitcoinTestFramework):
 
         try:
             self.nodes[0].z_sendmany(myzaddr, recipients)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert("size of raw transaction would be larger than limit" in errorString)
 
@@ -352,9 +351,9 @@ class WalletTest (BitcoinTestFramework):
         myjoinsplit = self.nodes[2].getrawtransaction(mytxid, 1)["vjoinsplit"][0]
         assert_equal(myjoinsplit["vpub_old"], zsendmanynotevalue)
         assert_equal(myjoinsplit["vpub_new"], 0)
-        assert("onetimePubKey" in myjoinsplit.keys())
-        assert("randomSeed" in myjoinsplit.keys())
-        assert("ciphertexts" in myjoinsplit.keys())
+        assert("onetimePubKey" in list(myjoinsplit.keys()))
+        assert("randomSeed" in list(myjoinsplit.keys()))
+        assert("ciphertexts" in list(myjoinsplit.keys()))
 
         # send from private note to node 0 and node 2
         node0balance = self.nodes[0].getbalance() # 25.99794745
@@ -395,7 +394,7 @@ class WalletTest (BitcoinTestFramework):
         errorString = ""
         try:
             txId  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), "1f-4")
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
 
         assert_equal("Invalid amount" in errorString, True)
@@ -403,7 +402,7 @@ class WalletTest (BitcoinTestFramework):
         errorString = ""
         try:
             self.nodes[0].generate("2") #use a string to as block amount parameter must fail because it's not interpreted as amount
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
 
         assert_equal("not an integer" in errorString, True)
@@ -417,9 +416,9 @@ class WalletTest (BitcoinTestFramework):
         try:
             myopid = self.nodes[0].z_sendmany(myzaddr, recipients)
             assert(myopid)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
-            print errorString
+            print(errorString)
             assert(False)
 
         # This fee is larger than the default fee and since amount=0
@@ -431,7 +430,7 @@ class WalletTest (BitcoinTestFramework):
 
         try:
             myopid = self.nodes[0].z_sendmany(myzaddr, recipients, minconf, fee)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert('Small transaction amount' in errorString)
 
@@ -444,9 +443,9 @@ class WalletTest (BitcoinTestFramework):
         try:
             myopid = self.nodes[0].z_sendmany(myzaddr, recipients, minconf, fee)
             assert(myopid)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
-            print errorString
+            print(errorString)
             assert(False)
 
         # Make sure amount=0, fee=0 transaction are valid to add to mempool
@@ -459,9 +458,9 @@ class WalletTest (BitcoinTestFramework):
         try:
             myopid = self.nodes[0].z_sendmany(myzaddr, recipients, minconf, fee)
             assert(myopid)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
-            print errorString
+            print(errorString)
             assert(False)
 
 

--- a/qa/rpc-tests/wallet_1941.py
+++ b/qa/rpc-tests/wallet_1941.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2016 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 # This is a regression test for #1941.
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
@@ -44,7 +43,7 @@ class Wallet1941RegressionTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         self.nodes[0].setmocktime(starttime)
         self.nodes[0].generate(101)

--- a/qa/rpc-tests/wallet_addresses.py
+++ b/qa/rpc-tests/wallet_addresses.py
@@ -1,15 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
 # Test wallet address behaviour across network upgrades
 class WalletAddressesTest(BitcoinTestFramework):
+
 
     def run_test(self):
         def addr_checks(default_type):
@@ -32,9 +31,8 @@ class WalletAddressesTest(BitcoinTestFramework):
         # Sanity-check the test harness
         assert_equal(self.nodes[0].getblockcount(), 200)
 
-        # Current height = 200 -> Sapling
         # Default address type is Sapling
-        print "Testing height 200 (Sapling)"
+        print("Testing height 200 (Sapling)")
         addr_checks('sapling')
 
         self.nodes[0].generate(1)
@@ -42,7 +40,7 @@ class WalletAddressesTest(BitcoinTestFramework):
 
         # Current height = 201 -> Sapling
         # Default address type is Sapling
-        print "Testing height 201 (Sapling)"
+        print("Testing height 201 (Sapling)")
         addr_checks('sapling')
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/wallet_anchorfork.py
+++ b/qa/rpc-tests/wallet_anchorfork.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
@@ -27,7 +25,7 @@ class WalletAnchorForkTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(4)
         self.sync_all()
 

--- a/qa/rpc-tests/wallet_changeaddresses.py
+++ b/qa/rpc-tests/wallet_changeaddresses.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -27,7 +26,8 @@ class WalletChangeAddressesTest(BitcoinTestFramework):
         args = [
             '-nuparams=5ba81b19:1', # Overwinter
             '-nuparams=76b809bb:1', # Sapling
-            '-txindex'              # Avoid JSONRPC error: No information available about transaction
+            '-txindex',             # Avoid JSONRPC error: No information available about transaction
+            '-experimentalfeatures', '-zmergetoaddress',
         ]
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, args))
@@ -50,7 +50,6 @@ class WalletChangeAddressesTest(BitcoinTestFramework):
             recipients = [{"address": taddrSource, "amount": Decimal('2')}]
             myopid = self.nodes[0].z_sendmany(midAddr, recipients, 1, Decimal('0'))
             wait_and_assert_operationid_status(self.nodes[0], myopid)
-            self.sync_all()
             self.nodes[1].generate(1)
             self.sync_all()
 
@@ -83,13 +82,13 @@ class WalletChangeAddressesTest(BitcoinTestFramework):
         saplingAddr = self.nodes[0].z_getnewaddress('sapling')
         sproutAddr = self.nodes[0].z_getnewaddress('sprout')
 
-        print
+        print()
         print('Checking z_sendmany(taddr->Sapling)')
         check_change_taddr_reuse(saplingAddr)
-        print
+        print()
         print('Checking z_sendmany(taddr->Sprout)')
         check_change_taddr_reuse(sproutAddr)
-        print
+        print()
         print('Checking z_sendmany(taddr->taddr)')
         check_change_taddr_reuse(taddr)
 

--- a/qa/rpc-tests/wallet_changeindicator.py
+++ b/qa/rpc-tests/wallet_changeindicator.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_true, assert_false, wait_and_assert_operationid_status

--- a/qa/rpc-tests/wallet_import_export.py
+++ b/qa/rpc-tests/wallet_import_export.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_true, start_nodes

--- a/qa/rpc-tests/wallet_listnotes.py
+++ b/qa/rpc-tests/wallet_listnotes.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_true, assert_false
@@ -18,6 +17,7 @@ no_memo = 'f6' + ('0'*1022) # see section 5.5 of the protocol spec
 fee = Decimal('0.0001')
 
 class ListReceivedTest (BitcoinTestFramework):
+
 
     def generate_and_sync(self, new_height):
         current_height = self.nodes[0].getblockcount()

--- a/qa/rpc-tests/wallet_nullifiers.py
+++ b/qa/rpc-tests/wallet_nullifiers.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2016 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_true, bitcoind_processes, \
@@ -118,7 +116,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
         # Test viewing keys
 
         node3mined = Decimal('250.0')
-        assert_equal({k: Decimal(v) for k, v in self.nodes[3].z_gettotalbalance().items()}, {
+        assert_equal({k: Decimal(v) for k, v in list(self.nodes[3].z_gettotalbalance().items())}, {
             'transparent': node3mined,
             'private': zsendmany2notevalue,
             'total': node3mined + zsendmany2notevalue,
@@ -153,7 +151,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
 
         # Node 3's balances should be unchanged without explicitly requesting
         # to include watch-only balances
-        assert_equal({k: Decimal(v) for k, v in self.nodes[3].z_gettotalbalance().items()}, {
+        assert_equal({k: Decimal(v) for k, v in list(self.nodes[3].z_gettotalbalance().items())}, {
             'transparent': node3mined,
             'private': zsendmany2notevalue,
             'total': node3mined + zsendmany2notevalue,
@@ -163,7 +161,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
         # viewing key for, and therefore can't detect spends. So it sees a balance
         # corresponding to the sum of all notes the address received.
         # TODO: Fix this during the Sapling upgrade (via #2277)
-        assert_equal({k: Decimal(v) for k, v in self.nodes[3].z_gettotalbalance(1, True).items()}, {
+        assert_equal({k: Decimal(v) for k, v in list(self.nodes[3].z_gettotalbalance(1, True).items())}, {
             'transparent': node3mined + Decimal('1.0'),
             'private': zsendmany2notevalue + zsendmanynotevalue + zaddrremaining + zaddrremaining2,
             'total': node3mined + Decimal('1.0') + zsendmany2notevalue + zsendmanynotevalue + zaddrremaining + zaddrremaining2,

--- a/qa/rpc-tests/wallet_overwintertx.py
+++ b/qa/rpc-tests/wallet_overwintertx.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -112,22 +110,22 @@ class WalletOverwinterTxTest (BitcoinTestFramework):
         errorString = ""
         try:
             self.nodes[0].createrawtransaction([], {}, 0, 499999999)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert_equal("", errorString)
         try:
             self.nodes[0].createrawtransaction([], {}, 0, -1)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert_equal("Invalid parameter, expiryheight must be nonnegative and less than 500000000" in errorString, True)
         try:
             self.nodes[0].createrawtransaction([], {}, 0, 500000000)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert_equal("Invalid parameter, expiryheight must be nonnegative and less than 500000000" in errorString, True)
         try:
             self.nodes[0].createrawtransaction([], {}, 0, 200)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert_equal("Invalid parameter, expiryheight should be at least 203 to avoid transaction expiring soon" in errorString, True)
 

--- a/qa/rpc-tests/wallet_sapling.py
+++ b/qa/rpc-tests/wallet_sapling.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException

--- a/qa/rpc-tests/wallet_shieldcoinbase_sapling.py
+++ b/qa/rpc-tests/wallet_shieldcoinbase_sapling.py
@@ -1,14 +1,6 @@
-#!/usr/bin/env python
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+#!/usr/bin/env python3
 
-import inspect
-import os
-
-# To keep pyflakes happy
-WalletShieldCoinbaseTest = object
-
-cwd = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
-execfile(os.path.join(cwd, 'wallet_shieldcoinbase.py'))
+from test_framework.wallet_shieldcoinbase import WalletShieldCoinbaseTest
 
 class WalletShieldCoinbaseSapling(WalletShieldCoinbaseTest):
     def __init__(self):

--- a/qa/rpc-tests/wallet_shieldcoinbase_sprout.py
+++ b/qa/rpc-tests/wallet_shieldcoinbase_sprout.py
@@ -1,14 +1,6 @@
-#!/usr/bin/env python
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+#!/usr/bin/env python3
 
-import inspect
-import os
-
-# To keep pyflakes happy
-WalletShieldCoinbaseTest = object
-
-cwd = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
-execfile(os.path.join(cwd, 'wallet_shieldcoinbase.py'))
+from test_framework.wallet_shieldcoinbase import WalletShieldCoinbaseTest
 
 class WalletShieldCoinbaseSprout(WalletShieldCoinbaseTest):
     def __init__(self):

--- a/qa/rpc-tests/wallet_shieldingcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldingcoinbase.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2016 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -44,7 +42,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         self.nodes[0].generate(4)
         self.sync_all()
@@ -72,7 +70,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         errorString = ""
         try:
             self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert_equal("Coinbase funds can only be sent to a zaddr" in errorString, True)
 
@@ -231,7 +229,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         errorString = ""
         try:
             self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 99999)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert_equal("Insufficient funds" in errorString, True)
 
@@ -246,7 +244,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         # Send will fail because of insufficient funds unless sender uses coinbase utxos
         try:
             self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 21)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert_equal("Insufficient funds, coinbase funds can only be spent after they have been sent to a zaddr" in errorString, True)
 
@@ -261,7 +259,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         # Note that regtest chainparams does not require standard tx, so setting the amount to be
         # less than the dust threshold, e.g. 0.00000001 will not result in mempool rejection.
         start_time = timeit.default_timer()
-        for i in xrange(0,num_t_recipients):
+        for i in range(0,num_t_recipients):
             newtaddr = self.nodes[2].getnewaddress()
             recipients.append({"address":newtaddr, "amount":amount_per_recipient})
         elapsed = timeit.default_timer() - start_time
@@ -299,21 +297,21 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         # Send will fail because fee is negative
         try:
             self.nodes[0].z_sendmany(myzaddr, recipients, 1, -1)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert_equal("Amount out of range" in errorString, True)
 
         # Send will fail because fee is larger than MAX_MONEY
         try:
             self.nodes[0].z_sendmany(myzaddr, recipients, 1, Decimal('21000000.00000001'))
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert_equal("Amount out of range" in errorString, True)
 
         # Send will fail because fee is larger than sum of outputs
         try:
             self.nodes[0].z_sendmany(myzaddr, recipients, 1, (amount_per_recipient * num_t_recipients) + Decimal('0.00000001'))
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
         assert_equal("is greater than the sum of outputs" in errorString, True)
 
@@ -339,7 +337,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         send_amount = num_recipients * amount_per_recipient
         custom_fee = Decimal('0.00012345')
         zbalance = self.nodes[0].z_getbalance(myzaddr)
-        for i in xrange(0,num_recipients):
+        for i in range(0,num_recipients):
             newzaddr = self.nodes[2].z_getnewaddress('sprout')
             recipients.append({"address":newzaddr, "amount":amount_per_recipient})
         myopid = self.nodes[0].z_sendmany(myzaddr, recipients, minconf, custom_fee)

--- a/qa/rpc-tests/wallet_treestate.py
+++ b/qa/rpc-tests/wallet_treestate.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2016 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
@@ -29,7 +27,7 @@ class WalletTreeStateTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         self.nodes[0].generate(100)
         self.sync_all()
@@ -80,7 +78,7 @@ class WalletTreeStateTest (BitcoinTestFramework):
         myopid = self.nodes[0].z_sendmany(myzaddr, recipients)
 
         # Wait for Tx 2 to begin executing...
-        for x in xrange(1, 60):
+        for x in range(1, 60):
             results = self.nodes[0].z_getoperationstatus([myopid])
             status = results[0]["status"]
             if status == "executing":

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -33,7 +33,7 @@ Shutdown again, restore using importwallet,
 and confirm again balances are correct.
 """
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -74,7 +74,7 @@ class WalletBackupTest(BitcoinTestFramework):
 
     def one_send(self, from_node, to_address):
         if (randint(1,2) == 1):
-            amount = Decimal(randint(1,10)) / Decimal(10)
+            amount = Decimal(randint(1,10)) / Decimal("10")
             self.nodes[from_node].sendtoaddress(to_address, amount)
 
     def do_one_round(self):

--- a/qa/rpc-tests/zapwallettxes.py
+++ b/qa/rpc-tests/zapwallettxes.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -26,7 +26,7 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(4)
         self.sync_all()
         self.nodes[1].generate(101)
@@ -72,8 +72,8 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         aException = False
         try:
             tx3 = self.nodes[0].gettransaction(txid3)
-        except JSONRPCException,e:
-            print e
+        except JSONRPCException as e:
+            print(e)
             aException = True
 
         assert_equal(aException, True) # there must be a expection because the unconfirmed wallettx0 must be gone by now

--- a/qa/rpc-tests/zcjoinsplit.py
+++ b/qa/rpc-tests/zcjoinsplit.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Test joinsplit semantics
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, start_node, \
@@ -53,7 +53,7 @@ class JoinSplitTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
-        print "Done!"
+        print("Done!")
         receive_result = self.nodes[0].zcrawreceive(zcsecretkey, joinsplit_result["encryptednote1"])
         assert_equal(receive_result["exists"], True)
 

--- a/qa/rpc-tests/zcjoinsplitdoublespend.py
+++ b/qa/rpc-tests/zcjoinsplitdoublespend.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Tests a joinsplit double-spend and a subsequent reorg.
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -133,12 +133,12 @@ class JoinSplitTest(BitcoinTestFramework):
 
         # Wait until node[1] receives AB before we attempt to double-spend
         # with BC.
-        print "Waiting for AB_txid...\n"
+        print("Waiting for AB_txid...\n")
         while True:
             if self.txid_in_mempool(self.nodes[1], AB_txid):
                 break
             time.sleep(0.2)
-        print "Done!\n"
+        print("Done!\n")
 
         self.expect_cannot_joinsplit(self.nodes[1], joinsplit_BC["rawtxn"])
 

--- a/qa/rpc-tests/zkey_import_export.py
+++ b/qa/rpc-tests/zkey_import_export.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+
 
 from decimal import Decimal
 from test_framework.test_framework import BitcoinTestFramework
@@ -11,6 +11,7 @@ from test_framework.util import assert_equal, assert_greater_than, start_nodes,\
     initialize_chain_clean, connect_nodes_bi, wait_and_assert_operationid_status
 
 import logging
+from functools import reduce
 
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 
@@ -48,11 +49,8 @@ class ZkeyImportExportTest (BitcoinTestFramework):
         def verify_utxos(node, amts, zaddr):
             amts.sort(reverse=True)
             txs = node.z_listreceivedbyaddress(zaddr)
-
-            def cmp_confirmations_high_to_low(a, b):
-                return cmp(b["amount"], a["amount"])
-
-            txs.sort(cmp_confirmations_high_to_low)
+            txs.sort(key=lambda x: x["amount"])
+            txs.reverse()
             print("Sorted txs", txs)
             print("amts", amts)
 
@@ -94,11 +92,11 @@ class ZkeyImportExportTest (BitcoinTestFramework):
         # verify_utxos(charlie, [])
 
         # the amounts of each txn embodied which generates a single UTXO:
-        amounts = map(Decimal, ['2.3', '3.7', '0.1', '0.5', '1.0', '0.19'])
+        amounts = list(map(Decimal, ['2.3', '3.7', '0.1', '0.5', '1.0', '0.19']))
 
         # Internal test consistency assertion:
         assert_greater_than(
-            get_private_balance(alice),
+            Decimal(get_private_balance(alice)),
             reduce(Decimal.__add__, amounts))
 
         logging.info("Sending pre-export txns...")
@@ -141,7 +139,7 @@ class ZkeyImportExportTest (BitcoinTestFramework):
         verify_utxos(charlie, amounts, ipk_zaddr2["address"])
 
         # keep track of the fees incurred by bob (his sends)
-        bob_fee = Decimal(0)
+        bob_fee = Decimal("0")
 
         # Try to reproduce zombie balance reported in #1936
         # At generated zaddr, receive ZEC, and send ZEC back out. bob -> alice

--- a/qa/rpc-tests/zmq_test.py
+++ b/qa/rpc-tests/zmq_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -6,8 +6,6 @@
 #
 # Test ZMQ interface
 #
-
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, bytes_to_hex_str, start_nodes
@@ -38,7 +36,7 @@ class ZMQTest(BitcoinTestFramework):
         genhashes = self.nodes[0].generate(1)
         self.sync_all()
 
-        print "listen..."
+        print("listen...")
         msg = self.zmqSubSocket.recv_multipart()
         topic = msg[0]
         body = msg[1]

--- a/qa/zcash/create_benchmark_archive.py
+++ b/qa/zcash/create_benchmark_archive.py
@@ -30,7 +30,7 @@ LD_LIBRARY_PATH=src/leveldb python qa/zcash/create_benchmark_archive.py
 
 def check_deps():
     if subprocess.call(['which', 'find', 'xz', ZCASH_CLI], stdout=subprocess.PIPE):
-        print USAGE
+        print(USAGE)
         sys.exit()
 
 def encode_varint(n):
@@ -155,8 +155,8 @@ def deterministic_filter(tarinfo):
 
 def create_benchmark_archive(blk_hash):
     blk = json.loads(subprocess.check_output([ZCASH_CLI, 'getblock', blk_hash]))
-    print 'Height: %d' % blk['height']
-    print 'Transactions: %d' % len(blk['tx'])
+    print('Height: %d' % blk['height'])
+    print('Transactions: %d' % len(blk['tx']))
 
     os.mkdir('benchmark')
     with open('benchmark/block-%d.dat' % blk['height'], 'wb') as f:
@@ -167,26 +167,26 @@ def create_benchmark_archive(blk_hash):
 
     js_txs = len([tx for tx in txs if len(tx['vjoinsplit']) > 0])
     if js_txs:
-        print 'Block contains %d JoinSplit-containing transactions' % js_txs
+        print('Block contains %d JoinSplit-containing transactions' % js_txs)
         return
 
-    inputs = [(x['txid'], x['vout']) for tx in txs for x in tx['vin'] if x.has_key('txid')]
-    print 'Total inputs: %d' % len(inputs)
+    inputs = [(x['txid'], x['vout']) for tx in txs for x in tx['vin'] if 'txid' in x]
+    print('Total inputs: %d' % len(inputs))
 
     unique_inputs = {}
     for i in sorted(inputs):
-        if unique_inputs.has_key(i[0]):
+        if i[0] in unique_inputs:
             unique_inputs[i[0]].append(i[1])
         else:
             unique_inputs[i[0]] = [i[1]]
-    print 'Unique input transactions: %d' % len(unique_inputs)
+    print('Unique input transactions: %d' % len(unique_inputs))
 
     db_path = 'benchmark/block-%d-inputs' % blk['height']
     db = plyvel.DB(db_path, create_if_missing=True)
     wb = db.write_batch()
     bar = progressbar.ProgressBar(redirect_stdout=True)
-    print 'Collecting input coins for block'
-    for tx in bar(unique_inputs.keys()):
+    print('Collecting input coins for block')
+    for tx in bar(list(unique_inputs.keys())):
         rawtx = json.loads(subprocess.check_output([ZCASH_CLI, 'getrawtransaction', tx, '1']))
 
         mask_size = 0
@@ -254,7 +254,7 @@ def create_benchmark_archive(blk_hash):
         tar.add(name, recursive=False, filter=deterministic_filter)
     tar.close()
     subprocess.check_call(['xz', '-6', archive_name])
-    print 'Created archive %s.xz' % archive_name
+    print('Created archive %s.xz' % archive_name)
     subprocess.call(['rm', '-r', 'benchmark'])
 
 if __name__ == '__main__':

--- a/qa/zcash/create_wallet_200k_utxos.py
+++ b/qa/zcash/create_wallet_200k_utxos.py
@@ -13,7 +13,7 @@
 # - Archive the resulting /tmp/test###### directory
 #
 
-import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
+import sys; assert sys.version_info < (3,), r"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -29,7 +29,7 @@ from decimal import Decimal
 class LargeWalletTest(BitcoinTestFramework):
 
     def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
+        print(("Initializing test directory "+self.options.tmpdir))
         initialize_chain_clean(self.options.tmpdir, 2)
 
     def setup_network(self):
@@ -52,10 +52,10 @@ class LargeWalletTest(BitcoinTestFramework):
 
         self.nodes[1].generate(1)
         self.sync_all()
-        print('Node 0: %d transactions, %d UTXOs' %
-              (len(self.nodes[0].listtransactions()), len(self.nodes[0].listunspent())))
-        print('Node 1: %d transactions, %d UTXOs' %
-              (len(self.nodes[1].listtransactions()), len(self.nodes[1].listunspent())))
+        print(('Node 0: %d transactions, %d UTXOs' %
+              (len(self.nodes[0].listtransactions()), len(self.nodes[0].listunspent()))))
+        print(('Node 1: %d transactions, %d UTXOs' %
+              (len(self.nodes[1].listtransactions()), len(self.nodes[1].listunspent()))))
         assert_equal(len(self.nodes[0].listunspent()), len(inputs))
 
 if __name__ == '__main__':

--- a/qa/zcash/create_wallet_200k_utxos.py
+++ b/qa/zcash/create_wallet_200k_utxos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
@@ -12,8 +12,6 @@
 # - ./qa/pull-tester/rpc-tests.sh wallet_large --nocleanup
 # - Archive the resulting /tmp/test###### directory
 #
-
-import sys; assert sys.version_info < (3,), r"This script does not run under Python 3. Please use Python 2.7.x."
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -29,7 +27,7 @@ from decimal import Decimal
 class LargeWalletTest(BitcoinTestFramework):
 
     def setup_chain(self):
-        print(("Initializing test directory "+self.options.tmpdir))
+        print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 2)
 
     def setup_network(self):
@@ -52,10 +50,10 @@ class LargeWalletTest(BitcoinTestFramework):
 
         self.nodes[1].generate(1)
         self.sync_all()
-        print(('Node 0: %d transactions, %d UTXOs' %
-              (len(self.nodes[0].listtransactions()), len(self.nodes[0].listunspent()))))
-        print(('Node 1: %d transactions, %d UTXOs' %
-              (len(self.nodes[1].listtransactions()), len(self.nodes[1].listunspent()))))
+        print('Node 0: %d transactions, %d UTXOs' %
+              (len(self.nodes[0].listtransactions()), len(self.nodes[0].listunspent())))
+        print('Node 1: %d transactions, %d UTXOs' %
+              (len(self.nodes[1].listtransactions()), len(self.nodes[1].listunspent())))
         assert_equal(len(self.nodes[0].listunspent()), len(inputs))
 
 if __name__ == '__main__':

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Execute all of the automated tests related to Zcash.
 #
@@ -26,9 +26,9 @@ def repofile(filename):
 # Custom test runners
 #
 
-RE_RPATH_RUNPATH = re.compile('No RPATH.*No RUNPATH')
-RE_FORTIFY_AVAILABLE = re.compile('FORTIFY_SOURCE support available.*Yes')
-RE_FORTIFY_USED = re.compile('Binary compiled with FORTIFY_SOURCE support.*Yes')
+RE_RPATH_RUNPATH = re.compile(b'No RPATH.*No RUNPATH')
+RE_FORTIFY_AVAILABLE = re.compile(b'FORTIFY_SOURCE support available.*Yes')
+RE_FORTIFY_USED = re.compile(b'Binary compiled with FORTIFY_SOURCE support.*Yes')
 
 def test_rpath_runpath(filename):
     output = subprocess.check_output(
@@ -104,18 +104,18 @@ def ensure_no_dot_so_in_depends():
 
         for lib in libraries:
             if lib.find(".so") != -1:
-                print lib
+                print(lib)
                 exit_code = 1
     else:
         exit_code = 2
-        print "arch-specific build dir not present"
-        print "Did you build the ./depends tree?"
-        print "Are you on a currently unsupported architecture?"
+        print("arch-specific build dir not present")
+        print("Did you build the ./depends tree?")
+        print("Are you on a currently unsupported architecture?")
 
     if exit_code == 0:
-        print "PASS."
+        print("PASS.")
     else:
-        print "FAIL."
+        print("FAIL.")
 
     return exit_code == 0
 
@@ -132,25 +132,25 @@ def util_test():
 #
 
 STAGES = [
-    'check-depends',
     'btest',
     'gtest',
     'sec-hard',
     'no-dot-so',
     'util-test',
     'secp256k1',
+    'libsnark',
     'univalue',
     'rpc',
 ]
 
 STAGE_COMMANDS = {
-    'check-depends': ['qa/zcash/test-depends-sources-mirror.py'],
     'btest': [repofile('src/test/test_bitcoin'), '-p'],
     'gtest': [repofile('src/zcash-gtest')],
     'sec-hard': check_security_hardening,
     'no-dot-so': ensure_no_dot_so_in_depends,
     'util-test': util_test,
     'secp256k1': ['make', '-C', repofile('src/secp256k1'), 'check'],
+    'libsnark': ['make', '-C', repofile('src'), 'libsnark-tests'],
     'univalue': ['make', '-C', repofile('src/univalue'), 'check'],
     'rpc': [repofile('qa/pull-tester/rpc-tests.sh')],
 }
@@ -163,7 +163,7 @@ STAGE_COMMANDS = {
 def run_stage(stage):
     print('Running stage %s' % stage)
     print('=' * (len(stage) + 14))
-    print
+    print()
 
     cmd = STAGE_COMMANDS[stage]
     if type(cmd) == type([]):
@@ -171,10 +171,10 @@ def run_stage(stage):
     else:
         ret = cmd()
 
-    print
+    print()
     print('-' * (len(stage) + 15))
     print('Finished stage %s' % stage)
-    print
+    print()
 
     return ret
 

--- a/qa/zcash/test-depends-sources-mirror.py
+++ b/qa/zcash/test-depends-sources-mirror.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
-# This script tests that the package mirror at https://download.z.cash/depends-sources/
+# This script tests that the package mirror at https://z.cash/depends-sources/
 # contains all of the packages required to build this version of Zcash.
 #
 # This script assumes you've just built Zcash, and that as a result of that
@@ -12,32 +12,29 @@ import sys
 import os
 import requests
 
-MIRROR_URL_DIR="https://download.z.cash/depends-sources/"
+MIRROR_URL_DIR="https://z.cash/depends-sources/"
 DEPENDS_SOURCES_DIR=os.path.realpath(os.path.join(
     os.path.dirname(__file__),
     "..", "..", "depends", "sources"
 ))
 
 def get_depends_sources_list():
-    return filter(
-	lambda f: os.path.isfile(os.path.join(DEPENDS_SOURCES_DIR, f)),
-	os.listdir(DEPENDS_SOURCES_DIR)
-    )
+    return [f for f in os.listdir(DEPENDS_SOURCES_DIR) if os.path.isfile(os.path.join(DEPENDS_SOURCES_DIR, f))]
 
 for filename in get_depends_sources_list():
     resp = requests.head(MIRROR_URL_DIR + filename)
 
-    print "Checking [" + filename + "] ..."
+    print("Checking [" + filename + "] ...")
 
     if resp.status_code != 200:
-	print "FAIL. File not found on server: " + filename
+	print("FAIL. File not found on server: " + filename)
 	sys.exit(1)
 
     expected_size = os.path.getsize(os.path.join(DEPENDS_SOURCES_DIR, filename))
     server_size = int(resp.headers['Content-Length'])
     if expected_size != server_size:
-	print "FAIL. On the server, %s is %d bytes, but locally it is %d bytes." % (filename, server_size, expected_size)
+	print("FAIL. On the server, %s is %d bytes, but locally it is %d bytes." % (filename, server_size, expected_size))
 	sys.exit(1)
 
-print "PASS."
+print("PASS.")
 sys.exit(0)


### PR DESCRIPTION
When executed with the `zcash/qa/pull-tester/rpc-tests.sh` script the Python code in the `zcash/qa/rpc-tests` directory, and subdirectories, runs under Python 3.5.3.

I tried to _only_ make changes that were necessary for this goal, and nothing else (like causing `BitcoinTestFramework` to inherit from `unittest.TestCase`, deduplicating repeated code, replacing bespoke components with standard solutions, etc.)

I've begun collecting ideas related to such potential improvements here:

https://github.com/zcash/zcash/issues/4076  <- (Note: This "improvement list" is, itself, much in need of improvement.)
