### PR TITLE
Balance log

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1615,6 +1615,9 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
         //// debug print
         LogPrintf("AddToWallet %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""), (fUpdated ? "update" : ""));
 
+        // Call to balance slot
+        LogBalanceChanged();
+
         // Write to disk
         if (fInsertedNew || fUpdated)
             if (!wtx.WriteToDisk(pwalletdb))
@@ -4744,6 +4747,12 @@ bool CWallet::InitLoadWallet(bool clearWitnessCaches)
         }
     }
     walletInstance->SetBroadcastTransactions(GetBoolArg("-walletbroadcast", DEFAULT_WALLETBROADCAST));
+
+    // Connect a LogBalance slot
+    if (fDebug) {
+        LogBalance balance;
+        walletInstance->LogBalanceChanged.connect(balance);
+    }
 
     pwalletMain = walletInstance;
     return true;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -10,6 +10,7 @@
 #include "asyncrpcoperation.h"
 #include "coins.h"
 #include "key.h"
+#include "key_io.h"
 #include "keystore.h"
 #include "main.h"
 #include "primitives/block.h"
@@ -1164,6 +1165,9 @@ public:
     CAmount GetWatchOnlyBalance() const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
+
+    static CAmount getBalanceTaddr(std::string transparentAddress, int minDepth=1, bool ignoreUnspendable=true);
+    static CAmount getBalanceZaddr(std::string address, int minDepth = 1, bool ignoreUnspendable=true);
 
     /**
      * Insert additional inputs into the transaction by


### PR DESCRIPTION
This is a signal/slot approach to do part 2 of https://github.com/zcash/zcash/issues/4279#issuecomment-570421471

First, it moves 2 functions that we are going to need from `rpcwallet.cpp` to `wallet.cpp`. This are `getBalanceTaddr` and `getBalanceZaddr`.

Then, signal and slots are created to log balance changes in the 3 addresses type(`sprout`, `sapling`, `transparent`).
I left coinbase balance outside but can be added, not sure if it is needed.

A connection to the signal is created once at wallet load(at `CWallet::CWallet::InitLoadWallet`), then slot is called at every transaction added to the wallet(at `CWallet::AddToWallet`).

Initially i am looking for fatal flaws in the design of this approach, had been testing it in `regtest` mode, seems to work however i didn't tested extensively yet.