### PR TITLE
Add integrity checks when deserializing z-keys from the walletdb.

### DIFF
--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -212,5 +212,8 @@ private:
 
 bool BackupWallet(const CWallet& wallet, const std::string& strDest);
 void ThreadFlushWalletDB(const std::string& strFile);
+uint256 SproutKeyChecksum(const libzcash::SproutPaymentAddress& addr, const libzcash::SproutSpendingKey& key);
+uint256 SaplingKeyChecksum(const libzcash::SaplingIncomingViewingKey& ivk,
+                           const libzcash::SaplingExtendedSpendingKey& key);
 
 #endif // BITCOIN_WALLET_WALLETDB_H


### PR DESCRIPTION
closes #3576

Add integrity checks when loading Sappling and Sprout keys from the wallet database on load. Create a checksum hash of the address and the key and add it as another serialized item. This is backwards compatible and uses the same general style that is used for the checksum and integrity check for normal `"key"` databased values.

For sprout checksum it hashes the address hash with the full `libzcash::SproutSpendingKey`.
For sappling checksum it hashes the view key and the spending key together. 

Note that for both hashing techniques the hash is performed over the existing memory, instead of copy constructing this sensitive data (throwing it into a datastream or other container).
