### PR TITLE
Remove an unused CCriticalSection.

### DIFF
--- a/src/zcash/JoinSplit.cpp
+++ b/src/zcash/JoinSplit.cpp
@@ -20,8 +20,6 @@
 
 namespace libzcash {
 
-static CCriticalSection cs_ParamsIO;
-
 template<size_t NumInputs, size_t NumOutputs>
 class JoinSplitCircuit : public JoinSplit<NumInputs, NumOutputs> {
 public:


### PR DESCRIPTION
The code that used this was removed in 5f84491d829e26a9c676a4e7acfff1feb37f5545.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>
