### PR TITLE
Shows reindex progress in metrics screen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,8 +69,6 @@ int nScriptCheckThreads = 0;
 bool fExperimentalMode = false;
 bool fImporting = false;
 std::atomic_bool fReindex(false);
-std::atomic<size_t> nSizeReindexed(0);   // valid only during reindex
-std::atomic<size_t> nFullSizeToReindex(1);   // valid only during reindex
 bool fTxIndex = false;
 bool fInsightExplorer = false;  // insightexplorer
 bool fAddressIndex = false;     // insightexplorer

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,8 @@ int nScriptCheckThreads = 0;
 bool fExperimentalMode = false;
 bool fImporting = false;
 std::atomic_bool fReindex(false);
+std::atomic<size_t> nSizeReindexed(0);   // valid only during reindex
+std::atomic<size_t> nFullSizeToReindex(1);   // valid only during reindex
 bool fTxIndex = false;
 bool fInsightExplorer = false;  // insightexplorer
 bool fAddressIndex = false;     // insightexplorer
@@ -4855,8 +4857,12 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
         // This takes over fileIn and calls fclose() on it in the CBufferedFile destructor
         CBufferedFile blkdat(fileIn, 2*MAX_BLOCK_SIZE, MAX_BLOCK_SIZE+8, SER_DISK, CLIENT_VERSION);
         uint64_t nRewind = blkdat.GetPos();
+        size_t initialSize = nSizeReindexed;
         while (!blkdat.eof()) {
             boost::this_thread::interruption_point();
+
+            if (fReindex)
+               nSizeReindexed = initialSize + nRewind;
 
             blkdat.SetPos(nRewind);
             nRewind++; // start one byte further next time, in case of failure

--- a/src/main.h
+++ b/src/main.h
@@ -140,6 +140,8 @@ extern CConditionVariable cvBlockChange;
 extern bool fExperimentalMode;
 extern bool fImporting;
 extern std::atomic_bool fReindex;
+extern std::atomic<size_t> nSizeReindexed; // valid only during reindex
+extern std::atomic<size_t> nFullSizeToReindex; // valid only during reindex
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
 

--- a/src/main.h
+++ b/src/main.h
@@ -140,8 +140,6 @@ extern CConditionVariable cvBlockChange;
 extern bool fExperimentalMode;
 extern bool fImporting;
 extern std::atomic_bool fReindex;
-extern std::atomic<size_t> nSizeReindexed; // valid only during reindex
-extern std::atomic<size_t> nFullSizeToReindex; // valid only during reindex
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
 

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -235,6 +235,24 @@ std::string DisplayDuration(int64_t time, DurationFormat format)
     return strDuration;
 }
 
+std::string DisplaySize(size_t value)
+{
+    double coef = 1.0;
+    if (value < 1024.0 * coef)
+       return strprintf(_("%d Bytes"), value);
+    coef *= 1024.0;
+    if (value < 1024.0 * coef)
+       return strprintf(_("%.2f KiB"), value / coef);
+    coef *= 1024.0;
+    if (value < 1024.0 * coef)
+       return strprintf(_("%.2f MiB"), value / coef);
+    coef *= 1024.0;
+    if (value < 1024.0 * coef)
+       return strprintf(_("%.2f GiB"), value / coef);
+    coef *= 1024.0;
+    return strprintf(_("%.2f TiB"), value / coef);
+}
+
 boost::optional<int64_t> SecondsLeftToNextEpoch(const Consensus::Params& params, int currentHeight)
 {
     auto nextHeight = NextActivationHeight(currentHeight, params);
@@ -269,7 +287,7 @@ int printStats(bool mining)
     if (IsInitialBlockDownload(Params())) {
        if (fReindex) {
            int downloadPercent = nSizeReindexed * 100 / nFullSizeToReindex;
-           std::cout << "      " << _("Reindexing blocks") << " | " << nSizeReindexed << " / " << nFullSizeToReindex << " " << _("bytes") << " (" << downloadPercent << "%, " << height << " " << _("blocks") << ")" << std::endl;
+           std::cout << "      " << _("Reindexing blocks") << " | " << DisplaySize(nSizeReindexed) << " / " << DisplaySize(nFullSizeToReindex) << " (" << downloadPercent << "%, " << height << " " << _("blocks") << ")" << std::endl;
        } else {
            int netheight = currentHeadersHeight == -1 || currentHeadersTime == 0 ?
                0 : EstimateNetHeight(params, currentHeadersHeight, currentHeadersTime);

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -267,13 +267,15 @@ int printStats(bool mining)
     auto localsolps = GetLocalSolPS();
 
     if (IsInitialBlockDownload(Params())) {
-        int netheight = currentHeadersHeight == -1 || currentHeadersTime == 0 ?
-            0 : EstimateNetHeight(params, currentHeadersHeight, currentHeadersTime);
-        int downloadPercent = height * 100 / netheight;
-        if (fReindex)
-            std::cout << "      " << _("Reindexing blocks") << " | " << height << " / ~" << netheight << " (" << downloadPercent << "%)" << std::endl;
-        else
-            std::cout << "     " << _("Downloading blocks") << " | " << height << " / ~" << netheight << " (" << downloadPercent << "%)" << std::endl;
+       if (fReindex) {
+           int downloadPercent = nSizeReindexed * 100 / nFullSizeToReindex;
+           std::cout << "      " << _("Reindexing blocks") << " | " << nSizeReindexed << " / " << nFullSizeToReindex << " " << _("bytes") << " (" << downloadPercent << "%, " << height << " " << _("blocks") << ")" << std::endl;
+       } else {
+           int netheight = currentHeadersHeight == -1 || currentHeadersTime == 0 ?
+               0 : EstimateNetHeight(params, currentHeadersHeight, currentHeadersTime);
+           int downloadPercent = height * 100 / netheight;
+           std::cout << "     " << _("Downloading blocks") << " | " << height << " / ~" << netheight << " (" << downloadPercent << "%)" << std::endl;
+       }
     } else {
         std::cout << "           " << _("Block height") << " | " << height << std::endl;
     }

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -267,10 +267,13 @@ int printStats(bool mining)
     auto localsolps = GetLocalSolPS();
 
     if (IsInitialBlockDownload(Params())) {
-        int netheight = currentHeadersHeight == -1 || currentHeadersTime == 0 ? 
+        int netheight = currentHeadersHeight == -1 || currentHeadersTime == 0 ?
             0 : EstimateNetHeight(params, currentHeadersHeight, currentHeadersTime);
         int downloadPercent = height * 100 / netheight;
-        std::cout << "     " << _("Downloading blocks") << " | " << height << " / ~" << netheight << " (" << downloadPercent << "%)" << std::endl;
+        if (fReindex)
+            std::cout << "      " << _("Reindexing blocks") << " | " << height << " / ~" << netheight << " (" << downloadPercent << "%)" << std::endl;
+        else
+            std::cout << "     " << _("Downloading blocks") << " | " << height << " / ~" << netheight << " (" << downloadPercent << "%)" << std::endl;
     } else {
         std::cout << "           " << _("Block height") << " | " << height << std::endl;
     }

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -78,6 +78,8 @@ AtomicCounter ehSolverRuns;
 AtomicCounter solutionTargetChecks;
 static AtomicCounter minedBlocks;
 AtomicTimer miningTimer;
+std::atomic<size_t> nSizeReindexed(0);   // valid only during reindex
+std::atomic<size_t> nFullSizeToReindex(1);   // valid only during reindex
 
 static boost::synchronized_value<std::list<uint256>> trackedBlocks;
 

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -64,6 +64,8 @@ extern AtomicCounter transactionsValidated;
 extern AtomicCounter ehSolverRuns;
 extern AtomicCounter solutionTargetChecks;
 extern AtomicTimer miningTimer;
+extern std::atomic<size_t> nSizeReindexed; // valid only during reindex
+extern std::atomic<size_t> nFullSizeToReindex; // valid only during reindex
 
 void TrackMinedBlock(uint256 hash);
 


### PR DESCRIPTION
Resolves issue #3813.

The "Downloading blocks" message is changed to "Reindexing blocks" during reindex, after reindex is completed the text is reverted back to the first variant.

Reindex progress is shown as a sum of processed file size (we can't use reindexed block number as a progress because we can't predict how many blocks to process at all, we don't know the size of the block before we process it), the result looks like 
```
Reindexing blocks | 22.64 MiB / 336.00 MiB (6%, 13583 blocks)
```