### PR TITLE
Deferred initialization of EmptyMerklePath structures till first use …

### DIFF
--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -59,16 +59,14 @@ template<size_t Depth, typename Hash>
 class EmptyMerkleRoots {
 public:
     void initialize() {
+        LOCK(cs);
         if (!initialized) {
-     LOCK(cs_EmptyMerkleRoots_private_variables_write);
-          if (!initialized) {
             empty_roots.at(0) = Hash::uncommitted();
             for (size_t d = 1; d <= Depth; d++) {
                 empty_roots.at(d) = Hash::combine(empty_roots.at(d-1), empty_roots.at(d-1), d-1);
             }
             initialized = true;
-          }
-       }
+        }
     }
     EmptyMerkleRoots() { initialized = false; }
     Hash empty_root(size_t depth) {
@@ -79,9 +77,9 @@ public:
     friend bool operator==(const EmptyMerkleRoots<D, H>& a,
                            const EmptyMerkleRoots<D, H>& b);
 private:
-    CCriticalSection cs_EmptyMerkleRoots_private_variables_write;
-    bool initialized;
-    std::array<Hash, Depth+1> empty_roots;
+    CCriticalSection cs;
+    mutable bool initialized;
+    mutable std::array<Hash, Depth+1> empty_roots;
 };
 
 template<size_t Depth, typename Hash>

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -58,7 +58,7 @@ public:
 template<size_t Depth, typename Hash>
 class EmptyMerkleRoots {
 public:
-    void initialize() {
+    void initialize() const {
         LOCK(cs);
         if (!initialized) {
             empty_roots.at(0) = Hash::uncommitted();

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -69,7 +69,7 @@ public:
         }
     }
     EmptyMerkleRoots() { initialized = false; }
-    Hash empty_root(size_t depth) {
+     Hash empty_root(size_t depth) const {
         initialize();
         return empty_roots.at(depth);
     }


### PR DESCRIPTION
…to reduce monolith startup penalty for fuzzing. These structures were previously filled statically at load time.

The performance cost of monolith startup even with an alternative main function is significant when you're loading it many times. 

Notes on the approach to fuzzing (why do this patch?):

Yes there are other ways to write fuzzers, but their cost is also higher than necessary. This allows us to access any namespace we need within the monolith and know that at least the build requisites are available without having to do a lot of mocking, shimming, etc.. for each fuzzer.

Notes on the structure of the change:

Larry convinced me to use "LOCK" in the end, which meant bringing in another header. I've added optimization around the lock so that it's not needed every time.

I've added calls to initialize into the comparison operator as well as the accessor. I think that's all the places that are relevant.