### PR TITLE
#4114 Don't call GetSpentIndex() when converting txs to JSON if spent index is disabled

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1633,7 +1633,7 @@ bool GetSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value)
 {
     AssertLockHeld(cs_main);
     if (!fSpentIndex)
-        return error("spent index not enabled");
+        return false;
     if (mempool.getSpentIndex(key, value))
         return true;
     return pblocktree->ReadSpentIndex(key, value);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1633,10 +1633,15 @@ bool GetSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value)
 {
     AssertLockHeld(cs_main);
     if (!fSpentIndex)
-        return false;
+        return error("Spent index not enabled");
+
     if (mempool.getSpentIndex(key, value))
         return true;
-    return pblocktree->ReadSpentIndex(key, value);
+
+    if (!pblocktree->ReadSpentIndex(key, value))
+        return error("Unable to get spent index information");
+
+    return true;
 }
 
 bool GetAddressIndex(const uint160& addressHash, int type,

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -176,7 +176,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
             // Add address and value info if spentindex enabled
             CSpentIndexValue spentInfo;
             CSpentIndexKey spentKey(txin.prevout.hash, txin.prevout.n);
-            if (GetSpentIndex(spentKey, spentInfo)) {
+            if (fSpentIndex && GetSpentIndex(spentKey, spentInfo)) {
                 in.push_back(Pair("value", ValueFromAmount(spentInfo.satoshis)));
                 in.push_back(Pair("valueSat", spentInfo.satoshis));
 
@@ -206,7 +206,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
         // Add spent information if spentindex is enabled
         CSpentIndexValue spentInfo;
         CSpentIndexKey spentKey(txid, i);
-        if (GetSpentIndex(spentKey, spentInfo)) {
+        if (fSpentIndex && GetSpentIndex(spentKey, spentInfo)) {
             out.push_back(Pair("spentTxId", spentInfo.txid.GetHex()));
             out.push_back(Pair("spentIndex", (int)spentInfo.inputIndex));
             out.push_back(Pair("spentHeight", spentInfo.blockHeight));


### PR DESCRIPTION
Closes #4114.