### PR TITLE
Fix advertised version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5427,7 +5427,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             vRecv >> addrFrom >> nNonce;
         if (!vRecv.empty()) {
             vRecv >> LIMITED_STRING(pfrom->strSubVer, MAX_SUBVERSION_LENGTH);
-            pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
+            pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer, SAFE_CHARS_SUBVERSION);
         }
         if (!vRecv.empty())
             vRecv >> pfrom->nStartingHeight;

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -420,6 +420,11 @@ BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
     BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99950, comments),  std::string("/Test:0.9.99(comment1)/"));
     BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2), std::string("/Test:0.9.99-beta1(comment1; Comment2; .,_?@; )/"));
     BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99950, comments2), std::string("/Test:0.9.99(comment1; Comment2; .,_?@; )/"));
+
+    // bug https://github.com/zcash/zcash/issues/4375
+    BOOST_CHECK_EQUAL(SanitizeString(std::string("MagicBean:2.1.1-1")), "MagicBean:2.1.11");
+    // fixed by adding new rule https://github.com/zcash/zcash/pull/4444
+    BOOST_CHECK_EQUAL(SanitizeString(std::string("MagicBean:2.1.1-1"), SAFE_CHARS_SUBVERSION), "MagicBean:2.1.1-1");
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseFixedPoint)

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -20,7 +20,9 @@ static const string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO
 static const string SAFE_CHARS[] =
 {
     CHARS_ALPHA_NUM + " .,;_/:?@()", // SAFE_CHARS_DEFAULT
-    CHARS_ALPHA_NUM + " .,;_?@" // SAFE_CHARS_UA_COMMENT
+    CHARS_ALPHA_NUM + " .,;_?@", // SAFE_CHARS_UA_COMMENT
+    CHARS_ALPHA_NUM + " .-/:" // SAFE_CHARS_SUBVERSION
+
 };
 
 string SanitizeString(const string& str, int rule)

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -26,7 +26,8 @@
 enum SafeChars
 {
     SAFE_CHARS_DEFAULT, //!< The full set of allowed chars
-    SAFE_CHARS_UA_COMMENT //!< BIP-0014 subset
+    SAFE_CHARS_UA_COMMENT, //!< BIP-0014 subset
+    SAFE_CHARS_SUBVERSION //!< Peer subversion string subset
 };
 
 std::string SanitizeFilename(const std::string& str);


### PR DESCRIPTION
Closes https://github.com/zcash/zcash/issues/4375 by adding the `-` character to the list of safe ones.

Now i can see stuff like the following in the logs:

```
...
2020-04-13 14:19:37 receive version message: /MagicBean:2.1.1-1/: version 170009, blocks=795400, us=[2800:a4:316b:8e00:ceb:c7b4:3481:197f]:59754, peer=2
...
```

API call `getpeerinfo` will also gets fixed. 