### PR TITLE
Enable Heartwood activation on mainnet

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,3 +4,29 @@ release-notes at release time)
 Notable changes
 ===============
 
+The mainnet activation of the Heartwood network upgrade is supported by this
+release, with an activation height of 903000, which should occur in the middle
+of July — following the targeted EOS halt of our 2.1.2-3 release. Please upgrade
+to this release, or any subsequent release, in order to follow the Heartwood
+network upgrade.
+
+The following two ZIPs are being deployed as part of this upgrade:
+
+- [ZIP 213: Shielded Coinbase](https://zips.z.cash/zip-0213)
+- [ZIP 221: FlyClient - Consensus-Layer Changes](https://zips.z.cash/zip-0221)
+
+In order to help the ecosystem prepare for the mainnet activiation, Heartwood
+has already been activated on the Zcash testnet. Any node version 2.1.2 or
+higher, including this release, supports the Heartwood activation on testnet.
+
+## Mining to Sapling addresses
+
+After the mainnet activation of Heartwood, miners can mine directly into a
+Sapling shielded address. Miners should wait until after Heartwood activation
+before they make changes to their configuration to leverage this new feature.
+After activation of Heartwood, miners can add `mineraddress=SAPLING_ADDRESS` to
+their `zcash.conf` file, where `SAPLING_ADDRESS` represents a Sapling address
+that can be generated locally with the `z_getnewaddress` RPC command. Restart
+your node, and block templates produced by the `getblocktemplate` RPC command
+will now have coinbase transactions that mine directly into this shielded
+address.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -120,8 +120,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].nProtocolVersion = 170009;
         consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].nActivationHeight = 653600;
         consensus.vUpgrades[Consensus::UPGRADE_HEARTWOOD].nProtocolVersion = 170011;
-        consensus.vUpgrades[Consensus::UPGRADE_HEARTWOOD].nActivationHeight =
-            Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.vUpgrades[Consensus::UPGRADE_HEARTWOOD].nActivationHeight = 903000;
         consensus.vUpgrades[Consensus::UPGRADE_NU4].nProtocolVersion = 170013;
         consensus.vUpgrades[Consensus::UPGRADE_NU4].nActivationHeight =
             Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 170010;
+static const int PROTOCOL_VERSION = 170011;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
This sets the Heartwood activation height to `903000`, which follows the deprecation height of `v2.1.2-3` (which is set to deprecate on block `901475`, roughly 31 hours earlier, sometime mid-July).