### PR TITLE
Remove spurious "virtual" and add "override" in leaf subclasses

### DIFF
--- a/src/gtest/test_checkblock.cpp
+++ b/src/gtest/test_checkblock.cpp
@@ -70,11 +70,11 @@ TEST(CheckBlock, BlockSproutRejectsBadVersion) {
 
 class ContextualCheckBlockTest : public ::testing::Test {
 protected:
-    virtual void SetUp() {
+    void SetUp() override {
         SelectParams(CBaseChainParams::MAIN);
     }
 
-    virtual void TearDown() {
+    void TearDown() override {
         // Revert to test default. No-op on mainnet params.
         RegtestDeactivateSapling();
     }

--- a/src/gtest/test_deprecation.cpp
+++ b/src/gtest/test_deprecation.cpp
@@ -34,14 +34,14 @@ static bool ThreadSafeMessageBox(MockUIInterface *mock,
 
 class DeprecationTest : public ::testing::Test {
 protected:
-    virtual void SetUp() {
+    void SetUp() override {
         uiInterface.ThreadSafeMessageBox.disconnect_all_slots();
         uiInterface.ThreadSafeMessageBox.connect(boost::bind(ThreadSafeMessageBox, &mock_, _1, _2, _3));
         SelectParams(CBaseChainParams::MAIN);
         
     }
 
-    virtual void TearDown() {
+    void TearDown() override {
         fRequestShutdown = false;
         mapArgs.clear();
     }

--- a/src/gtest/test_upgrades.cpp
+++ b/src/gtest/test_upgrades.cpp
@@ -7,10 +7,10 @@
 
 class UpgradesTest : public ::testing::Test {
 protected:
-    virtual void SetUp() {
+    void SetUp() override {
     }
 
-    virtual void TearDown() {
+    void TearDown() override {
         // Revert to default
         UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
     }


### PR DESCRIPTION
Fixes: #4319

The use of virtual on these lines was unnecessary.

I ran:

"rm -f ./src/zcash-gtest && rm -f ./src/gtest/*.o && rm -f ./src/gtest/*.Po && make && ./src/zcash-gtest"

before and after making the change.   In both cases:

206 test ran from 32 cases and 1 test was DISABLED