### PR TITLE
Add key_constants.h to src/Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -194,6 +194,7 @@ BITCOIN_CORE_H = \
   httpserver.h \
   init.h \
   key.h \
+  key_constants.h \
   key_io.h \
   keystore.h \
   dbwrapper.h \


### PR DESCRIPTION
This should fix Gitian builds.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>
