### PR TITLE
Balance change notifications

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -82,6 +82,7 @@ testScripts=(
     'sprout_sapling_migration.py'
     'turnstile.py'
     'mining_shielded_coinbase.py'
+    'wallet_logging.py'
 );
 testScriptsExt=(
     'getblocktemplate_longpoll.py'

--- a/qa/rpc-tests/wallet_logging.py
+++ b/qa/rpc-tests/wallet_logging.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import start_nodes, wait_and_assert_operationid_status, \
+    get_coinbase_address, check_node_log
+
+from decimal import Decimal
+
+class WalletNotifyTest (BitcoinTestFramework):
+
+    def setup_nodes(self):
+        return start_nodes(4, self.options.tmpdir, extra_args=[['-debug=balance'], [], [], []])
+
+    def run_test (self):
+        # generate some address of different type
+        zaddr_sprout = self.nodes[0].z_getnewaddress('sprout')
+        zaddr_sapling = self.nodes[0].z_getnewaddress('sapling')
+        taddr = self.nodes[0].getnewaddress()
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # check logs for new balances associated with addresses
+        string_to_find = "New balance created for address " + taddr
+        check_node_log(self, 0, string_to_find, False)
+        string_to_find = "New balance created for address " + zaddr_sprout
+        check_node_log(self, 0, string_to_find, False)
+        string_to_find = "New balance created for address " + zaddr_sapling
+        check_node_log(self, 0, string_to_find, False)
+
+        # funds are in coinbase
+        taddr_coinbase = get_coinbase_address(self.nodes[0])
+
+        # send from coinbase to sprout
+        recipients = []
+        recipients.append({"address":zaddr_sprout, "amount":Decimal('10.0')-Decimal('0.0001')})
+        wait_and_assert_operationid_status(self.nodes[0], self.nodes[0].z_sendmany(taddr_coinbase, recipients), timeout=120)
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # check
+        string_to_find = "Balance changed in address " + zaddr_sprout + " from 0.00000000 to 9.99990000"
+        check_node_log(self, 0, string_to_find, False)
+
+        # send from sprout to taddr
+        recipients = []
+        recipients.append({"address":taddr, "amount":Decimal('5.0')-Decimal('0.0001')})
+        wait_and_assert_operationid_status(self.nodes[0], self.nodes[0].z_sendmany(zaddr_sprout, recipients), timeout=120)
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # check
+        string_to_find = "Balance changed in address " + zaddr_sprout + " from 9.99990000 to 4.99990000"
+        check_node_log(self, 0, string_to_find, False)
+        string_to_find = "Balance changed in address " + taddr + " from 0.00000000 to 4.99990000"
+        check_node_log(self, 0, string_to_find, False)
+
+        # send from coinbase to taddr
+        self.nodes[0].sendtoaddress(taddr, Decimal('1.0'))
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # check
+        string_to_find = "Balance changed in address " + taddr + " from 4.99990000 to 5.99990000"
+        check_node_log(self, 0, string_to_find, False)
+
+        # send from taddr to sapling
+        recipients = []
+        recipients.append({"address":zaddr_sapling, "amount":Decimal('0.5')-Decimal('0.0001')})
+        wait_and_assert_operationid_status(self.nodes[0], self.nodes[0].z_sendmany(taddr, recipients), timeout=120)
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        string_to_find = "Balance changed in address " + taddr + " from 5.99990000 to 4.99990000"
+        check_node_log(self, 0, string_to_find, False)
+
+        string_to_find = "Balance changed in address " + zaddr_sapling + " from 0.00000000 to 0.49990000"
+        check_node_log(self, 0, string_to_find, False)
+
+if __name__ == '__main__':
+    WalletNotifyTest().main ()

--- a/qa/rpc-tests/wallet_logging.py
+++ b/qa/rpc-tests/wallet_logging.py
@@ -12,7 +12,7 @@ from decimal import Decimal
 class WalletNotifyTest (BitcoinTestFramework):
 
     def setup_nodes(self):
-        return start_nodes(4, self.options.tmpdir, extra_args=[['-debug=balance'], [], [], []])
+        return start_nodes(4, self.options.tmpdir, extra_args=[['-debug=balanceunsafe'], [], [], []])
 
     def run_test (self):
         # generate some address of different type
@@ -24,11 +24,11 @@ class WalletNotifyTest (BitcoinTestFramework):
         self.sync_all()
 
         # check logs for new balances associated with addresses
-        string_to_find = "New balance created for address " + taddr
+        string_to_find = "New balance created for address " + taddr + " with balance 0.00000000"
         check_node_log(self, 0, string_to_find, False)
-        string_to_find = "New balance created for address " + zaddr_sprout
+        string_to_find = "New balance created for address " + zaddr_sprout + " with balance 0.00000000"
         check_node_log(self, 0, string_to_find, False)
-        string_to_find = "New balance created for address " + zaddr_sapling
+        string_to_find = "New balance created for address " + zaddr_sapling + " with balance 0.00000000"
         check_node_log(self, 0, string_to_find, False)
 
         # funds are in coinbase

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1635,6 +1635,8 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
             boost::thread t(runCommand, strCmd); // thread runs free
         }
 
+        // Check if balances changed
+        NotifyBalanceChanged();
     }
     return true;
 }
@@ -4744,6 +4746,11 @@ bool CWallet::InitLoadWallet(bool clearWitnessCaches)
         }
     }
     walletInstance->SetBroadcastTransactions(GetBoolArg("-walletbroadcast", DEFAULT_WALLETBROADCAST));
+
+    if (fDebug) {
+        LogBalance balance;
+        walletInstance->NotifyBalanceChanged.connect(balance);
+    }
 
     pwalletMain = walletInstance;
     return true;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -10,6 +10,7 @@
 #include "asyncrpcoperation.h"
 #include "coins.h"
 #include "key.h"
+#include "key_io.h"
 #include "keystore.h"
 #include "main.h"
 #include "primitives/block.h"
@@ -1164,6 +1165,9 @@ public:
     CAmount GetWatchOnlyBalance() const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
+
+    static CAmount getBalanceTaddr(std::string transparentAddress, int minDepth=1, bool ignoreUnspendable=true);
+    static CAmount getBalanceZaddr(std::string address, int minDepth = 1, bool ignoreUnspendable=true);
 
     /**
      * Insert additional inputs into the transaction by


### PR DESCRIPTION
This is a signal/slot approach to do part 2 of #4279 (comment)

First, it moves 2 functions that we are going to need from rpcwallet.cpp to wallet.cpp. This are getBalanceTaddr and getBalanceZaddr.

Then, signal and slots are created to log balance changes in the 3 addresses type(sprout, sapling, transparent).
I left coinbase balance outside but can be added, not sure if it is needed.

A connection to the signal is created once at wallet load(at CWallet::CWallet::InitLoadWallet), then slot is called at every transaction added to the wallet(at CWallet::AddToWallet).

