### PR TITLE
IPv6 RPC patch

### DIFF
--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -5,13 +5,13 @@
 
 import sys; assert sys.version_info < (3,), ur"This script does not run under Python 3. Please use Python 2.7.x."
 
-from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, start_nodes
-
 import socket
 import os
 
+from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.netutil import test_ipv6_local
 '''
 Test plan:
 - Start bitcoind's with different proxy configurations
@@ -38,6 +38,7 @@ addnode connect to generic DNS name
 
 class ProxyTest(BitcoinTestFramework):        
     def __init__(self):
+        self.have_ipv6 = test_ipv6_local()
         # Create two proxies on different ports
         # ... one unauthenticated
         self.conf1 = Socks5Configuration()
@@ -49,29 +50,36 @@ class ProxyTest(BitcoinTestFramework):
         self.conf2.addr = ('127.0.0.1', 14000 + (os.getpid() % 1000))
         self.conf2.unauth = True
         self.conf2.auth = True
-        # ... one on IPv6 with similar configuration
-        self.conf3 = Socks5Configuration()
-        self.conf3.af = socket.AF_INET6
-        self.conf3.addr = ('::1', 15000 + (os.getpid() % 1000))
-        self.conf3.unauth = True
-        self.conf3.auth = True
+        if self.have_ipv6:
+            # ... one on IPv6 with similar configuration
+            self.conf3 = Socks5Configuration()
+            self.conf3.af = socket.AF_INET6
+            self.conf3.addr = ('::1', 15000 + (os.getpid() % 1000))
+            self.conf3.unauth = True
+            self.conf3.auth = True
+        else:
+            print "Warning: testing without local IPv6 support"
 
         self.serv1 = Socks5Server(self.conf1)
         self.serv1.start()
         self.serv2 = Socks5Server(self.conf2)
         self.serv2.start()
-        self.serv3 = Socks5Server(self.conf3)
-        self.serv3.start()
+        if self.have_ipv6:
+            self.serv3 = Socks5Server(self.conf3)
+            self.serv3.start()
 
     def setup_nodes(self):
         # Note: proxies are not used to connect to local nodes
         # this is because the proxy to use is based on CService.GetNetwork(), which return NET_UNROUTABLE for localhost
-        return start_nodes(4, self.options.tmpdir, extra_args=[
+        args = [
             ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf1.addr),'-proxyrandomize=1'], 
             ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf1.addr),'-onion=%s:%i' % (self.conf2.addr),'-proxyrandomize=0'], 
             ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf2.addr),'-proxyrandomize=1'], 
-            ['-listen', '-debug=net', '-debug=proxy', '-proxy=[%s]:%i' % (self.conf3.addr),'-proxyrandomize=0', '-noonion']
-            ])
+            []
+            ]
+        if self.have_ipv6:
+            args[3] = ['-listen', '-debug=net', '-debug=proxy', '-proxy=[%s]:%i' % (self.conf3.addr),'-proxyrandomize=0', '-noonion']
+        return start_nodes(4, self.options.tmpdir, extra_args=args)
 
     def node_test(self, node, proxies, auth, test_onion=True):
         rv = []
@@ -88,18 +96,19 @@ class ProxyTest(BitcoinTestFramework):
             assert_equal(cmd.password, None)
         rv.append(cmd)
 
-        # Test: outgoing IPv6 connection through node
-        node.addnode("[1233:3432:2434:2343:3234:2345:6546:4534]:5443", "onetry")
-        cmd = proxies[1].queue.get()
-        assert(isinstance(cmd, Socks5Command))
-        # Note: bitcoind's SOCKS5 implementation only sends atyp DOMAINNAME, even if connecting directly to IPv4/IPv6
-        assert_equal(cmd.atyp, AddressType.DOMAINNAME)
-        assert_equal(cmd.addr, "1233:3432:2434:2343:3234:2345:6546:4534")
-        assert_equal(cmd.port, 5443)
-        if not auth:
-            assert_equal(cmd.username, None)
-            assert_equal(cmd.password, None)
-        rv.append(cmd)
+        if self.have_ipv6:
+            # Test: outgoing IPv6 connection through node
+            node.addnode("[1233:3432:2434:2343:3234:2345:6546:4534]:5443", "onetry")
+            cmd = proxies[1].queue.get()
+            assert(isinstance(cmd, Socks5Command))
+            # Note: bitcoind's SOCKS5 implementation only sends atyp DOMAINNAME, even if connecting directly to IPv4/IPv6
+            assert_equal(cmd.atyp, AddressType.DOMAINNAME)
+            assert_equal(cmd.addr, "1233:3432:2434:2343:3234:2345:6546:4534")
+            assert_equal(cmd.port, 5443)
+            if not auth:
+                assert_equal(cmd.username, None)
+                assert_equal(cmd.password, None)
+            rv.append(cmd)
 
         if test_onion:
             # Test: outgoing onion connection through node
@@ -139,10 +148,11 @@ class ProxyTest(BitcoinTestFramework):
         rv = self.node_test(self.nodes[2], [self.serv2, self.serv2, self.serv2, self.serv2], True)
         # Check that credentials as used for -proxyrandomize connections are unique
         credentials = set((x.username,x.password) for x in rv)
-        assert_equal(len(credentials), 4)
+        assert_equal(len(credentials), len(rv))
 
-        # proxy on IPv6 localhost
-        self.node_test(self.nodes[3], [self.serv3, self.serv3, self.serv3, self.serv3], False, False)
+        if self.have_ipv6:
+            # proxy on IPv6 localhost
+            self.node_test(self.nodes[3], [self.serv3, self.serv3, self.serv3, self.serv3], False, False)
 
         def networks_dict(d):
             r = {}
@@ -171,11 +181,12 @@ class ProxyTest(BitcoinTestFramework):
             assert_equal(n2[net]['proxy_randomize_credentials'], True)
         assert_equal(n2['onion']['reachable'], True)
 
-        n3 = networks_dict(self.nodes[3].getnetworkinfo())
-        for net in ['ipv4','ipv6']:
-            assert_equal(n3[net]['proxy'], '[%s]:%i' % (self.conf3.addr))
-            assert_equal(n3[net]['proxy_randomize_credentials'], False)
-        assert_equal(n3['onion']['reachable'], False)
+        if self.have_ipv6:
+            n3 = networks_dict(self.nodes[3].getnetworkinfo())
+            for net in ['ipv4','ipv6']:
+                assert_equal(n3[net]['proxy'], '[%s]:%i' % (self.conf3.addr))
+                assert_equal(n3[net]['proxy_randomize_credentials'], False)
+            assert_equal(n3['onion']['reachable'], False)
 
 if __name__ == '__main__':
     ProxyTest().main()

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -10,7 +10,7 @@ import os
 
 from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, start_nodes
 from test_framework.netutil import test_ipv6_local
 '''
 Test plan:

--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -137,3 +137,18 @@ def addr_to_hex(addr):
     else:
         raise ValueError('Could not parse address %s' % addr)
     return binascii.hexlify(bytearray(addr))
+
+def test_ipv6_local():
+    '''
+    Check for (local) IPv6 support.
+    '''
+    import socket
+    # By using SOCK_DGRAM this will not actually make a connection, but it will
+    # fail if there is no route to IPv6 localhost.
+    have_ipv6 = True
+    try:
+        s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        s.connect(('::1', 0))
+    except socket.error:
+        have_ipv6 = False
+    return have_ipv6

--- a/qa/rpc-tests/wallet_changeaddresses.py
+++ b/qa/rpc-tests/wallet_changeaddresses.py
@@ -48,7 +48,7 @@ class WalletChangeAddressesTest(BitcoinTestFramework):
         taddrSource = self.nodes[0].getnewaddress()
         for _ in range(6):
             recipients = [{"address": taddrSource, "amount": Decimal('2')}]
-            myopid = self.nodes[0].z_sendmany(midAddr, recipients, 1, 0)
+            myopid = self.nodes[0].z_sendmany(midAddr, recipients, 1, Decimal('0'))
             wait_and_assert_operationid_status(self.nodes[0], myopid)
             self.nodes[1].generate(1)
             self.sync_all()
@@ -57,11 +57,11 @@ class WalletChangeAddressesTest(BitcoinTestFramework):
             recipients = [{"address": target, "amount": Decimal('1')}]
 
             # Send funds to recipient address twice
-            myopid = self.nodes[0].z_sendmany(taddrSource, recipients, 1, 0)
+            myopid = self.nodes[0].z_sendmany(taddrSource, recipients, 1, Decimal('0'))
             txid1 = wait_and_assert_operationid_status(self.nodes[0], myopid)
             self.nodes[1].generate(1)
             self.sync_all()
-            myopid = self.nodes[0].z_sendmany(taddrSource, recipients, 1, 0)
+            myopid = self.nodes[0].z_sendmany(taddrSource, recipients, 1, Decimal('0'))
             txid2 = wait_and_assert_operationid_status(self.nodes[0], myopid)
             self.nodes[1].generate(1)
             self.sync_all()

--- a/qa/rpc-tests/wallet_changeaddresses.py
+++ b/qa/rpc-tests/wallet_changeaddresses.py
@@ -50,6 +50,7 @@ class WalletChangeAddressesTest(BitcoinTestFramework):
             recipients = [{"address": taddrSource, "amount": Decimal('2')}]
             myopid = self.nodes[0].z_sendmany(midAddr, recipients, 1, Decimal('0'))
             wait_and_assert_operationid_status(self.nodes[0], myopid)
+            self.sync_all()
             self.nodes[1].generate(1)
             self.sync_all()
 


### PR DESCRIPTION
Cherry-picked from bitcoin/bitcoin#7489.

To support CI updates via GKE, this patch ensures hosts using only IPv4 can function gracefully on `proxy_test.py`.