### PR TITLE
add rpc call z_removeaddress

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -30,6 +30,7 @@ testScripts=(
     'wallet_addresses.py'
     'wallet_sapling.py'
     'wallet_listnotes.py'
+    'wallet_removeaddress.py'
     'mergetoaddress_sprout.py'
     'mergetoaddress_sapling.py'
     'mergetoaddress_mixednotes.py'

--- a/qa/rpc-tests/wallet_removeaddress.py
+++ b/qa/rpc-tests/wallet_removeaddress.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import (
+    assert_equal,
+    get_coinbase_address,
+    start_nodes,
+    wait_and_assert_operationid_status,
+    start_node,
+    stop_node,
+    initialize_chain_clean,
+    connect_nodes_bi
+)
+
+from decimal import Decimal
+
+class WalletRemoveAddressTest(BitcoinTestFramework):
+
+    def setup_chain(self):
+        initialize_chain_clean(self.options.tmpdir, 2)
+
+    def setup_network(self):
+        self.nodes = start_nodes(2, self.options.tmpdir)
+        connect_nodes_bi(self.nodes, 0, 1)
+        self.is_network_split = False
+        self.sync_all()
+
+    def fundzaddress(self, address, amount):
+        recipients = []
+        recipients.append({"address": address, "amount": amount})
+        myopid = self.nodes[0].z_sendmany(get_coinbase_address(self.nodes[0]), recipients, 1, 0)
+        wait_and_assert_operationid_status(self.nodes[0], myopid)
+        
+        self.sync_all()
+        self.nodes[1].generate(1)
+        self.sync_all()
+
+        assert_equal(self.nodes[0].z_getbalance(address), amount)
+
+    def send(self, from_, to, amount):
+        recipients = []
+        recipients.append({"address": to, "amount": amount})
+        myopid = self.nodes[0].z_sendmany(from_, recipients, 1, 0)
+        wait_and_assert_operationid_status(self.nodes[0], myopid)
+
+        self.sync_all()
+        self.nodes[1].generate(1)
+        self.sync_all()
+
+    def getbalance(self, address):
+        try:
+            return self.nodes[0].z_getbalance(address)
+        except JSONRPCException as e:
+            assert_equal("From address does not belong to this node, spending key or viewing key not found.", e.error['message'])
+            return "e"
+
+    def run_test(self):
+        self.nodes[0].generate(200)
+        self.sync_all()
+
+        transparent = self.nodes[0].getnewaddress()
+        sapling = self.nodes[0].z_getnewaddress('sapling')
+        sprout = self.nodes[0].z_getnewaddress('sprout')
+
+        self.fundzaddress(sapling, Decimal('10'))
+        assert_equal(self.getbalance(sapling), 10)
+
+        # transparent
+        assert_equal(self.getbalance(transparent), 0)
+        # remove transparent key
+        self.nodes[0].z_removeaddress(transparent, False)
+        # send to transparent
+        self.send(sapling, transparent, Decimal('1'))
+        # as we dont have the key anymore balance will not be reflected
+        assert_equal(self.getbalance(transparent), 0)
+        # however the coin left sapling
+        assert_equal(self.getbalance(sapling), 9)
+
+        # sprout
+        assert_equal(self.getbalance(sprout), 0)
+        # remove sprout key
+        self.nodes[0].z_removeaddress(sprout, False)
+        # exception
+        assert_equal(self.getbalance(sprout), "e")
+
+        # sapling
+        assert_equal(self.getbalance(sapling), 9)
+        # remove sapling
+        self.nodes[0].z_removeaddress(sapling, False)
+        # exception
+        assert_equal(self.getbalance(sapling), "e")
+
+        # lets restart the node
+        stop_node(self.nodes[0],0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, [], timewait=60)
+
+        # no exception should happen
+        assert_equal(self.getbalance(transparent), 1)
+        assert_equal(self.getbalance(sprout), 0)
+        assert_equal(self.getbalance(sapling), 9)
+
+        # now remove everything from ram and from disk
+        self.nodes[0].z_removeaddress(transparent, True)
+        self.nodes[0].z_removeaddress(sprout, True)
+        self.nodes[0].z_removeaddress(sapling, True)
+
+        # restart node
+        stop_node(self.nodes[0],0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, [], timewait=60)
+
+        assert_equal(self.nodes[0].z_getbalance(transparent), 0)
+        assert_equal(self.getbalance(sprout), "e")
+        assert_equal(self.getbalance(sapling), "e")
+
+if __name__ == '__main__':
+    WalletRemoveAddressTest().main()

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -66,6 +66,14 @@ bool CBasicKeyStore::AddKeyPubKey(const CKey& key, const CPubKey &pubkey)
     return true;
 }
 
+bool CBasicKeyStore::RemoveKey(const CPubKey &pubkey)
+{
+    LOCK(cs_KeyStore);
+    mapKeys.erase(pubkey.GetID());
+    mapWatchKeys.erase(pubkey.GetID());
+    return true;
+}
+
 bool CBasicKeyStore::AddCScript(const CScript& redeemScript)
 {
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)
@@ -151,6 +159,15 @@ bool CBasicKeyStore::AddSproutSpendingKey(const libzcash::SproutSpendingKey &sk)
     return true;
 }
 
+bool CBasicKeyStore::RemoveSproutSpendingKey(const libzcash::SproutSpendingKey &sk)
+{
+    LOCK(cs_KeyStore);
+    const auto address = sk.address();
+    mapSproutSpendingKeys.erase(address);
+    mapNoteDecryptors.erase(address);
+    return true;
+}
+
 //! Sapling 
 bool CBasicKeyStore::AddSaplingSpendingKey(
     const libzcash::SaplingExtendedSpendingKey &sk)
@@ -165,6 +182,15 @@ bool CBasicKeyStore::AddSaplingSpendingKey(
 
     mapSaplingSpendingKeys[extfvk] = sk;
 
+    return true;
+}
+
+bool CBasicKeyStore::RemoveSaplingSpendingKey(const libzcash::SaplingExtendedSpendingKey &sk)
+{
+    LOCK(cs_KeyStore);
+    const auto extfvk = sk.ToXFVK();
+    mapSaplingSpendingKeys.erase(extfvk);
+    mapSaplingFullViewingKeys.erase(extfvk.fvk.in_viewing_key());
     return true;
 }
 

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -36,6 +36,9 @@ public:
     virtual bool AddKeyPubKey(const CKey &key, const CPubKey &pubkey) =0;
     virtual bool AddKey(const CKey &key);
 
+    //! Remove a key from the store
+    virtual bool RemoveKey(const CPubKey &pubkey) =0;
+
     //! Check whether a key corresponding to a given address is present in the store.
     virtual bool HaveKey(const CKeyID &address) const =0;
     virtual bool GetKey(const CKeyID &address, CKey& keyOut) const =0;
@@ -56,6 +59,9 @@ public:
     //! Add a spending key to the store.
     virtual bool AddSproutSpendingKey(const libzcash::SproutSpendingKey &sk) =0;
 
+    //! Remove a Sprout spending key from the store.
+    virtual bool RemoveSproutSpendingKey(const libzcash::SproutSpendingKey &sk) =0;
+
     //! Check whether a spending key corresponding to a given payment address is present in the store.
     virtual bool HaveSproutSpendingKey(const libzcash::SproutPaymentAddress &address) const =0;
     virtual bool GetSproutSpendingKey(const libzcash::SproutPaymentAddress &address, libzcash::SproutSpendingKey& skOut) const =0;
@@ -63,6 +69,9 @@ public:
     
     //! Add a Sapling spending key to the store.
     virtual bool AddSaplingSpendingKey(const libzcash::SaplingExtendedSpendingKey &sk) =0;
+
+    //! Remove a Sapling spending key from the store.
+    virtual bool RemoveSaplingSpendingKey(const libzcash::SaplingExtendedSpendingKey &sk) =0;
     
     //! Check whether a Sapling spending key corresponding to a given Sapling viewing key is present in the store.
     virtual bool HaveSaplingSpendingKey(
@@ -139,6 +148,7 @@ public:
     bool GetHDSeed(HDSeed& seedOut) const;
 
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
+    bool RemoveKey(const CPubKey &pubkey);
     bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const;
     bool HaveKey(const CKeyID &address) const
     {
@@ -185,6 +195,7 @@ public:
     virtual bool HaveWatchOnly() const;
 
     bool AddSproutSpendingKey(const libzcash::SproutSpendingKey &sk);
+    bool RemoveSproutSpendingKey(const libzcash::SproutSpendingKey &sk);
     bool HaveSproutSpendingKey(const libzcash::SproutPaymentAddress &address) const
     {
         bool result;
@@ -242,6 +253,7 @@ public:
 
     //! Sapling 
     bool AddSaplingSpendingKey(const libzcash::SaplingExtendedSpendingKey &sk);
+    bool RemoveSaplingSpendingKey(const libzcash::SaplingExtendedSpendingKey &sk);
     bool HaveSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk) const
     {
         bool result;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -145,6 +145,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "z_getpaymentdisclosure", 2},
     { "z_setmigration", 0},
     { "z_getnotescount", 0},
+    { "z_removeaddress", 1},
 };
 
 class CRPCConvertTable

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5028,6 +5028,72 @@ UniValue z_getnotescount(const UniValue& params, bool fHelp)
     return ret;
 }
 
+
+UniValue z_removeaddress(const UniValue& params, bool fHelp)
+{
+    if (!EnsureWalletIsAvailable(fHelp))
+        return NullUniValue;
+
+    if (fHelp || params.size() > 2)
+        throw runtime_error(
+            "z_removekey\n"
+            "\nRemoves related entires of address from wallet.\n"
+            "\nArguments:\n"
+            "1. \"address\"      (string) Address to remove.\n"
+            "2. permanent      (bool, optional, default=false) Remove the address keys from the disk. "
+            "Use with caution, this is a dangerous operation, misused can result in loss of funds.\n"
+            "\nReturns true if the address keys were removed.\n"
+            "\nExamples:\n"
+            + HelpExampleCli("z_removeaddress", "\"myaddress\"")
+            + HelpExampleRpc("z_removeaddress", "\"myaddress\"")
+        );
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    string strAddress = params[0].get_str();
+
+    bool permanent = false;
+    if (params.size() > 1)
+        permanent = params[1].get_bool();
+
+    if (!IsValidDestination(DecodeDestination(strAddress))) { // not a taddr
+        const auto address = DecodePaymentAddress(strAddress);
+        if (!IsValidPaymentAddress(address)) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid zaddr.");
+        }
+        if (!boost::apply_visitor(PaymentAddressBelongsToWallet(pwalletMain), address)) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Address does not belong to this node, spending key or viewing key not found.");
+        }
+
+        if(boost::get<libzcash::SproutPaymentAddress>(&address) != nullptr) {
+            libzcash::SproutSpendingKey sk;
+            pwalletMain->GetSproutSpendingKey(*boost::get<libzcash::SproutPaymentAddress>(&address), sk);
+            if (pwalletMain->RemoveSproutZKey(sk, permanent))
+                return true;
+        }
+        else if(boost::get<libzcash::SaplingPaymentAddress>(&address) != nullptr) {
+            libzcash::SaplingExtendedSpendingKey extsk;
+            pwalletMain->GetSaplingExtendedSpendingKey(*boost::get<libzcash::SaplingPaymentAddress>(&address), extsk);
+            if (pwalletMain->RemoveSaplingZKey(extsk, permanent))
+                return true;
+        }
+    }
+    else {
+        const CTxDestination taddr = DecodeDestination(strAddress);
+        const CKeyID *keyID = boost::get<CKeyID>(&taddr);
+        if (!keyID) {
+            throw std::runtime_error(strprintf("%s does not refer to a key", strAddress));
+        }
+        CPubKey vchPubKey;
+        if (!pwalletMain->GetPubKey(*keyID, vchPubKey)) {
+            throw std::runtime_error(strprintf("no full public key for address %s", strAddress));
+        }
+        if (pwalletMain->RemoveKey(vchPubKey, permanent))
+            return true;
+    }
+    return false;
+}
+
 extern UniValue dumpprivkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue importprivkey(const UniValue& params, bool fHelp);
 extern UniValue importaddress(const UniValue& params, bool fHelp);
@@ -5116,6 +5182,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "z_importwallet",           &z_importwallet,           true  },
     { "wallet",             "z_viewtransaction",        &z_viewtransaction,        false },
     { "wallet",             "z_getnotescount",          &z_getnotescount,          false },
+    { "wallet",             "z_removeaddress",          &z_removeaddress,          false },
     // TODO: rearrange into another category
     { "disclosure",         "z_getpaymentdisclosure",   &z_getpaymentdisclosure,   true  },
     { "disclosure",         "z_validatepaymentdisclosure", &z_validatepaymentdisclosure, true }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -175,6 +175,26 @@ bool CWallet::AddSaplingZKey(const libzcash::SaplingExtendedSpendingKey &sk)
     return true;
 }
 
+
+// Remove sapling spending key from the keystore
+bool CWallet::RemoveSaplingZKey(const libzcash::SaplingExtendedSpendingKey &sk, const bool permanent)
+{
+    AssertLockHeld(cs_wallet);
+    const auto ivk = sk.expsk.full_viewing_key().in_viewing_key();
+    mapSaplingZKeyMetadata.erase(ivk);
+
+    if (!CCryptoKeyStore::RemoveSaplingSpendingKey(sk)) {
+        return false;
+    }
+
+    if (permanent) {
+        if (!CWalletDB(strWalletFile).EraseSaplingZKey(ivk))
+            return false;
+    }
+
+    return true;
+}
+
 bool CWallet::AddSaplingFullViewingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk)
 {
     AssertLockHeld(cs_wallet);
@@ -237,6 +257,24 @@ bool CWallet::AddSproutZKey(const libzcash::SproutSpendingKey &key)
     return true;
 }
 
+//
+bool CWallet::RemoveSproutZKey(const libzcash::SproutSpendingKey &key, const bool permanent)
+{
+    AssertLockHeld(cs_wallet);
+    const auto addr = key.address();
+    mapSproutZKeyMetadata.erase(addr);
+
+    if (!CCryptoKeyStore::RemoveSproutSpendingKey(key))
+        return false;
+
+    if (permanent) {
+        if (!CWalletDB(strWalletFile).EraseZKey(addr))
+            return false;
+    }
+
+    return true;
+}
+
 CPubKey CWallet::GenerateNewKey()
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
@@ -285,6 +323,22 @@ bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)
                                                  secret.GetPrivKey(),
                                                  mapKeyMetadata[pubkey.GetID()]);
     }
+    return true;
+}
+
+bool CWallet::RemoveKey(const CPubKey &pubkey, const bool permanent)
+{
+    AssertLockHeld(cs_wallet);
+    mapKeyMetadata.erase(pubkey.GetID());
+
+    if (!CCryptoKeyStore::RemoveKey(pubkey))
+        return false;
+
+    if (permanent) {
+        if (!CWalletDB(strWalletFile).EraseKey(pubkey))
+            return false;
+    }
+
     return true;
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1039,6 +1039,8 @@ public:
     CPubKey GenerateNewKey();
     //! Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
+    //! Removes a key to from store, optionally delete it from disk.
+    bool RemoveKey(const CPubKey &pubkey, const bool permanent);
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key, const CPubKey &pubkey) { return CCryptoKeyStore::AddKeyPubKey(key, pubkey); }
     //! Load metadata (used by LoadWallet)
@@ -1081,6 +1083,8 @@ public:
     libzcash::SproutPaymentAddress GenerateNewSproutZKey();
     //! Adds spending key to the store, and saves it to disk
     bool AddSproutZKey(const libzcash::SproutSpendingKey &key);
+    //! Remove spending key from the store, and optionally remove it from disk
+    bool RemoveSproutZKey(const libzcash::SproutSpendingKey &key, const bool permanent);
     //! Adds spending key to the store, without saving it to disk (used by LoadWallet)
     bool LoadZKey(const libzcash::SproutSpendingKey &key);
     //! Load spending key metadata (used by LoadWallet)
@@ -1106,6 +1110,8 @@ public:
     libzcash::SaplingPaymentAddress GenerateNewSaplingZKey();
     //! Adds Sapling spending key to the store, and saves it to disk
     bool AddSaplingZKey(const libzcash::SaplingExtendedSpendingKey &key);
+    //! Remove Sapling spending key from the store, and optionally removes it from disk
+    bool RemoveSaplingZKey(const libzcash::SaplingExtendedSpendingKey &key, const bool permanent);
     //! Add Sapling full viewing key to the wallet.
     //!
     //! This overrides CBasicKeyStore::AddSaplingFullViewingKey to persist the

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -84,6 +84,14 @@ bool CWalletDB::WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, c
     return Write(std::make_pair(std::string("key"), vchPubKey), std::make_pair(vchPrivKey, Hash(vchKey.begin(), vchKey.end())), false);
 }
 
+bool CWalletDB::EraseKey(const CPubKey& vchPubKey)
+{
+    nWalletDBUpdated++;
+    if (!Erase(std::make_pair(std::string("key"), vchPubKey)) || !Erase(std::make_pair(std::string("keymeta"), vchPubKey)))
+        return false;
+    return true;
+}
+
 bool CWalletDB::WriteCryptedKey(const CPubKey& vchPubKey,
                                 const std::vector<unsigned char>& vchCryptedSecret,
                                 const CKeyMetadata &keyMeta)
@@ -163,6 +171,15 @@ bool CWalletDB::WriteZKey(const libzcash::SproutPaymentAddress& addr, const libz
     // pair is: tuple_key("zkey", paymentaddress) --> secretkey
     return Write(std::make_pair(std::string("zkey"), addr), key, false);
 }
+
+bool CWalletDB::EraseZKey(const libzcash::SproutPaymentAddress& addr)
+{
+    nWalletDBUpdated++;
+    if (!Erase(std::make_pair(std::string("zkey"), addr)) || !Erase(std::make_pair(std::string("zkeymeta"), addr)))
+        return false;
+    return true;
+}
+
 bool CWalletDB::WriteSaplingZKey(const libzcash::SaplingIncomingViewingKey &ivk,
                 const libzcash::SaplingExtendedSpendingKey &key,
                 const CKeyMetadata &keyMeta)
@@ -173,6 +190,14 @@ bool CWalletDB::WriteSaplingZKey(const libzcash::SaplingIncomingViewingKey &ivk,
         return false;
 
     return Write(std::make_pair(std::string("sapzkey"), ivk), key, false);
+}
+
+bool CWalletDB::EraseSaplingZKey(const libzcash::SaplingIncomingViewingKey &ivk)
+{
+    nWalletDBUpdated++;
+    if (!Erase(std::make_pair(std::string("sapzkey"), ivk)) || !Erase(std::make_pair(std::string("sapzkeymeta"), ivk)))
+        return false;
+    return true;
 }
 
 bool CWalletDB::WriteSaplingPaymentAddress(

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -136,6 +136,7 @@ public:
     bool EraseTx(uint256 hash);
 
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
+    bool EraseKey(const CPubKey& vchPubKey);
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyMetadata &keyMeta);
     bool WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey);
 
@@ -185,9 +186,11 @@ public:
 
     /// Write spending key to wallet database, where key is payment address and value is spending key.
     bool WriteZKey(const libzcash::SproutPaymentAddress& addr, const libzcash::SproutSpendingKey& key, const CKeyMetadata &keyMeta);
+    bool EraseZKey(const libzcash::SproutPaymentAddress& addr);
     bool WriteSaplingZKey(const libzcash::SaplingIncomingViewingKey &ivk,
                           const libzcash::SaplingExtendedSpendingKey &key,
                           const CKeyMetadata  &keyMeta);
+    bool EraseSaplingZKey(const libzcash::SaplingIncomingViewingKey &ivk);
     bool WriteSaplingPaymentAddress(const libzcash::SaplingPaymentAddress &addr,
                                     const libzcash::SaplingIncomingViewingKey &ivk);
     bool WriteCryptedZKey(const libzcash::SproutPaymentAddress & addr,


### PR DESCRIPTION
If merged, will close https://github.com/zcash/zcash/issues/4549

```
$ ./src/zcash-cli -regtest help z_removeaddress
z_removekey

Removes related entires of address from wallet.

Arguments:
1. "address"      (string) Address to remove.
2. permanent      (bool, optional, default=false) Remove the address keys from the disk. Use with caution, this is a dangerous operation, misused can result in loss of funds.

Returns true if the address keys were removed.

Examples:
> zcash-cli z_removeaddress "myaddress"
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "z_removeaddress", "params": ["myaddress"] }' -H 'content-type: text/plain;' http://127.0.0.1:8232/

$ 
```

- Do not have support for viewing keys, maybe we can do it in a separated api call.
- It seems `virtual` declarations in `keystore.h` are not needed, however added as all the other calls do it. There is probably a reason but i cant find it ... 
