### PR TITLE
Wallet interface refactor

### DIFF
--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -56,6 +56,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         spends2_id = [ self.nodes[0].sendrawtransaction(tx) for tx in spends2_raw ]
 
         blocks.extend(self.nodes[0].generate(1))
+        self.sync_all()
 
         # mempool should be empty, all txns confirmed
         assert_equal(set(self.nodes[0].getrawmempool()), set())
@@ -76,6 +77,8 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
         # Generate another block, they should all get mined
         self.nodes[0].generate(1)
+        self.sync_all()
+
         # mempool should be empty, all txns confirmed
         assert_equal(set(self.nodes[0].getrawmempool()), set())
         for txid in spends1_id+spends2_id:

--- a/qa/rpc-tests/mergetoaddress_helper.py
+++ b/qa/rpc-tests/mergetoaddress_helper.py
@@ -62,6 +62,7 @@ class MergeToAddressHelper:
         do_not_shield_taddr = test.nodes[0].getnewaddress()
 
         test.nodes[0].generate(4)
+        test.sync_all()
         walletinfo = test.nodes[0].getwalletinfo()
         assert_equal(walletinfo['immature_balance'], 50)
         assert_equal(walletinfo['balance'], 0)

--- a/qa/rpc-tests/paymentdisclosure.py
+++ b/qa/rpc-tests/paymentdisclosure.py
@@ -37,6 +37,7 @@ class PaymentDisclosureTest (BitcoinTestFramework):
         print "Mining blocks..."
 
         self.nodes[0].generate(4)
+        self.sync_all()
         walletinfo = self.nodes[0].getwalletinfo()
         assert_equal(walletinfo['immature_balance'], 40)
         assert_equal(walletinfo['balance'], 0)

--- a/qa/rpc-tests/shorter_block_times.py
+++ b/qa/rpc-tests/shorter_block_times.py
@@ -19,8 +19,6 @@ from test_framework.util import (
 class ShorterBlockTimes(BitcoinTestFramework):
     def setup_nodes(self):
         return start_nodes(4, self.options.tmpdir, [[
-            '-nuparams=5ba81b19:0', # Overwinter
-            '-nuparams=76b809bb:0', # Sapling
             '-nuparams=2bb40e60:106', # Blossom
         ]] * 4)
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -46,11 +46,20 @@ def str_to_b64str(string):
 
 def sync_blocks(rpc_connections, wait=1):
     """
-    Wait until everybody has the same block count
+    Wait until everybody has the same block count, and has notified
+    all internal listeners of them
     """
     while True:
         counts = [ x.getblockcount() for x in rpc_connections ]
         if counts == [ counts[0] ]*len(counts):
+            break
+        time.sleep(wait)
+
+    # Now that the block counts are in sync, wait for the internal
+    # notifications to finish
+    while True:
+        notified = [ x.getblockchaininfo()['fullyNotified'] for x in rpc_connections ]
+        if notified == [ True ] * len(notified):
             break
         time.sleep(wait)
 

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -32,6 +32,7 @@ class WalletTest (BitcoinTestFramework):
         print "Mining blocks..."
 
         self.nodes[0].generate(4)
+        self.sync_all()
 
         walletinfo = self.nodes[0].getwalletinfo()
         assert_equal(walletinfo['immature_balance'], 40)

--- a/qa/rpc-tests/wallet_1941.py
+++ b/qa/rpc-tests/wallet_1941.py
@@ -48,6 +48,7 @@ class Wallet1941RegressionTest (BitcoinTestFramework):
 
         self.nodes[0].setmocktime(starttime)
         self.nodes[0].generate(101)
+        self.sync_all()
 
         mytaddr = get_coinbase_address(self.nodes[0])
         myzaddr = self.nodes[0].z_getnewaddress('sprout')
@@ -66,6 +67,7 @@ class Wallet1941RegressionTest (BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.nodes[0].setmocktime(starttime + 9000)
         self.nodes[0].generate(1)
+        self.sync_all()
 
         # Confirm the balance on node 0.
         resp = self.nodes[0].z_getbalance(myzaddr)

--- a/qa/rpc-tests/wallet_anchorfork.py
+++ b/qa/rpc-tests/wallet_anchorfork.py
@@ -29,6 +29,7 @@ class WalletAnchorForkTest (BitcoinTestFramework):
     def run_test (self):
         print "Mining blocks..."
         self.nodes[0].generate(4)
+        self.sync_all()
 
         walletinfo = self.nodes[0].getwalletinfo()
         assert_equal(walletinfo['immature_balance'], 40)

--- a/qa/rpc-tests/wallet_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldcoinbase.py
@@ -39,6 +39,7 @@ class WalletShieldCoinbaseTest (BitcoinTestFramework):
 
         self.nodes[0].generate(1)
         self.nodes[0].generate(4)
+        self.sync_all()
         walletinfo = self.nodes[0].getwalletinfo()
         assert_equal(walletinfo['immature_balance'], 50)
         assert_equal(walletinfo['balance'], 0)

--- a/qa/rpc-tests/wallet_shieldingcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldingcoinbase.py
@@ -47,6 +47,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         print "Mining blocks..."
 
         self.nodes[0].generate(4)
+        self.sync_all()
 
         walletinfo = self.nodes[0].getwalletinfo()
         assert_equal(walletinfo['immature_balance'], 40)

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -93,6 +93,7 @@ class WalletBackupTest(BitcoinTestFramework):
         # Must sync mempools before mining.
         sync_mempools(self.nodes)
         self.nodes[3].generate(1)
+        self.sync_all()
 
     # As above, this mirrors the original bash test.
     def start_three(self):

--- a/qa/rpc-tests/zcjoinsplit.py
+++ b/qa/rpc-tests/zcjoinsplit.py
@@ -32,6 +32,7 @@ class JoinSplitTest(BitcoinTestFramework):
         shield_tx = self.nodes[0].signrawtransaction(joinsplit_result["rawtxn"])
         self.nodes[0].sendrawtransaction(shield_tx["hex"])
         self.nodes[0].generate(1)
+        self.sync_all()
 
         receive_result = self.nodes[0].zcrawreceive(zcsecretkey, joinsplit_result["encryptednote1"])
         assert_equal(receive_result["exists"], True)
@@ -41,6 +42,7 @@ class JoinSplitTest(BitcoinTestFramework):
         addrtest = self.nodes[0].getnewaddress()
         for xx in range(0,10):
             self.nodes[0].generate(1)
+            self.sync_all()
             for x in range(0,50):
                 self.nodes[0].sendtoaddress(addrtest, 0.01);
 
@@ -49,6 +51,7 @@ class JoinSplitTest(BitcoinTestFramework):
 
         self.nodes[0].sendrawtransaction(joinsplit_result["rawtxn"])
         self.nodes[0].generate(1)
+        self.sync_all()
 
         print "Done!"
         receive_result = self.nodes[0].zcrawreceive(zcsecretkey, joinsplit_result["encryptednote1"])

--- a/qa/rpc-tests/zmq_test.py
+++ b/qa/rpc-tests/zmq_test.py
@@ -41,21 +41,21 @@ class ZMQTest(BitcoinTestFramework):
         print "listen..."
         msg = self.zmqSubSocket.recv_multipart()
         topic = msg[0]
-        assert_equal(topic, b"hashtx")
-        body = msg[1]
-        nseq = msg[2]
-        [nseq] # hush pyflakes
-        msgSequence = struct.unpack('<I', msg[-1])[-1]
-        assert_equal(msgSequence, 0) # must be sequence 0 on hashtx
-
-        msg = self.zmqSubSocket.recv_multipart()
-        topic = msg[0]
         body = msg[1]
         msgSequence = struct.unpack('<I', msg[-1])[-1]
         assert_equal(msgSequence, 0) #must be sequence 0 on hashblock
         blkhash = bytes_to_hex_str(body)
 
         assert_equal(genhashes[0], blkhash) #blockhash from generate must be equal to the hash received over zmq
+
+        msg = self.zmqSubSocket.recv_multipart()
+        topic = msg[0]
+        assert_equal(topic, b"hashtx")
+        body = msg[1]
+        nseq = msg[2]
+        [nseq] # hush pyflakes
+        msgSequence = struct.unpack('<I', msg[-1])[-1]
+        assert_equal(msgSequence, 0) # must be sequence 0 on hashtx
 
         n = 10
         genhashes = self.nodes[1].generate(n)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -675,22 +675,6 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
     }
 }
 
-void ThreadNotifyRecentlyAdded()
-{
-    while (true) {
-        // Run the notifier on an integer second in the steady clock.
-        auto now = std::chrono::steady_clock::now().time_since_epoch();
-        auto nextFire = std::chrono::duration_cast<std::chrono::seconds>(
-            now + std::chrono::seconds(1));
-        std::this_thread::sleep_until(
-            std::chrono::time_point<std::chrono::steady_clock>(nextFire));
-
-        boost::this_thread::interruption_point();
-
-        mempool.NotifyRecentlyAdded();
-    }
-}
-
 bool InitExperimentalMode()
 {
     fExperimentalMode = GetBoolArg("-experimentalfeatures", false);
@@ -1867,8 +1851,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 #endif
 
     // Start the thread that notifies listeners of transactions that have been
-    // recently added to the mempool.
-    threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "txnotify", &ThreadNotifyRecentlyAdded));
+    // recently added to the mempool, or have been added to or removed from the
+    // chain.
+    threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "txnotify", &ThreadNotifyWallets));
 
     if (GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))
         StartTorControl(threadGroup, scheduler);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3014,18 +3014,13 @@ bool static DisconnectTip(CValidationState &state, const CChainParams& chainpara
 
     // Update chainActive and related variables.
     UpdateTip(pindexDelete->pprev, chainparams);
-    // Get the current commitment tree
-    SproutMerkleTree newSproutTree;
-    SaplingMerkleTree newSaplingTree;
-    assert(pcoinsTip->GetSproutAnchorAt(pcoinsTip->GetBestAnchor(SPROUT), newSproutTree));
-    assert(pcoinsTip->GetSaplingAnchorAt(pcoinsTip->GetBestAnchor(SAPLING), newSaplingTree));
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
     BOOST_FOREACH(const CTransaction &tx, block.vtx) {
         SyncWithWallets(tx, NULL);
     }
     // Update cached incremental witnesses
-    GetMainSignals().ChainTip(pindexDelete, &block, newSproutTree, newSaplingTree, false);
+    GetMainSignals().ChainTip(pindexDelete, &block, boost::none);
     return true;
 }
 
@@ -3100,7 +3095,7 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
         SyncWithWallets(tx, pblock);
     }
     // Update cached incremental witnesses
-    GetMainSignals().ChainTip(pindexNew, pblock, oldSproutTree, oldSaplingTree, true);
+    GetMainSignals().ChainTip(pindexNew, pblock, std::make_pair(oldSproutTree, oldSaplingTree));
 
     EnforceNodeDeprecation(pindexNew->nHeight);
 

--- a/src/main.h
+++ b/src/main.h
@@ -512,4 +512,6 @@ uint64_t CalculateCurrentUsage();
  */
 CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Params& consensusParams, int nHeight);
 
+std::map<CBlockIndex*, std::list<CTransaction>> DrainRecentlyConflicted();
+
 #endif // BITCOIN_MAIN_H

--- a/src/main.h
+++ b/src/main.h
@@ -512,6 +512,8 @@ uint64_t CalculateCurrentUsage();
  */
 CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Params& consensusParams, int nHeight);
 
-std::map<CBlockIndex*, std::list<CTransaction>> DrainRecentlyConflicted();
+std::pair<std::map<CBlockIndex*, std::list<CTransaction>>, uint64_t> DrainRecentlyConflicted();
+void SetChainNotifiedSequence(uint64_t recentlyConflictedSequence);
+bool ChainIsFullyNotified();
 
 #endif // BITCOIN_MAIN_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1070,6 +1070,11 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
 
         obj.push_back(Pair("pruneheight",        block->nHeight));
     }
+
+    if (Params().NetworkIDString() == "regtest") {
+        obj.push_back(Pair("fullyNotified", ChainIsFullyNotified()));
+    }
+
     return obj;
 }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -224,7 +224,8 @@ public:
 
     bool nullifierExists(const uint256& nullifier, ShieldedType type) const;
 
-    void NotifyRecentlyAdded();
+    std::pair<std::vector<CTransaction>, uint64_t> DrainRecentlyAdded();
+    void SetNotifiedSequence(uint64_t recentlyAddedSequence);
     bool IsFullyNotified();
 
     unsigned long size()

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -112,7 +112,7 @@ void ThreadNotifyWallets()
         // Pushed in reverse, popped in order.
         std::vector<CachedBlockData> blockStack;
         // Transactions that have been recently conflicted out of the mempool.
-        std::map<CBlockIndex*, std::list<CTransaction>> recentlyConflicted;
+        std::pair<std::map<CBlockIndex*, std::list<CTransaction>>, uint64_t> recentlyConflicted;
         // Transactions that have been recently added to the mempool.
         std::pair<std::vector<CTransaction>, uint64_t> recentlyAdded;
 
@@ -152,7 +152,7 @@ void ThreadNotifyWallets()
                 blockStack.emplace_back(
                     pindex,
                     std::make_pair(oldSproutTree, oldSaplingTree),
-                    recentlyConflicted.at(pindex));
+                    recentlyConflicted.first.at(pindex));
 
                 pindex = pindex->pprev;
             }
@@ -236,6 +236,7 @@ void ThreadNotifyWallets()
         // Update the notified sequence numbers. We only need this in regtest mode,
         // and should not lock on cs or cs_main here otherwise.
         if (chainParams.NetworkIDString() == "regtest") {
+            SetChainNotifiedSequence(recentlyConflicted.second);
             mempool.SetNotifiedSequence(recentlyAdded.second);
         }
     }

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -25,7 +25,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
     g_signals.EraseTransaction.connect(boost::bind(&CValidationInterface::EraseFromWallet, pwalletIn, _1));
     g_signals.UpdatedTransaction.connect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
-    g_signals.ChainTip.connect(boost::bind(&CValidationInterface::ChainTip, pwalletIn, _1, _2, _3, _4, _5));
+    g_signals.ChainTip.connect(boost::bind(&CValidationInterface::ChainTip, pwalletIn, _1, _2, _3));
     g_signals.SetBestChain.connect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.Broadcast.connect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));
@@ -40,7 +40,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.BlockChecked.disconnect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
     g_signals.Broadcast.disconnect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));
     g_signals.Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
-    g_signals.ChainTip.disconnect(boost::bind(&CValidationInterface::ChainTip, pwalletIn, _1, _2, _3, _4, _5));
+    g_signals.ChainTip.disconnect(boost::bind(&CValidationInterface::ChainTip, pwalletIn, _1, _2, _3));
     g_signals.SetBestChain.disconnect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.UpdatedTransaction.disconnect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.EraseTransaction.disconnect(boost::bind(&CValidationInterface::EraseFromWallet, pwalletIn, _1));

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -162,7 +162,9 @@ void ThreadNotifyWallets()
 
         //
         // Execute wallet logic based on the collected state. We MUST NOT take
-        // the cs_main or mempool.cs locks again until after the next sleep.
+        // the cs_main or mempool.cs locks again until after the next sleep;
+        // doing so introduces a locking side-channel between this code and the
+        // network message processing thread.
         //
 
         // Notify block disconnects

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -36,7 +36,7 @@ protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindex) {}
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
     virtual void EraseFromWallet(const uint256 &hash) {}
-    virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, SproutMerkleTree sproutTree, SaplingMerkleTree saplingTree, bool added) {}
+    virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, boost::optional<std::pair<SproutMerkleTree, SaplingMerkleTree>> added) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual void UpdatedTransaction(const uint256 &hash) {}
     virtual void Inventory(const uint256 &hash) {}
@@ -59,7 +59,7 @@ struct CMainSignals {
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming visible). */
     boost::signals2::signal<void (const uint256 &)> UpdatedTransaction;
     /** Notifies listeners of a change to the tip of the active block chain. */
-    boost::signals2::signal<void (const CBlockIndex *, const CBlock *, SproutMerkleTree, SaplingMerkleTree, bool)> ChainTip;
+    boost::signals2::signal<void (const CBlockIndex *, const CBlock *, boost::optional<std::pair<SproutMerkleTree, SaplingMerkleTree>>)> ChainTip;
     /** Notifies listeners of a new active block chain. */
     boost::signals2::signal<void (const CBlockLocator &)> SetBestChain;
     /** Notifies listeners about an inventory item being seen on the network. */

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -76,4 +76,6 @@ struct CMainSignals {
 
 CMainSignals& GetMainSignals();
 
+void ThreadNotifyWallets();
+
 #endif // BITCOIN_VALIDATIONINTERFACE_H

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -28,8 +28,6 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn);
 void UnregisterValidationInterface(CValidationInterface* pwalletIn);
 /** Unregister all wallets from core */
 void UnregisterAllValidationInterfaces();
-/** Push an updated transaction to all registered wallets */
-void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL);
 
 class CValidationInterface {
 protected:

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -574,12 +574,10 @@ void CWallet::ChainTipAdded(const CBlockIndex *pindex,
 
 void CWallet::ChainTip(const CBlockIndex *pindex, 
                        const CBlock *pblock,
-                       SproutMerkleTree sproutTree,
-                       SaplingMerkleTree saplingTree, 
-                       bool added)
+                       boost::optional<std::pair<SproutMerkleTree, SaplingMerkleTree>> added)
 {
     if (added) {
-        ChainTipAdded(pindex, pblock, sproutTree, saplingTree);
+        ChainTipAdded(pindex, pblock, added->first, added->second);
         // Prevent migration transactions from being created when node is syncing after launch,
         // and also when node wakes up from suspension/hibernation and incoming blocks are old.
         if (!IsInitialBlockDownload(Params()) &&

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1195,7 +1195,10 @@ public:
     CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetChange(const CTransaction& tx) const;
-    void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, SproutMerkleTree sproutTree, SaplingMerkleTree saplingTree, bool added);
+    void ChainTip(
+        const CBlockIndex *pindex,
+        const CBlock *pblock,
+        boost::optional<std::pair<SproutMerkleTree, SaplingMerkleTree>> added);
     void RunSaplingMigration(int blockHeight);
     void AddPendingSaplingMigrationTx(const CTransaction& tx);
     /** Saves witness caches and best block locator to disk. */

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -350,7 +350,7 @@ double benchmark_increment_sprout_note_witnesses(size_t nTxs)
     index1.nHeight = 1;
 
     // Increment to get transactions witnessed
-    wallet.ChainTip(&index1, &block1, sproutTree, saplingTree, true);
+    wallet.ChainTip(&index1, &block1, std::make_pair(sproutTree, saplingTree));
 
     // Second block
     CBlock block2;
@@ -366,7 +366,7 @@ double benchmark_increment_sprout_note_witnesses(size_t nTxs)
 
     struct timeval tv_start;
     timer_start(tv_start);
-    wallet.ChainTip(&index2, &block2, sproutTree, saplingTree, true);
+    wallet.ChainTip(&index2, &block2, std::make_pair(sproutTree, saplingTree));
     return timer_stop(tv_start);
 }
 
@@ -412,7 +412,7 @@ double benchmark_increment_sapling_note_witnesses(size_t nTxs)
     index1.nHeight = 1;
 
     // Increment to get transactions witnessed
-    wallet.ChainTip(&index1, &block1, sproutTree, saplingTree, true);
+    wallet.ChainTip(&index1, &block1, std::make_pair(sproutTree, saplingTree));
 
     // Second block
     CBlock block2;
@@ -428,7 +428,7 @@ double benchmark_increment_sapling_note_witnesses(size_t nTxs)
 
     struct timeval tv_start;
     timer_start(tv_start);
-    wallet.ChainTip(&index2, &block2, sproutTree, saplingTree, true);
+    wallet.ChainTip(&index2, &block2, std::make_pair(sproutTree, saplingTree));
     return timer_stop(tv_start);
 }
 


### PR DESCRIPTION
This refactors the logic introduced in #4144 to improve the separation between the node and wallet. The notifier thread now lives next in `src/validationinterface.cpp` directly next to the existing `CMainSignals` node-wallet interface.

Part of #3877.