### PR TITLE
Add `zcutil/clean.sh` and `zcutil/distclean.sh` scripts that work reliably (unlike `make clean`)

### DIFF
--- a/zcutil/clean.sh
+++ b/zcutil/clean.sh
@@ -6,6 +6,10 @@ rm -f src/Makefile.in
 rm -f doc/man/Makefile
 rm -f doc/man/Makefile.in
 
+rm -f .cargo/config
+rm -f .cargo/.configured-for-online
+rm -f .cargo/.configured-for-offline
+
 rm -f src/config/stamp-h1
 rm -f src/config/bitcoin-config.h
 rm -f src/obj/build.h
@@ -17,9 +21,16 @@ rm -f qa/pull-tester/run-bitcoind-for-test.sh
 rm -f qa/pull-tester/tests-config.sh
 
 rm -f src/test/data/*.json.h
+rm -f src/test/data/*.raw.h
 
+rm -f src/fuzz.cpp
 
-find src -type f -and \( -name '*.Po' -or -name '*.Plo' -or -name '*.o' -or -name '*.a' -or -name '*.la' -or -name '*.lo' -or -name '*.lai' -or -name '*.pc' -or -name '.dirstamp' \) -delete
+rm -rf test_bitcoin.coverage/ zcash-gtest.coverage/ total.coverage/
+
+rm -rf cache
+
+find src -type f -and \( -name '*.Po' -or -name '*.Plo' -or -name '*.o' -or -name '*.a' -or -name '*.la' -or -name '*.lo' -or -name '*.lai' -or -name '*.pc' -or -name '.dirstamp' -or -name '*.gcda' -or -name '*.gcno' -or -name '*.sage.py' -or -name '*.trs' \) -delete
+
 clean_dirs()
 {
     find . -depth -path "*/$1/*" -delete
@@ -60,6 +71,8 @@ clean_dep()
 }
 
 clean_dirs .deps
+clean_dirs .libs
+clean_dirs __pycache__
 
 clean_exe src/bench/bench_bitcoin
 clean_exe src/zcash-cli
@@ -68,13 +81,26 @@ clean_exe src/zcash-gtest
 clean_exe src/zcash-tx
 clean_exe src/test/test_bitcoin
 
+clean_exe src/leveldb/db_bench
+clean_exe src/leveldb/leveldbutil
+rm -f src/leveldb/*_test src/leveldb/*_test.exe
+rm -f src/leveldb/*.so src/leveldb/*.so.*
+
 clean_dep . src/config/bitcoin-config.h.in
 
 clean_dep src/secp256k1 src/libsecp256k1-config.h.in
 rm -f src/secp256k1/src/ecmult_static_context.h
 rm -f src/secp256k1/src/libsecp256k1-config.h
 rm -f src/secp256k1/src/stamp-h1
+rm -f src/secp256k1/.so_locations
+clean_exe src/secp256k1/tests
+clean_exe src/secp256k1/exhaustive_tests
+rm -f src/secp256k1/tests.log src/secp256k1/exhaustive-tests.log src/secp256k1/test-suite.log
 
 clean_dep src/univalue univalue-config.h.in
 rm -f src/univalue/univalue-config.h
 rm -f src/univalue/stamp-h1
+clean_exe src/univalue/test_json
+clean_exe src/univalue/unitester
+clean_exe src/univalue/no_nul
+rm -f src/univalue/test/*.log

--- a/zcutil/clean.sh
+++ b/zcutil/clean.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Copyright (c) 2020 The Zcash developers
+
+rm -rf depends/*-*-*
+rm -rf depends/built
+rm -rf depends/sources
+rm -rf target
+
+rm -f src/Makefile
+rm -f src/Makefile.in
+rm -f doc/man/Makefile
+rm -f doc/man/Makefile.in
+
+rm -f src/config/stamp-h1
+rm -f src/config/bitcoin-config.h
+rm -f src/obj/build.h
+rm -f src/leveldb/build_config.mk
+rm -f src/test/buildenv.py
+rm -f src/test/data/alertTests.raw.h
+
+rm -f .cargo/config
+rm -f .cargo/.configured-for-offline
+
+rm -f qa/pull-tester/run-bitcoind-for-test.sh
+rm -f qa/pull-tester/tests-config.sh
+
+rm -rf src/test/data/*.json.h
+
+rm -f src/bench/bench_bitcoin
+rm -f src/zcash-cli
+rm -f src/zcashd
+rm -f src/zcash-gtest
+rm -f src/zcash-tx
+rm -f src/test/test_bitcoin
+
+find src -type f -and \( -name '*.Po' -or -name '*.Plo' -or -name '*.o' -or -name '*.a' -or -name '*.la' -or -name '*.lo' -or -name '*.lai' -or -name '*.pc' -or -name '.dirstamp' \) -delete
+find . -depth -path '*/.deps/*' -or \( -type d -and -name '.deps' \) -delete
+
+cleanme()
+{
+    rm -rf "$1/autom4te.cache"
+    rm -f "$1/build-aux/compile"
+    rm -f "$1/build-aux/config.guess"
+    rm -f "$1/build-aux/config.sub"
+    rm -f "$1/build-aux/depcomp"
+    rm -f "$1/build-aux/install-sh"
+    rm -f "$1/build-aux/ltmain.sh"
+    rm -f "$1/build-aux/missing"
+    rm -f "$1/build-aux/test-driver"
+    rm -f "$1/build-aux/m4/libtool.m4"
+    rm -f "$1/build-aux/m4/lt~obsolete.m4"
+    rm -f "$1/build-aux/m4/ltoptions.m4"
+    rm -f "$1/build-aux/m4/ltsugar.m4"
+    rm -f "$1/build-aux/m4/ltversion.m4"
+    rm -f "$1/aclocal.m4"
+    rm -f "$1/config.log"
+    rm -f "$1/config.status"
+    rm -f "$1/gen_context"
+    rm -f "$1/configure"
+    rm -f "$1/libtool"
+    rm -f "$1/Makefile"
+    rm -f "$1/Makefile.in"
+    rm -f "$1/$2"
+    rm -f "$1/$2~"
+}
+
+cleanme . src/config/bitcoin-config.h.in
+
+cleanme src/secp256k1 src/libsecp256k1-config.h.in
+rm -f src/secp256k1/src/ecmult_static_context.h
+rm -f src/secp256k1/src/libsecp256k1-config.h
+rm -f src/secp256k1/src/stamp-h1
+
+cleanme src/univalue univalue-config.h.in
+rm -f src/univalue/univalue-config.h
+rm -f src/univalue/stamp-h1

--- a/zcutil/clean.sh
+++ b/zcutil/clean.sh
@@ -20,7 +20,11 @@ rm -f src/test/data/*.json.h
 
 
 find src -type f -and \( -name '*.Po' -or -name '*.Plo' -or -name '*.o' -or -name '*.a' -or -name '*.la' -or -name '*.lo' -or -name '*.lai' -or -name '*.pc' -or -name '.dirstamp' \) -delete
-find . -depth -path '*/.deps/*' -or \( -type d -and -name '.deps' \) -delete
+clean_dirs()
+{
+    find . -depth -path "*/$1/*" -delete
+    find . -type d -name "$1" -delete
+}
 
 clean_exe()
 {
@@ -54,6 +58,8 @@ clean_dep()
     rm -f "$1/$2"
     rm -f "$1/$2~"
 }
+
+clean_dirs .deps
 
 clean_exe src/bench/bench_bitcoin
 clean_exe src/zcash-cli

--- a/zcutil/clean.sh
+++ b/zcutil/clean.sh
@@ -14,14 +14,13 @@ rm -f src/config/stamp-h1
 rm -f src/config/bitcoin-config.h
 rm -f src/obj/build.h
 rm -f src/leveldb/build_config.mk
+
 rm -f src/test/buildenv.py
-rm -f src/test/data/alertTests.raw.h
+rm -f src/test/data/*.json.h
+rm -f src/test/data/*.raw.h
 
 rm -f qa/pull-tester/run-bitcoind-for-test.sh
 rm -f qa/pull-tester/tests-config.sh
-
-rm -f src/test/data/*.json.h
-rm -f src/test/data/*.raw.h
 
 rm -f src/fuzz.cpp
 

--- a/zcutil/clean.sh
+++ b/zcutil/clean.sh
@@ -18,15 +18,14 @@ rm -f qa/pull-tester/tests-config.sh
 
 rm -f src/test/data/*.json.h
 
-rm -f src/bench/bench_bitcoin
-rm -f src/zcash-cli
-rm -f src/zcashd
-rm -f src/zcash-gtest
-rm -f src/zcash-tx
-rm -f src/test/test_bitcoin
 
 find src -type f -and \( -name '*.Po' -or -name '*.Plo' -or -name '*.o' -or -name '*.a' -or -name '*.la' -or -name '*.lo' -or -name '*.lai' -or -name '*.pc' -or -name '.dirstamp' \) -delete
 find . -depth -path '*/.deps/*' -or \( -type d -and -name '.deps' \) -delete
+
+clean_exe()
+{
+    rm -f "$1" "$1.exe"
+}
 
 clean_dep()
 {
@@ -55,6 +54,13 @@ clean_dep()
     rm -f "$1/$2"
     rm -f "$1/$2~"
 }
+
+clean_exe src/bench/bench_bitcoin
+clean_exe src/zcash-cli
+clean_exe src/zcashd
+clean_exe src/zcash-gtest
+clean_exe src/zcash-tx
+clean_exe src/test/test_bitcoin
 
 clean_dep . src/config/bitcoin-config.h.in
 

--- a/zcutil/clean.sh
+++ b/zcutil/clean.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
 # Copyright (c) 2020 The Zcash developers
 
-rm -rf depends/*-*-*
-rm -rf depends/built
-rm -rf depends/sources
-rm -rf target
-
 rm -f src/Makefile
 rm -f src/Makefile.in
 rm -f doc/man/Makefile
@@ -17,9 +12,6 @@ rm -f src/obj/build.h
 rm -f src/leveldb/build_config.mk
 rm -f src/test/buildenv.py
 rm -f src/test/data/alertTests.raw.h
-
-rm -f .cargo/config
-rm -f .cargo/.configured-for-offline
 
 rm -f qa/pull-tester/run-bitcoind-for-test.sh
 rm -f qa/pull-tester/tests-config.sh

--- a/zcutil/clean.sh
+++ b/zcutil/clean.sh
@@ -16,7 +16,7 @@ rm -f src/test/data/alertTests.raw.h
 rm -f qa/pull-tester/run-bitcoind-for-test.sh
 rm -f qa/pull-tester/tests-config.sh
 
-rm -rf src/test/data/*.json.h
+rm -f src/test/data/*.json.h
 
 rm -f src/bench/bench_bitcoin
 rm -f src/zcash-cli
@@ -28,7 +28,7 @@ rm -f src/test/test_bitcoin
 find src -type f -and \( -name '*.Po' -or -name '*.Plo' -or -name '*.o' -or -name '*.a' -or -name '*.la' -or -name '*.lo' -or -name '*.lai' -or -name '*.pc' -or -name '.dirstamp' \) -delete
 find . -depth -path '*/.deps/*' -or \( -type d -and -name '.deps' \) -delete
 
-cleanme()
+clean_dep()
 {
     rm -rf "$1/autom4te.cache"
     rm -f "$1/build-aux/compile"
@@ -56,13 +56,13 @@ cleanme()
     rm -f "$1/$2~"
 }
 
-cleanme . src/config/bitcoin-config.h.in
+clean_dep . src/config/bitcoin-config.h.in
 
-cleanme src/secp256k1 src/libsecp256k1-config.h.in
+clean_dep src/secp256k1 src/libsecp256k1-config.h.in
 rm -f src/secp256k1/src/ecmult_static_context.h
 rm -f src/secp256k1/src/libsecp256k1-config.h
 rm -f src/secp256k1/src/stamp-h1
 
-cleanme src/univalue univalue-config.h.in
+clean_dep src/univalue univalue-config.h.in
 rm -f src/univalue/univalue-config.h
 rm -f src/univalue/stamp-h1

--- a/zcutil/clean.sh
+++ b/zcutil/clean.sh
@@ -27,6 +27,8 @@ rm -f src/fuzz.cpp
 rm -rf test_bitcoin.coverage/ zcash-gtest.coverage/ total.coverage/
 
 rm -rf cache
+rm -rf target
+rm -rf depends/work
 
 find src -type f -and \( -name '*.Po' -or -name '*.Plo' -or -name '*.o' -or -name '*.a' -or -name '*.la' -or -name '*.lo' -or -name '*.lai' -or -name '*.pc' -or -name '.dirstamp' -or -name '*.gcda' -or -name '*.gcno' -or -name '*.sage.py' -or -name '*.trs' \) -delete
 

--- a/zcutil/distclean.sh
+++ b/zcutil/distclean.sh
@@ -4,9 +4,11 @@
 zcutil/clean.sh
 
 rm -rf depends/*-*-*
+rm -rf depends/work
 rm -rf depends/built
 rm -rf depends/sources
 rm -rf target
 
-rm -f .cargo/config
-rm -f .cargo/.configured-for-offline
+rm -rf afl-temp
+rm -rf src/fuzzing/*/output
+

--- a/zcutil/distclean.sh
+++ b/zcutil/distclean.sh
@@ -4,10 +4,8 @@
 zcutil/clean.sh
 
 rm -rf depends/*-*-*
-rm -rf depends/work
 rm -rf depends/built
 rm -rf depends/sources
-rm -rf target
 
 rm -rf afl-temp
 rm -rf src/fuzzing/*/output

--- a/zcutil/distclean.sh
+++ b/zcutil/distclean.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Copyright (c) 2020 The Zcash developers
+
+zcutil/clean.sh
+
+rm -rf depends/*-*-*
+rm -rf depends/built
+rm -rf depends/sources
+rm -rf target
+
+rm -f .cargo/config
+rm -f .cargo/.configured-for-offline


### PR DESCRIPTION
Workaround for #2226.