### PR TITLE
WIP:  add code to provision ec2

### DIFF
--- a/contrib/ci-workers/provisionec2/.gitignore
+++ b/contrib/ci-workers/provisionec2/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/*

--- a/contrib/ci-workers/provisionec2/Cargo.toml
+++ b/contrib/ci-workers/provisionec2/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "provisionec2"
+version = "0.1.0"
+authors = ["Za Wilcox <zancas@protonmail.com>"]
+edition = "2018"
+
+[dependencies]
+rusoto_ec2 = {version = "0.40.0"}
+rusoto_core = {version = "0.40.0"}

--- a/contrib/ci-workers/provisionec2/provision_ec2.sh_template
+++ b/contrib/ci-workers/provisionec2/provision_ec2.sh_template
@@ -1,11 +1,13 @@
 #! /usr/bin/env bash
-RUST_BACKTRACE={{ Make this 1, or just delete this line. }} \
-PRIVATE_SSH_KEY={{ The absolute path to the ec2 ssh private key. }} \
-AWS_ACCESS_KEY_ID={{ Get this from your AWS account. }} \
-AWS_SECRET_ACCESS_KEY={{ Get this from your AWS account. }} \\
-BBMASTER_HOSTNAME={{ e.g. dev-ci.z.cash }}\
-BBMASTER_PORT={{ e.g. 9899 }} \
-BB_WORKER_ADMIN={{  I DON\'T KNOW }} \
-BB_WORKER_NAME={{ must match master.cfg   c[\'workers\'] element }} \
-BB_WORKER_PASS={{ must match master.cfg   c[\'workers\'] element }} \
+RUST_BACKTRACE=1 \
+PRIVATE_SSH_KEY=`pwd`/YOUR_AWS_SSHKEY_NAME \
+AWS_ACCESS_KEY_ID=REDACTED_YOUR_AWS_ACCESS_KEY_ID \
+AWS_SECRET_ACCESS_KEY=REDACTED_YOUR_AWS_SECRET_KEY \
+BBMASTER_HOSTNAME=bbmaster.zingolabs.com \
+BBMASTER_PORT=9989 \
+BB_WORKER_ADMIN=ec2test \
+BB_WORKER_NAME=ec2test \
+BB_WORKER_PASS=REDACTED_NEEDS_TO_MATCH_MASTERCFG \
+AMI_ID=ami-0b3c43897b5d26f4a \
+INSTANCE_TYPE=m5.4xlarge \
 cargo run

--- a/contrib/ci-workers/provisionec2/provision_ec2.sh_template
+++ b/contrib/ci-workers/provisionec2/provision_ec2.sh_template
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+RUST_BACKTRACE={{ Make this 1, or just delete this line. }} \
+PRIVATE_SSH_KEY={{ The absolute path to the ec2 ssh private key. }} \
+AWS_ACCESS_KEY_ID={{ Get this from your AWS account. }} \
+AWS_SECRET_ACCESS_KEY={{ Get this from your AWS account. }} \\
+BBMASTER_HOSTNAME={{ e.g. dev-ci.z.cash }}\
+BBMASTER_PORT={{ e.g. 9899 }} \
+BB_WORKER_ADMIN={{  I DON\'T KNOW }} \
+BB_WORKER_NAME={{ must match master.cfg   c[\'workers\'] element }} \
+BB_WORKER_PASS={{ must match master.cfg   c[\'workers\'] element }} \
+cargo run

--- a/contrib/ci-workers/provisionec2/src/bin/provision.rs
+++ b/contrib/ci-workers/provisionec2/src/bin/provision.rs
@@ -55,12 +55,17 @@ fn main() {
     std::fs::write("vars/rusoto_provision.yml", rusoto_provision_yaml);
     let client = rusoto_ec2::Ec2Client::new(rusoto_core::Region::UsEast2);
     let key_pathname = &std::env::var("PRIVATE_SSH_KEY").unwrap();
+    let key_filepath = *key_pathname
+        .split("/")
+        .collect::<Vec<&str>>()
+        .last()
+        .unwrap();
     let run_instance_request = rusoto_ec2::RunInstancesRequest {
         dry_run: Some(false),
         image_id: Some(String::from("ami-0b3c43897b5d26f4a")),
         min_count: 1,
         max_count: 1,
-        key_name: Some(String::from(key_pathname)),
+        key_name: Some(String::from(key_filepath)),
         instance_type: Some(String::from("m5.4xlarge")),
         tag_specifications: Some(vec![TagSpecification {
             resource_type: Some(String::from("instance")),

--- a/contrib/ci-workers/provisionec2/src/bin/provision.rs
+++ b/contrib/ci-workers/provisionec2/src/bin/provision.rs
@@ -1,0 +1,161 @@
+#![deny(unsafe_code)]
+const INVENTORY_TEMPLATE_PREFIX: &str = "
+all:
+  hosts:
+    zcash-ci-worker-unix:
+      ansible_host: ";
+const INVENTORY_TEMPLATE_SUFFIX: &str = "
+      ansible_ssh_user: ubuntu";
+
+const BBCONFIG_TEMPLATE_PREFIX: &str = "
+---
+buildbot_worker_user: zcbbworker
+buildbot_master_host: ";
+const BBCONFIG_TEMPLATE_INFIX: &str = "
+buildbot_master_port: ";
+const BBCONFIG_TEMPLATE_SUFFIX: &str = "
+buildbot_worker_host_template: templates/host.j2";
+
+const RUSOTO_PROVISION_VARS_TEMPLATE_PREFIX: &str = "
+---
+buildbot_worker_admin: ";
+const RUSOTO_PROVISION_VARS_TEMPLATE_INFIX: &str = "
+buildbot_worker_name: ";
+const RUSOTO_PROVISION_VARS_TEMPLATE_SUFFIX: &str = "
+buildbot_worker_password: ";
+use rusoto_ec2::{
+    DescribeInstancesRequest, DescribeInstancesResult, Ec2, Filter, Reservation, Tag,
+    TagSpecification,
+};
+fn main() {
+    let current_dir = std::env::current_dir().expect("Couldn't create current dir PathBuf");
+    let parent_dir = current_dir
+        .parent()
+        .expect("Couldn't create parent dir PathBuf!");
+    println!("{:#?}", parent_dir);
+    std::env::set_current_dir(parent_dir);
+    let bb_yaml = format!(
+        "{}{}{}{}{}",
+        BBCONFIG_TEMPLATE_PREFIX,
+        std::env::var("BBMASTER_HOSTNAME").expect("Unable to determine bbmaster hostname!"),
+        BBCONFIG_TEMPLATE_INFIX,
+        std::env::var("BBMASTER_PORT").expect("Unable to determine bbmaster port!"),
+        BBCONFIG_TEMPLATE_SUFFIX
+    );
+    std::fs::write("vars/buildbot.yml", bb_yaml);
+    let rusoto_provision_yaml = format!(
+        "{}{}{}{}{}{}",
+        RUSOTO_PROVISION_VARS_TEMPLATE_PREFIX,
+        std::env::var("BB_WORKER_ADMIN").expect("Unable to determine bb worker admin!"),
+        RUSOTO_PROVISION_VARS_TEMPLATE_INFIX,
+        std::env::var("BB_WORKER_NAME").expect("Unable to determine bb worker name!"),
+        RUSOTO_PROVISION_VARS_TEMPLATE_SUFFIX,
+        std::env::var("BB_WORKER_PASS").expect("Unable to determine bb worker passwd!"),
+    );
+    std::fs::write("vars/rusoto_provision.yml", rusoto_provision_yaml);
+    let client = rusoto_ec2::Ec2Client::new(rusoto_core::Region::UsEast2);
+    let run_instance_request = rusoto_ec2::RunInstancesRequest {
+        dry_run: Some(false),
+        image_id: Some(String::from("ami-0b3c43897b5d26f4a")),
+        min_count: 1,
+        max_count: 1,
+        key_name: Some(String::from("rsa_aws_ec2")),
+        instance_type: Some(String::from("m5.4xlarge")),
+        tag_specifications: Some(vec![TagSpecification {
+            resource_type: Some(String::from("instance")),
+            tags: Some(vec![Tag {
+                key: Some(String::from("amibuilder")),
+                value: Some(String::from("test1")),
+            }]),
+        }]),
+        ..Default::default()
+    };
+    client
+        .run_instances(run_instance_request)
+        .sync()
+        .unwrap()
+        .instances
+        .unwrap();
+    let describe_instance_request = DescribeInstancesRequest {
+        dry_run: Some(false),
+        filters: Some(vec![
+            Filter {
+                name: Some(String::from("tag:amibuilder")),
+                values: Some(vec![String::from("test1")]),
+            },
+            Filter {
+                name: Some(String::from("instance-state-code")),
+                values: Some(vec![String::from("16")]),
+            },
+        ]),
+        ..Default::default()
+    };
+    let reservations = loop {
+        let reservations = extract_reservations(
+            client
+                .describe_instances(describe_instance_request.clone())
+                .sync()
+                .unwrap(),
+        );
+        if *reservations != [] {
+            break reservations;
+        }
+        std::thread::sleep(std::time::Duration::new(1, 500_000_000));
+    };
+    let pub_ip = loop {
+        let pub_ip = extract_pub_ip(&extract_reservations(
+            client
+                .describe_instances(describe_instance_request.clone())
+                .sync()
+                .unwrap(),
+        ));
+        if pub_ip != "" {
+            break pub_ip;
+        }
+        std::thread::sleep(std::time::Duration::new(1, 500_000_000));
+    };
+    let hosts_text = format!(
+        "{}{}{}",
+        INVENTORY_TEMPLATE_PREFIX,
+        &pub_ip.replace("\"", ""),
+        INVENTORY_TEMPLATE_SUFFIX
+    );
+    std::fs::write("inventory/hosts", hosts_text).expect("Write failure!");
+    let key_pathname = std::env::var("PRIVATE_SSH_KEY").unwrap();
+    let ssh_out = loop {
+        let output = std::process::Command::new("ssh")
+            .args(&["-o", "StrictHostKeyChecking=no"])
+            .args(&["-i", &key_pathname])
+            .arg(format!("ubuntu@{}", pub_ip))
+            .output()
+            .expect("Couldn't run ssh");
+        let mut err_output = String::from_utf8(output.stderr).unwrap();
+        let error_end = err_output.split_off(92);
+        if err_output != "Pseudo-terminal will not be allocated because stdin is not a terminal.\r\nssh: connect to host" {
+            break output.stdout;
+        }
+        std::thread::sleep(std::time::Duration::new(10, 0));
+    };
+    println!("About to make blocking call to ansible-playbook!");
+    std::process::Command::new("ansible-playbook")
+        .args(&["-e", "buildbot_worker_host_template=templates/host.ec2.j2"])
+        .arg(format!("--private-key={}", &key_pathname))
+        .args(&["-i", "inventory/hosts"])
+        .arg("unix.yml")
+        .output()
+        .expect("ansible-playbook invocation failed!");
+    println!("ansible-playbook completed without an error being detected in the process return!");
+}
+
+fn extract_reservations(describe_instances_result: DescribeInstancesResult) -> Vec<Reservation> {
+    describe_instances_result.reservations.unwrap()
+}
+
+fn extract_pub_ip(reservations: &Vec<Reservation>) -> String {
+    assert_eq!(reservations.len(), 1);
+    reservations[0].instances.as_ref().unwrap()[0]
+        .public_ip_address
+        .as_ref()
+        .unwrap()
+        .clone()
+}

--- a/contrib/ci-workers/provisionec2/src/bin/provision.rs
+++ b/contrib/ci-workers/provisionec2/src/bin/provision.rs
@@ -62,11 +62,13 @@ fn main() {
         .unwrap();
     let run_instance_request = rusoto_ec2::RunInstancesRequest {
         dry_run: Some(false),
-        image_id: Some(String::from("ami-0b3c43897b5d26f4a")),
+        image_id: Some(std::env::var("AMI_ID").expect("Unable to obtain AMI ID!")),
         min_count: 1,
         max_count: 1,
         key_name: Some(String::from(key_filepath)),
-        instance_type: Some(String::from("m5.4xlarge")),
+        instance_type: Some(
+            std::env::var("INSTANCE_TYPE").expect("Unable to obtain instance_type!"),
+        ),
         tag_specifications: Some(vec![TagSpecification {
             resource_type: Some(String::from("instance")),
             tags: Some(vec![Tag {

--- a/contrib/ci-workers/unix.yml
+++ b/contrib/ci-workers/unix.yml
@@ -7,16 +7,7 @@
   vars_files:
     - vars/default.yml
     - vars/buildbot.yml
-
-  vars_prompt:
-    - name: "buildbot_worker_admin"
-      prompt: "Admin details"
-      default: "Zcash <sysadmin@z.cash>"
-    - name: "buildbot_worker_name"
-      prompt: "Buildbot worker name (provided by ZECC)"
-      private: no
-    - name: "buildbot_worker_password"
-      prompt: "Buildbot worker password (provided by ZECC)"
+    - vars/rusoto_provision.yml
 
   pre_tasks:
     - name: Install Python 2.7 for Ansible and Buildbot


### PR DESCRIPTION
I monitor this, to confirm successful completion of the Ansible run:

http://bbmaster.zingolabs.com:8010/#/workers

For the ECC different credentials will be injected and the worker will register with the ECC bbmaster.

The basic scheme is that the User sets environment variables which are consumed by the executable that is built and run by `cargo run`.   The User's system, with cargo, must also have Ansible.

I'll be documenting the interface here, soon.