### PR TITLE
Change getblocks limit to match getheaders.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5685,7 +5685,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         // Send the rest of the chain
         if (pindex)
             pindex = chainActive.Next(pindex);
-        int nLimit = 500;
+        int nLimit = 2000;
         LogPrint("net", "getblocks %d to %s limit %d from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.IsNull() ? "end" : hashStop.ToString(), nLimit, pfrom->id);
         for (; pindex; pindex = chainActive.Next(pindex))
         {


### PR DESCRIPTION
A node can ask a peer for following blocks in one of two ways: by sending a
`getblocks` message, or by sending a `getheaders` message.  Nodes respond to
`getblocks` with a list of hashes of subsequent blocks, and to `getheaders`
with a list of block headers.  In zcashd, the responses are capped at 500 and
2000, respectively.

This commit changes the limit for `getblocks` messages to match `getheaders`
messages, so that they are on equal footing.

The motivation is that in Zcash, `getheaders` is considerably less useful than
in Bitcoin.  In Bitcoin, headers are 80 bytes long, while in Zcash, they are
much larger -- just the Equihash solution for the proof of work is 1347 bytes.
And, many Zcash blocks have relatively few transactions, so the block header is
a considerable fraction of the total size of the block, and downloading it
twice wastes network bandwidth.