### PR TITLE
Bitcoin wallet PRs 3

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -32,3 +32,16 @@ Command line options are now parsed strictly in the order in which they are
 specified. It used to be the case that `-X -noX` ends up, unintuitively, with X
 set, as `-X` had precedence over `-noX`. This is no longer the case. Like for
 other software, the last specified value for an option will hold.
+
+Low-level RPC changes
+---------------------
+
+- Bare multisig outputs to our keys are no longer automatically treated as
+  incoming payments. As this feature was only available for multisig outputs for
+  which you had all private keys in your wallet, there was generally no use for
+  them compared to single-key schemes. Furthermore, no address format for such
+  outputs is defined, and wallet software can't easily send to it. These outputs
+  will no longer show up in `listtransactions`, `listunspent`, or contribute to
+  your balance, unless they are explicitly watched (using `importaddress` or
+  `importmulti` with hex script argument). `signrawtransaction*` also still
+  works for them.

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -90,6 +90,7 @@ BITCOIN_TESTS =\
   test/script_P2SH_tests.cpp \
   test/script_P2PKH_tests.cpp \
   test/script_tests.cpp \
+  test/script_standard_tests.cpp \
   test/scriptnum_tests.cpp \
   test/serialize_tests.cpp \
   test/sighash_tests.cpp \

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -15,6 +15,8 @@
 
 using namespace std;
 
+namespace {
+
 /**
  * This is an enum that tracks the execution context of a script, similar to
  * SigVersion in script/interpreter. It is separate however because we want to
@@ -27,7 +29,7 @@ enum class IsMineSigVersion
     P2SH = 1,       //! P2SH redeemScript
 };
 
-static bool PermitsUncompressed(IsMineSigVersion sigversion)
+bool PermitsUncompressed(IsMineSigVersion sigversion)
 {
     return sigversion == IsMineSigVersion::TOP || sigversion == IsMineSigVersion::P2SH;
 }
@@ -46,7 +48,7 @@ unsigned int HaveKeys(const vector<valtype>& pubkeys, const CKeyStore& keystore)
     return nResult;
 }
 
-static isminetype IsMineInner(const CKeyStore& keystore, const CScript& scriptPubKey, IsMineSigVersion sigversion)
+isminetype IsMineInner(const CKeyStore& keystore, const CScript& scriptPubKey, IsMineSigVersion sigversion)
 {
     vector<valtype> vSolutions;
     txnouttype whichType;
@@ -108,6 +110,8 @@ static isminetype IsMineInner(const CKeyStore& keystore, const CScript& scriptPu
     }
     return ISMINE_NO;
 }
+
+} // namespace
 
 isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey)
 {

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -15,6 +15,11 @@
 
 using namespace std;
 
+enum class IsMineSigVersion
+{
+    BASE = 0
+};
+
 typedef vector<unsigned char> valtype;
 
 unsigned int HaveKeys(const vector<valtype>& pubkeys, const CKeyStore& keystore)
@@ -29,7 +34,7 @@ unsigned int HaveKeys(const vector<valtype>& pubkeys, const CKeyStore& keystore)
     return nResult;
 }
 
-static isminetype IsMineInner(const CKeyStore& keystore, const CScript& scriptPubKey, SigVersion sigversion)
+static isminetype IsMineInner(const CKeyStore& keystore, const CScript& scriptPubKey, IsMineSigVersion sigversion)
 {
     vector<valtype> vSolutions;
     txnouttype whichType;
@@ -60,7 +65,7 @@ static isminetype IsMineInner(const CKeyStore& keystore, const CScript& scriptPu
         CScriptID scriptID = CScriptID(uint160(vSolutions[0]));
         CScript subscript;
         if (keystore.GetCScript(scriptID, subscript)) {
-            isminetype ret = IsMineInner(keystore, subscript, SigVersion::SIGVERSION_SPROUT);
+            isminetype ret = IsMineInner(keystore, subscript, IsMineSigVersion::BASE);
             if (ret == ISMINE_SPENDABLE)
                 return ret;
         }
@@ -91,7 +96,7 @@ static isminetype IsMineInner(const CKeyStore& keystore, const CScript& scriptPu
 
 isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey)
 {
-    return IsMineInner(keystore, scriptPubKey, SigVersion::SIGVERSION_SPROUT);
+    return IsMineInner(keystore, scriptPubKey, IsMineSigVersion::BASE);
 }
 
 isminetype IsMine(const CKeyStore& keystore, const CTxDestination& dest)

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -86,6 +86,9 @@ static isminetype IsMineInner(const CKeyStore& keystore, const CScript& scriptPu
 
     case TX_MULTISIG:
     {
+        // Never treat bare multisig outputs as ours (they can still be made watchonly-though)
+        if (sigversion == IsMineSigVersion::TOP) break;
+
         // Only consider transactions "mine" if we own ALL the
         // keys involved. Multi-signature transactions that are
         // partially owned (somebody else has a key that can spend

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -23,7 +23,7 @@ class CScriptID : public uint160
 {
 public:
     CScriptID() : uint160() {}
-    CScriptID(const CScript& in);
+    explicit CScriptID(const CScript& in);
     CScriptID(const uint160& in) : uint160(in) {}
 };
 

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -21,8 +21,6 @@
 
 using namespace std;
 
-typedef vector<unsigned char> valtype;
-
 BOOST_FIXTURE_TEST_SUITE(multisig_tests, BasicTestingSetup)
 
 CScript
@@ -178,95 +176,6 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
 
     for (int i = 0; i < 6; i++)
         BOOST_CHECK(!::IsStandard(malformed[i], whichType));
-}
-
-BOOST_AUTO_TEST_CASE(multisig_Solver1)
-{
-    // Tests Solver() that returns lists of keys that are
-    // required to satisfy a ScriptPubKey
-    //
-    // Also tests IsMine() and ExtractDestination()
-    //
-    // Note: ExtractDestination for the multisignature transactions
-    // always returns false for this release, even if you have
-    // one key that would satisfy an (a|b) or 2-of-3 keys needed
-    // to spend an escrow transaction.
-    //
-    CBasicKeyStore keystore, emptykeystore, partialkeystore;
-    CKey key[3];
-    CTxDestination keyaddr[3];
-    for (int i = 0; i < 3; i++)
-    {
-        key[i].MakeNewKey(true);
-        keystore.AddKey(key[i]);
-        keyaddr[i] = key[i].GetPubKey().GetID();
-    }
-    partialkeystore.AddKey(key[0]);
-
-    {
-        vector<valtype> solutions;
-        txnouttype whichType;
-        CScript s;
-        s << ToByteVector(key[0].GetPubKey()) << OP_CHECKSIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK(solutions.size() == 1);
-        CTxDestination addr;
-        BOOST_CHECK(ExtractDestination(s, addr));
-        BOOST_CHECK(addr == keyaddr[0]);
-        BOOST_CHECK(IsMine(keystore, s));
-        BOOST_CHECK(!IsMine(emptykeystore, s));
-    }
-    {
-        vector<valtype> solutions;
-        txnouttype whichType;
-        CScript s;
-        s << OP_DUP << OP_HASH160 << ToByteVector(key[0].GetPubKey().GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK(solutions.size() == 1);
-        CTxDestination addr;
-        BOOST_CHECK(ExtractDestination(s, addr));
-        BOOST_CHECK(addr == keyaddr[0]);
-        BOOST_CHECK(IsMine(keystore, s));
-        BOOST_CHECK(!IsMine(emptykeystore, s));
-    }
-    {
-        vector<valtype> solutions;
-        txnouttype whichType;
-        CScript s;
-        s << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK_EQUAL(solutions.size(), 4U);
-        CTxDestination addr;
-        BOOST_CHECK(!ExtractDestination(s, addr));
-        BOOST_CHECK(IsMine(keystore, s));
-        BOOST_CHECK(!IsMine(emptykeystore, s));
-        BOOST_CHECK(!IsMine(partialkeystore, s));
-    }
-    {
-        vector<valtype> solutions;
-        txnouttype whichType;
-        CScript s;
-        s << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK_EQUAL(solutions.size(), 4U);
-        vector<CTxDestination> addrs;
-        int nRequired;
-        BOOST_CHECK(ExtractDestinations(s, whichType, addrs, nRequired));
-        BOOST_CHECK(addrs[0] == keyaddr[0]);
-        BOOST_CHECK(addrs[1] == keyaddr[1]);
-        BOOST_CHECK(nRequired == 1);
-        BOOST_CHECK(IsMine(keystore, s));
-        BOOST_CHECK(!IsMine(emptykeystore, s));
-        BOOST_CHECK(!IsMine(partialkeystore, s));
-    }
-    {
-        vector<valtype> solutions;
-        txnouttype whichType;
-        CScript s;
-        s << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << ToByteVector(key[2].GetPubKey()) << OP_3 << OP_CHECKMULTISIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK(solutions.size() == 5);
-    }
 }
 
 // Parameterized testing over consensus branch ids

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -465,7 +465,13 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         keystore.AddKey(keys[1]);
 
         result = IsMine(keystore, scriptPubKey);
-        BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+        // Keystore has 2/2 keys and the script
+        keystore.AddCScript(scriptPubKey);
+
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
     }
 
     // P2SH multisig

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -1,0 +1,339 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "key.h"
+#include "script/script.h"
+#include "script/script_error.h"
+#include "script/standard.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+
+BOOST_FIXTURE_TEST_SUITE(script_standard_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
+{
+    CKey keys[3];
+    CPubKey pubkeys[3];
+    for (int i = 0; i < 3; i++) {
+        keys[i].MakeNewKey(true);
+        pubkeys[i] = keys[i].GetPubKey();
+    }
+
+    CScript s;
+    txnouttype whichType;
+    std::vector<std::vector<unsigned char> > solutions;
+
+    // TX_PUBKEY
+    s.clear();
+    s << ToByteVector(pubkeys[0]) << OP_CHECKSIG;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_PUBKEY);
+    BOOST_CHECK_EQUAL(solutions.size(), 1);
+    BOOST_CHECK(solutions[0] == ToByteVector(pubkeys[0]));
+
+    // TX_PUBKEYHASH
+    s.clear();
+    s << OP_DUP << OP_HASH160 << ToByteVector(pubkeys[0].GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_PUBKEYHASH);
+    BOOST_CHECK_EQUAL(solutions.size(), 1);
+    BOOST_CHECK(solutions[0] == ToByteVector(pubkeys[0].GetID()));
+
+    // TX_SCRIPTHASH
+    CScript redeemScript(s); // initialize with leftover P2PKH script
+    s.clear();
+    s << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_SCRIPTHASH);
+    BOOST_CHECK_EQUAL(solutions.size(), 1);
+    BOOST_CHECK(solutions[0] == ToByteVector(CScriptID(redeemScript)));
+
+    // TX_MULTISIG
+    s.clear();
+    s << OP_1 <<
+        ToByteVector(pubkeys[0]) <<
+        ToByteVector(pubkeys[1]) <<
+        OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_MULTISIG);
+    BOOST_CHECK_EQUAL(solutions.size(), 4);
+    BOOST_CHECK(solutions[0] == std::vector<unsigned char>({1}));
+    BOOST_CHECK(solutions[1] == ToByteVector(pubkeys[0]));
+    BOOST_CHECK(solutions[2] == ToByteVector(pubkeys[1]));
+    BOOST_CHECK(solutions[3] == std::vector<unsigned char>({2}));
+
+    s.clear();
+    s << OP_2 <<
+        ToByteVector(pubkeys[0]) <<
+        ToByteVector(pubkeys[1]) <<
+        ToByteVector(pubkeys[2]) <<
+        OP_3 << OP_CHECKMULTISIG;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_MULTISIG);
+    BOOST_CHECK_EQUAL(solutions.size(), 5);
+    BOOST_CHECK(solutions[0] == std::vector<unsigned char>({2}));
+    BOOST_CHECK(solutions[1] == ToByteVector(pubkeys[0]));
+    BOOST_CHECK(solutions[2] == ToByteVector(pubkeys[1]));
+    BOOST_CHECK(solutions[3] == ToByteVector(pubkeys[2]));
+    BOOST_CHECK(solutions[4] == std::vector<unsigned char>({3}));
+
+    // TX_NULL_DATA
+    solutions.clear();
+    s.clear();
+    s << OP_RETURN <<
+        std::vector<unsigned char>({0}) <<
+        std::vector<unsigned char>({75}) <<
+        std::vector<unsigned char>({255});
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_NULL_DATA);
+    BOOST_CHECK_EQUAL(solutions.size(), 0);
+
+    // TX_NONSTANDARD
+    solutions.clear();
+    s.clear();
+    s << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_NONSTANDARD);
+}
+
+BOOST_AUTO_TEST_CASE(script_standard_Solver_failure)
+{
+    CKey key;
+    CPubKey pubkey;
+    key.MakeNewKey(true);
+    pubkey = key.GetPubKey();
+
+    CScript s;
+    txnouttype whichType;
+    std::vector<std::vector<unsigned char> > solutions;
+
+    // TX_PUBKEY with incorrectly sized pubkey
+    s.clear();
+    s << std::vector<unsigned char>(30, 0x01) << OP_CHECKSIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_PUBKEYHASH with incorrectly sized key hash
+    s.clear();
+    s << OP_DUP << OP_HASH160 << ToByteVector(pubkey) << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_SCRIPTHASH with incorrectly sized script hash
+    s.clear();
+    s << OP_HASH160 << std::vector<unsigned char>(21, 0x01) << OP_EQUAL;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_MULTISIG 0/2
+    s.clear();
+    s << OP_0 << ToByteVector(pubkey) << OP_1 << OP_CHECKMULTISIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_MULTISIG 2/1
+    s.clear();
+    s << OP_2 << ToByteVector(pubkey) << OP_1 << OP_CHECKMULTISIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_MULTISIG n = 2 with 1 pubkey
+    s.clear();
+    s << OP_1 << ToByteVector(pubkey) << OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_MULTISIG n = 1 with 0 pubkeys
+    s.clear();
+    s << OP_1 << OP_1 << OP_CHECKMULTISIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_NULL_DATA with other opcodes
+    s.clear();
+    s << OP_RETURN << std::vector<unsigned char>({75}) << OP_ADD;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_WITNESS with unknown version
+    s.clear();
+    s << OP_1 << ToByteVector(pubkey);
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_WITNESS with incorrect program size
+    s.clear();
+    s << OP_0 << std::vector<unsigned char>(19, 0x01);
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+}
+
+BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)
+{
+    CKey key;
+    CPubKey pubkey;
+    key.MakeNewKey(true);
+    pubkey = key.GetPubKey();
+
+    CScript s;
+    CTxDestination address;
+
+    // TX_PUBKEY
+    s.clear();
+    s << ToByteVector(pubkey) << OP_CHECKSIG;
+    BOOST_CHECK(ExtractDestination(s, address));
+    BOOST_CHECK(boost::get<CKeyID>(&address) &&
+                *boost::get<CKeyID>(&address) == pubkey.GetID());
+
+    // TX_PUBKEYHASH
+    s.clear();
+    s << OP_DUP << OP_HASH160 << ToByteVector(pubkey.GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK(ExtractDestination(s, address));
+    BOOST_CHECK(boost::get<CKeyID>(&address) &&
+                *boost::get<CKeyID>(&address) == pubkey.GetID());
+
+    // TX_SCRIPTHASH
+    CScript redeemScript(s); // initialize with leftover P2PKH script
+    s.clear();
+    s << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
+    BOOST_CHECK(ExtractDestination(s, address));
+    BOOST_CHECK(boost::get<CScriptID>(&address) &&
+                *boost::get<CScriptID>(&address) == CScriptID(redeemScript));
+
+    // TX_MULTISIG
+    s.clear();
+    s << OP_1 << ToByteVector(pubkey) << OP_1 << OP_CHECKMULTISIG;
+    BOOST_CHECK(!ExtractDestination(s, address));
+
+    // TX_NULL_DATA
+    s.clear();
+    s << OP_RETURN << std::vector<unsigned char>({75});
+    BOOST_CHECK(!ExtractDestination(s, address));
+
+    // TX_WITNESS_V0_KEYHASH
+    s.clear();
+    s << OP_0 << ToByteVector(pubkey);
+    BOOST_CHECK(!ExtractDestination(s, address));
+
+    // TX_WITNESS_V0_SCRIPTHASH
+    s.clear();
+    s << OP_0 << ToByteVector(CScriptID(redeemScript));
+    BOOST_CHECK(!ExtractDestination(s, address));
+}
+
+BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
+{
+    CKey keys[3];
+    CPubKey pubkeys[3];
+    for (int i = 0; i < 3; i++) {
+        keys[i].MakeNewKey(true);
+        pubkeys[i] = keys[i].GetPubKey();
+    }
+
+    CScript s;
+    txnouttype whichType;
+    std::vector<CTxDestination> addresses;
+    int nRequired;
+
+    // TX_PUBKEY
+    s.clear();
+    s << ToByteVector(pubkeys[0]) << OP_CHECKSIG;
+    BOOST_CHECK(ExtractDestinations(s, whichType, addresses, nRequired));
+    BOOST_CHECK_EQUAL(whichType, TX_PUBKEY);
+    BOOST_CHECK_EQUAL(addresses.size(), 1);
+    BOOST_CHECK_EQUAL(nRequired, 1);
+    BOOST_CHECK(boost::get<CKeyID>(&addresses[0]) &&
+                *boost::get<CKeyID>(&addresses[0]) == pubkeys[0].GetID());
+
+    // TX_PUBKEYHASH
+    s.clear();
+    s << OP_DUP << OP_HASH160 << ToByteVector(pubkeys[0].GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK(ExtractDestinations(s, whichType, addresses, nRequired));
+    BOOST_CHECK_EQUAL(whichType, TX_PUBKEYHASH);
+    BOOST_CHECK_EQUAL(addresses.size(), 1);
+    BOOST_CHECK_EQUAL(nRequired, 1);
+    BOOST_CHECK(boost::get<CKeyID>(&addresses[0]) &&
+                *boost::get<CKeyID>(&addresses[0]) == pubkeys[0].GetID());
+
+    // TX_SCRIPTHASH
+    CScript redeemScript(s); // initialize with leftover P2PKH script
+    s.clear();
+    s << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
+    BOOST_CHECK(ExtractDestinations(s, whichType, addresses, nRequired));
+    BOOST_CHECK_EQUAL(whichType, TX_SCRIPTHASH);
+    BOOST_CHECK_EQUAL(addresses.size(), 1);
+    BOOST_CHECK_EQUAL(nRequired, 1);
+    BOOST_CHECK(boost::get<CScriptID>(&addresses[0]) &&
+                *boost::get<CScriptID>(&addresses[0]) == CScriptID(redeemScript));
+
+    // TX_MULTISIG
+    s.clear();
+    s << OP_2 <<
+        ToByteVector(pubkeys[0]) <<
+        ToByteVector(pubkeys[1]) <<
+        OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK(ExtractDestinations(s, whichType, addresses, nRequired));
+    BOOST_CHECK_EQUAL(whichType, TX_MULTISIG);
+    BOOST_CHECK_EQUAL(addresses.size(), 2);
+    BOOST_CHECK_EQUAL(nRequired, 2);
+    BOOST_CHECK(boost::get<CKeyID>(&addresses[0]) &&
+                *boost::get<CKeyID>(&addresses[0]) == pubkeys[0].GetID());
+    BOOST_CHECK(boost::get<CKeyID>(&addresses[1]) &&
+                *boost::get<CKeyID>(&addresses[1]) == pubkeys[1].GetID());
+
+    // TX_NULL_DATA
+    s.clear();
+    s << OP_RETURN << std::vector<unsigned char>({75});
+    BOOST_CHECK(!ExtractDestinations(s, whichType, addresses, nRequired));
+
+    // TX_WITNESS_V0_KEYHASH
+    s.clear();
+    s << OP_0 << ToByteVector(pubkeys[0].GetID());
+    BOOST_CHECK(!ExtractDestinations(s, whichType, addresses, nRequired));
+
+    // TX_WITNESS_V0_SCRIPTHASH
+    s.clear();
+    s << OP_0 << ToByteVector(CScriptID(redeemScript));
+    BOOST_CHECK(!ExtractDestinations(s, whichType, addresses, nRequired));
+}
+
+BOOST_AUTO_TEST_CASE(script_standard_GetScriptFor_)
+{
+    CKey keys[3];
+    CPubKey pubkeys[3];
+    for (int i = 0; i < 3; i++) {
+        keys[i].MakeNewKey(true);
+        pubkeys[i] = keys[i].GetPubKey();
+    }
+
+    CScript expected, result;
+
+    // CKeyID
+    expected.clear();
+    expected << OP_DUP << OP_HASH160 << ToByteVector(pubkeys[0].GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    result = GetScriptForDestination(pubkeys[0].GetID());
+    BOOST_CHECK(result == expected);
+
+    // CScriptID
+    CScript redeemScript(result);
+    expected.clear();
+    expected << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
+    result = GetScriptForDestination(CScriptID(redeemScript));
+    BOOST_CHECK(result == expected);
+
+    // CNoDestination
+    expected.clear();
+    result = GetScriptForDestination(CNoDestination());
+    BOOST_CHECK(result == expected);
+
+    // GetScriptForRawPubKey
+    expected.clear();
+    expected << ToByteVector(pubkeys[0]) << OP_CHECKSIG;
+    result = GetScriptForRawPubKey(pubkeys[0]);
+    BOOST_CHECK(result == expected);
+
+    // GetScriptForMultisig
+    expected.clear();
+    expected << OP_2 <<
+        ToByteVector(pubkeys[0]) <<
+        ToByteVector(pubkeys[1]) <<
+        ToByteVector(pubkeys[2]) <<
+        OP_3 << OP_CHECKMULTISIG;
+    result = GetScriptForMultisig(2, std::vector<CPubKey>(pubkeys, pubkeys + 3));
+    BOOST_CHECK(result == expected);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -162,6 +162,11 @@ void ImportScript(const CScript& script, const string& strLabel, bool isRedeemSc
         if (!pwalletMain->HaveCScript(script) && !pwalletMain->AddCScript(script))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding p2sh redeemScript to wallet");
         ImportAddress(CScriptID(script), strLabel);
+    } else {
+        CTxDestination destination;
+        if (ExtractDestination(script, destination)) {
+            pwalletMain->SetAddressBook(destination, strLabel, "receive");
+        }
     }
 }
 
@@ -190,6 +195,8 @@ UniValue importaddress(const UniValue& params, bool fHelp)
             "4. p2sh                 (boolean, optional, default=false) Add the P2SH version of the script as well\n"
             "\nNote: This call can take minutes to complete if rescan is true.\n"
             "If you have the full public key, you should call importpubkey instead of this.\n"
+            "\nNote: If you import a non-standard raw script in hex form, outputs sending to it will be treated\n"
+            "as change, and not show up in many RPCs.\n"
             "\nExamples:\n"
             "\nImport a script with rescan\n"
             + HelpExampleCli("importaddress", "\"myscript\"") +

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -159,9 +159,11 @@ void ImportScript(const CScript& script, const string& strLabel, bool isRedeemSc
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
 
     if (isRedeemScript) {
-        if (!pwalletMain->HaveCScript(script) && !pwalletMain->AddCScript(script))
+        const CScriptID id(script);
+        if (!pwalletMain->HaveCScript(id) && !pwalletMain->AddCScript(script)) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding p2sh redeemScript to wallet");
-        ImportAddress(CScriptID(script), strLabel);
+        }
+        ImportAddress(id, strLabel);
     } else {
         CTxDestination destination;
         if (ExtractDestination(script, destination)) {


### PR DESCRIPTION
Cherry-picked from the following upstream PRs:

- bitcoin/bitcoin#7687
- bitcoin/bitcoin#11116
  - Excludes SegWit tests
  - Excludes `isInvalid` code (which is part of the SegWit support structure)
- bitcoin/bitcoin#13002
  - Excludes changes to `importwallet` (missing bitcoin/bitcoin#11667)
  - Excludes changes to `ProcessImport` (missing bitcoin/bitcoin#7551)
  - Third commit was rewritten to add an internal SigVersion argument (which we didn't have because it was added to support SegWit logic).
