### PR TITLE
Check failing transparent and JoinSplit signatures against the previous network upgrade

### DIFF
--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -84,6 +84,16 @@ uint32_t CurrentEpochBranchId(int nHeight, const Consensus::Params& params) {
     return NetworkUpgradeInfo[CurrentEpoch(nHeight, params)].nBranchId;
 }
 
+uint32_t PrevEpochBranchId(uint32_t currentBranchId, const Consensus::Params& params) {
+    for (int idx = Consensus::BASE_SPROUT + 1; idx < Consensus::MAX_NETWORK_UPGRADES; idx++) {
+        if (currentBranchId == NetworkUpgradeInfo[idx].nBranchId) {
+            return NetworkUpgradeInfo[idx - 1].nBranchId;
+        }
+    }
+    // Base case
+    return NetworkUpgradeInfo[Consensus::BASE_SPROUT].nBranchId;
+}
+
 bool IsConsensusBranchId(int branchId) {
     for (int idx = Consensus::BASE_SPROUT; idx < Consensus::MAX_NETWORK_UPGRADES; idx++) {
         if (branchId == NetworkUpgradeInfo[idx].nBranchId) {

--- a/src/consensus/upgrades.h
+++ b/src/consensus/upgrades.h
@@ -54,6 +54,12 @@ int CurrentEpoch(int nHeight, const Consensus::Params& params);
 uint32_t CurrentEpochBranchId(int nHeight, const Consensus::Params& params);
 
 /**
+ * Returns the branch ID that preceded currentBranchId, or 0 if no upgrade
+ * matches currentBranchId.
+ */
+uint32_t PrevEpochBranchId(uint32_t currentBranchId, const Consensus::Params& params);
+
+/**
  * Returns true if a given branch id is a valid nBranchId for one of the network
  * upgrades contained in NetworkUpgradeInfo.
  */

--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -62,6 +62,9 @@ CMutableTransaction GetValidTransaction(uint32_t consensusBranchId=SPROUT_BRANCH
         mtx.fOverwintered = true;
         mtx.nVersionGroupId = SAPLING_VERSION_GROUP_ID;
         mtx.nVersion = SAPLING_TX_VERSION;
+    } else if (consensusBranchId != SPROUT_BRANCH_ID) {
+        // Unsupported consensus branch ID
+        assert(false);
     }
 
     mtx.vin.resize(2);

--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -535,6 +535,54 @@ TEST(ChecktransactionTests, BadTxnsInvalidJoinsplitSignature) {
     ContextualCheckTransaction(tx, state, chainparams, 0, true, [](const CChainParams&) { return false; });
 }
 
+TEST(ChecktransactionTests, JoinsplitSignatureDetectsOldBranchId) {
+    SelectParams(CBaseChainParams::REGTEST);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, 1);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, 1);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_BLOSSOM, 10);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_HEARTWOOD, 20);
+    auto chainparams = Params();
+
+    auto saplingBranchId = NetworkUpgradeInfo[Consensus::UPGRADE_SAPLING].nBranchId;
+    auto blossomBranchId = NetworkUpgradeInfo[Consensus::UPGRADE_BLOSSOM].nBranchId;
+
+    // Create a valid transaction for the Sapling epoch.
+    CMutableTransaction mtx = GetValidTransaction(saplingBranchId);
+    CTransaction tx(mtx);
+
+    MockCValidationState state;
+    // Ensure that the transaction validates against Sapling.
+    EXPECT_TRUE(ContextualCheckTransaction(
+        tx, state, chainparams, 5, false,
+        [](const CChainParams&) { return false; }));
+
+    // Attempt to validate the inputs against Blossom. We should be notified
+    // that an old consensus branch ID was used for an input.
+    EXPECT_CALL(state, DoS(
+        10, false, REJECT_INVALID,
+        strprintf("old-consensus-branch-id (Expected %s, found %s)",
+            HexInt(blossomBranchId),
+            HexInt(saplingBranchId)),
+        false)).Times(1);
+    EXPECT_FALSE(ContextualCheckTransaction(
+        tx, state, chainparams, 15, false,
+        [](const CChainParams&) { return false; }));
+
+    // Attempt to validate the inputs against Heartwood. All we should learn is
+    // that the signature is invalid, because we don't check more than one
+    // network upgrade back.
+    EXPECT_CALL(state, DoS(
+        10, false, REJECT_INVALID,
+        "bad-txns-invalid-joinsplit-signature", false)).Times(1);
+    EXPECT_FALSE(ContextualCheckTransaction(
+        tx, state, chainparams, 25, false,
+        [](const CChainParams&) { return false; }));
+
+    // Revert to default
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_HEARTWOOD, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    RegtestDeactivateBlossom();
+}
+
 TEST(ChecktransactionTests, NonCanonicalEd25519Signature) {
     SelectParams(CBaseChainParams::REGTEST);
     auto chainparams = Params();

--- a/src/gtest/test_mempool.cpp
+++ b/src/gtest/test_mempool.cpp
@@ -11,7 +11,7 @@
 #include "util.h"
 
 // Implementation is in test_checktransaction.cpp
-extern CMutableTransaction GetValidTransaction();
+extern CMutableTransaction GetValidTransaction(uint32_t consensusBranchId=SPROUT_BRANCH_ID);
 
 // Fake the input of transaction 5295156213414ed77f6e538e7e8ebe14492156906b9fe995b242477818789364
 // - 532639cc6bebed47c1c69ae36dd498c68a012e74ad12729adbd3dbb56f8f3f4a, 0

--- a/src/gtest/test_validation.cpp
+++ b/src/gtest/test_validation.cpp
@@ -113,6 +113,7 @@ TEST(Validation, ContextualCheckInputsPassesWithCoinbase) {
 }
 
 TEST(Validation, ReceivedBlockTransactions) {
+    SelectParams(CBaseChainParams::REGTEST);
     auto chainParams = Params();
     auto sk = libzcash::SproutSpendingKey::random();
 

--- a/src/gtest/test_validation.cpp
+++ b/src/gtest/test_validation.cpp
@@ -22,9 +22,9 @@ void ExpectOptionalAmount(CAmount expected, boost::optional<CAmount> actual) {
 }
 
 // Fake an empty view
-class FakeCoinsViewDB : public CCoinsView {
+class ValidationFakeCoinsViewDB : public CCoinsView {
 public:
-    FakeCoinsViewDB() {}
+    ValidationFakeCoinsViewDB() {}
 
     bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const {
         return false;
@@ -80,7 +80,7 @@ TEST(Validation, ContextualCheckInputsPassesWithCoinbase) {
     ASSERT_TRUE(tx.IsCoinBase());
 
     // Fake an empty view
-    FakeCoinsViewDB fakeDB;
+    ValidationFakeCoinsViewDB fakeDB;
     CCoinsViewCache view(&fakeDB);
 
     for (int idx = Consensus::BASE_SPROUT; idx < Consensus::MAX_NETWORK_UPGRADES; idx++) {

--- a/src/gtest/test_validation.cpp
+++ b/src/gtest/test_validation.cpp
@@ -23,7 +23,7 @@ void ExpectOptionalAmount(CAmount expected, boost::optional<CAmount> actual) {
     }
 }
 
-// Fake a view containing a single coin
+// Fake a view that optionally contains a single coin.
 class ValidationFakeCoinsViewDB : public CCoinsView {
 public:
     boost::optional<std::pair<std::pair<uint256, uint256>, std::pair<CTxOut, int>>> coin;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1327,6 +1327,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         *pfMissingInputs = false;
 
     int nextBlockHeight = chainActive.Height() + 1;
+
+    // Grab the branch ID we expect this transaction to commit to.
     auto consensusBranchId = CurrentEpochBranchId(nextBlockHeight, Params().GetConsensus());
 
     if (pool.IsRecentlyEvicted(tx.GetHash())) {
@@ -1475,11 +1477,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             }
         }
 
-        // Grab the branch ID we expect this transaction to commit to. We don't
-        // yet know if it does, but if the entry gets added to the mempool, then
-        // it has passed ContextualCheckInputs and therefore this is correct.
-        auto consensusBranchId = CurrentEpochBranchId(chainActive.Height() + 1, Params().GetConsensus());
-
+        // We don't yet know if the transaction commits to consensusBranchId,
+        // but if the entry gets added to the mempool, then it has passed
+        // ContextualCheckInputs and therefore this is correct.
         CTxMemPoolEntry entry(tx, nFees, GetTime(), dPriority, chainActive.Height(), mempool.HasNoInputsOf(tx), fSpendsCoinbase, consensusBranchId);
         unsigned int nSize = entry.GetTxSize();
 

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -209,7 +209,7 @@ void TransactionBuilder::AddTransparentInput(COutPoint utxo, CScript scriptPubKe
     tIns.emplace_back(scriptPubKey, value);
 }
 
-void TransactionBuilder::AddTransparentOutput(CTxDestination& to, CAmount value)
+void TransactionBuilder::AddTransparentOutput(const CTxDestination& to, CAmount value)
 {
     if (!IsValidDestination(to)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid output address, not a valid taddr.");

--- a/src/transaction_builder.h
+++ b/src/transaction_builder.h
@@ -135,7 +135,7 @@ public:
     // Assumes that the value correctly corresponds to the provided UTXO.
     void AddTransparentInput(COutPoint utxo, CScript scriptPubKey, CAmount value);
 
-    void AddTransparentOutput(CTxDestination& to, CAmount value);
+    void AddTransparentOutput(const CTxDestination& to, CAmount value);
 
     void SendChangeTo(libzcash::SaplingPaymentAddress changeAddr, uint256 ovk);
 


### PR DESCRIPTION
This change improves usability across network upgrades, by informing
users when their new transactions are being created with the consensus
branch ID from the previous epoch.

We only check failing signatures against the previous epoch to minimise
the extra computational load on nodes.

A future refactor is needed to similarly check Sapling signatures.

Part of #4260.