### PR TITLE
Compute more structures in CTxMemPool::DynamicMemoryUsage()

### DIFF
--- a/src/memusage.h
+++ b/src/memusage.h
@@ -88,8 +88,8 @@ static inline size_t DynamicUsage(const std::set<X>& s)
     return MallocUsage(sizeof(stl_tree_node<X>)) * s.size();
 }
 
-template<typename X, typename Y>
-static inline size_t DynamicUsage(const std::map<X, Y>& m)
+template<typename X, typename Y, typename C>
+static inline size_t DynamicUsage(const std::map<X, Y, C>& m)
 {
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X, Y> >)) * m.size();
 }


### PR DESCRIPTION
Closes https://github.com/zcash/zcash/issues/4224

Added more structures to the computation of the mempool memory size as indicated in the issue. RPC call `getmempoolinfo` is the only place where this is used to get the `usage` result.