### PR TITLE
[WIP] ZIP 212 Implementation

### DIFF
--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -1134,7 +1134,7 @@ TEST(CheckTransaction, HeartwoodAcceptsShieldedCoinbase) {
 
     uint256 ovk;
     auto note = libzcash::SaplingNote(
-        libzcash::SaplingSpendingKey::random().default_address(), CAmount(123456));
+        libzcash::SaplingSpendingKey::random().default_address(), CAmount(123456), false);
     auto output = OutputDescriptionInfo(ovk, note, {{0xF6}});
 
     auto ctx = librustzcash_sapling_proving_ctx_init();
@@ -1217,7 +1217,7 @@ TEST(CheckTransaction, HeartwoodEnforcesSaplingRulesOnShieldedCoinbase) {
 
     uint256 ovk;
     auto note = libzcash::SaplingNote(
-        libzcash::SaplingSpendingKey::random().default_address(), CAmount(123456));
+        libzcash::SaplingSpendingKey::random().default_address(), CAmount(123456), false);
     auto output = OutputDescriptionInfo(ovk, note, {{0xF6}});
 
     CMutableTransaction mtx = GetValidTransaction();

--- a/src/gtest/test_noteencryption.cpp
+++ b/src/gtest/test_noteencryption.cpp
@@ -34,7 +34,7 @@ TEST(noteencryption, NotePlaintext)
         memo[i] = (unsigned char) i;
     }
 
-    SaplingNote note(addr, 39393);
+    SaplingNote note(addr, 39393, false);
     auto cmu_opt = note.cmu();
     if (!cmu_opt) {
         FAIL();
@@ -91,7 +91,7 @@ TEST(noteencryption, NotePlaintext)
     ASSERT_TRUE(note.value() == new_note.value());
     ASSERT_TRUE(note.d == new_note.d);
     ASSERT_TRUE(note.pk_d == new_note.pk_d);
-    ASSERT_TRUE(note.r == new_note.r);
+    ASSERT_TRUE(note.rcm() == new_note.rcm());
     ASSERT_TRUE(note.cmu() == new_note.cmu());
 
     SaplingOutgoingPlaintext out_pt;
@@ -183,10 +183,10 @@ TEST(noteencryption, SaplingApi)
     }
 
     // Invalid diversifier
-    ASSERT_EQ(boost::none, SaplingNoteEncryption::FromDiversifier({1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+    ASSERT_EQ(boost::none, SaplingNoteEncryption::FromDiversifier({1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, boost::none));
 
     // Encrypt to pk_1
-    auto enc = *SaplingNoteEncryption::FromDiversifier(pk_1.d);
+    auto enc = *SaplingNoteEncryption::FromDiversifier(pk_1.d, boost::none);
     auto ciphertext_1 = *enc.encrypt_to_recipient(
         pk_1.pk_d,
         message
@@ -208,7 +208,7 @@ TEST(noteencryption, SaplingApi)
     );
 
     // Encrypt to pk_2
-    enc = *SaplingNoteEncryption::FromDiversifier(pk_2.d);
+    enc = *SaplingNoteEncryption::FromDiversifier(pk_2.d, boost::none);
     auto ciphertext_2 = *enc.encrypt_to_recipient(
         pk_2.pk_d,
         message
@@ -226,7 +226,7 @@ TEST(noteencryption, SaplingApi)
 
     // Test nonce-reuse resistance of API
     {
-        auto tmp_enc = *SaplingNoteEncryption::FromDiversifier(pk_1.d);
+        auto tmp_enc = *SaplingNoteEncryption::FromDiversifier(pk_1.d, boost::none);
         
         tmp_enc.encrypt_to_recipient(
             pk_1.pk_d,

--- a/src/gtest/test_noteencryption.cpp
+++ b/src/gtest/test_noteencryption.cpp
@@ -78,7 +78,7 @@ TEST(noteencryption, NotePlaintext)
     ASSERT_TRUE(bar.value() == pt.value());
     ASSERT_TRUE(bar.memo() == pt.memo());
     ASSERT_TRUE(bar.d == pt.d);
-    ASSERT_TRUE(bar.rcm == pt.rcm);
+    ASSERT_TRUE(bar.rcm() == pt.rcm());
 
     auto foobar = bar.note(ivk);
 
@@ -155,7 +155,7 @@ TEST(noteencryption, NotePlaintext)
     ASSERT_TRUE(bar.value() == pt.value());
     ASSERT_TRUE(bar.memo() == pt.memo());
     ASSERT_TRUE(bar.d == pt.d);
-    ASSERT_TRUE(bar.rcm == pt.rcm);
+    ASSERT_TRUE(bar.rcm() == pt.rcm());
 }
 
 TEST(noteencryption, SaplingApi)

--- a/src/gtest/test_sapling_note.cpp
+++ b/src/gtest/test_sapling_note.cpp
@@ -57,16 +57,16 @@ TEST(SaplingNote, Random)
 {
     // Test creating random notes using the same spending key
     auto address = SaplingSpendingKey::random().default_address();
-    SaplingNote note1(address, GetRand(MAX_MONEY));
-    SaplingNote note2(address, GetRand(MAX_MONEY));
+    SaplingNote note1(address, GetRand(MAX_MONEY), false);
+    SaplingNote note2(address, GetRand(MAX_MONEY), false);
 
     ASSERT_EQ(note1.d, note2.d);
     ASSERT_EQ(note1.pk_d, note2.pk_d);
     ASSERT_NE(note1.value(), note2.value());
-    ASSERT_NE(note1.r, note2.r);
+    ASSERT_NE(note1.rcm(), note2.rcm());
 
     // Test diversifier and pk_d are not the same for different spending keys
-    SaplingNote note3(SaplingSpendingKey::random().default_address(), GetRand(MAX_MONEY));
+    SaplingNote note3(SaplingSpendingKey::random().default_address(), GetRand(MAX_MONEY), false);
     ASSERT_NE(note1.d, note3.d);
     ASSERT_NE(note1.pk_d, note3.pk_d);
 }

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -482,7 +482,7 @@ TEST(TransactionBuilder, CheckSaplingTxVersion)
     }
 
     // Cannot add Sapling spends to a non-Sapling transaction
-    libzcash::SaplingNote note(pk, 50000);
+    libzcash::SaplingNote note(pk, 50000, false);
     SaplingMerkleTree tree;
     try {
         builder.AddSaplingSpend(expsk, note, uint256(), tree.witness());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -792,6 +792,7 @@ bool ContextualCheckTransaction(
     bool saplingActive = chainparams.GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_SAPLING);
     bool isSprout = !overwinterActive;
     bool heartwoodActive = chainparams.GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_HEARTWOOD);
+    bool canopyActive = chainparams.GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_CANOPY);
 
     // If Sprout rules apply, reject transactions which are intended for Overwinter and beyond
     if (isSprout && tx.fOverwintered) {
@@ -919,18 +920,28 @@ bool ContextualCheckTransaction(
                 }
 
                 // SaplingNotePlaintext::decrypt() checks note commitment validity.
-                if (!SaplingNotePlaintext::decrypt(
+                auto encPlaintext = SaplingNotePlaintext::decrypt(
                     output.encCiphertext,
                     output.ephemeralKey,
                     outPlaintext->esk,
                     outPlaintext->pk_d,
-                    output.cmu)
-                ) {
+                    output.cmu);
+                if (!encPlaintext) {
                     return state.DoS(
                         DOS_LEVEL_BLOCK,
                         error("CheckTransaction(): coinbase output description has invalid encCiphertext"),
                         REJECT_INVALID,
                         "bad-cb-output-desc-invalid-encct");
+                }
+
+                // ZIP 212: Check that the note plaintexts use the v2 note plaintext
+                // version.
+                if (canopyActive && !encPlaintext->is_v2()) {
+                    return state.DoS(
+                        DOS_LEVEL_BLOCK,
+                        error("CheckTransaction(): coinbase output description has invalid note plaintext version"),
+                        REJECT_INVALID,
+                        "bad-cb-output-desc-invalid-note-plaintext-version");
                 }
             }
         }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -157,7 +157,7 @@ public:
         mtx.valueBalance = -value;
 
         uint256 ovk;
-        auto note = libzcash::SaplingNote(pa, value);
+        auto note = libzcash::SaplingNote(pa, value, false); // TODO
         auto output = OutputDescriptionInfo(ovk, note, {{0xF6}});
 
         auto ctx = librustzcash_sapling_proving_ctx_init();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -157,7 +157,11 @@ public:
         mtx.valueBalance = -value;
 
         uint256 ovk;
-        auto note = libzcash::SaplingNote(pa, value, false); // TODO
+        bool zip212_active = false;
+        if (Params().GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_CANOPY)) {
+            zip212_active = true;
+        }
+        auto note = libzcash::SaplingNote(pa, value, zip212_active);
         auto output = OutputDescriptionInfo(ovk, note, {{0xF6}});
 
         auto ctx = librustzcash_sapling_proving_ctx_init();

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -163,7 +163,7 @@ void TransactionBuilder::AddSaplingOutput(
     }
 
     bool zip212_active = false;
-    if (Params().GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_CANOPY)) {
+    if (Params().GetConsensus().NetworkUpgradeActive(nHeight + 1, Consensus::UPGRADE_CANOPY)) {
         zip212_active = true;
     }
     auto note = libzcash::SaplingNote(to, value, zip212_active);

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -43,11 +43,12 @@ boost::optional<OutputDescription> OutputDescriptionInfo::Build(void* ctx) {
     std::vector<unsigned char> addressBytes(ss.begin(), ss.end());
 
     OutputDescription odesc;
+    uint256 rcm = this->note.rcm();
     if (!librustzcash_sapling_output_proof(
             ctx,
             encryptor.get_esk().begin(),
             addressBytes.data(),
-            this->note.r.begin(),
+            rcm.begin(),
             this->note.value(),
             odesc.cv.begin(),
             odesc.zkproof.begin())) {
@@ -161,7 +162,7 @@ void TransactionBuilder::AddSaplingOutput(
         throw std::runtime_error("TransactionBuilder cannot add Sapling output to pre-Sapling transaction");
     }
 
-    auto note = libzcash::SaplingNote(to, value);
+    auto note = libzcash::SaplingNote(to, value, false); // TODO
     outputs.emplace_back(ovk, note, memo);
     mtx.valueBalance -= value;
 }
@@ -324,12 +325,13 @@ TransactionBuilderResult TransactionBuilder::Build()
         std::vector<unsigned char> witness(ss.begin(), ss.end());
 
         SpendDescription sdesc;
+        uint256 rcm = spend.note.rcm();
         if (!librustzcash_sapling_spend_proof(
                 ctx,
                 spend.expsk.full_viewing_key().ak.begin(),
                 spend.expsk.nsk.begin(),
                 spend.note.d.data(),
-                spend.note.r.begin(),
+                rcm.begin(),
                 spend.alpha.begin(),
                 spend.note.value(),
                 spend.anchor.begin(),

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -162,7 +162,11 @@ void TransactionBuilder::AddSaplingOutput(
         throw std::runtime_error("TransactionBuilder cannot add Sapling output to pre-Sapling transaction");
     }
 
-    auto note = libzcash::SaplingNote(to, value, false); // TODO
+    bool zip212_active = false;
+    if (Params().GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_CANOPY)) {
+        zip212_active = true;
+    }
+    auto note = libzcash::SaplingNote(to, value, zip212_active);
     outputs.emplace_back(ovk, note, memo);
     mtx.valueBalance -= value;
 }

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -289,7 +289,7 @@ CKey AddTestCKeyToKeyStore(CBasicKeyStore& keyStore) {
 
 TestSaplingNote GetTestSaplingNote(const libzcash::SaplingPaymentAddress& pa, CAmount value) {
     // Generate dummy Sapling note
-    libzcash::SaplingNote note(pa, value);
+    libzcash::SaplingNote note(pa, value, false);
     uint256 cm = note.cmu().get();
     SaplingMerkleTree tree;
     tree.append(cm);

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -387,7 +387,7 @@ TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
     auto ivk = fvk.in_viewing_key();
     auto pk = sk.DefaultAddress();
 
-    libzcash::SaplingNote note(pk, 50000);
+    libzcash::SaplingNote note(pk, 50000, false);
     auto cm = note.cmu().get();
     SaplingMerkleTree tree;
     tree.append(cm);
@@ -654,7 +654,7 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
     ASSERT_TRUE(wallet.HaveSaplingSpendingKey(extfvk));
 
     // Generate note A
-    libzcash::SaplingNote note(pk, 50000);
+    libzcash::SaplingNote note(pk, 50000, false);
     auto cm = note.cmu().get();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);
@@ -1018,7 +1018,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     auto pk = sk.DefaultAddress();
 
     // Generate Sapling note A
-    libzcash::SaplingNote note(pk, 50000);
+    libzcash::SaplingNote note(pk, 50000, false);
     auto cm = note.cmu().get();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);

--- a/src/wallet/test/rpc_wallet_tests.cpp
+++ b/src/wallet/test/rpc_wallet_tests.cpp
@@ -1837,7 +1837,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_parameters)
     std::vector<MergeToAddressInputSproutNote> sproutNoteInputs = 
         {MergeToAddressInputSproutNote{JSOutPoint(), SproutNote(), 0, SproutSpendingKey()}};
     std::vector<MergeToAddressInputSaplingNote> saplingNoteInputs = 
-        {MergeToAddressInputSaplingNote{SaplingOutPoint(), SaplingNote(), 0, SaplingExpandedSpendingKey()}};
+        {MergeToAddressInputSaplingNote{SaplingOutPoint(), SaplingNote({}, uint256(), 0, uint256()), 0, SaplingExpandedSpendingKey()}};
 
     // Sprout and Sapling inputs -> throw
     try {

--- a/src/zcash/Note.cpp
+++ b/src/zcash/Note.cpp
@@ -145,7 +145,7 @@ SaplingNotePlaintext::SaplingNotePlaintext(
     std::array<unsigned char, ZC_MEMO_SIZE> memo) : BaseNotePlaintext(note, memo)
 {
     d = note.d;
-    rcm = note.r;
+    rseed = note.r;
 }
 
 
@@ -153,7 +153,7 @@ boost::optional<SaplingNote> SaplingNotePlaintext::note(const SaplingIncomingVie
 {
     auto addr = ivk.address(d);
     if (addr) {
-        return SaplingNote(d, addr.get().pk_d, value_, rcm);
+        return SaplingNote(d, addr.get().pk_d, value_, rcm());
     } else {
         return boost::none;
     }
@@ -221,11 +221,12 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
     }
 
     uint256 cmu_expected;
+    uint256 rcm = ret.rcm();
     if (!librustzcash_sapling_compute_cm(
         ret.d.data(),
         pk_d.begin(),
         ret.value(),
-        ret.rcm.begin(),
+        rcm.begin(),
         cmu_expected.begin()
     ))
     {
@@ -266,11 +267,12 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
     }
 
     uint256 cmu_expected;
+    uint256 rcm = ret.rcm();
     if (!librustzcash_sapling_compute_cm(
         ret.d.data(),
         pk_d.begin(),
         ret.value(),
-        ret.rcm.begin(),
+        rcm.begin(),
         cmu_expected.begin()
     ))
     {
@@ -324,4 +326,8 @@ SaplingOutCiphertext SaplingOutgoingPlaintext::encrypt(
     memcpy(&pt[0], &ss[0], pt.size());
 
     return enc.encrypt_to_ourselves(ovk, cv, cm, pt);
+}
+
+uint256 SaplingNotePlaintext::rcm() const {
+    return rseed;
 }

--- a/src/zcash/Note.cpp
+++ b/src/zcash/Note.cpp
@@ -41,20 +41,31 @@ uint256 SproutNote::nullifier(const SproutSpendingKey& a_sk) const {
 }
 
 // Construct and populate Sapling note for a given payment address and value.
-SaplingNote::SaplingNote(const SaplingPaymentAddress& address, const uint64_t value) : BaseNote(value) {
+SaplingNote::SaplingNote(
+    const SaplingPaymentAddress& address,
+    const uint64_t value,
+    bool enable_zip212
+) : BaseNote(value) {
     d = address.d;
     pk_d = address.pk_d;
-    librustzcash_sapling_generate_r(r.begin());
+    zip212 = enable_zip212;
+    if (zip212) {
+        // Per ZIP 212, the rseed field is 32 random bytes.
+        rseed = random_uint256();
+    } else {
+        librustzcash_sapling_generate_r(rseed.begin());
+    }
 }
 
 // Call librustzcash to compute the commitment
 boost::optional<uint256> SaplingNote::cmu() const {
     uint256 result;
+    uint256 rcm_tmp = rcm();
     if (!librustzcash_sapling_compute_cm(
             d.data(),
             pk_d.begin(),
             value(),
-            r.begin(),
+            rcm_tmp.begin(),
             result.begin()
         ))
     {
@@ -71,11 +82,12 @@ boost::optional<uint256> SaplingNote::nullifier(const SaplingFullViewingKey& vk,
     auto nk = vk.nk;
 
     uint256 result;
+    uint256 rcm_tmp = rcm();
     if (!librustzcash_sapling_compute_nf(
             d.data(),
             pk_d.begin(),
             value(),
-            r.begin(),
+            rcm_tmp.begin(),
             ak.begin(),
             nk.begin(),
             position,
@@ -145,7 +157,8 @@ SaplingNotePlaintext::SaplingNotePlaintext(
     std::array<unsigned char, ZC_MEMO_SIZE> memo) : BaseNotePlaintext(note, memo)
 {
     d = note.d;
-    rseed = note.r;
+    rseed = note.rseed;
+    zip212 = note.zip212;
 }
 
 
@@ -153,7 +166,9 @@ boost::optional<SaplingNote> SaplingNotePlaintext::note(const SaplingIncomingVie
 {
     auto addr = ivk.address(d);
     if (addr) {
-        return SaplingNote(d, addr.get().pk_d, value_, rcm());
+        auto tmp = SaplingNote(d, addr.get().pk_d, value_, rseed);
+        tmp.zip212 = zip212;
+        return tmp;
     } else {
         return boost::none;
     }
@@ -237,6 +252,19 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
         return boost::none;
     }
 
+    if (ret.zip212 == true) {
+        // ZIP 212: Check that epk is consistent to prevent against linkability
+        // attacks without relying on the soundness of the SNARK.
+        uint256 expected_epk;
+        uint256 esk = ret.generate_esk();
+        if (!librustzcash_sapling_ka_derivepublic(ret.d.data(), esk.begin(), expected_epk.begin())) {
+            return boost::none;
+        }
+        if (expected_epk != epk) {
+            return boost::none;
+        }
+    }
+
     return ret;
 }
 
@@ -283,13 +311,31 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
         return boost::none;
     }
 
+    if (ret.zip212 == true) {
+        // ZIP 212: Check that epk is consistent to prevent against linkability
+        // attacks without relying on the soundness of the SNARK.
+        uint256 expected_epk;
+        if (!librustzcash_sapling_ka_derivepublic(ret.d.data(), esk.begin(), expected_epk.begin())) {
+            return boost::none;
+        }
+        if (expected_epk != epk) {
+            return boost::none;
+        }
+
+        // ZIP 212: Additionally check that the esk provided to this function
+        // is consistent with the esk we can derive
+        if (esk != ret.generate_esk()) {
+            return boost::none;
+        }
+    }
+
     return ret;
 }
 
 boost::optional<SaplingNotePlaintextEncryptionResult> SaplingNotePlaintext::encrypt(const uint256& pk_d) const
 {
     // Get the encryptor
-    auto sne = SaplingNoteEncryption::FromDiversifier(d);
+    auto sne = SaplingNoteEncryption::FromDiversifier(d, generate_esk());
     if (!sne) {
         return boost::none;
     }
@@ -329,5 +375,28 @@ SaplingOutCiphertext SaplingOutgoingPlaintext::encrypt(
 }
 
 uint256 SaplingNotePlaintext::rcm() const {
-    return rseed;
+    if (zip212) {
+        return PRF_rcm(rseed);
+    } else {
+        return rseed;
+    }
+}
+
+uint256 SaplingNote::rcm() const {
+    if (zip212) {
+        return PRF_rcm(rseed);
+    } else {
+        return rseed;
+    }
+}
+
+uint256 SaplingNotePlaintext::generate_esk() const {
+    if (zip212) {
+        return PRF_esk(rseed);
+    } else {
+        uint256 esk;
+        // Pick random esk
+        librustzcash_sapling_generate_r(esk.begin());
+        return esk;
+    }
 }

--- a/src/zcash/Note.hpp
+++ b/src/zcash/Note.hpp
@@ -50,8 +50,6 @@ public:
     SaplingNote(diversifier_t d, uint256 pk_d, uint64_t value, uint256 r)
             : BaseNote(value), d(d), pk_d(pk_d), r(r) {}
 
-    SaplingNote() {};
-
     SaplingNote(const SaplingPaymentAddress &address, uint64_t value);
 
     virtual ~SaplingNote() {};

--- a/src/zcash/Note.hpp
+++ b/src/zcash/Note.hpp
@@ -117,9 +117,10 @@ public:
 typedef std::pair<SaplingEncCiphertext, SaplingNoteEncryption> SaplingNotePlaintextEncryptionResult;
 
 class SaplingNotePlaintext : public BaseNotePlaintext {
+private:
+    uint256 rseed;
 public:
     diversifier_t d;
-    uint256 rcm;
 
     SaplingNotePlaintext() {}
 
@@ -157,11 +158,13 @@ public:
 
         READWRITE(d);           // 11 bytes
         READWRITE(value_);      // 8 bytes
-        READWRITE(rcm);         // 32 bytes
+        READWRITE(rseed);       // 32 bytes
         READWRITE(memo_);       // 512 bytes
     }
 
     boost::optional<SaplingNotePlaintextEncryptionResult> encrypt(const uint256& pk_d) const;
+
+    uint256 rcm() const;
 };
 
 class SaplingOutgoingPlaintext

--- a/src/zcash/Note.hpp
+++ b/src/zcash/Note.hpp
@@ -178,6 +178,9 @@ public:
 
     uint256 rcm() const;
     uint256 generate_esk() const;
+    bool is_v2() const {
+        return zip212;
+    }
 };
 
 class SaplingOutgoingPlaintext

--- a/src/zcash/NoteEncryption.cpp
+++ b/src/zcash/NoteEncryption.cpp
@@ -101,12 +101,19 @@ void KDF(unsigned char K[NOTEENCRYPTION_CIPHER_KEYSIZE],
 
 namespace libzcash {
 
-boost::optional<SaplingNoteEncryption> SaplingNoteEncryption::FromDiversifier(diversifier_t d) {
+boost::optional<SaplingNoteEncryption> SaplingNoteEncryption::FromDiversifier(
+    diversifier_t d,
+    boost::optional<uint256> esk_provided
+)
+{
     uint256 epk;
     uint256 esk;
-
-    // Pick random esk
-    librustzcash_sapling_generate_r(esk.begin());
+    if (esk_provided) {
+        esk = esk_provided.get();
+    } else {
+        // Pick random esk
+        librustzcash_sapling_generate_r(esk.begin());
+    }
 
     // Compute epk given the diversifier
     if (!librustzcash_sapling_ka_derivepublic(d.begin(), esk.begin(), epk.begin())) {

--- a/src/zcash/NoteEncryption.hpp
+++ b/src/zcash/NoteEncryption.hpp
@@ -42,7 +42,7 @@ protected:
 
 public:
 
-    static boost::optional<SaplingNoteEncryption> FromDiversifier(diversifier_t d);
+    static boost::optional<SaplingNoteEncryption> FromDiversifier(diversifier_t d, boost::optional<uint256> esk);
 
     boost::optional<SaplingEncCiphertext> encrypt_to_recipient(
         const uint256 &pk_d,

--- a/src/zcash/prf.cpp
+++ b/src/zcash/prf.cpp
@@ -24,6 +24,22 @@ std::array<unsigned char, 64> PRF_expand(const uint256& sk, unsigned char t)
     return res;
 }
 
+uint256 PRF_rcm(const uint256& rseed)
+{
+    uint256 rcm;
+    auto tmp = PRF_expand(rseed, 4);
+    librustzcash_to_scalar(tmp.data(), rcm.begin());
+    return rcm;
+}
+
+uint256 PRF_esk(const uint256& rseed)
+{
+    uint256 esk;
+    auto tmp = PRF_expand(rseed, 5);
+    librustzcash_to_scalar(tmp.data(), esk.begin());
+    return esk;
+}
+
 uint256 PRF_ask(const uint256& sk)
 {
     uint256 ask;

--- a/src/zcash/prf.h
+++ b/src/zcash/prf.h
@@ -22,6 +22,8 @@ uint256 PRF_rho(const uint252& phi, size_t i0, const uint256& h_sig);
 uint256 PRF_ask(const uint256& sk);
 uint256 PRF_nsk(const uint256& sk);
 uint256 PRF_ovk(const uint256& sk);
+uint256 PRF_rcm(const uint256& rseed);
+uint256 PRF_esk(const uint256& rseed);
 
 std::array<unsigned char, 11> default_diversifier(const uint256& sk);
 

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -594,7 +594,7 @@ double benchmark_create_sapling_spend()
     auto sk = libzcash::SaplingSpendingKey::random();
     auto expsk = sk.expanded_spending_key();
     auto address = sk.default_address();
-    SaplingNote note(address, GetRand(MAX_MONEY));
+    SaplingNote note(address, GetRand(MAX_MONEY), false);
     SaplingMerkleTree tree;
     auto maybe_cmu = note.cmu();
     tree.append(maybe_cmu.get());
@@ -618,12 +618,13 @@ double benchmark_create_sapling_spend()
     timer_start(tv_start);
 
     SpendDescription sdesc;
+    uint256 rcm = note.rcm();
     bool result = librustzcash_sapling_spend_proof(
         ctx,
         expsk.full_viewing_key().ak.begin(),
         expsk.nsk.begin(),
         note.d.data(),
-        note.r.begin(),
+        rcm.begin(),
         alpha.begin(),
         note.value(),
         anchor.begin(),
@@ -646,7 +647,7 @@ double benchmark_create_sapling_output()
     auto address = sk.default_address();
 
     std::array<unsigned char, ZC_MEMO_SIZE> memo;
-    SaplingNote note(address, GetRand(MAX_MONEY));
+    SaplingNote note(address, GetRand(MAX_MONEY), false);
 
     libzcash::SaplingNotePlaintext notePlaintext(note, memo);
     auto res = notePlaintext.encrypt(note.pk_d);
@@ -667,11 +668,12 @@ double benchmark_create_sapling_output()
     timer_start(tv_start);
 
     OutputDescription odesc;
+    uint256 rcm = note.rcm();
     bool result = librustzcash_sapling_output_proof(
         ctx,
         encryptor.get_esk().begin(),
         addressBytes.data(),
-        note.r.begin(),
+        rcm.begin(),
         note.value(),
         odesc.cv.begin(),
         odesc.zkproof.begin());


### PR DESCRIPTION
* The `SaplingNote` and `SaplingNotePlaintext` structures have a new boolean member called `zip212`. This member is private and reflects whether the note was or is being created using the derivation method of ZIP 212.
* The serialization of `SaplingNotePlaintext` sets `zip212` to `true` iff the serialized note plaintext version is `0x02`, and vice versa.
* The `r`/`rcm` fields have been removed and replaced with a private field `rseed`.
* `SaplingNote` and `SaplingNotePlaintext` now have a helper method `rcm()` which returns the `rcm` either by deriving it with `rseed` (if `zip212` is true) or returning `rseed` by interpreting `rseed` as `rcm`.
* All the methods of obtaining a `SaplingNote` account for these changes.
    - The `SaplingNote` constructor that is used by e.g. the transaction builder, and internally samples random `rcm`, now takes a boolean argument to decide whether to sample `rcm` the "old" way or the "new" way.
    - The bare constructor for `SaplingNote` is removed.
    - The other constructor which takes the raw contents of the note is only used in tests or in `Note.cpp` so changes involving `zip212` here are unnecessary.
    - The other way of obtaining a note, by calling `SaplingNotePlaintext::note()`, has been adjusted.
* The `SaplingNotePlaintext` class now has an `generate_esk()` method that either samples a random `esk` or derives it using the local `rseed` depending on whether `zip212` is set.
* The encryption routine is modified to consult `generate_esk()` and provide it to the note encryption object.
* The note encryption objects now take an optional `esk` as input and otherwise sample a random `esk` internally. This API functionality is preserved to allow for testing.
* The `SaplingNotePlaintext` decryption routines are modified
    - The out and enc decryption routines now check that `epk` is consistent with the derived `esk`.
    -  The out decryption routine for plaintexts also checks that `esk` is consistent with what is derived by the note.
* The miner and transaction builder consult the activation of Canopy when creating `SaplingNote`s.
* The consensus rules are modified so that shielded outputs (miner rewards) must have `v2` note plaintexts after Canopy has activated.

TODO:

- [x] Make transaction builder (and miner?) check the next block height when deciding if zip212 should be enabled.
- [ ] Daira would rather we not have a `zip212` bool but instead have the leadingByte exposed.
- [ ] Make it so that we always check epk versus esk when caller has esk.
- [ ] Make it so that the recipient rejects transactions using v1 plaintexts after the grace period.
- [ ] Tests.