### PR TITLE
Use SA_RESTART in sa_flags when setting up signal handlers

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -873,7 +873,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     struct sigaction sa;
     sa.sa_handler = HandleSIGTERM;
     sigemptyset(&sa.sa_mask);
-    sa.sa_flags = 0;
+    sa.sa_flags = SA_RESTART;
     sigaction(SIGTERM, &sa, NULL);
     sigaction(SIGINT, &sa, NULL);
 
@@ -882,7 +882,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     struct sigaction sa_hup;
     sa_hup.sa_handler = HandleSIGHUP;
     sigemptyset(&sa_hup.sa_mask);
-    sa_hup.sa_flags = 0;
+    sa_hup.sa_flags = SA_RESTART;
     sigaction(SIGHUP, &sa_hup, NULL);
 
     // Ignore SIGPIPE, otherwise it will bring the daemon down if the client closes unexpectedly


### PR DESCRIPTION
Explanation: if a signal interrupts certain syscalls such as `open`, `read`, or `write`,
then the library function will by default fail with `errno` `EINTR`. But we [almost](https://github.com/zcash/zcash/search?q=WSAEINTR) [never](https://github.com/zcash/zcash/search?q=EINTR)
check for `EINTR`, so this is likely to cause spurious errors. We want to restart the syscall
instead, which is what `SA_RESTART` is intended to do. Since our signal handlers (defined
in init.cpp) only set a flag, restarting the syscall is safe and is always the Right Thing.

See <https://www.gnu.org/software/libc/manual/html_node/Flags-for-Sigaction.html> and
<https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html> for
further information.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>