### PR TITLE
upgrade depends sha2 v0.8.1

### DIFF
--- a/depends/packages/crate_sha2.mk
+++ b/depends/packages/crate_sha2.mk
@@ -1,9 +1,9 @@
 package=crate_sha2
 $(package)_crate_name=sha2
-$(package)_version=0.8.0
+$(package)_version=0.8.1
 $(package)_download_path=https://static.crates.io/crates/$($(package)_crate_name)
 $(package)_file_name=$($(package)_crate_name)-$($(package)_version).crate
-$(package)_sha256_hash=7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d
+$(package)_sha256_hash=c373d34566859195f3fa8473f1ccba508148cbf905d4c44941b69cb079ea24eb
 $(package)_crate_versioned_name=$($(package)_crate_name)
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
according #4297 

### release notes:

https://github.com/RustCrypto/hashes/releases/tag/sha2-v0.8.1 


## references
https://github.com/RustCrypto/hashes/tree/master/sha2  
https://docs.rs/sha2/0.8.1/sha2/ 
