### PR TITLE
Fix coment in serialize.h

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -196,7 +196,7 @@ enum
 #define READWRITEMANY(...)      (::SerReadWriteMany(s, ser_action, __VA_ARGS__))
 
 /** 
- * Implement three methods for serializable objects. These are actually wrappers over
+ * Implement two methods for serializable objects. These are actually wrappers over
  * "SerializationOp" template, which implements the body of each class' serialization
  * code. Adding "ADD_SERIALIZE_METHODS" in the body of the class causes these wrappers to be
  * added as members. 


### PR DESCRIPTION
Found by @zancas in the chat room. The third method `GetSerializeSize` was removed long time ago at https://github.com/zcash/zcash/commit/b8a6579366711127364b807ab62db391eee7d07a but the comment never updated.