### PR TITLE
Change Debian package description

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -17,5 +17,6 @@ Description: Zcash libraries and tools
  Based on Bitcoin's code, it intends to offer a far higher standard
  of privacy and anonymity through a sophisticiated zero-knowledge
  proving scheme which preserves confidentiality of transaction metadata.
+ Think of it as HTTPS for money.
  This package provides the daemon, zcashd, and the CLI tool,
- zcash-cli, to interact with the daemon. Think of it as HTTPS for money.
+ zcash-cli, to interact with the daemon.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -13,9 +13,9 @@ Vcs-Browser: https://github.com/zcash/zcash
 Package: zcash
 Architecture: amd64
 Depends: ${shlibs:Depends}
-Description: HTTPS for money.
+Description: Zcash libraries and tools
  Based on Bitcoin's code, it intends to offer a far higher standard
  of privacy and anonymity through a sophisticiated zero-knowledge
  proving scheme which preserves confidentiality of transaction metadata.
  This package provides the daemon, zcashd, and the CLI tool,
- zcash-cli, to interact with the daemon.
+ zcash-cli, to interact with the daemon. Think of it as HTTPS for money.


### PR DESCRIPTION
Some GUI Debian package managers only show the first line of the description. This PR alters the description to indicate that this is a Zcash package.