### PR TITLE
Async options for z_importkey and z_importviewingkey 

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -81,6 +81,7 @@ testScripts=(
     'shorter_block_times.py'
     'sprout_sapling_migration.py'
     'turnstile.py'
+    'wallet_async_rescan.py'
 );
 testScriptsExt=(
     'getblocktemplate_longpoll.py'

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -472,12 +472,16 @@ def wait_and_assert_operationid_status_result(node, myopid, in_status='success',
 
 
 # Returns txid if operation was a success or None
-def wait_and_assert_operationid_status(node, myopid, in_status='success', in_errormsg=None, timeout=300):
+def wait_and_assert_operationid_status(node, myopid, in_status='success', in_errormsg=None, timeout=300, is_tx=True):
     result = wait_and_assert_operationid_status_result(node, myopid, in_status, in_errormsg, timeout)
     if result['status'] == "success":
-        return result['result']['txid']
+        if is_tx:
+            return result['result']['txid']
+        else: # Used when async is not a blockchain tx but just a time consuming wallet operation
+            return result['result']
     else:
         return None
+
 
 # Find a coinbase address on the node, filtering by the number of UTXOs it has.
 # If no filter is provided, returns the coinbase address on the node containing

--- a/qa/rpc-tests/wallet_async_rescan.py
+++ b/qa/rpc-tests/wallet_async_rescan.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, start_nodes, wait_and_assert_operationid_status
+
+from decimal import Decimal
+
+class WalletAsyncRescanTest (BitcoinTestFramework):
+
+    def setup_nodes(self):
+        return start_nodes(4, self.options.tmpdir)
+
+    def run_test (self):
+        # add zaddr to node 0
+        myzaddr = self.nodes[0].z_getnewaddress('sprout')
+
+        # import node 0 zaddr into node 1
+        myzkey = self.nodes[0].z_exportkey(myzaddr)
+        opid = self.nodes[1].z_importkey(myzkey, 'yes', 1, 'yes')
+        result = wait_and_assert_operationid_status(self.nodes[1], opid, timeout=120, is_tx=False)
+
+        # Check the address has been imported
+        assert_equal(result['address'], myzaddr)
+
+        # add node 0 viewing key to node 2
+        myzvkey = self.nodes[0].z_exportviewingkey(myzaddr)
+        opid = self.nodes[2].z_importviewingkey(myzvkey, 'whenkeyisnew', 1, 'yes')
+        wait_and_assert_operationid_status(self.nodes[2], opid, timeout=120, is_tx=False)
+        
+        # Check the address has been imported
+        assert_equal(myzaddr in self.nodes[2].z_listaddresses(), False)
+        assert_equal(myzaddr in self.nodes[2].z_listaddresses(True), True)
+
+
+if __name__ == '__main__':
+    WalletAsyncRescanTest().main ()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -212,6 +212,7 @@ BITCOIN_CORE_H = \
   version.h \
   wallet/asyncrpcoperation_common.h \
   wallet/asyncrpcoperation_mergetoaddress.h \
+  wallet/asyncrpcoperation_rescan.h \
   wallet/asyncrpcoperation_saplingmigration.h \
   wallet/asyncrpcoperation_sendmany.h \
   wallet/asyncrpcoperation_shieldcoinbase.h \
@@ -306,6 +307,7 @@ libbitcoin_wallet_a_SOURCES = \
   zcbenchmarks.h \
   wallet/asyncrpcoperation_common.cpp \
   wallet/asyncrpcoperation_mergetoaddress.cpp \
+  wallet/asyncrpcoperation_rescan.cpp \
   wallet/asyncrpcoperation_saplingmigration.cpp \
   wallet/asyncrpcoperation_sendmany.cpp \
   wallet/asyncrpcoperation_shieldcoinbase.cpp \

--- a/src/wallet/asyncrpcoperation_rescan.cpp
+++ b/src/wallet/asyncrpcoperation_rescan.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#include "asyncrpcoperation_rescan.h"
+
+#include "asyncrpcoperation_common.h"
+#include "asyncrpcqueue.h"
+
+AsyncRPCOperation_rescan::AsyncRPCOperation_rescan(
+        int nRescanHeight,
+        std::string caller, 
+        UniValue result) :
+        height_(nRescanHeight), caller_(caller), result_(result)
+{
+    LogPrint("zrpc", "%s: Async rescan initialized\n", getId());
+}
+
+AsyncRPCOperation_rescan::~AsyncRPCOperation_rescan() {
+}
+
+void AsyncRPCOperation_rescan::main() {
+    if (isCancelled()) {
+        return;
+    }
+
+    set_state(OperationStatus::EXECUTING);
+    start_execution_clock();
+
+    bool success = false;
+
+    try {
+        success = main_impl();
+    } catch (const UniValue& objError) {
+        int code = find_value(objError, "code").get_int();
+        std::string message = find_value(objError, "message").get_str();
+        set_error_code(code);
+        set_error_message(message);
+    } catch (const runtime_error& e) {
+        set_error_code(-1);
+        set_error_message("runtime error: " + string(e.what()));
+    } catch (const logic_error& e) {
+        set_error_code(-1);
+        set_error_message("logic error: " + string(e.what()));
+    } catch (const exception& e) {
+        set_error_code(-1);
+        set_error_message("general exception: " + string(e.what()));
+    } catch (...) {
+        set_error_code(-2);
+        set_error_message("unknown error");
+    }
+
+    stop_execution_clock();
+
+    if (success) {
+        set_state(OperationStatus::SUCCESS);
+        set_result(result_);
+    } else {
+        set_state(OperationStatus::FAILED);
+    }
+
+    std::string s = strprintf("%s: rescan finished (status=%s", getId(), getStateAsString());
+    if (success) {
+        s += strprintf(", type=%s, address=%s)\n", find_value(result_, "type").get_str(), find_value(result_, "address").get_str());
+    } else {
+        s += strprintf(", error=%s)\n", getErrorMessage());
+    }
+    LogPrintf("%s",s);
+}
+
+bool AsyncRPCOperation_rescan::main_impl() {
+    pwalletMain->ScanForWalletTransactions(chainActive[height_], true);
+    return true;
+}
+
+UniValue AsyncRPCOperation_rescan::getStatus() const {
+    UniValue v = AsyncRPCOperation::getStatus();
+    UniValue obj = v.get_obj();
+    obj.push_back(Pair("method", caller_));
+    return obj;
+}

--- a/src/wallet/asyncrpcoperation_rescan.h
+++ b/src/wallet/asyncrpcoperation_rescan.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#ifndef ASYNCRPCOPERATION_RESCAN_H
+#define ASYNCRPCOPERATION_RESCAN_H
+
+#include "asyncrpcoperation.h"
+#include "wallet.h"
+
+#include <univalue.h>
+
+class AsyncRPCOperation_rescan : public AsyncRPCOperation {
+public:
+    AsyncRPCOperation_rescan(
+        int nRescanHeight,
+        std::string caller,
+        UniValue result);
+    virtual ~AsyncRPCOperation_rescan();
+
+    // We don't want to be copied or moved around
+    AsyncRPCOperation_rescan(AsyncRPCOperation_rescan const&) = delete;             // Copy construct
+    AsyncRPCOperation_rescan(AsyncRPCOperation_rescan&&) = delete;                  // Move construct
+    AsyncRPCOperation_rescan& operator=(AsyncRPCOperation_rescan const&) = delete;  // Copy assign
+    AsyncRPCOperation_rescan& operator=(AsyncRPCOperation_rescan &&) = delete;      // Move assign
+
+    virtual void main();
+
+    virtual UniValue getStatus() const;
+
+private:
+    int height_;
+    std::string caller_;
+    UniValue result_;
+
+    bool main_impl();
+};
+
+#endif /* ASYNCRPCOPERATION_RESCAN_H */


### PR DESCRIPTION
Attempts to resolve https://github.com/zcash/zcash/issues/3965

Currently only certain operations with a blockchain transaction are in async mode. In this PR we add a new async operation that is not a real blockchain transaction but just a wallet time consuming task, in this case a rescan.

I am not totally sure this is the best approach for the issue, open to comments.

