### PR TITLE
Set Blossom activation height

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,6 +4,19 @@ release-notes at release time)
 Notable changes
 ===============
 
+Blossom network upgrade
+-----------------------
+
+The mainnet activation of the Blossom network upgrade is supported by this
+release, with an activation height of 653600, which should occur in early
+December — roughly one day following the targeted EOS halt of our 2.0.7-3
+release. Please upgrade to this release, or any subsequent release, in order to
+follow the Blossom network upgrade.
+
+The Blossom network upgrade implements
+[ZIP208](https://github.com/zcash/zips/blob/master/zip-0208.rst) which shortens
+block times from 150s to 75s.
+
 DoS Mitigation: Mempool Size Limit and Random Drop
 --------------------------------------------------
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -117,8 +117,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_SAPLING].hashActivationBlock =
             uint256S("00000000025a57200d898ac7f21e26bf29028bbe96ec46e05b2c17cc9db9e4f3");
         consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].nProtocolVersion = 170009;
-        consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].nActivationHeight =
-            Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].nActivationHeight = 653600;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("000000000000000000000000000000000000000000000000017e73a331fae01c");

--- a/src/deprecation.h
+++ b/src/deprecation.h
@@ -10,10 +10,19 @@
 // * A warning is shown during the 2 weeks' worth of blocks prior to shut down.
 static const int APPROX_RELEASE_HEIGHT = 625500;
 static const int WEEKS_UNTIL_DEPRECATION = 16;
-static const int DEPRECATION_HEIGHT = APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 24);
+// static const int DEPRECATION_HEIGHT = APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 24);
+
+// TEMPORARY!
+// This is hardcoded to a height that is roughly 10 weeks following the
+// activation of Blossom on mainnet, which is itself almost 6 weeks following
+// this release. This is done because the calculation of the deprecation height
+// does not account for the change in block target spacing; after Blossom has
+// activated, this should be removed and the previous line fixed to use
+// APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 48)
+static const int DEPRECATION_HEIGHT = 734240;
 
 // Number of blocks before deprecation to warn users
-static const int DEPRECATION_WARN_LIMIT = 14 * 24 * 24; // 2 weeks
+static const int DEPRECATION_WARN_LIMIT = 14 * 24 * 48; // 2 weeks
 
 /**
  * Checks whether the node is deprecated based on the current block height, and

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -98,16 +98,12 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 
     // Changing the block interval from 10 to 2.5 minutes causes truncation
     // effects to occur earlier (from the 9th halving interval instead of the
-    // 11th), decreasing the total monetary supply by 0.0693 ZEC. If the
-    // transaction output field is widened, this discrepancy will become smaller
-    // or disappear entirely.
-    //BOOST_CHECK_EQUAL(nSum, 2099999997690000ULL);
+    // 11th), decreasing the total monetary supply by 0.0693 ZEC.
+    // BOOST_CHECK_EQUAL(nSum, 2099999997690000ULL);
     // Reducing the interval further to 1.25 minutes has a similar effect,
     // decreasing the total monetary supply by another 0.09240 ZEC.
-    // TODO Change this assert when setting the blossom activation height
-    // Note that these numbers may or may not change depending on the activation height
-    BOOST_CHECK_EQUAL(nSum, 2099999990760000ULL);
-    // BOOST_CHECK_EQUAL(nSum, 2099999981520000LL);
+    // BOOST_CHECK_EQUAL(nSum, 2099999990760000ULL);
+    BOOST_CHECK_EQUAL(nSum, 2099999981520000LL);
 }
 
 bool ReturnFalse() { return false; }

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -270,17 +270,40 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
      */
     BOOST_CHECK_THROW(CallRPC("getblocksubsidy too many args"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getblocksubsidy -1"), runtime_error);
+
     BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 50000"));
     UniValue obj = retValue.get_obj();
     BOOST_CHECK_EQUAL(find_value(obj, "miner").get_real(), 10.0);
     BOOST_CHECK_EQUAL(find_value(obj, "founders").get_real(), 2.5);
-    BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 1000000"));
+
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 653599")); // Blossom activation - 1
     obj = retValue.get_obj();
-    BOOST_CHECK_EQUAL(find_value(obj, "miner").get_real(), 6.25);
-    BOOST_CHECK_EQUAL(find_value(obj, "founders").get_real(), 0.0);
-    BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 2000000"));
+    BOOST_CHECK_EQUAL(find_value(obj, "miner").get_real(), 10.0);
+    BOOST_CHECK_EQUAL(find_value(obj, "founders").get_real(), 2.5);
+
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 653600")); // Blossom activation
+    obj = retValue.get_obj();
+    BOOST_CHECK_EQUAL(find_value(obj, "miner").get_real(), 5.0);
+    BOOST_CHECK_EQUAL(find_value(obj, "founders").get_real(), 1.25);
+
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 1046399"));
+    obj = retValue.get_obj();
+    BOOST_CHECK_EQUAL(find_value(obj, "miner").get_real(), 5.0);
+    BOOST_CHECK_EQUAL(find_value(obj, "founders").get_real(), 1.25);
+    // slow start + pre blossom halving + (pre blossom halving - blossom activation) * 2
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 1046400"));
     obj = retValue.get_obj();
     BOOST_CHECK_EQUAL(find_value(obj, "miner").get_real(), 3.125);
+    BOOST_CHECK_EQUAL(find_value(obj, "founders").get_real(), 0.0);
+
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 2726399"));
+    obj = retValue.get_obj();
+    BOOST_CHECK_EQUAL(find_value(obj, "miner").get_real(), 3.125);
+    BOOST_CHECK_EQUAL(find_value(obj, "founders").get_real(), 0.0);
+
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 2726400"));
+    obj = retValue.get_obj();
+    BOOST_CHECK_EQUAL(find_value(obj, "miner").get_real(), 1.5625);
     BOOST_CHECK_EQUAL(find_value(obj, "founders").get_real(), 0.0);
 
     /*

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -290,7 +290,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     obj = retValue.get_obj();
     BOOST_CHECK_EQUAL(find_value(obj, "miner").get_real(), 5.0);
     BOOST_CHECK_EQUAL(find_value(obj, "founders").get_real(), 1.25);
-    // slow start + pre blossom halving + (pre blossom halving - blossom activation) * 2
+    // slow start + blossom activation + (pre blossom halving - blossom activation) * 2
     BOOST_CHECK_NO_THROW(retValue = CallRPC("getblocksubsidy 1046400"));
     obj = retValue.get_obj();
     BOOST_CHECK_EQUAL(find_value(obj, "miner").get_real(), 3.125);

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 170008;
+static const int PROTOCOL_VERSION = 170009;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
* This PR sets Blossom activation to height 653600.
* This PR bumps the protocol version to 170009.
* This PR hardcodes the deprecation height to 734240 to account for the fact that activation of Blossom decreases the block interval prior to the deprecation height, so the ordinary formula for deciding deprecation does not work.