### PR TITLE
Fix comment in rpc_wallet_tests

### DIFF
--- a/src/wallet/test/rpc_wallet_tests.cpp
+++ b/src/wallet/test/rpc_wallet_tests.cpp
@@ -1636,7 +1636,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_shieldcoinbase_parameters)
         mtx.nVersion = 2;
     }
 
-    // Test constructor of AsyncRPCOperation_sendmany
+    // Test constructor of AsyncRPCOperation_shieldcoinbase
     std::string testnetzaddr = "ztjiDe569DPNbyTE6TSdJTaSDhoXEHLGvYoUnBU1wfVNU52TEyT6berYtySkd21njAeEoh8fFJUT42kua9r8EnhBaEKqCpP";
     std::string mainnetzaddr = "zcMuhvq8sEkHALuSU2i4NbNQxshSAYrpCExec45ZjtivYPbuiFPwk6WHy4SvsbeZ4siy1WheuRGjtaJmoD1J8bFqNXhsG6U";
 
@@ -1661,7 +1661,6 @@ BOOST_AUTO_TEST_CASE(rpc_z_shieldcoinbase_parameters)
     }
 
 }
-
 
 
 BOOST_AUTO_TEST_CASE(rpc_z_shieldcoinbase_internals)


### PR DESCRIPTION
Address a small comment issue in `rpc_z_shieldcoinbase_parameters` rpx wallet tests.