### PR TITLE
Added support for afl-clang-fast.

### DIFF
--- a/zcutil/afl/afl-build.sh
+++ b/zcutil/afl/afl-build.sh
@@ -13,7 +13,7 @@ export ZCUTIL=$(realpath "./zcutil")
 
 cp "./src/fuzzing/$FUZZ_CASE/fuzz.cpp" src/fuzz.cpp
 
-CONFIGURE_FLAGS="--enable-tests=no --enable-fuzz-main" "$ZCUTIL/build.sh" "CC=$ZCUTIL/afl/zcash-wrapper-gcc" "CXX=$ZCUTIL/afl/zcash-wrapper-g++" AFL_HARDEN=1 "$@"
+CONFIGURE_FLAGS="--enable-tests=no --enable-fuzz-main" "$ZCUTIL/build.sh" "CC=$ZCUTIL/afl/zcash-wrapper-clang" "CXX=$ZCUTIL/afl/zcash-wrapper-clang++" AFL_HARDEN=1 "$@"
 
 echo "You can now run AFL as follows:"
 echo "$ ./zcutil/afl/afl-run.sh '$AFL_INSTALL_DIR' '$FUZZ_CASE'"

--- a/zcutil/afl/afl-run.sh
+++ b/zcutil/afl/afl-run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu -o pipefail
+set -exu -o pipefail
 
 AFL_INSTALL_DIR="$1"
 FUZZ_CASE="$2"

--- a/zcutil/afl/zcash-wrapper
+++ b/zcutil/afl/zcash-wrapper
@@ -2,7 +2,16 @@
 
 set -ex -o pipefail
 
-export ARGS=$@
+#for arg
+#do
+#  shift
+#  [ "$arg" = "-fPIE" ] && continue
+#  [ "$arg" = "-pie" ] && continue
+#  set -- "$@" "$arg"
+#done
+
+#set -- "$@" "-no-pie"
+#set -- "$@" "-Wl,-z,norelro"
 
 instrument=(
 "\/src$"
@@ -22,10 +31,22 @@ fi
 
 case $0 in
 *zcash-wrapper-g++)
-  COMPILER="g++"
+  OCOMPILER="g++"
+  ACOMPILER=$OCOMPILER
   ;;
 *zcash-wrapper-gcc)
-  COMPILER="gcc"
+  OCOMPILER="gcc"
+  ACOMPILER=$OCOMPILER
+  ;;
+*zcash-wrapper-clang)
+  OCOMPILER="clang-6.0"
+  ACOMPILER="clang-fast"
+  CFLAGS="-fsanitize=address -static"
+  ;;
+*zcash-wrapper-clang++)
+  OCOMPILER="clang++-6.0"
+  ACOMPILER="clang-fast++"
+  CPPFLAGS="-fsanitize=address -static"
   ;;
 *zcash-wrapper)
   echo "Call this script instead of your regular compiler, and if the absolute path of the CWD the wrapper was called from matches a regex in the array 'instrument', it will call AFL to instrument the resulting binary. Otherwise it will call either g++ or gcc depending on how it was invoked. \$AFL_INSTALL_DIR must be set to the path where AFL is installed."
@@ -40,9 +61,9 @@ do
   if echo -- "`pwd`" | grep "$i"; then
     # We found a match, let's instrument this one.
     echo "Matched directory `pwd` to instrument element $i. Instrumenting this call." >> "$AFL_LOG_DIR/zcash-build-wrapper.log"
-    exec -- "$AFL_INSTALL_DIR/afl-$COMPILER" "$@"
+    exec -- "$AFL_INSTALL_DIR/afl-$ACOMPILER" "$@"
   fi
 done
 
 # No match, just pass-through.
-exec -- "$COMPILER" "$@"
+exec -- "$OCOMPILER" "$@"

--- a/zcutil/afl/zcash-wrapper-clang
+++ b/zcutil/afl/zcash-wrapper-clang
@@ -1,0 +1,1 @@
+zcash-wrapper

--- a/zcutil/afl/zcash-wrapper-clang++
+++ b/zcutil/afl/zcash-wrapper-clang++
@@ -1,0 +1,1 @@
+zcash-wrapper


### PR DESCRIPTION
This was an experiment to try to see what speedup we get in AFL from just using "clang-fast" - ie, the llvm-native instrumentation.

It's not that much faster, but there is a speed increase - up to about 500 exec/s.