### PR TITLE
PopHistoryNode() from previous epochs for post-Heartwood rollbacks

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -85,6 +85,7 @@ testScripts=(
     'framework.py'
     'sapling_rewind_check.py'
     'feature_zip221.py'
+    'post_heartwood_rollback.py'
 );
 testScriptsExt=(
     'getblocktemplate_longpoll.py'

--- a/qa/rpc-tests/post_heartwood_rollback.py
+++ b/qa/rpc-tests/post_heartwood_rollback.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+'''
+Test rollbacks on post-Heartwood chains.
+'''
+
+from decimal import Decimal
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises,
+    bitcoind_processes,
+    connect_nodes_bi,
+    initialize_chain,
+    start_nodes, start_node, get_coinbase_address,
+    wait_and_assert_operationid_status,
+    check_node_log, 
+    nuparams, BLOSSOM_BRANCH_ID, HEARTWOOD_BRANCH_ID, NU4_BRANCH_ID
+)
+
+import logging
+import time
+
+HAS_NU4 = [nuparams(BLOSSOM_BRANCH_ID, 205), nuparams(HEARTWOOD_BRANCH_ID, 210), nuparams(NU4_BRANCH_ID, 220), '-nurejectoldversions=false']
+NO_NU4 = [nuparams(BLOSSOM_BRANCH_ID, 205), nuparams(HEARTWOOD_BRANCH_ID, 210), '-nurejectoldversions=false']
+
+class PostHeartwoodRollbackTest (BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain(self.options.tmpdir)
+
+    def setup_nodes(self):
+        return start_nodes(4, self.options.tmpdir, extra_args=[
+            HAS_NU4,
+            HAS_NU4,
+            NO_NU4,
+            NO_NU4
+        ])
+
+    def run_test (self):
+
+        # Generate shared state beyond Heartwood activation
+        print("Generating shared state beyond Heartwood activation")
+        logging.info("Generating initial blocks.")
+        self.nodes[0].generate(15)
+        self.sync_all()
+
+        # Split network at block 215 (after Heartwood, before NU4)
+        print("Splitting network at block 215 (after Heartwood, before NU4)")
+        self.split_network()
+
+        # Activate NU4 on node 0
+        print("Activating NU4 on node 0")
+        self.nodes[0].generate(5) 
+        self.sync_all()
+
+        # Mine past NU4 activation height on node 2 
+        print("Mining past NU4 activation height on node 2 ")       
+        self.nodes[2].generate(20)        
+        self.sync_all()
+
+        # print("nodes[0].getblockcount()", self.nodes[0].getblockcount())
+        # print("nodes[2].getblockcount()", self.nodes[2].getblockcount())
+
+        # for i in range (0,3,2):
+        #     blockcount = self.nodes[i].getblockcount()
+        #     for j in range (201,blockcount + 1):
+        #         print("\n before shutdown node: ", i, "block: ", j, "\n")
+        #         print(self.nodes[i].getblock(str(j)))
+
+        # Upgrade node 2 and 3 to NU4
+        print("Upgrading nodes 2 and 3 to NU4")
+        self.nodes[2].stop()
+        bitcoind_processes[2].wait()
+        self.nodes[2] = start_node(2, self.options.tmpdir, extra_args=HAS_NU4)
+
+        self.nodes[3].stop()
+        bitcoind_processes[3].wait()
+        self.nodes[3] = start_node(3, self.options.tmpdir, extra_args=HAS_NU4)
+
+        # for i in range (0,3,2):
+        #     blockcount = self.nodes[i].getblockcount()
+        #     for j in range (201,blockcount + 1):
+        #         print("\n after shutdown node: ", i, "block: ", j, "\n")
+        #         print(self.nodes[i].getblock(str(j)))
+
+        # Join network
+        print("Joining network")
+        # (if we used self.sync_all() here and there was a bug, the test would hang)
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,0,2)
+        connect_nodes_bi(self.nodes,0,3)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,1,3)
+        connect_nodes_bi(self.nodes,2,3)
+
+        time.sleep(5)
+
+        # for i in range (0,3,2):
+        #     blockcount = self.nodes[i].getblockcount()
+        #     for j in range (201,blockcount + 1):
+        #         print("\n after sync node: ", i, "block: ", j, "\n")
+        #         print(self.nodes[i].getblock(str(j)))
+
+        node0_blockcount = self.nodes[0].getblockcount()
+        node2_blockcount = self.nodes[2].getblockcount()
+
+        assert_equal(node0_blockcount, node2_blockcount, "node 0 blockcount: " + str(node0_blockcount) + "node 2 blockcount: " + str(node2_blockcount))
+
+        node0_bestblockhash = self.nodes[0].getbestblockhash()
+        node2_bestblockhash = self.nodes[2].getbestblockhash()
+
+        assert_equal(node0_bestblockhash, node2_bestblockhash, "node 0 bestblockhash: " + str(node0_bestblockhash) + "node 2 bestblockhash: " + str(node2_blockcount))
+
+if __name__ == '__main__':
+    PostHeartwoodRollbackTest().main()
+


### PR DESCRIPTION
When rolling back from post-Heartwood epochs, `DisconnectBlock()` should switch to the previous epoch and pop `HistoryCache` from there. 

Previously, `DisconnectBlock()` used the current epoch, thus popping empty `HistoryCache`s during the rollback while leaving the invalidated blocks' `historyRoot`s to accumulate. 