### PR TITLE
Initialize ThreadNotifyWallets before additional blocks are imported

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1547,8 +1547,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // Start the thread that notifies listeners of transactions that have been
     // recently added to the mempool, or have been added to or removed from the
-    // chain.
-
+    // chain. We perform this before step 10 (import blocks) so that the
+    // original value of chainActive.Tip(), which corresponds with the wallet's
+    // view of the chaintip, is passed to ThreadNotifyWallets before the chain
+    // tip changes again.
     boost::function<void()> threadnotifywallets = boost::bind(&ThreadNotifyWallets, chainActive.Tip());
     threadGroup.create_thread(
         boost::bind(&TraceThread<boost::function<void()>>, "txnotify", threadnotifywallets)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1545,6 +1545,15 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 #endif // ENABLE_MINING
 
+    // Start the thread that notifies listeners of transactions that have been
+    // recently added to the mempool, or have been added to or removed from the
+    // chain.
+
+    boost::function<void()> threadnotifywallets = boost::bind(&ThreadNotifyWallets, chainActive.Tip());
+    threadGroup.create_thread(
+        boost::bind(&TraceThread<boost::function<void()>>, "txnotify", threadnotifywallets)
+    );
+
     // ********************************************************* Step 9: data directory maintenance
 
     // if pruning, unset the service bit and perform the initial blockstore prune
@@ -1599,10 +1608,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("mapAddressBook.size() = %u\n",  pwalletMain ? pwalletMain->mapAddressBook.size() : 0);
 #endif
 
-    // Start the thread that notifies listeners of transactions that have been
-    // recently added to the mempool, or have been added to or removed from the
-    // chain.
-    threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "txnotify", &ThreadNotifyWallets));
 
     if (GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))
         StartTorControl(threadGroup, scheduler);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -81,13 +81,9 @@ struct CachedBlockData {
         pindex(pindex), oldTrees(oldTrees), txConflicted(txConflicted) {}
 };
 
-void ThreadNotifyWallets()
+void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
 {
-    CBlockIndex *pindexLastTip = nullptr;
-    {
-        LOCK(cs_main);
-        pindexLastTip = chainActive.Tip();
-    }
+    assert(pindexLastTip != nullptr);
 
     while (true) {
         // Run the notifier on an integer second in the steady clock.

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -74,6 +74,6 @@ struct CMainSignals {
 
 CMainSignals& GetMainSignals();
 
-void ThreadNotifyWallets();
+void ThreadNotifyWallets(CBlockIndex *pindexLastTip);
 
 #endif // BITCOIN_VALIDATIONINTERFACE_H


### PR DESCRIPTION
The intention of this PR is to address #4301. It seems `ThreadNotifyWallets` assumes that `chainActive.Tip()` on initialization reflects the wallet's view of the active tip, but prior to `ThreadNotifyWallets`'s initialization the active chain ends up being modified by blocks that are imported from disk, so our local `pindexLastTip` ends up out of sync with the wallet's actual "last" tip.

This PR moves the initialization of `ThreadNotifyWallets` to earlier in the process while passing in the current active tip. This addresses the problem for non-fresh nodes, and then for fresh nodes we have the notification thread wait until the genesis block has been loaded.