### PR TITLE
Fix off-by-one error in CreateNewBlock()

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -518,12 +518,14 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const MinerAddre
         nonce >>= 16;
         pblock->nNonce = ArithToUint256(nonce);
 
+        uint32_t prevConsensusBranchId = CurrentEpochBranchId(pindexPrev->nHeight, chainparams.GetConsensus());
+
         // Fill in header
         pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
         if (IsActivationHeight(nHeight, chainparams.GetConsensus(), Consensus::UPGRADE_HEARTWOOD)) {
             pblock->hashLightClientRoot.SetNull();
         } else if (chainparams.GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_HEARTWOOD)) {
-            pblock->hashLightClientRoot = view.GetHistoryRoot(consensusBranchId);
+            pblock->hashLightClientRoot = view.GetHistoryRoot(prevConsensusBranchId);
         } else {
             pblock->hashLightClientRoot = sapling_tree.root();
         }


### PR DESCRIPTION
When calling `GetHistoryRoot()`, use `prevConsensusBranchId` instead of `consensusBranchId` for compatibility with NU4 and future upgrades.

Co-authored by @str4d 

Closes #4524 