### PR TITLE
Build BDB utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ src/zcash-cli
 src/zcash-gtest
 src/zcash-tx
 src/test/test_bitcoin
+zcutil/bin/
 
 *zcashTest.pk
 *zcashTest.vk
@@ -116,5 +117,6 @@ libzcashconsensus.pc
 contrib/debian/files
 contrib/debian/substvars
 
+src/fuzzing/*/input
 src/fuzzing/*/output
 src/fuzz.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -169,3 +169,4 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-man
 clean-local:
 	rm -rf test_bitcoin.coverage/ zcash-gtest.coverage/ total.coverage/
 	rm -rf afl-temp
+	rm -rf zcutil/bin

--- a/Makefile.am
+++ b/Makefile.am
@@ -169,4 +169,7 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-man
 clean-local:
 	rm -rf test_bitcoin.coverage/ zcash-gtest.coverage/ total.coverage/
 	rm -rf afl-temp
-	rm -rf zcutil/bin
+
+distclean-local:
+	rm -f zcutil/bin/db_*
+	rmdir zcutil/bin 2>/dev/null || true

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -32,5 +32,11 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install_lib install_include
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+
+define $(package)_postprocess_cmds
+  cd $(BASEDIR)/../zcutil && \
+  mkdir -p bin && \
+  mv -f $($(package)_staging_dir)$(host_prefix)/bin/db_* bin
 endef

--- a/zcutil/distclean.sh
+++ b/zcutil/distclean.sh
@@ -10,3 +10,6 @@ rm -rf depends/sources
 rm -rf afl-temp
 rm -rf src/fuzzing/*/output
 
+# These are not in clean.sh because they are only generated when building dependencies.
+rm -f zcutil/bin/db_*
+rmdir zcutil/bin 2>/dev/null

--- a/zcutil/distclean.sh
+++ b/zcutil/distclean.sh
@@ -12,4 +12,4 @@ rm -rf src/fuzzing/*/output
 
 # These are not in clean.sh because they are only generated when building dependencies.
 rm -f zcutil/bin/db_*
-rmdir zcutil/bin 2>/dev/null
+rmdir zcutil/bin 2>/dev/null || true


### PR DESCRIPTION
To install the binaries we need to build with just `install` instead of `install_lib` and `install_include`, this will install everything.

Then the binaries will be moved to a folder in `zcutil` directory. We can just leave them in staging however the user might have a hard time to find them there.

Closes https://github.com/zcash/zcash/issues/4537

