### PR TITLE
Overrride -addnode if -noconnect

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1787,12 +1787,13 @@ void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
     // Send and receive from sockets, accept connections
     threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "net", &ThreadSocketHandler));
 
-    // Initiate outbound connections from -addnode
-    threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "addcon", &ThreadOpenAddedConnections));
-
     // Initiate outbound connections unless connect=0
-    if (!mapArgs.count("-connect") || mapMultiArgs["-connect"].size() != 1 || mapMultiArgs["-connect"][0] != "0")
+    if (!mapArgs.count("-connect") || mapMultiArgs["-connect"].size() != 1 || mapMultiArgs["-connect"][0] != "0") {
+        // Initiate outbound connections from -addnode
+        threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "addcon", &ThreadOpenAddedConnections));
+        // Initiate outbound connections from -connect
         threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "opencon", &ThreadOpenConnections));
+    }
 
     // Process messages
     threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "msghand", &ThreadMessageHandler));


### PR DESCRIPTION
Attempt to resolve https://github.com/zcash/zcash/issues/4474

Blocks the initialization of the added nodes thread if `noconnect` or `connect=0` options are present.

For some reason i was not able to find when i start a node with no `addnode` anywhere(command line nor config file) the net code still connect to peers. The only way i found to block this behaviour when specified is to dont start the thread. 