### PR TITLE
Refactor experimental feature handling

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -141,6 +141,7 @@ BITCOIN_CORE_H = \
   core_io.h \
   core_memusage.h \
   deprecation.h \
+  experimental_features.h \
   hash.h \
   httprpc.h \
   httpserver.h \
@@ -249,6 +250,7 @@ libbitcoin_server_a_SOURCES = \
   chain.cpp \
   checkpoints.cpp \
   deprecation.cpp \
+  experimental_features.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \

--- a/src/experimental_features.cpp
+++ b/src/experimental_features.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#include "experimental_features.h"
+
+#include "util.h"
+
+bool fExperimentalDeveloperEncryptWallet = false;
+bool fExperimentalDeveloperSetPoolSizeZero = false;
+bool fExperimentalPaymentDisclosure = false;
+bool fExperimentalInsightExplorer = false;
+
+boost::optional<std::string> InitExperimentalMode()
+{
+    auto fExperimentalMode = GetBoolArg("-experimentalfeatures", false);
+    fExperimentalDeveloperEncryptWallet = GetBoolArg("-developerencryptwallet", false);
+    fExperimentalDeveloperSetPoolSizeZero = GetBoolArg("-developersetpoolsizezero", false);
+    fExperimentalPaymentDisclosure = GetBoolArg("-paymentdisclosure", false);
+    fExperimentalInsightExplorer = GetBoolArg("-insightexplorer", false);
+
+    // Fail if user has set experimental options without the global flag
+    if (!fExperimentalMode) {
+        if (fExperimentalDeveloperEncryptWallet) {
+            return _("Wallet encryption requires -experimentalfeatures.");
+        } else if (fExperimentalDeveloperSetPoolSizeZero) {
+            return _("Setting the size of shielded pools to zero requires -experimentalfeatures.");
+        } else if (fExperimentalPaymentDisclosure) {
+            return _("Payment disclosure requires -experimentalfeatures.");
+        } else if (fExperimentalInsightExplorer) {
+            return _("Insight explorer requires -experimentalfeatures.");
+        }
+    }
+    return boost::none;
+}
+
+std::vector<std::string> GetExperimentalFeatures()
+{
+    std::vector<std::string> experimentalfeatures;
+    if (fExperimentalDeveloperEncryptWallet)
+        experimentalfeatures.push_back("developerencryptwallet");
+    if (fExperimentalDeveloperSetPoolSizeZero)
+        experimentalfeatures.push_back("developersetpoolsizezero");
+    if (fExperimentalPaymentDisclosure)
+        experimentalfeatures.push_back("paymentdisclosure");
+    if (fExperimentalInsightExplorer)
+        experimentalfeatures.push_back("insightexplorer");
+
+    return experimentalfeatures;
+}

--- a/src/experimental_features.h
+++ b/src/experimental_features.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#include <string>
+#include <vector>
+#include <boost/optional.hpp>
+
+extern bool fExperimentalDeveloperEncryptWallet;
+extern bool fExperimentalDeveloperSetPoolSizeZero;
+extern bool fExperimentalPaymentDisclosure;
+extern bool fExperimentalInsightExplorer;
+
+boost::optional<std::string> InitExperimentalMode();
+std::vector<std::string> GetExperimentalFeatures();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,7 +69,6 @@ int nScriptCheckThreads = 0;
 bool fImporting = false;
 bool fReindex = false;
 bool fTxIndex = false;
-bool fInsightExplorer = false;  // insightexplorer
 bool fAddressIndex = false;     // insightexplorer
 bool fSpentIndex = false;       // insightexplorer
 bool fTimestampIndex = false;   // insightexplorer
@@ -4416,6 +4415,7 @@ bool static LoadBlockIndexDB()
 
     // insightexplorer
     // Check whether block explorer features are enabled
+    bool fInsightExplorer = false;
     pblocktree->ReadFlag("insightexplorer", fInsightExplorer);
     LogPrintf("%s: insight explorer %s\n", __func__, fInsightExplorer ? "enabled" : "disabled");
     fAddressIndex = fInsightExplorer;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include "consensus/upgrades.h"
 #include "consensus/validation.h"
 #include "deprecation.h"
+#include "experimental_features.h"
 #include "init.h"
 #include "merkleblock.h"
 #include "metrics.h"
@@ -65,7 +66,6 @@ static int64_t nTimeBestReceived = 0;
 CWaitableCriticalSection csBestBlock;
 CConditionVariable cvBlockChange;
 int nScriptCheckThreads = 0;
-bool fExperimentalMode = false;
 bool fImporting = false;
 bool fReindex = false;
 bool fTxIndex = false;
@@ -3505,7 +3505,7 @@ void FallbackSproutValuePoolBalance(
     }
 
     // When developer option -developersetpoolsizezero is enabled, we don't need a fallback balance.
-    if (fExperimentalMode && mapArgs.count("-developersetpoolsizezero")) {
+    if (fExperimentalDeveloperSetPoolSizeZero) {
         return;
     }
 
@@ -4337,7 +4337,7 @@ bool static LoadBlockIndexDB()
             // If developer option -developersetpoolsizezero has been enabled,
             // override and set the in-memory size of shielded pools to zero.  An unshielding transaction
             // can then be used to trigger and test the handling of turnstile violations.
-            if (fExperimentalMode && mapArgs.count("-developersetpoolsizezero")) {
+            if (fExperimentalDeveloperSetPoolSizeZero) {
                 pindex->nChainSproutValue = 0;
                 pindex->nChainSaplingValue = 0;
             }
@@ -4761,11 +4761,10 @@ bool InitBlockIndex(const CChainParams& chainparams)
     pblocktree->WriteFlag("txindex", fTxIndex);
 
     // Use the provided setting for -insightexplorer in the new database
-    fInsightExplorer = GetBoolArg("-insightexplorer", false);
-    pblocktree->WriteFlag("insightexplorer", fInsightExplorer);
-    fAddressIndex = fInsightExplorer;
-    fSpentIndex = fInsightExplorer;
-    fTimestampIndex = fInsightExplorer;
+    pblocktree->WriteFlag("insightexplorer", fExperimentalInsightExplorer);
+    fAddressIndex = fExperimentalInsightExplorer;
+    fSpentIndex = fExperimentalInsightExplorer;
+    fTimestampIndex = fExperimentalInsightExplorer;
 
     LogPrintf("Initializing databases...\n");
 

--- a/src/main.h
+++ b/src/main.h
@@ -134,18 +134,13 @@ extern uint64_t nLastBlockSize;
 extern const std::string strMessageMagic;
 extern CWaitableCriticalSection csBestBlock;
 extern CConditionVariable cvBlockChange;
-extern bool fExperimentalMode;
 extern bool fImporting;
 extern bool fReindex;
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
 
-// START insightexplorer
-extern bool fInsightExplorer;
-
 // The following flags enable specific indices (DB tables), but are not exposed as
 // separate command-line options; instead they are enabled by experimental feature "-insightexplorer"
-// and are always equal to the overall controlling flag, fInsightExplorer.
 
 // Maintain a full address index, used to query for the balance, txids and unspent outputs for addresses
 extern bool fAddressIndex;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -8,6 +8,7 @@
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "consensus/validation.h"
+#include "experimental_features.h"
 #include "key_io.h"
 #include "main.h"
 #include "primitives/transaction.h"
@@ -77,21 +78,6 @@ double GetDifficulty(const CBlockIndex* blockindex)
 double GetNetworkDifficulty(const CBlockIndex* blockindex)
 {
     return GetDifficultyINTERNAL(blockindex, true);
-}
-
-UniValue GetExperimentalFeatures()
-{
-    UniValue experimentalfeatures(UniValue::VARR);
-    if (mapArgs.count("-developerencryptwallet"))
-        experimentalfeatures.push_back("developerencryptwallet");
-    if (mapArgs.count("-developersetpoolsizezero"))
-        experimentalfeatures.push_back("developersetpoolsizezero");
-    if (mapArgs.count("-paymentdisclosure"))
-        experimentalfeatures.push_back("paymentdisclosure");
-    if (mapArgs.count("-insightexplorer"))
-        experimentalfeatures.push_back("insightexplorer");
-
-    return experimentalfeatures;
 }
 
 static UniValue ValuePoolDesc(
@@ -421,11 +407,9 @@ UniValue getrawmempool(const UniValue& params, bool fHelp)
 // insightexplorer
 UniValue getblockdeltas(const UniValue& params, bool fHelp)
 {
-    std::string enableArg = "insightexplorer";
-    bool enabled = fExperimentalMode && fInsightExplorer;
     std::string disabledMsg = "";
-    if (!enabled) {
-        disabledMsg = experimentalDisabledHelpMsg("getblockdeltas", enableArg);
+    if (!fExperimentalInsightExplorer) {
+        disabledMsg = experimentalDisabledHelpMsg("getblockdeltas", "insightexplorer");
     }
     if (fHelp || params.size() != 1)
         throw runtime_error(
@@ -478,7 +462,7 @@ UniValue getblockdeltas(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getblockdeltas", "\"00227e566682aebd6a7a5b772c96d7a999cadaebeaf1ce96f4191a3aad58b00b\"")
         );
 
-    if (!enabled) {
+    if (!fExperimentalInsightExplorer) {
         throw JSONRPCError(RPC_MISC_ERROR, "Error: getblockdeltas is disabled. "
             "Run './zcash-cli help getblockdeltas' for instructions on how to enable this feature.");
     }
@@ -506,11 +490,9 @@ UniValue getblockdeltas(const UniValue& params, bool fHelp)
 // insightexplorer
 UniValue getblockhashes(const UniValue& params, bool fHelp)
 {
-    std::string enableArg = "insightexplorer";
-    bool fEnableGetBlockHashes = fExperimentalMode && fInsightExplorer;
     std::string disabledMsg = "";
-    if (!fEnableGetBlockHashes) {
-        disabledMsg = experimentalDisabledHelpMsg("getblockhashes", enableArg);
+    if (!fExperimentalInsightExplorer) {
+        disabledMsg = experimentalDisabledHelpMsg("getblockhashes", "insightexplorer");
     }
     if (fHelp || params.size() < 2)
         throw runtime_error(
@@ -543,7 +525,7 @@ UniValue getblockhashes(const UniValue& params, bool fHelp)
             + HelpExampleCli("getblockhashes", "1558141697 1558141576 '{\"noOrphans\":false, \"logicalTimes\":true}'")
             );
 
-    if (!fEnableGetBlockHashes) {
+    if (!fExperimentalInsightExplorer) {
         throw JSONRPCError(RPC_MISC_ERROR, "Error: getblockhashes is disabled. "
             "Run './zcash-cli help getblockhashes' for instructions on how to enable this feature.");
     }
@@ -936,24 +918,6 @@ UniValue verifychain(const UniValue& params, bool fHelp)
     return CVerifyDB().VerifyDB(Params(), pcoinsTip, nCheckLevel, nCheckDepth);
 }
 
-UniValue getexperimentalfeatures(const UniValue& params, bool fHelp)
-{
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-            "getexperimentalfeatures\n"
-            "\nReturns enabled experimental features.\n"
-            "\nResult:\n"
-            "  [\n"
-            "     \"experimentalfeature\"     (string) The enabled experimental feature\n"
-            "     ,...\n"
-            "  ],\n"            "\nExamples:\n"
-            + HelpExampleCli("getexperimentalfeatures", "")
-            + HelpExampleRpc("getexperimentalfeatures", "")
-        );
-
-    LOCK(cs_main);
-    return GetExperimentalFeatures();
-}
 /** Implementation of IsSuperMajority with better feedback */
 static UniValue SoftForkMajorityDesc(int minVersion, CBlockIndex* pindex, int nRequired, const Consensus::Params& consensusParams)
 {
@@ -1119,7 +1083,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     if (Params().NetworkIDString() == "regtest") {
         obj.push_back(Pair("fullyNotified", ChainIsFullyNotified()));
     }
-    
+
     return obj;
 }
 
@@ -1355,7 +1319,6 @@ static const CRPCCommand commands[] =
     { "blockchain",         "gettxout",               &gettxout,               true  },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true  },
     { "blockchain",         "verifychain",            &verifychain,            true  },
-    { "blockchain",         "getexperimentalfeatures",&getexperimentalfeatures,true  },
 
     // insightexplorer
     { "blockchain",         "getblockdeltas",         &getblockdeltas,         false },    

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -79,6 +79,21 @@ double GetNetworkDifficulty(const CBlockIndex* blockindex)
     return GetDifficultyINTERNAL(blockindex, true);
 }
 
+UniValue GetExperimentalFeatures()
+{
+    UniValue experimentalfeatures(UniValue::VARR);
+    if (mapArgs.count("-developerencryptwallet"))
+        experimentalfeatures.push_back("developerencryptwallet");
+    if (mapArgs.count("-developersetpoolsizezero"))
+        experimentalfeatures.push_back("developersetpoolsizezero");
+    if (mapArgs.count("-paymentdisclosure"))
+        experimentalfeatures.push_back("paymentdisclosure");
+    if (mapArgs.count("-insightexplorer"))
+        experimentalfeatures.push_back("insightexplorer");
+
+    return experimentalfeatures;
+}
+
 static UniValue ValuePoolDesc(
     const std::string &name,
     const boost::optional<CAmount> chainValue,
@@ -921,6 +936,24 @@ UniValue verifychain(const UniValue& params, bool fHelp)
     return CVerifyDB().VerifyDB(Params(), pcoinsTip, nCheckLevel, nCheckDepth);
 }
 
+UniValue getexperimentalfeatures(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getexperimentalfeatures\n"
+            "\nReturns enabled experimental features.\n"
+            "\nResult:\n"
+            "  [\n"
+            "     \"experimentalfeature\"     (string) The enabled experimental feature\n"
+            "     ,...\n"
+            "  ],\n"            "\nExamples:\n"
+            + HelpExampleCli("getexperimentalfeatures", "")
+            + HelpExampleRpc("getexperimentalfeatures", "")
+        );
+
+    LOCK(cs_main);
+    return GetExperimentalFeatures();
+}
 /** Implementation of IsSuperMajority with better feedback */
 static UniValue SoftForkMajorityDesc(int minVersion, CBlockIndex* pindex, int nRequired, const Consensus::Params& consensusParams)
 {
@@ -1086,7 +1119,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     if (Params().NetworkIDString() == "regtest") {
         obj.push_back(Pair("fullyNotified", ChainIsFullyNotified()));
     }
-
+    
     return obj;
 }
 
@@ -1322,6 +1355,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "gettxout",               &gettxout,               true  },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true  },
     { "blockchain",         "verifychain",            &verifychain,            true  },
+    { "blockchain",         "getexperimentalfeatures",&getexperimentalfeatures,true  },
 
     // insightexplorer
     { "blockchain",         "getblockdeltas",         &getblockdeltas,         false },    

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -6,6 +6,7 @@
 #include "clientversion.h"
 #include "init.h"
 #include "key_io.h"
+#include "experimental_features.h"
 #include "main.h"
 #include "net.h"
 #include "netbase.h"
@@ -479,6 +480,29 @@ UniValue setmocktime(const UniValue& params, bool fHelp)
     return NullUniValue;
 }
 
+UniValue getexperimentalfeatures(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getexperimentalfeatures\n"
+            "\nReturns enabled experimental features.\n"
+            "\nResult:\n"
+            "  [\n"
+            "     \"experimentalfeature\"     (string) The enabled experimental feature\n"
+            "     ,...\n"
+            "  ],\n"            "\nExamples:\n"
+            + HelpExampleCli("getexperimentalfeatures", "")
+            + HelpExampleRpc("getexperimentalfeatures", "")
+        );
+
+    LOCK(cs_main);
+    UniValue experimentalfeatures(UniValue::VARR);
+    for (auto& enabledfeature : GetExperimentalFeatures()) {
+        experimentalfeatures.push_back(enabledfeature);
+    }
+    return experimentalfeatures;
+}
+
 // insightexplorer
 static bool getAddressFromIndex(
     int type, const uint160 &hash, std::string &address)
@@ -552,11 +576,9 @@ static bool getAddressesFromParams(
 // insightexplorer
 UniValue getaddressmempool(const UniValue& params, bool fHelp)
 {
-    std::string enableArg = "insightexplorer";
-    bool enabled = fExperimentalMode && fInsightExplorer;
     std::string disabledMsg = "";
-    if (!enabled) {
-        disabledMsg = experimentalDisabledHelpMsg("getaddressmempool", enableArg);
+    if (!fExperimentalInsightExplorer) {
+        disabledMsg = experimentalDisabledHelpMsg("getaddressmempool", "insightexplorer");
     }
     if (fHelp || params.size() != 1)
         throw runtime_error(
@@ -590,7 +612,7 @@ UniValue getaddressmempool(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getaddressmempool", "{\"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"]}")
         );
 
-    if (!enabled) {
+    if (!fExperimentalInsightExplorer) {
         throw JSONRPCError(RPC_MISC_ERROR, "Error: getaddressmempool is disabled. "
             "Run './zcash-cli help getaddressmempool' for instructions on how to enable this feature.");
     }
@@ -633,11 +655,9 @@ UniValue getaddressmempool(const UniValue& params, bool fHelp)
 // insightexplorer
 UniValue getaddressutxos(const UniValue& params, bool fHelp)
 {
-    std::string enableArg = "insightexplorer";
-    bool enabled = fExperimentalMode && fInsightExplorer;
     std::string disabledMsg = "";
-    if (!enabled) {
-        disabledMsg = experimentalDisabledHelpMsg("getaddressutxos", enableArg);
+    if (!fExperimentalInsightExplorer) {
+        disabledMsg = experimentalDisabledHelpMsg("getaddressutxos", "insightexplorer");
     }
     if (fHelp || params.size() != 1)
         throw runtime_error(
@@ -687,7 +707,7 @@ UniValue getaddressutxos(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getaddressutxos", "{\"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"], \"chainInfo\": true}")
             );
 
-    if (!enabled) {
+    if (!fExperimentalInsightExplorer) {
         throw JSONRPCError(RPC_MISC_ERROR, "Error: getaddressutxos is disabled. "
             "Run './zcash-cli help getaddressutxos' for instructions on how to enable this feature.");
     }
@@ -792,11 +812,9 @@ static void getAddressesInHeightRange(
 // insightexplorer
 UniValue getaddressdeltas(const UniValue& params, bool fHelp)
 {
-    std::string enableArg = "insightexplorer";
-    bool enabled = fExperimentalMode && fInsightExplorer;
     std::string disabledMsg = "";
-    if (!enabled) {
-        disabledMsg = experimentalDisabledHelpMsg("getaddressdeltas", enableArg);
+    if (!fExperimentalInsightExplorer) {
+        disabledMsg = experimentalDisabledHelpMsg("getaddressdeltas", "insightexplorer");
     }
     if (fHelp || params.size() != 1)
         throw runtime_error(
@@ -856,7 +874,7 @@ UniValue getaddressdeltas(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getaddressdeltas", "{\"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"], \"start\": 1000, \"end\": 2000, \"chainInfo\": true}")
         );
 
-    if (!enabled) {
+    if (!fExperimentalInsightExplorer) {
         throw JSONRPCError(RPC_MISC_ERROR, "Error: getaddressdeltas is disabled. "
             "Run './zcash-cli help getaddressdeltas' for instructions on how to enable this feature.");
     }
@@ -923,11 +941,9 @@ UniValue getaddressdeltas(const UniValue& params, bool fHelp)
 // insightexplorer
 UniValue getaddressbalance(const UniValue& params, bool fHelp)
 {
-    std::string enableArg = "insightexplorer";
-    bool enabled = fExperimentalMode && fInsightExplorer;
     std::string disabledMsg = "";
-    if (!enabled) {
-        disabledMsg = experimentalDisabledHelpMsg("getaddressbalance", enableArg);
+    if (!fExperimentalInsightExplorer) {
+        disabledMsg = experimentalDisabledHelpMsg("getaddressbalance", "insightexplorer");
     }
     if (fHelp || params.size() != 1)
         throw runtime_error(
@@ -954,7 +970,7 @@ UniValue getaddressbalance(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getaddressbalance", "{\"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"]}")
         );
 
-    if (!enabled) {
+    if (!fExperimentalInsightExplorer) {
         throw JSONRPCError(RPC_MISC_ERROR, "Error: getaddressbalance is disabled. "
             "Run './zcash-cli help getaddressbalance' for instructions on how to enable this feature.");
     }
@@ -982,11 +998,9 @@ UniValue getaddressbalance(const UniValue& params, bool fHelp)
 // insightexplorer
 UniValue getaddresstxids(const UniValue& params, bool fHelp)
 {
-    std::string enableArg = "insightexplorer";
-    bool enabled = fExperimentalMode && fInsightExplorer;
     std::string disabledMsg = "";
-    if (!enabled) {
-        disabledMsg = experimentalDisabledHelpMsg("getaddresstxids", enableArg);
+    if (!fExperimentalInsightExplorer) {
+        disabledMsg = experimentalDisabledHelpMsg("getaddresstxids", "insightexplorer");
     }
     if (fHelp || params.size() != 1)
         throw runtime_error(
@@ -1016,7 +1030,7 @@ UniValue getaddresstxids(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getaddresstxids", "{\"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"], \"start\": 1000, \"end\": 2000}")
         );
 
-    if (!enabled) {
+    if (!fExperimentalInsightExplorer) {
         throw JSONRPCError(RPC_MISC_ERROR, "Error: getaddresstxids is disabled. "
             "Run './zcash-cli help getaddresstxids' for instructions on how to enable this feature.");
     }
@@ -1049,11 +1063,9 @@ UniValue getaddresstxids(const UniValue& params, bool fHelp)
 // insightexplorer
 UniValue getspentinfo(const UniValue& params, bool fHelp)
 {
-    std::string enableArg = "insightexplorer";
-    bool enabled = fExperimentalMode && fInsightExplorer;
     std::string disabledMsg = "";
-    if (!enabled) {
-        disabledMsg = experimentalDisabledHelpMsg("getspentinfo", enableArg);
+    if (!fExperimentalInsightExplorer) {
+        disabledMsg = experimentalDisabledHelpMsg("getspentinfo", "insightexplorer");
     }
     if (fHelp || params.size() != 1 || !params[0].isObject())
         throw runtime_error(
@@ -1076,7 +1088,7 @@ UniValue getspentinfo(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getspentinfo", "{\"txid\": \"33990288fb116981260be1de10b8c764f997674545ab14f9240f00346333b780\", \"index\": 4}")
         );
 
-    if (!enabled) {
+    if (!fExperimentalInsightExplorer) {
         throw JSONRPCError(RPC_MISC_ERROR, "Error: getspentinfo is disabled. "
             "Run './zcash-cli help getspentinfo' for instructions on how to enable this feature.");
     }
@@ -1116,6 +1128,7 @@ static const CRPCCommand commands[] =
     { "util",               "z_validateaddress",      &z_validateaddress,      true  }, /* uses wallet if enabled */
     { "util",               "createmultisig",         &createmultisig,         true  },
     { "util",               "verifymessage",          &verifymessage,          true  },
+    { "control",            "getexperimentalfeatures",&getexperimentalfeatures,true  },
 
     // START insightexplorer
     /* Address index */

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -5,6 +5,7 @@
 #include "rpc/server.h"
 #include "rpc/client.h"
 
+#include "experimental_features.h"
 #include "key_io.h"
 #include "main.h"
 #include "netbase.h"
@@ -389,10 +390,9 @@ BOOST_AUTO_TEST_CASE(rpc_insightexplorer)
         "Error: getblockhashes is disabled. "
         "Run './zcash-cli help getblockhashes' for instructions on how to enable this feature.");
 
-    // During startup of the real system, fInsightExplorer ("-insightexplorer")
-    // automatically enables the next three, but not here, must explicitly enable.
-    fExperimentalMode = true;
-    fInsightExplorer = true;
+    fExperimentalInsightExplorer = true;
+    // During startup of the real system, fExperimentalInsightExplorer ("-insightexplorer")
+    // automatically enables the next four, but not here, must explicitly enable.
     fAddressIndex = true;
     fSpentIndex = true;
     fTimestampIndex = true;
@@ -455,8 +455,7 @@ BOOST_AUTO_TEST_CASE(rpc_insightexplorer)
         "Error parsing JSON:{\"noOrphans\":True,\"logicalTimes\":false}");
 
     // revert
-    fExperimentalMode = false;
-    fInsightExplorer = false;
+    fExperimentalInsightExplorer = false;
     fAddressIndex = false;
     fSpentIndex = false;
     fTimestampIndex = false;

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -8,6 +8,7 @@
 #include "asyncrpcoperation_common.h"
 #include "asyncrpcqueue.h"
 #include "core_io.h"
+#include "experimental_features.h"
 #include "init.h"
 #include "key_io.h"
 #include "main.h"
@@ -116,7 +117,7 @@ AsyncRPCOperation_mergetoaddress::AsyncRPCOperation_mergetoaddress(
     lock_notes();
 
     // Enable payment disclosure if requested
-    paymentDisclosureMode = fExperimentalMode && GetBoolArg("-paymentdisclosure", false);
+    paymentDisclosureMode = fExperimentalPaymentDisclosure;
 }
 
 AsyncRPCOperation_mergetoaddress::~AsyncRPCOperation_mergetoaddress()

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -9,6 +9,7 @@
 #include "asyncrpcqueue.h"
 #include "consensus/upgrades.h"
 #include "core_io.h"
+#include "experimental_features.h"
 #include "init.h"
 #include "key_io.h"
 #include "main.h"
@@ -115,9 +116,8 @@ AsyncRPCOperation_sendmany::AsyncRPCOperation_sendmany(
         LogPrint("zrpc", "%s: z_sendmany initialized\n", getId());
     }
 
-
     // Enable payment disclosure if requested
-    paymentDisclosureMode = fExperimentalMode && GetBoolArg("-paymentdisclosure", false);
+    paymentDisclosureMode = fExperimentalPaymentDisclosure;
 }
 
 AsyncRPCOperation_sendmany::~AsyncRPCOperation_sendmany() {

--- a/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
+++ b/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
@@ -9,6 +9,7 @@
 #include "asyncrpcqueue.h"
 #include "consensus/upgrades.h"
 #include "core_io.h"
+#include "experimental_features.h"
 #include "init.h"
 #include "key_io.h"
 #include "main.h"
@@ -91,7 +92,7 @@ AsyncRPCOperation_shieldcoinbase::AsyncRPCOperation_shieldcoinbase(
     lock_utxos();
 
     // Enable payment disclosure if requested
-    paymentDisclosureMode = fExperimentalMode && GetBoolArg("-paymentdisclosure", false);
+    paymentDisclosureMode = fExperimentalPaymentDisclosure;
 }
 
 AsyncRPCOperation_shieldcoinbase::~AsyncRPCOperation_shieldcoinbase() {

--- a/src/wallet/rpcdisclosure.cpp
+++ b/src/wallet/rpcdisclosure.cpp
@@ -2,10 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-#include "rpc/server.h"
+#include "experimental_features.h"
 #include "init.h"
 #include "key_io.h"
 #include "main.h"
+#include "rpc/server.h"
 #include "script/script.h"
 #include "script/standard.h"
 #include "sync.h"
@@ -40,11 +41,9 @@ UniValue z_getpaymentdisclosure(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    string enableArg = "paymentdisclosure";
-    auto fEnablePaymentDisclosure = fExperimentalMode && GetBoolArg("-" + enableArg, false);
-    string strPaymentDisclosureDisabledMsg = "";
-    if (!fEnablePaymentDisclosure) {
-        strPaymentDisclosureDisabledMsg = experimentalDisabledHelpMsg("z_getpaymentdisclosure", enableArg);
+    string disabledMsg = "";
+    if (!fExperimentalPaymentDisclosure) {
+        disabledMsg = experimentalDisabledHelpMsg("z_getpaymentdisclosure", "paymentdisclosure");
     }
 
     if (fHelp || params.size() < 3 || params.size() > 4 )
@@ -52,7 +51,7 @@ UniValue z_getpaymentdisclosure(const UniValue& params, bool fHelp)
             "z_getpaymentdisclosure \"txid\" \"js_index\" \"output_index\" (\"message\") \n"
             "\nGenerate a payment disclosure for a given joinsplit output.\n"
             "\nEXPERIMENTAL FEATURE\n"
-            + strPaymentDisclosureDisabledMsg +
+            + disabledMsg +
             "\nArguments:\n"
             "1. \"txid\"            (string, required) \n"
             "2. \"js_index\"        (string, required) \n"
@@ -65,7 +64,7 @@ UniValue z_getpaymentdisclosure(const UniValue& params, bool fHelp)
             + HelpExampleRpc("z_getpaymentdisclosure", "\"96f12882450429324d5f3b48630e3168220e49ab7b0f066e5c2935a6b88bb0f2\", 0, 0, \"refund\"")
         );
 
-    if (!fEnablePaymentDisclosure) {
+    if (!fExperimentalPaymentDisclosure) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: payment disclosure is disabled.");
     }
 
@@ -147,11 +146,9 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    string enableArg = "paymentdisclosure";
-    auto fEnablePaymentDisclosure = fExperimentalMode && GetBoolArg("-" + enableArg, false);
-    string strPaymentDisclosureDisabledMsg = "";
-    if (!fEnablePaymentDisclosure) {
-        strPaymentDisclosureDisabledMsg = experimentalDisabledHelpMsg("z_validatepaymentdisclosure", enableArg);
+    string disabledMsg = "";
+    if (!fExperimentalPaymentDisclosure) {
+        disabledMsg = experimentalDisabledHelpMsg("z_validatepaymentdisclosure", "paymentdisclosure");
     }
 
     if (fHelp || params.size() != 1)
@@ -159,7 +156,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
             "z_validatepaymentdisclosure \"paymentdisclosure\"\n"
             "\nValidates a payment disclosure.\n"
             "\nEXPERIMENTAL FEATURE\n"
-            + strPaymentDisclosureDisabledMsg +
+            + disabledMsg +
             "\nArguments:\n"
             "1. \"paymentdisclosure\"     (string, required) Hex data string, with \"zpd:\" prefix.\n"
             "\nExamples:\n"
@@ -167,7 +164,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
             + HelpExampleRpc("z_validatepaymentdisclosure", "\"zpd:706462ff004c561a0447ba2ec51184e6c204...\"")
         );
 
-    if (!fEnablePaymentDisclosure) {
+    if (!fExperimentalPaymentDisclosure) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: payment disclosure is disabled.");
     }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -6,6 +6,7 @@
 #include "amount.h"
 #include "consensus/upgrades.h"
 #include "core_io.h"
+#include "experimental_features.h"
 #include "init.h"
 #include "key_io.h"
 #include "main.h"
@@ -2038,18 +2039,15 @@ UniValue encryptwallet(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    string enableArg = "developerencryptwallet";
-    auto fEnableWalletEncryption = fExperimentalMode && GetBoolArg("-" + enableArg, false);
-
-    std::string strWalletEncryptionDisabledMsg = "";
-    if (!fEnableWalletEncryption) {
-        strWalletEncryptionDisabledMsg = experimentalDisabledHelpMsg("encryptwallet", enableArg);
+    std::string disabledMsg = "";
+    if (!fExperimentalDeveloperEncryptWallet) {
+        disabledMsg = experimentalDisabledHelpMsg("encryptwallet", "developerencryptwallet");
     }
 
     if (!pwalletMain->IsCrypted() && (fHelp || params.size() != 1))
         throw runtime_error(
             "encryptwallet \"passphrase\"\n"
-            + strWalletEncryptionDisabledMsg +
+            + disabledMsg +
             "\nEncrypts the wallet with 'passphrase'. This is for first time encryption.\n"
             "After this, any calls that interact with private keys such as sending or signing \n"
             "will require the passphrase to be set prior the making these calls.\n"
@@ -2075,7 +2073,7 @@ UniValue encryptwallet(const UniValue& params, bool fHelp)
 
     if (fHelp)
         return true;
-    if (!fEnableWalletEncryption) {
+    if (!fExperimentalDeveloperEncryptWallet) {
         throw JSONRPCError(RPC_WALLET_ENCRYPTION_FAILED, "Error: wallet encryption is disabled.");
     }
     if (pwalletMain->IsCrypted())


### PR DESCRIPTION
Adds new rpc call `getexperimentalfeatures` and also adds experimental features to `getblockchaininfo` output.

Closes #2671.