### PR TITLE
Add options and help to AFL scripts

### DIFF
--- a/zcutil/afl/afl-build.sh
+++ b/zcutil/afl/afl-build.sh
@@ -29,7 +29,7 @@ Usage:
     $0 --afl-install=AFL_INSTALL_DIR --fuzz-case=FUZZ_CASE [ OPTIONS ... ] [ ARGUMENTS ... ]
 
     OPTIONS:
-        -a, --harden            Turn off AFL_HARDEN. Default: $AFL_HARDEN
+        -a, --disable-harden    Turn off AFL_HARDEN. Default: $AFL_HARDEN
         -c, --configure-flags   Pass this flags to ./configure. Default: $CONFIGURE_FLAGS
         -f, --fuzz-case         $FUZZ_OPTIONS_STRING
         -h, --help              Print this help message
@@ -48,7 +48,7 @@ EOF
 
 while (( "$#" )); do
     case "$1" in
-        -a|--harden)
+        -a|--disable-harden)
             AFL_HARDEN=0
             shift
         ;;

--- a/zcutil/afl/afl-build.sh
+++ b/zcutil/afl/afl-build.sh
@@ -1,19 +1,100 @@
 #!/usr/bin/env bash
-# A wrapper around ./zcutil/build.sh for instrumenting the build with AFL:
-#   ./zcutil/afl/afl-build.sh <directory where AFL is installed> <fuzz case>
-# You may obtain a copy of AFL using ./zcutil/afl/afl-get.sh.
 
 set -eu -o pipefail
 
-export AFL_INSTALL_DIR=$(realpath "$1")
-FUZZ_CASE="$2"
-shift 2
+AFL_HARDEN=1
+CONFIGURE_FLAGS="--enable-tests=no --enable-fuzz-main"
+ZCUTIL=$(realpath "./zcutil")
 export AFL_LOG_DIR="$(pwd)"
-export ZCUTIL=$(realpath "./zcutil")
+
+FUZZ_OPTIONS_STRING="Options are: CheckBlock, DecodeHexTx, DeserializeAddrMan, DeserializeTx or ReadFeeEstimates"
+
+required_options_count=0
+DEFAULT_BUILD_CC="CC=$ZCUTIL/afl/zcash-wrapper-gcc"
+DEFAULT_BUILD_CXX="CXX=$ZCUTIL/afl/zcash-wrapper-g++"
+
+function help {
+    cat <<EOF
+A wrapper around ./zcutil/build.sh for instrumenting the build with AFL.
+You may obtain a copy of AFL using ./zcutil/afl/afl-get.sh.
+Additional arguments are passed-through to build.sh.
+
+Usage:
+    $0 --afl-install=AFL_INSTALL_DIR --fuzz-case=FUZZ_CASE [ OPTIONS ... ] [ ARGUMENTS ... ]
+
+    OPTIONS:
+        -a, --harden            Turn off AFL_HARDEN. Default: $AFL_HARDEN
+        -c, --configure-flags   Pass this flags to ./configure. Default: $CONFIGURE_FLAGS
+        -f, --fuzz-case         $FUZZ_OPTIONS_STRING
+        -h, --help              Print this help message
+        -l, --afl-log           Directory to save AFL logs. Default: $AFL_LOG_DIR
+        -i, --afl-install       Directory where AFL is installed
+        -z, --zcutil            The zcutil directory. Default $(realpath "./zcutil")
+    ARGUMENTS:
+        By default we are passing to build.sh the following flags:
+            $DEFAULT_BUILD_CC
+            $DEFAULT_BUILD_CXX
+    EXAMPLE:
+        ./zcutil/afl/afl-build.sh -i /tmp/afl -f DecodeHexTx
+
+EOF
+}
+
+while (( "$#" )); do
+    case "$1" in
+        -a|--harden)
+            AFL_HARDEN=0
+            shift
+        ;;
+        -c|--configure-flags)
+            CONFIGURE_FLAGS=$2
+            shift 2
+        ;;
+        -f|--fuzz-case)
+            FUZZ_CASE=$2
+            ((++required_options_count))
+            shift 2
+        ;;
+        -h|--help)
+            help
+            exit 0
+        ;;
+        -i|--afl-install-dir)
+            AFL_INSTALL_DIR=$(realpath "$2")
+            ((++required_options_count))
+            shift 2
+        ;;
+        -l|--afl-logs)
+            AFL_LOG_DIR=$(realpath "$2")
+            shift 2
+        ;;
+        -z|--zcutil)
+            ZCUTIL=$(realpath "$2")
+            shift 2
+        ;;
+        -*|--*=)
+            echo "Error: Unsupported flag $1" >&2
+            help
+            exit 1
+        ;;
+    esac
+done
+
+if ((required_options_count < 2)); then
+    help
+    exit 1
+fi
+
+case $FUZZ_CASE in
+    CheckBlock|DecodeHexTx|DeserializeAddrMan|DeserializeTx|ReadFeeEstimates);;
+    *) echo "fuzz case option is invalid. ($FUZZ_OPTIONS_STRING)"
+    exit 1
+    ;;
+esac
 
 cp "./src/fuzzing/$FUZZ_CASE/fuzz.cpp" src/fuzz.cpp
 
-CONFIGURE_FLAGS="--enable-tests=no --enable-fuzz-main" "$ZCUTIL/build.sh" "CC=$ZCUTIL/afl/zcash-wrapper-gcc" "CXX=$ZCUTIL/afl/zcash-wrapper-g++" AFL_HARDEN=1 "$@"
+CONFIGURE_FLAGS="$CONFIGURE_FLAGS" $ZCUTIL/build.sh $DEFAULT_BUILD_CC $DEFAULT_BUILD_CXX AFL_HARDEN=$AFL_HARDEN -j$(nproc) "$@"
 
-echo "You can now run AFL as follows:"
-echo "$ ./zcutil/afl/afl-run.sh '$AFL_INSTALL_DIR' '$FUZZ_CASE'"
+echo "Build finished. You can now run AFL as follows:"
+echo "./zcutil/afl/afl-run.sh -i $AFL_INSTALL_DIR -f $FUZZ_CASE"

--- a/zcutil/afl/afl-get.sh
+++ b/zcutil/afl/afl-get.sh
@@ -2,13 +2,18 @@
 
 set -eu -o pipefail
 
-FUZZ_OPTIONS_STRING="Where FUZZ_CASE is one of the following: CheckBlock, DecodeHexTx, DeserializeAddrMan, DeserializeTx or ReadFeeEstimates"
+for d in src/fuzzing/*/ ; do
+    fuzz_cases+="$(basename "$d"), "
+done
+
+FUZZ_OPTIONS_STRING="Where FUZZ_CASE is one of the following: ${fuzz_cases::-2}"
 
 required_options_count=0
 
 function help {
     cat <<EOF
 Obtains and builds a copy of AFL from source.
+This script must be run from within the top level directory of a zcash clone.
 
 Usage:
     $0 --afl-install=AFL_INSTALL_DIR

--- a/zcutil/afl/afl-get.sh
+++ b/zcutil/afl/afl-get.sh
@@ -1,11 +1,53 @@
 #!/usr/bin/env bash
-# Obtains and builds a copy of AFL from source.
-#   ./zcutil/afl/afl-get.sh <directory to build and install AFL in>
 
 set -eu -o pipefail
 
-mkdir -p "$1"
-cd "$1"
+FUZZ_OPTIONS_STRING="Where FUZZ_CASE is one of the following: CheckBlock, DecodeHexTx, DeserializeAddrMan, DeserializeTx or ReadFeeEstimates"
+
+required_options_count=0
+
+function help {
+    cat <<EOF
+Obtains and builds a copy of AFL from source.
+
+Usage:
+    $0 --afl-install=AFL_INSTALL_DIR
+
+    OPTIONS:
+        -h, --help              Print this help message
+        -i, --afl-install       Directory where AFL is going to be installed
+    EXAMPLE:
+        ./zcutil/afl/afl-get.sh -i /tmp/afl
+
+EOF
+}
+
+while (( "$#" )); do
+    case "$1" in
+        -i|--afl-install)
+            AFL_INSTALL_DIR=$2
+            required_options_count=1
+            break
+        ;;
+        -h|--help)
+            help
+            exit 0
+        ;;
+        -*|--*=)
+            echo "Error: Unsupported flag $1" >&2
+            help
+            exit 1
+        ;;
+    esac
+done
+
+if ((required_options_count == 0)); then
+    help
+    exit 1
+fi
+
+mkdir -p "$AFL_INSTALL_DIR"
+cd "$AFL_INSTALL_DIR"
 
 if [ ! -z "$(ls -A .)" ]; then
     echo "$1 is not empty. This script will only attempt to build AFL in an empty directory."
@@ -29,5 +71,5 @@ make
 
 echo "You can now build zcashd with AFL instrumentation as follows:"
 echo "$ make clean # if you've already built zcashd without AFL instrumentation"
-echo "$ ./zcutil/afl/afl-build.sh '$(pwd)' <fuzz case> -j\$(nproc)"
-echo "...where <fuzz case> is the name of a directory in src/fuzzing."
+echo "$ ./zcutil/afl/afl-build.sh -i $(pwd) -f FUZZ_CASE"
+echo $FUZZ_OPTIONS_STRING

--- a/zcutil/afl/afl-getbuildrun.sh
+++ b/zcutil/afl/afl-getbuildrun.sh
@@ -2,7 +2,11 @@
 
 set -eu -o pipefail
 
-FUZZ_OPTIONS_STRING="Options are: CheckBlock, DecodeHexTx, DeserializeAddrMan, DeserializeTx or ReadFeeEstimates"
+for d in src/fuzzing/*/ ; do
+    fuzz_cases+="$(basename "$d"), "
+done
+
+FUZZ_OPTIONS_STRING="Options are: ${fuzz_cases::-2}"
 
 required_options_count=0
 

--- a/zcutil/afl/afl-getbuildrun.sh
+++ b/zcutil/afl/afl-getbuildrun.sh
@@ -1,20 +1,64 @@
 #!/usr/bin/env bash
-# Builds AFL and an instrumented zcashd, then begins fuzzing.
-# This script must be run from within the top level directory of a zcash clone.
-# Pass it the name of a directory in ./src/fuzzing.
-# Additional arguments are passed-through to AFL.
 
 set -eu -o pipefail
 
-FUZZ_CASE="$1"
-shift 1
+FUZZ_OPTIONS_STRING="Options are: CheckBlock, DecodeHexTx, DeserializeAddrMan, DeserializeTx or ReadFeeEstimates"
+
+required_options_count=0
 
 export AFL_INSTALL_DIR=$(realpath "./afl-temp")
 
-if [ ! -d "$AFL_INSTALL_DIR" ]; then
-    mkdir "$AFL_INSTALL_DIR"
-    ./zcutil/afl/afl-get.sh "$AFL_INSTALL_DIR"
+function help {
+    cat <<EOF
+Builds AFL and an instrumented zcashd, then begins fuzzing.
+This script must be run from within the top level directory of a zcash clone.
+Additional arguments are passed-through to AFL.
+
+Usage:
+    $0 --fuzz-case=FUZZ_CASE [ OPTIONS ... ] [ ARGUMENTS... ]
+
+    OPTIONS:
+        -f, --fuzz-case         $FUZZ_OPTIONS_STRING
+        -h, --help              Print this help message
+        -i, --afl-install       Directory where AFL is installed. Default: $AFL_INSTALL_DIR
+    EXAMPLE:
+        ./zcutil/afl/afl-getbuildrun.sh -f DecodeHexTx
+
+EOF
+}
+
+while (( "$#" )); do
+    case "$1" in
+        -f|--fuzz-case)
+            FUZZ_CASE=$2
+            ((++required_options_count))
+            shift 2
+        ;;
+        -i|--afl-install)
+            AFL_INSTALL_DIR=$2
+            shift 2
+        ;;
+        -h|--help)
+            help
+            exit 0
+        ;;
+        -*|--*=)
+            echo "Error: Unsupported flag $1" >&2
+            help
+            exit 1
+        ;;
+    esac
+done
+
+if ((required_options_count < 1)); then
+    help
+    exit 1
 fi
 
-./zcutil/afl/afl-build.sh "$AFL_INSTALL_DIR" "$FUZZ_CASE" -j$(nproc)
-./zcutil/afl/afl-run.sh "$AFL_INSTALL_DIR" "$FUZZ_CASE" "$@"
+if [ ! -d "$AFL_INSTALL_DIR" ]; then
+    mkdir "$AFL_INSTALL_DIR"
+fi
+
+./zcutil/afl/afl-get.sh -i "$AFL_INSTALL_DIR"
+./zcutil/afl/afl-build.sh -i "$AFL_INSTALL_DIR" -f "$FUZZ_CASE"
+./zcutil/afl/afl-run.sh -i "$AFL_INSTALL_DIR" -f "$FUZZ_CASE" "$@"

--- a/zcutil/afl/afl-run.sh
+++ b/zcutil/afl/afl-run.sh
@@ -2,13 +2,18 @@
 
 set -eu -o pipefail
 
-FUZZ_OPTIONS_STRING="Options are: CheckBlock, DecodeHexTx, DeserializeAddrMan, DeserializeTx or ReadFeeEstimates"
+for d in src/fuzzing/*/ ; do
+    fuzz_cases+="$(basename "$d"), "
+done
+
+FUZZ_OPTIONS_STRING="Options are: ${fuzz_cases::-2}"
 
 required_options_count=0
 
 function help {
     cat <<EOF
 Start fuzzing a case in a previously zcashd built for AFL.
+This script must be run from within the top level directory of a zcash clone.
 Additional arguments are passed-through to AFL.
 
 Usage:

--- a/zcutil/afl/afl-run.sh
+++ b/zcutil/afl/afl-run.sh
@@ -2,8 +2,55 @@
 
 set -eu -o pipefail
 
-AFL_INSTALL_DIR="$1"
-FUZZ_CASE="$2"
-shift 2
+FUZZ_OPTIONS_STRING="Options are: CheckBlock, DecodeHexTx, DeserializeAddrMan, DeserializeTx or ReadFeeEstimates"
+
+required_options_count=0
+
+function help {
+    cat <<EOF
+Start fuzzing a case in a previously zcashd built for AFL.
+Additional arguments are passed-through to AFL.
+
+Usage:
+    $0 --afl-install=AFL_INSTALL_DIR --fuzz-case=FUZZ_CASE [ ARGUMENTS... ]
+
+    OPTIONS:
+        -f, --fuzz-case         $FUZZ_OPTIONS_STRING
+        -h, --help              Print this help message
+        -i, --afl-install       Directory where AFL is installed
+    EXAMPLE:
+        ./zcutil/afl/afl-run.sh -i /tmp/afl -f DecodeHexTx
+
+EOF
+}
+
+while (( "$#" )); do
+    case "$1" in
+        -f|--fuzz-case)
+            FUZZ_CASE=$2
+            ((++required_options_count))
+            shift 2
+        ;;
+        -i|--afl-install)
+            AFL_INSTALL_DIR=$2
+            ((++required_options_count))
+            shift 2
+        ;;
+        -h|--help)
+            help
+            exit 0
+        ;;
+        -*|--*=)
+            echo "Error: Unsupported flag $1" >&2
+            help
+            exit 1
+        ;;
+    esac
+done
+
+if ((required_options_count < 2)); then
+    help
+    exit 1
+fi
 
 "$AFL_INSTALL_DIR/afl-fuzz" -i "./src/fuzzing/$FUZZ_CASE/input" -o "./src/fuzzing/$FUZZ_CASE/output" "$@" ./src/zcashd @@


### PR DESCRIPTION
Closes https://github.com/zcash/zcash/issues/4315

For reference here is how the help of each command is script:

**afl-get.sh**:
```
$ ./zcutil/afl/afl-get.sh --help
Obtains and builds a copy of AFL from source.

Usage:
    ./zcutil/afl/afl-get.sh --afl-install=AFL_INSTALL_DIR

    OPTIONS:
        -h, --help              Print this help message
        -i, --afl-install       Directory where AFL is going to be installed
    EXAMPLE:
        ./zcutil/afl/afl-get.sh -i /tmp/afl

$ 
```

**afl-build.sh**:

```
$ ./zcutil/afl/afl-build.sh --help
A wrapper around ./zcutil/build.sh for instrumenting the build with AFL.
You may obtain a copy of AFL using ./zcutil/afl/afl-get.sh.
Additional arguments are passed-through to build.sh.

Usage:
    ./zcutil/afl/afl-build.sh --afl-install=AFL_INSTALL_DIR --fuzz-case=FUZZ_CASE [ OPTIONS ... ] [ ARGUMENTS ... ]

    OPTIONS:
        -a, --harden            Turn off AFL_HARDEN. Default: 1
        -c, --configure-flags   Pass this flags to ./configure. Default: --enable-tests=no --enable-fuzz-main
        -f, --fuzz-case         Options are: CheckBlock, DecodeHexTx, DeserializeAddrMan, DeserializeTx or ReadFeeEstimates
        -h, --help              Print this help message
        -l, --afl-log           Directory to save AFL logs. Default: /home/oxarbitrage/zcash/zcash4/zcash
        -i, --afl-install       Directory where AFL is installed
        -z, --zcutil            The zcutil directory. Default /home/oxarbitrage/zcash/zcash4/zcash/zcutil
    ARGUMENTS:
        By default we are passing to build.sh the following flags:
            CC=/home/oxarbitrage/zcash/zcash4/zcash/zcutil/afl/zcash-wrapper-gcc
            CXX=/home/oxarbitrage/zcash/zcash4/zcash/zcutil/afl/zcash-wrapper-g++
    EXAMPLE:
        ./zcutil/afl/afl-build.sh -i /tmp/afl -f DecodeHexTx

$ 
```

**afl-run.sh**:

```
$ ./zcutil/afl/afl-run.sh --help
Start fuzzing a case in a previously zcashd built for AFL.
Additional arguments are passed-through to AFL.

Usage:
    ./zcutil/afl/afl-run.sh --afl-install=AFL_INSTALL_DIR --fuzz-case=FUZZ_CASE [ ARGUMENTS... ]

    OPTIONS:
        -f, --fuzz-case         Options are: CheckBlock, DecodeHexTx, DeserializeAddrMan, DeserializeTx or ReadFeeEstimates
        -h, --help              Print this help message
        -i, --afl-install       Directory where AFL is installed
    EXAMPLE:
        ./zcutil/afl/afl-run.sh -i /tmp/afl -f DecodeHexTx

$ 
```

**afl-getbuildrun.sh**:

```
$ ./zcutil/afl/afl-getbuildrun.sh --help
Builds AFL and an instrumented zcashd, then begins fuzzing.
This script must be run from within the top level directory of a zcash clone.
Additional arguments are passed-through to AFL.

Usage:
    ./zcutil/afl/afl-getbuildrun.sh --fuzz-case=FUZZ_CASE [ OPTIONS ... ] [ ARGUMENTS... ]

    OPTIONS:
        -f, --fuzz-case         Options are: CheckBlock, DecodeHexTx, DeserializeAddrMan, DeserializeTx or ReadFeeEstimates
        -h, --help              Print this help message
        -i, --afl-install       Directory where AFL is installed. Default: /home/oxarbitrage/zcash/zcash4/zcash/afl-temp
    EXAMPLE:
        ./zcutil/afl/afl-getbuildrun.sh -f DecodeHexTx

$ 
```