### PR TITLE
Additional librustzcash integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,8 @@ rand_core = "0.5.1"
 zcash_history = "0.2"
 zcash_primitives = "0.2"
 zcash_proofs = "0.2"
+
+[profile.release]
+lto = true
+panic = 'abort'
+codegen-units = 1

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -93,7 +93,7 @@ def ensure_no_dot_so_in_depends():
         # Not Linux, try MacOS
         arch_dirs = glob(os.path.join(depends_dir, 'x86_64-apple-darwin*'))
         if arch_dirs:
-            # Just try the first one; there will only be on in CI
+            # Just try the first one; there will only be one in CI
             arch_dir = arch_dirs[0]
 
     exit_code = 0
@@ -131,7 +131,7 @@ def rust_test():
     if not os.path.isdir(target_dir):
         arch_dirs = glob(os.path.join(REPOROOT, 'target', 'x86_64-apple-darwin*'))
         if arch_dirs:
-            # Just try the first one; there will only be on in CI
+            # Just try the first one; there will only be one in CI
             target_dir = arch_dirs[0]
 
     if os.path.isdir(target_dir):
@@ -146,6 +146,7 @@ def rust_test():
 
     # Didn't manage to run anything
     return False
+
 #
 # Tests
 #

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -129,10 +129,7 @@ def util_test():
 def rust_test():
     target_dir = os.path.join(REPOROOT, 'target', 'x86_64-unknown-linux-gnu')
     if not os.path.isdir(target_dir):
-        arch_dirs = glob(os.path.join(REPOROOT, 'target', 'x86_64-apple-darwin*'))
-        if arch_dirs:
-            # Just try the first one; there will only be one in CI
-            target_dir = arch_dirs[0]
+        target_dir = os.path.join(REPOROOT, 'target', 'x86_64-apple-darwin')
 
     if os.path.isdir(target_dir):
         # cargo build --tests will produce a binary named something

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -79,7 +79,7 @@ $(CARGO_CONFIGURED): $(top_srcdir)/.cargo/config.offline
 endif
 
 cargo-build: $(CARGO_CONFIGURED)
-	$(RUST_ENV_VARS) $(CARGO) build $(RUST_BUILD_OPTS) --manifest-path $(top_srcdir)/Cargo.toml
+	$(RUST_ENV_VARS) $(CARGO) build --lib --tests $(RUST_BUILD_OPTS) --manifest-path $(top_srcdir)/Cargo.toml
 
 if TARGET_WINDOWS
 LIBRUSTZCASH_WIN=$(top_builddir)/target/$(RUST_TARGET)/release/rustzcash.lib


### PR DESCRIPTION
This adds librustzcash tests to the full test suite, and brings in the release profile configurations that are currently present in the librustzcash workspace on the other repository. It's very important that we build librustzcash with panic=abort because otherwise the unwinding panics across FFI boundaries could cause undefined behavior.