### PR TITLE
WIP:  4342 resolve nondeterministic failures

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -81,6 +81,7 @@ testScripts=(
     'shorter_block_times.py'
     'sprout_sapling_migration.py'
     'turnstile.py'
+    'zgetoperation_latent_success.py'
 );
 testScriptsExt=(
     'getblocktemplate_longpoll.py'

--- a/qa/rpc-tests/zgetoperation_latent_success.py
+++ b/qa/rpc-tests/zgetoperation_latent_success.py
@@ -47,7 +47,7 @@ class ZGetOperationResultsLatentSuccess(BitcoinTestFramework):
         millizec = Decimal('0.001')
         lag_times = []
         sync_times = []
-        for iteration in range(1):
+        for iteration in range(100):
             print("Iteration: %s" % iteration)
             toaddr = self.nodes[0].z_getnewaddress('sapling')
             self._send_amt(faucet, toaddr, millizec)

--- a/qa/rpc-tests/zgetoperation_latent_success.py
+++ b/qa/rpc-tests/zgetoperation_latent_success.py
@@ -23,9 +23,13 @@ import time
 
 # Test wallet z_listunspent behaviour across network upgrades
 class ZGetOperationResultsLatentSuccess(BitcoinTestFramework):
+    def __init__(self):
+        super(ZGetOperationResultsLatentSuccess, self).__init__()
+        self.send_times = []
 
     def _send_amt(self, from_addr, to_addr, amnt):
         recipients = [{"address": to_addr, "amount": amnt}]
+        start_send = time.time()
         myopid = self.nodes[0].z_sendmany(from_addr, recipients)
         for _ in range(1, 3000):
             results = self.nodes[0].z_getoperationresult([myopid])
@@ -33,6 +37,8 @@ class ZGetOperationResultsLatentSuccess(BitcoinTestFramework):
                 result = results[0]
                 break
             time.sleep(.01)
+        stop_send = time.time()
+        self.send_times.append(stop_send - start_send)
         if result['status'] != 'success':
             sys.exit(56)
         return result # NOTE:  This test doesn't actually use this.
@@ -47,7 +53,7 @@ class ZGetOperationResultsLatentSuccess(BitcoinTestFramework):
         millizec = Decimal('0.001')
         lag_times = []
         sync_times = []
-        for iteration in range(100):
+        for iteration in range(10):
             print("Iteration: %s" % iteration)
             toaddr = self.nodes[0].z_getnewaddress('sapling')
             self._send_amt(faucet, toaddr, millizec)

--- a/qa/rpc-tests/zgetoperation_latent_success.py
+++ b/qa/rpc-tests/zgetoperation_latent_success.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+"""This isn't a standard RPC integration test, rather it's an experiment aimed at isolating sources
+of intermittent failures in the test suite.
+
+The wait_and_assert_oprationid_status function catches exceptions, and error states, only returning
+a txid if a successful transaction was reported for the operation <-- Hmmm...
+
+
+"""
+
+import sys
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import get_coinbase_address
+
+
+from decimal import Decimal
+import simplejson as json
+import time
+
+# Test wallet z_listunspent behaviour across network upgrades
+class ZGetOperationResultsLatentSuccess(BitcoinTestFramework):
+
+    def _send_amt(self, from_addr, to_addr, amnt):
+        recipients = [{"address": to_addr, "amount": amnt}]
+        myopid = self.nodes[0].z_sendmany(from_addr, recipients)
+        for _ in range(1, 3000):
+            results = self.nodes[0].z_getoperationresult([myopid])
+            if len(results) > 0:
+                result = results[0]
+                break
+            time.sleep(.01)
+        if result['status'] != 'success':
+            sys.exit(56)
+        return result # NOTE:  This test doesn't actually use this.
+
+    def run_test(self):
+        coinbase_addr = get_coinbase_address(self.nodes[0])
+        self.nodes[0].generate(10)
+        faucet = self.nodes[0].z_getnewaddress('sapling')
+        breward_minus_tx_fee = Decimal('9.9999')
+        self._send_amt(coinbase_addr, faucet, breward_minus_tx_fee)
+        self.nodes[0].generate(10)
+        millizec = Decimal('0.001')
+        lag_times = []
+        sync_times = []
+        for iteration in range(1):
+            print("Iteration: %s" % iteration)
+            toaddr = self.nodes[0].z_getnewaddress('sapling')
+            self._send_amt(faucet, toaddr, millizec)
+            start = time.time()
+            while self.nodes[0].z_listunspent(0, 9999, False, [toaddr]) == []:
+                time.sleep(0.001)
+            stop = time.time()
+            lagtime = Decimal(stop) - Decimal(start)
+            lag_times.append(lagtime)
+            self.nodes[0].generate(10)
+            sync_start = time.time()
+            self.sync_all()
+            sync_stop = time.time()
+            sync_times.append(sync_stop - sync_start)
+        print("Lag Loop Completed,")
+        print("lagtimes are:")
+        print(json.loads(str([str(x) for x in lag_times]).replace("'", '"')))
+
+if __name__ == '__main__':
+    ZGetOperationResultsLatentSuccess().main()


### PR DESCRIPTION
I believe `zgetoperation_latent_success.py` shows a pattern that may explain issue #4342.

The [call to wait_and_assert_operationid_status in wallet_changeaddresses.py](https://github.com/zcash/zcash/blob/b5e38edfda2c189f47fd6e0c6538da7106af4fc1/qa/rpc-tests/wallet_changeaddresses.py#L52) causes [the RPC method `z_getoperationresult`](https://github.com/zcash/zcash/blob/b5e38edfda2c189f47fd6e0c6538da7106af4fc1/qa/rpc-tests/test_framework/util.py#L449) to be invoked.

[wait_and_assert_operationid_status](https://github.com/zcash/zcash/blob/b5e38edfda2c189f47fd6e0c6538da7106af4fc1/qa/rpc-tests/test_framework/util.py#L445) polls until there's a response, to `z_getoperationresult`.  [Subsequent filtering](https://github.com/zcash/zcash/blob/b5e38edfda2c189f47fd6e0c6538da7106af4fc1/qa/rpc-tests/test_framework/util.py#L477) ensures that the result reported "success" (in the cases of interest).

Subsequent to the above-described call to `wait_and...` the test invokes RPC operations that depend on the outcome of the argument to `wait_and...` however a response (even a "success" response!) from the `z_getoperationresult` is _NOT_ sufficient to ensure that the expected state (in this case that the expected transactions [tx1 and tx2](https://github.com/zcash/zcash/blob/b5e38edfda2c189f47fd6e0c6538da7106af4fc1/qa/rpc-tests/wallet_changeaddresses.py#L71) has been reached.

More specifically, there's a detectable lag between the report of success and the desired state being made available.    All of this may be obvious to those familiar with the underlying system, and may be correct behavior, but it still seems likely that this lag explains intermittent test failures.

Perhaps most interestingly is the observation that the latency between `result['status'] == "success"` grows as a function of repeating the spend and list operations used in `zgetoperation_latent_success`..  again this may be both "correct", and "explanatory" in the case of the intermittently failing test.