### PR TITLE
Send alert to put pre-Heartwood nodes into safe mode.

### DIFF
--- a/src/sendalert.cpp
+++ b/src/sendalert.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 The Zcash developers
+// Copyright (c) 2016-2020 The Zcash developers
 // Original code from: https://gist.github.com/laanwj/0e689cfa37b52bcbbb44
 
 /*
@@ -72,15 +72,17 @@ void ThreadSendAlert()
     CAlert alert;
     alert.nRelayUntil   = GetTime() + 15 * 60;
     alert.nExpiration   = GetTime() + 10 * 365 * 24 * 60 * 60;
-    alert.nID           = 1006;  // use https://github.com/zcash/zcash/wiki/specification#assigned-numbers to keep track of alert IDs
-    alert.nCancel       = 1005;  // cancels previous messages up to this ID number
+    alert.nID           = 1007;  // use https://github.com/zcash/zcash/wiki/specification#assigned-numbers to keep track of alert IDs
+    alert.nCancel       = 1006;  // cancels previous messages up to this ID number
 
     // These versions are protocol versions
     // 170002 : 1.0.0
     // 170006 : 1.1.2
     // 170007 : 2.0.0
+    // 170010 : 2.1.2
+    // 170011 : 3.0.0
     alert.nMinVer       = 170002;
-    alert.nMaxVer       = 170006;
+    alert.nMaxVer       = 170010;
 
     //
     // main.cpp:
@@ -90,7 +92,7 @@ void ThreadSendAlert()
     //  4000 or higher will put the RPC into safe mode
     alert.nPriority     = 4000;
     alert.strComment    = "";
-    alert.strStatusBar  = "Your client is out of date and incompatible with the Sapling network upgrade. Please update to a recent version of Zcash (2.0.1 or later).";
+    alert.strStatusBar  = "Your client is out of date and incompatible with the Heartwood network upgrade. Please update to a recent version of Zcash (3.0.0 or later).";
     alert.strRPCError   = alert.strStatusBar;
 
     // Set specific client version/versions here. If setSubVer is empty, no filtering on subver is done:


### PR DESCRIPTION
The alert targets nodes running protocol version <= 170010.
Heartwood-compatible nodes run protocol version >= 170011.