### PR TITLE
txdb: Restrict Heartwood chain consistency check to BLOCK_VALID_CONSENSUS

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -567,10 +567,13 @@ bool CBlockTreeDB::LoadBlockIndexGuts(
 
                 // ZIP 221 consistency checks
                 if (chainParams.GetConsensus().NetworkUpgradeActive(pindexNew->nHeight, Consensus::UPGRADE_HEARTWOOD)) {
-                    if (pindexNew->hashLightClientRoot != pindexNew->hashChainHistoryRoot) {
+                    // Don't enforce consistency check for headers that aren't necessarily
+                    // Heartwood-aware (such as headers we receive from non-upgraded peers
+                    // immediately after Heartwood activation).
+                    if (pindexNew->IsValid(BLOCK_VALID_CONSENSUS) && pindexNew->hashLightClientRoot != pindexNew->hashChainHistoryRoot) {
                         return error(
-                            "LoadBlockIndex(): block index inconsistency detected (hashLightClientRoot != hashChainHistoryRoot): %s",
-                            pindexNew->ToString());
+                            "LoadBlockIndex(): block index inconsistency detected (hashLightClientRoot %s != hashChainHistoryRoot %s): %s",
+                            pindexNew->hashLightClientRoot.ToString(), pindexNew->hashChainHistoryRoot.ToString(), pindexNew->ToString());
                     }
                 } else {
                     if (pindexNew->hashLightClientRoot != pindexNew->hashFinalSaplingRoot) {


### PR DESCRIPTION
In the vicinity of a network upgrade, a zcashd node may receive headers
for a non-upgrading chain from its non-upgraded peers (e.g. if the block
at the NU activation height is found more quickly by the non-upgrading
chain). In this situation, the node will end up with two headers at the
NU activation height (and possibly for subsequent block heights).

In the case of Heartwood, the block headers from the non-upgrading chain
do not satisfy the Heartwood header consistency check in
CBlockTreeDB::LoadBlockIndexGuts. In this commit, we restrict the
Heartwood consistency checks to blocks with the BLOCK_VALID_CONSENSUS
status, which is guaranteed to be set by Heartwood-aware nodes only on
Heartwood-aware block headers.

Closes #4496.