### PR TITLE
Add AFL to zcutil

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,12 @@ AC_ARG_ENABLE(tests,
     [use_tests=$enableval],
     [use_tests=yes])
 
+AC_ARG_ENABLE([fuzz-main],
+  [AS_HELP_STRING([--enable-fuzz-main],
+  [Replace main() with a stub for fuzzing (default is no)])],
+  [use_fuzz_main=$enableval],
+  [use_fuzz_main=no])
+
 AC_ARG_ENABLE([asan],
   [AS_HELP_STRING([--enable-asan],
   [instrument the executables with asan (default is no)])],
@@ -445,6 +451,11 @@ fi
 if test x$TARGET_OS != xwindows; then
   # All windows code is PIC, forcing it on just adds useless compile warnings
   AX_CHECK_COMPILE_FLAG([-fPIC],[PIC_FLAGS="-fPIC"])
+fi
+
+if test x$use_fuzz_main == xyes; then
+    CFLAGS="$CFLAGS -DZCASH_FUZZ=1"
+    CXXFLAGS="$CXXFLAGS -DZCASH_FUZZ=1"
 fi
 
 #asan and tsan cannot be used together

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -186,7 +186,10 @@ bool AppInit(int argc, char* argv[])
 
     return fRet;
 }
-
+#include "fuzz.h"
+#ifdef ZCASH_FUZZ
+#include "fuzz.cpp"
+#else
 int main(int argc, char* argv[])
 {
     SetupEnvironment();
@@ -196,3 +199,4 @@ int main(int argc, char* argv[])
 
     return (AppInit(argc, argv) ? EXIT_SUCCESS : EXIT_FAILURE);
 }
+#endif

--- a/src/fuzz.cpp
+++ b/src/fuzz.cpp
@@ -1,0 +1,18 @@
+extern bool DecodeHexTx(CTransaction& tx, const std::string& strHexTx);
+
+bool fuzz_DecodeHexTxFunction (const std::string& strHexTx) {
+        CTransaction tx;
+        return DecodeHexTx(tx, strHexTx);
+}
+
+
+int fuzz_DecodeHexTx (int argc, char *argv[]) {
+        std::ifstream t(argv[1]);
+        std::string str((std::istreambuf_iterator<char>(t)),
+                                         std::istreambuf_iterator<char>());
+        if (fuzz_DecodeHexTxFunction (str)) { fprintf(stdout, "Decoded hex string") ; return 0; }
+        else { fprintf(stderr, "Could not decode hex string") ; return -1; }
+}
+
+int main (int argc, char *argv[]) { return ZCASH_FUZZER_MAIN(argc, argv); }
+#warning BUILDING A FUZZER, NOT THE REAL MAIN

--- a/src/fuzz.h
+++ b/src/fuzz.h
@@ -1,0 +1,2 @@
+//#define ZCASH_FUZZ
+#define ZCASH_FUZZER_MAIN fuzz_DecodeHexTx

--- a/zcutil/afl/afl-build.sh
+++ b/zcutil/afl/afl-build.sh
@@ -10,4 +10,4 @@ export AFL_LOG_DIR="$(pwd)"
 export ZCUTIL=$(realpath "./zcutil")
 shift 1
 
-CONFIGURE_FLAGS=--enable-tests=no "$ZCUTIL/build.sh" "CC=$ZCUTIL/afl/zcash-wrapper-gcc" "CXX=$ZCUTIL/afl/zcash-wrapper-g++" AFL_HARDEN=1 "$@"
+CONFIGURE_FLAGS="--enable-tests=no --enable-fuzz-main" "$ZCUTIL/build.sh" "CC=$ZCUTIL/afl/zcash-wrapper-gcc" "CXX=$ZCUTIL/afl/zcash-wrapper-g++" AFL_HARDEN=1 "$@"

--- a/zcutil/afl/afl-build.sh
+++ b/zcutil/afl/afl-build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# A wrapper around ./zcutil/build.sh for instrumenting the build with AFL:
+#   ./zcutil/afl/afl-build.sh <directory where AFL is installed>
+# You may obtain a copy of AFL using ./zcutil/afl/afl-get.sh.
+
+set -eu -o pipefail
+
+export AFL_INSTALL_DIR="$1"
+export AFL_LOG_DIR="$(pwd)"
+export ZCUTIL=$(realpath "./zcutil")
+shift 1
+
+CONFIGURE_FLAGS=--enable-tests=no "$ZCUTIL/build.sh" "CC=$ZCUTIL/afl/zcash-wrapper-gcc" "CXX=$ZCUTIL/afl/zcash-wrapper-g++" AFL_HARDEN=1 "$@"

--- a/zcutil/afl/afl-get.sh
+++ b/zcutil/afl/afl-get.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Obtains and builds a copy of AFL from source.
+#   ./zcutil/afl/afl-get.sh <directory to build and install AFL in>
+
+set -eu -o pipefail
+
+mkdir -p "$1"
+cd "$1"
+
+if [ ! -z "$(ls -A .)" ]; then
+    echo "$1 is not empty. This script will only attempt to build AFL in an empty directory."
+    exit 1
+fi
+
+# Get the AFL source
+rm -f afl-latest.tgz
+wget http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz
+sha256sum afl-latest.tgz | grep '43614b4b91c014d39ef086c5cc84ff5f068010c264c2c05bf199df60898ce045'
+if [ "$?" != "0" ]
+then
+    echo "Wrong SHA256 hash for afl"
+    exit
+fi
+tar xvf afl-latest.tgz
+mv afl-*/* .
+
+# Build AFL
+make
+
+echo "You can now build zcashd with AFL instrumentation as follows:"
+echo "$ make clean"
+echo "$ ./zcutil/afl/afl-build.sh '$(pwd)'"

--- a/zcutil/afl/zcash-wrapper
+++ b/zcutil/afl/zcash-wrapper
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -ex -o pipefail
+
+export ARGS=$@
+
+instrument=(
+"\/src$"
+
+)
+
+if [ "$override_instrument" != "" ]
+then
+  instrument = $override_instrument
+fi
+
+# Store the command line we were given to a file
+
+(echo "$ARGS" ; pwd) >> "$AFL_LOG_DIR/zcash-build-wrapper.log"
+
+# Work out which compiler we were called as 
+
+case $0 in
+*zcash-wrapper-g++)
+  COMPILER="g++"
+  ;;
+*zcash-wrapper-gcc)
+  COMPILER="gcc"
+  ;;
+*zcash-wrapper)
+  echo "Call this script instead of your regular compiler, and if the absolute path of the CWD the wrapper was called from matches a regex in the array 'instrument', it will call AFL to instrument the resulting binary. Otherwise it will call either g++ or gcc depending on how it was invoked. \$AFL_INSTALL_DIR must be set to the path where AFL is installed."
+  exit
+  ;;
+esac
+
+# Check if we should instrument
+
+for i in "${instrument[@]}"
+do
+  if echo -- "`pwd`" | grep "$i"; then
+    # We found a match, let's instrument this one.
+    echo "Matched directory `pwd` to instrument element $i. Instrumenting this call." >> "$AFL_LOG_DIR/zcash-build-wrapper.log"
+    exec -- "$AFL_INSTALL_DIR/afl-$COMPILER" "$@"
+  fi
+done
+
+# No match, just pass-through.
+exec -- "$COMPILER" "$@"

--- a/zcutil/afl/zcash-wrapper-g++
+++ b/zcutil/afl/zcash-wrapper-g++
@@ -1,0 +1,1 @@
+zcash-wrapper

--- a/zcutil/afl/zcash-wrapper-gcc
+++ b/zcutil/afl/zcash-wrapper-gcc
@@ -1,0 +1,1 @@
+zcash-wrapper


### PR DESCRIPTION
Probably superseded by #4171 

Builds on #4156

How to use it:

```
./zcutil/afl/afl-get.sh /tmp/afl   # (or wherever you want to build AFL)
./zcutil/afl/afl-build.sh /tmp/afl -j$(nproc)
```

Run `make clean` whenever you switch between a normal build and an AFL-instrumented build.