### PR TITLE
Cast uint8* in InterruptibleRecv to char* for recv

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -254,7 +254,13 @@ bool static InterruptibleRecv(uint8_t* data, size_t len, int timeout, SOCKET& hS
     // to break off in case of an interruption.
     const int64_t maxWait = 1000;
     while (len > 0 && curTime < endTime) {
-        ssize_t ret = recv(hSocket, data, len, 0); // Optimistically try the recv first
+        // Optimistically try the recv first.
+        //
+        // POSIX recv() does not require a cast, as it takes a void *buf:
+        //     ssize_t recv(int sockfd, void *buf, size_t len, int flags);
+        // However Windows explicitly requires a char *buf:
+        //     int recv(SOCKET s, char *buf, int len, int flags);
+        ssize_t ret = recv(hSocket, reinterpret_cast<char*>(data), len, 0);
         if (ret > 0) {
             len -= ret;
             data += ret;


### PR DESCRIPTION
Fixes a Windows-specific compile bug introduced in #4212.
Closes #4214.