### PR TITLE
Add confirmations, blockheight, blockindex and blocktime to z_listreceivedbyaddress

### DIFF
--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -56,13 +56,11 @@ class ListReceivedTest (BitcoinTestFramework):
         # Confirm transaction (1 ZEC from taddr to zaddr1)
         self.generate_and_sync(height+3)
 
-        # adjust previous result because now there is one more confirmation
-        r[0]['confirmations'] += 1
-
-        # adjust blockindex as now there are 2 transactions confirmed in the block
+        # adjust confirmations
+        r[0]['confirmations'] = 1
+        # adjust blockindex
         r[0]['blockindex'] = 1
-
-        # adjust height as we generated blocks
+        # adjust height
         r[0]['blockheight'] = height + 3
 
         # Require one confirmation, note should be present

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -49,12 +49,21 @@ class ListReceivedTest (BitcoinTestFramework):
         assert_equal(1, r[0]['amount'])
         assert_false(r[0]['change'], "Note should not be change")
         assert_equal(my_memo, r[0]['memo'])
+        assert_equal(0, r[0]['confirmations'])
+        assert_equal(-1, r[0]['blockindex'])
+        assert_equal(0, r[0]['blockheight'])
 
         # Confirm transaction (1 ZEC from taddr to zaddr1)
         self.generate_and_sync(height+3)
 
         # adjust previous result because now there is one more confirmation
         r[0]['confirmations'] += 1
+
+        # adjust blockindex as now there are 2 transactions confirmed in the block
+        r[0]['blockindex'] = 1
+
+        # adjust height as we generated blocks
+        r[0]['blockheight'] = height + 3
 
         # Require one confirmation, note should be present
         assert_equal(r, self.nodes[1].z_listreceivedbyaddress(zaddr1))

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -53,6 +53,9 @@ class ListReceivedTest (BitcoinTestFramework):
         # Confirm transaction (1 ZEC from taddr to zaddr1)
         self.generate_and_sync(height+3)
 
+        # adjust previous result because now there is one more confirmation
+        r[0]['confirmations'] += 1
+
         # Require one confirmation, note should be present
         assert_equal(r, self.nodes[1].z_listreceivedbyaddress(zaddr1))
 

--- a/qa/rpc-tests/wallet_nullifiers.py
+++ b/qa/rpc-tests/wallet_nullifiers.py
@@ -137,7 +137,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
         # - Some of the notes were change for node 2 but not for node 3.
         # - Each node wallet store transaction time as received. As
         #   `wait_and_assert_operationid_status` is called node 2 and 3 are off by a few seconds.
-        # Aside from that the recieved notes should be the same. So,
+        # Aside from that the received notes should be the same. So,
         # group by txid and then check that all properties aside from
         # change are equal.
         node2Received = dict([r['txid'], r] for r in self.nodes[2].z_listreceivedbyaddress(myzaddr))

--- a/qa/rpc-tests/wallet_nullifiers.py
+++ b/qa/rpc-tests/wallet_nullifiers.py
@@ -133,8 +133,10 @@ class WalletNullifiersTest (BitcoinTestFramework):
         assert_equal(myzaddr in self.nodes[3].z_listaddresses(), False)
         assert_equal(myzaddr in self.nodes[3].z_listaddresses(True), True)
 
-        # Node 3 should see the same received notes as node 2; however,
-        # some of the notes were change for node 2 but not for node 3.
+        # Node 3 should see the same received notes as node 2; however, there are 2 things:
+        # - Some of the notes were change for node 2 but not for node 3.
+        # - Each node wallet store transaction time as received. As
+        #   `wait_and_assert_operationid_status` is called node 2 and 3 are off by a few seconds.
         # Aside from that the recieved notes should be the same. So,
         # group by txid and then check that all properties aside from
         # change are equal.
@@ -147,8 +149,8 @@ class WalletNullifiersTest (BitcoinTestFramework):
             # the change field will be omitted for received3, but all other fields should be shared
             assert_true(len(received2) >= len(received3))
             for key in received2:
-                # check all the properties except for change
-                if key != 'change':
+                # check all the properties except for change and blocktime
+                if key != 'change' and key != 'blocktime':
                     assert_equal(received2[key], received3[key])
 
         # Node 3's balances should be unchanged without explicitly requesting

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3303,20 +3303,20 @@ CAmount getBalanceZaddr(std::string address, int minDepth = 1, bool ignoreUnspen
     return balance;
 }
 
-struct trxblock
+struct txblock
 {
-    int blockheight = 0;
-    int blockindex = -1;
-    int64_t blocktime = 0;
+    int height = 0;
+    int index = -1;
+    int64_t time = 0;
 
-    trxblock(uint256 hash)
+    txblock(uint256 hash)
     {
-        if(pwalletMain->mapWallet.count(hash)) {
+        if (pwalletMain->mapWallet.count(hash)) {
             const CWalletTx& wtx = pwalletMain->mapWallet[hash];
-            if(!wtx.hashBlock.IsNull())
-                blockheight = mapBlockIndex[wtx.hashBlock]->nHeight;
-            blockindex = wtx.nIndex;
-            blocktime = wtx.GetTxTime();
+            if (!wtx.hashBlock.IsNull())
+                height = mapBlockIndex[wtx.hashBlock]->nHeight;
+            index = wtx.nIndex;
+            time = wtx.GetTxTime();
         }
     }
 };
@@ -3397,10 +3397,10 @@ UniValue z_listreceivedbyaddress(const UniValue& params, bool fHelp)
             obj.push_back(Pair("jsoutindex", entry.jsop.n));
             obj.push_back(Pair("confirmations", entry.confirmations));
 
-            trxblock additional(entry.jsop.hash);
-            obj.push_back(Pair("blockheight", additional.blockheight));
-            obj.push_back(Pair("blockindex", additional.blockindex));
-            obj.push_back(Pair("blocktime", additional.blocktime));
+            txblock BlockData(entry.jsop.hash);
+            obj.push_back(Pair("blockheight", BlockData.height));
+            obj.push_back(Pair("blockindex", BlockData.index));
+            obj.push_back(Pair("blocktime", BlockData.time));
 
             if (hasSpendingKey) {
                 obj.push_back(Pair("change", pwalletMain->IsNoteSproutChange(nullifierSet, entry.address, entry.jsop)));
@@ -3416,10 +3416,10 @@ UniValue z_listreceivedbyaddress(const UniValue& params, bool fHelp)
             obj.push_back(Pair("outindex", (int)entry.op.n));
             obj.push_back(Pair("confirmations", entry.confirmations));
 
-            trxblock additional(entry.op.hash);
-            obj.push_back(Pair("blockheight", additional.blockheight));
-            obj.push_back(Pair("blockindex", additional.blockindex));
-            obj.push_back(Pair("blocktime", additional.blocktime));
+            txblock BlockData(entry.op.hash);
+            obj.push_back(Pair("blockheight", BlockData.height));
+            obj.push_back(Pair("blockindex", BlockData.index));
+            obj.push_back(Pair("blocktime", BlockData.time));
 
             if (hasSpendingKey) {
               obj.push_back(Pair("change", pwalletMain->IsNoteSaplingChange(nullifierSet, entry.address, entry.op)));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3321,6 +3321,7 @@ UniValue z_listreceivedbyaddress(const UniValue& params, bool fHelp)
             "  \"txid\": \"txid\",           (string) the transaction id\n"
             "  \"amount\": xxxxx,         (numeric) the amount of value in the note\n"
             "  \"memo\": xxxxx,           (string) hexadecimal string representation of memo field\n"
+            "  \"confirmations\" : n,     (numeric) the number of confirmations\n"
             "  \"jsindex\" (sprout) : n,     (numeric) the joinsplit index\n"
             "  \"jsoutindex\" (sprout) : n,     (numeric) the output index of the joinsplit\n"
             "  \"outindex\" (sapling) : n,     (numeric) the output index\n"
@@ -3374,6 +3375,7 @@ UniValue z_listreceivedbyaddress(const UniValue& params, bool fHelp)
             obj.push_back(Pair("memo", HexStr(data)));
             obj.push_back(Pair("jsindex", entry.jsop.js));
             obj.push_back(Pair("jsoutindex", entry.jsop.n));
+            obj.push_back(Pair("confirmations", entry.confirmations));
             if (hasSpendingKey) {
                 obj.push_back(Pair("change", pwalletMain->IsNoteSproutChange(nullifierSet, entry.address, entry.jsop)));
             }
@@ -3386,6 +3388,7 @@ UniValue z_listreceivedbyaddress(const UniValue& params, bool fHelp)
             obj.push_back(Pair("amount", ValueFromAmount(CAmount(entry.note.value()))));
             obj.push_back(Pair("memo", HexStr(entry.memo)));
             obj.push_back(Pair("outindex", (int)entry.op.n));
+            obj.push_back(Pair("confirmations", entry.confirmations));
             if (hasSpendingKey) {
               obj.push_back(Pair("change", pwalletMain->IsNoteSaplingChange(nullifierSet, entry.address, entry.op)));
             }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3341,7 +3341,7 @@ UniValue z_listreceivedbyaddress(const UniValue& params, bool fHelp)
             "  \"confirmations\" : n,     (numeric) the number of confirmations\n"
             "  \"blockheight\": n,         (numeric) The block height containing the transaction\n"
             "  \"blockindex\": n,         (numeric) The block index containing the transaction.\n"
-            "  \"time\": xxx,              (numeric) The transaction time in seconds since epoch (midnight Jan 1 1970 GMT).\n"
+            "  \"blocktime\": xxx,              (numeric) The transaction time in seconds since epoch (midnight Jan 1 1970 GMT).\n"
             "  \"jsindex\" (sprout) : n,     (numeric) the joinsplit index\n"
             "  \"jsoutindex\" (sprout) : n,     (numeric) the output index of the joinsplit\n"
             "  \"outindex\" (sapling) : n,     (numeric) the output index\n"


### PR DESCRIPTION
Fixes https://github.com/zcash/zcash/issues/3724

1- There was a PR to add confirmations to this call at https://github.com/zcash/zcash/pull/3836
I ported the commit from there and fixed test case by incrementing the confirmations as suggested at: https://github.com/zcash/zcash/pull/3836#issuecomment-499927807

2- Then added `blockheight`, `blockindex` and `blocktime`. To avoid some duplicated code (Sprout/Sapling) created a structure `trxblock`.

3- Original issue requests only time and blockindex however i think height is also important; if `blockindex` is the position of the transaction in the block then you are going to need also `height` to find it.