### PR TITLE
consensus: From Heartwood activation, use Rust Equihash validator

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -436,7 +436,7 @@ bool GetTimestampIndex(unsigned int high, unsigned int low, bool fActiveOnly,
 
 /** Functions for disk access for blocks */
 bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& messageStart);
-bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
+bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, int nHeight, const Consensus::Params& consensusParams);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 
 /** Functions for validating blocks and updating the block tree */
@@ -454,7 +454,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state,
  *  By "context", we mean only the previous block headers, but not the UTXO
  *  set; UTXO-related validity checks are done in ConnectBlock(). */
 bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state,
-                                const CChainParams& chainparams, CBlockIndex *pindexPrev);
+                                const CChainParams& chainparams, CBlockIndex *pindexPrev,
+                                bool fCheckPOW = true);
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state,
                           const CChainParams& chainparams, CBlockIndex *pindexPrev);
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -92,7 +92,7 @@ unsigned int CalculateNextWorkRequired(arith_uint256 bnAvg,
     return bnNew.GetCompact();
 }
 
-bool CheckEquihashSolution(const CBlockHeader *pblock, const Consensus::Params& params)
+bool CheckEquihashSolution(const CBlockHeader *pblock, int nHeight, const Consensus::Params& params)
 {
     unsigned int n = params.nEquihashN;
     unsigned int k = params.nEquihashK;

--- a/src/pow.h
+++ b/src/pow.h
@@ -23,7 +23,7 @@ unsigned int CalculateNextWorkRequired(arith_uint256 bnAvg,
                                        int nextHeight);
 
 /** Check whether the Equihash solution in a block header is valid */
-bool CheckEquihashSolution(const CBlockHeader *pblock, const Consensus::Params&);
+bool CheckEquihashSolution(const CBlockHeader *pblock, int nHeight, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);

--- a/src/test/equihash_tests.cpp
+++ b/src/test/equihash_tests.cpp
@@ -15,6 +15,8 @@
 
 #include "sodium.h"
 
+#include "librustzcash.h"
+
 #include <sstream>
 #include <set>
 #include <vector>
@@ -87,6 +89,9 @@ void TestEquihashSolvers(unsigned int n, unsigned int k, const std::string &I, c
 
 void TestEquihashValidator(unsigned int n, unsigned int k, const std::string &I, const arith_uint256 &nonce, std::vector<uint32_t> soln, bool expected) {
     size_t cBitLen { n/(k+1) };
+    auto minimal = GetMinimalFromIndices(soln, cBitLen);
+
+    // First test the C++ validator
     crypto_generichash_blake2b_state state;
     EhInitialiseState(n, k, state);
     uint256 V = ArithToUint256(nonce);
@@ -97,7 +102,15 @@ void TestEquihashValidator(unsigned int n, unsigned int k, const std::string &I,
     PrintSolution(strm, soln);
     BOOST_TEST_MESSAGE(strm.str());
     bool isValid;
-    EhIsValidSolution(n, k, state, GetMinimalFromIndices(soln, cBitLen), isValid);
+    EhIsValidSolution(n, k, state, minimal, isValid);
+    BOOST_CHECK(isValid == expected);
+
+    // The Rust validator should have the exact same result
+    isValid = librustzcash_eh_isvalid(
+        n, k,
+        (unsigned char*)&I[0], I.size(),
+        V.begin(), V.size(),
+        minimal.data(), minimal.size());
     BOOST_CHECK(isValid == expected);
 }
 
@@ -219,6 +232,11 @@ BOOST_AUTO_TEST_CASE(validator_allbitsmatter) {
     bool isValid;
     EhIsValidSolution(n, k, state, sol_char, isValid);
     BOOST_CHECK(isValid == true);
+    BOOST_CHECK(librustzcash_eh_isvalid(
+        n, k,
+        (unsigned char*)&I[0], I.size(),
+        V.begin(), V.size(),
+        sol_char.data(), sol_char.size()));
 
     // Changing any single bit of the encoded solution should make it invalid.
     for (size_t i = 0; i < sol_char.size() * 8; i++) {
@@ -226,6 +244,11 @@ BOOST_AUTO_TEST_CASE(validator_allbitsmatter) {
         mutated.at(i/8) ^= (1 << (i % 8));
         EhIsValidSolution(n, k, state, mutated, isValid);
         BOOST_CHECK(isValid == false);
+        BOOST_CHECK(!librustzcash_eh_isvalid(
+            n, k,
+            (unsigned char*)&I[0], I.size(),
+            V.begin(), V.size(),
+            mutated.data(), mutated.size()));
     }
 }
 

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -204,7 +204,7 @@ double benchmark_verify_equihash()
     CBlockHeader genesis_header = genesis.GetBlockHeader();
     struct timeval tv_start;
     timer_start(tv_start);
-    CheckEquihashSolution(&genesis_header, params.GetConsensus());
+    assert(CheckEquihashSolution(&genesis_header, 1, params.GetConsensus()));
     return timer_stop(tv_start);
 }
 


### PR DESCRIPTION
The C++ and Rust Equihash validators are intended to have an identical
set of valid Equihash solutions, so this should merely be an
implementation detail. However, deploying the Rust validator at the same
time as a network upgrade reduces the risk of an unintentional consensus
divergence due to undocumented behaviour in either implementation.

Once Heartwood has activated on mainnet, we can verify that all
pre-Heartwood blocks satisfy the Rust validator, and then remove the C++
validator and make Equihash-checking non-contextual again.

Replaces zcash/zcash#2851.