### PR TITLE
GetFilteredNotes argument change to pointer

### DIFF
--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -214,6 +214,17 @@ TEST(WalletTests, FindUnspentSproutNotes) {
     sproutEntries.clear();
     saplingEntries.clear();
 
+    // Check the empty set case
+    std::set<libzcash::PaymentAddress> addr = {};
+    wallet.GetFilteredNotes(sproutEntries, saplingEntries, &addr, 0);
+    EXPECT_EQ(0, sproutEntries.size());
+    sproutEntries.clear();
+    saplingEntries.clear();
+    wallet.GetFilteredNotes(sproutEntries, saplingEntries, &addr, -1);
+    EXPECT_EQ(0, sproutEntries.size());
+    sproutEntries.clear();
+    saplingEntries.clear();
+
     // Fake-mine the transaction
     EXPECT_EQ(-1, chainActive.Height());
     CBlock block;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2569,7 +2569,7 @@ UniValue z_listunspent(const UniValue& params, bool fHelp)
     if (zaddrs.size() > 0) {
         std::vector<SproutNoteEntry> sproutEntries;
         std::vector<SaplingNoteEntry> saplingEntries;
-        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, zaddrs, nMinDepth, nMaxDepth, true, !fIncludeWatchonly, false);
+        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, &zaddrs, nMinDepth, nMaxDepth, true, !fIncludeWatchonly, false);
         std::set<std::pair<PaymentAddress, uint256>> nullifierSet = pwalletMain->GetNullifiersForAddresses(zaddrs);
         
         for (auto & entry : sproutEntries) {
@@ -3980,10 +3980,9 @@ UniValue z_getmigrationstatus(const UniValue& params, bool fHelp) {
     {
         std::vector<SproutNoteEntry> sproutEntries;
         std::vector<SaplingNoteEntry> saplingEntries;
-        std::set<PaymentAddress> noFilter;
         // Here we are looking for any and all Sprout notes for which we have the spending key, including those
         // which are locked and/or only exist in the mempool, as they should be included in the unmigrated amount.
-        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, noFilter, 0, INT_MAX, true, true, false);
+        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, nullptr, 0, INT_MAX, true, true, false);
         CAmount unmigratedAmount = 0;
         for (const auto& sproutEntry : sproutEntries) {
             unmigratedAmount += sproutEntry.note.value();
@@ -4516,7 +4515,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
         // Get available notes
         std::vector<SproutNoteEntry> sproutEntries;
         std::vector<SaplingNoteEntry> saplingEntries;
-        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, zaddrs);
+        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, &zaddrs);
 
         // If Sapling is not active, do not allow sending from a sapling addresses.
         if (!saplingActive && saplingEntries.size() > 0) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4760,9 +4760,11 @@ void CWallet::GetFilteredNotes(
 
     if (address.length() > 0) {
         filterAddresses.insert(DecodePaymentAddress(address));
+        GetFilteredNotes(sproutEntries, saplingEntries, &filterAddresses, minDepth, INT_MAX, ignoreSpent, requireSpendingKey);
     }
-
-    GetFilteredNotes(sproutEntries, saplingEntries, filterAddresses, minDepth, INT_MAX, ignoreSpent, requireSpendingKey);
+    else {
+        GetFilteredNotes(sproutEntries, saplingEntries, nullptr, minDepth, INT_MAX, ignoreSpent, requireSpendingKey);
+    }
 }
 
 /**
@@ -4773,7 +4775,7 @@ void CWallet::GetFilteredNotes(
 void CWallet::GetFilteredNotes(
     std::vector<SproutNoteEntry>& sproutEntries,
     std::vector<SaplingNoteEntry>& saplingEntries,
-    std::set<PaymentAddress>& filterAddresses,
+    std::set<PaymentAddress>* filterAddresses,
     int minDepth,
     int maxDepth,
     bool ignoreSpent,
@@ -4799,7 +4801,7 @@ void CWallet::GetFilteredNotes(
             SproutPaymentAddress pa = nd.address;
 
             // skip notes which belong to a different payment address in the wallet
-            if (!(filterAddresses.empty() || filterAddresses.count(pa))) {
+            if (filterAddresses && !filterAddresses->count(pa)) {
                 continue;
             }
 
@@ -4867,7 +4869,7 @@ void CWallet::GetFilteredNotes(
             auto pa = maybe_pa.get();
 
             // skip notes which belong to a different payment address in the wallet
-            if (!(filterAddresses.empty() || filterAddresses.count(pa))) {
+            if (filterAddresses && !filterAddresses->count(pa)) {
                 continue;
             }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1358,7 +1358,7 @@ public:
        if a spending key is required, and if they are locked */
     void GetFilteredNotes(std::vector<SproutNoteEntry>& sproutEntries,
                           std::vector<SaplingNoteEntry>& saplingEntries,
-                          std::set<libzcash::PaymentAddress>& filterAddresses,
+                          std::set<libzcash::PaymentAddress>* filterAddresses,
                           int minDepth=1,
                           int maxDepth=INT_MAX,
                           bool ignoreSpent=true,


### PR DESCRIPTION
Used pointer suggestion for https://github.com/zcash/zcash/pull/2913#discussion_r176944190

In regards to https://github.com/zcash/zcash/pull/2913#discussion_r177241551 i was not able to find another call doing the same as `GetFilteredNotes()`.
`GetNullifiersForAddresses()` is similar but not the same, not sure if it should be changed.

If merged, should close https://github.com/zcash/zcash/issues/3118