### PR TITLE
Set Heartwood activation height for testnet to 903800.

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -13,7 +13,7 @@ included in this release. The following ZIPs are being deployed:
 - [ZIP 213: Shielded Coinbase](https://zips.z.cash/zip-0213)
 - [ZIP 221: FlyClient - Consensus-Layer Changes](https://zips.z.cash/zip-0221)
 
-Heartwood will activate on testnet at height XXXXXX, and can also be activated
+Heartwood will activate on testnet at height 903800, and can also be activated
 at a specific height in regtest mode by setting the config option
 `-nuparams=f5b9230b:HEIGHT`.
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -321,8 +321,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].hashActivationBlock =
             uint256S("00367515ef2e781b8c9358b443b6329572599edd02c59e8af67db9785122f298");
         consensus.vUpgrades[Consensus::UPGRADE_HEARTWOOD].nProtocolVersion = 170010;
-        consensus.vUpgrades[Consensus::UPGRADE_HEARTWOOD].nActivationHeight =
-            Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.vUpgrades[Consensus::UPGRADE_HEARTWOOD].nActivationHeight = 903800;
 
         // On testnet we activate this rule 6 blocks after Blossom activation. From block 299188 and
         // prior to Blossom activation, the testnet minimum-difficulty threshold was 15 minutes (i.e.

--- a/src/net.h
+++ b/src/net.h
@@ -59,8 +59,11 @@ static const size_t MAPASKFOR_MAX_SZ = MAX_INV_SZ;
 static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
-/** The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks). */
-static const int NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 24 * 24 * 3;
+/**
+ * The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks).
+ * This was three days for upgrades up to and including Blossom, and is 1.5 days from Heartwood onward.
+ */
+static const int NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 1728;
 
 static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 170009;
+static const int PROTOCOL_VERSION = 170010;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
Should activate on testnet approx 4PM MST on May 6th, 2020.