### PR TITLE
Remove option to load new blocks from ConnectTip

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3212,15 +3212,9 @@ uint64_t nNotifiedSequence = 0;
  */
 bool static ConnectTip(CValidationState& state, const CChainParams& chainparams, CBlockIndex* pindexNew, const CBlock* pblock)
 {
-    assert(pindexNew->pprev == chainActive.Tip());
+    assert(pblock && pindexNew->pprev == chainActive.Tip());
     // Read block from disk.
     int64_t nTime1 = GetTimeMicros();
-    CBlock block;
-    if (!pblock) {
-        if (!ReadBlockFromDisk(block, pindexNew, chainparams.GetConsensus()))
-            return AbortNode(state, "Failed to read block");
-        pblock = &block;
-    }
     // Apply the block atomically to the chain state.
     int64_t nTime2 = GetTimeMicros(); nTimeReadFromDisk += nTime2 - nTime1;
     int64_t nTime3;
@@ -3431,7 +3425,17 @@ static bool ActivateBestChainStep(CValidationState& state, const CChainParams& c
 
         // Connect new blocks.
         BOOST_REVERSE_FOREACH(CBlockIndex *pindexConnect, vpindexToConnect) {
-            if (!ConnectTip(state, chainparams, pindexConnect, pindexConnect == pindexMostWork ? pblock : NULL)) {
+            const CBlock* pconnectBlock = pblock;
+            CBlock block;
+            if (pindexConnect != pindexMostWork) {
+                if (!ReadBlockFromDisk(block, pindexConnect, chainparams.GetConsensus()))
+                    return AbortNode(state, "Failed to read block");
+                pconnectBlock = &block;
+            } else {
+                pconnectBlock = pblock;
+            }
+
+            if (!ConnectTip(state, chainparams, pindexConnect, pconnectBlock)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.
                     if (!state.CorruptionPossible())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3213,7 +3213,6 @@ uint64_t nNotifiedSequence = 0;
 bool static ConnectTip(CValidationState& state, const CChainParams& chainparams, CBlockIndex* pindexNew, const CBlock* pblock)
 {
     assert(pblock && pindexNew->pprev == chainActive.Tip());
-    // Read block from disk.
     int64_t nTime1 = GetTimeMicros();
     // Apply the block atomically to the chain state.
     int64_t nTime2 = GetTimeMicros(); nTimeReadFromDisk += nTime2 - nTime1;
@@ -3425,14 +3424,15 @@ static bool ActivateBestChainStep(CValidationState& state, const CChainParams& c
 
         // Connect new blocks.
         BOOST_REVERSE_FOREACH(CBlockIndex *pindexConnect, vpindexToConnect) {
-            const CBlock* pconnectBlock = pblock;
+            const CBlock* pconnectBlock;
             CBlock block;
-            if (pindexConnect != pindexMostWork) {
+            if (pindexConnect == pindexMostWork) {
+                pconnectBlock = pblock;
+            } else {
+                // read the block to be connected from disk
                 if (!ReadBlockFromDisk(block, pindexConnect, chainparams.GetConsensus()))
                     return AbortNode(state, "Failed to read block");
                 pconnectBlock = &block;
-            } else {
-                pconnectBlock = pblock;
             }
 
             if (!ConnectTip(state, chainparams, pindexConnect, pconnectBlock)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3426,7 +3426,7 @@ static bool ActivateBestChainStep(CValidationState& state, const CChainParams& c
         BOOST_REVERSE_FOREACH(CBlockIndex *pindexConnect, vpindexToConnect) {
             const CBlock* pconnectBlock;
             CBlock block;
-            if (pindexConnect == pindexMostWork) {
+            if (pblock && pindexConnect == pindexMostWork) {
                 pconnectBlock = pblock;
             } else {
                 // read the block to be connected from disk


### PR DESCRIPTION
A minor refactoring to move file IO out of ConnectTip, which has only a single caller.