### PR TITLE
insightexplorer: LOCK(cs_main) during rpcs

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -471,6 +471,8 @@ UniValue getblockdeltas(const UniValue& params, bool fHelp)
     std::string strHash = params[0].get_str();
     uint256 hash(uint256S(strHash));
 
+    LOCK(cs_main);
+
     if (mapBlockIndex.count(hash) == 0)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1099,8 +1099,11 @@ UniValue getspentinfo(const UniValue& params, bool fHelp)
     CSpentIndexKey key(txid, outputIndex);
     CSpentIndexValue value;
 
-    if (!GetSpentIndex(key, value)) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to get spent info");
+    {
+        LOCK(cs_main);
+        if (!GetSpentIndex(key, value)) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to get spent info");
+        }
     }
     UniValue obj(UniValue::VOBJ);
     obj.push_back(Pair("txid", value.txid.GetHex()));


### PR DESCRIPTION
Closes #4223. Ensure lock cs_main is held during calls to GetSpentIndex().