### PR TITLE
flush witness cache (SetBestChain()) on clean shutdown

### DIFF
--- a/qa/rpc-tests/wallet_anchorfork.py
+++ b/qa/rpc-tests/wallet_anchorfork.py
@@ -80,11 +80,15 @@ class WalletAnchorForkTest (BitcoinTestFramework):
 
         # Partition A, node 0 mines a block with the transaction
         self.nodes[0].generate(1)
+        # Same as self.sync_all() but only for node 0
+        sync_blocks(self.nodes[:1])
+        sync_mempools(self.nodes[:1])
 
         # Partition B, node 1 mines the same joinsplit transaction
         txid2 = self.nodes[1].sendrawtransaction(rawhex)
         assert_equal(txid, txid2)
         self.nodes[1].generate(1)
+        # Same as self.sync_all() but only for nodes 1 and 2
         sync_blocks(self.nodes[1:])
         sync_mempools(self.nodes[1:])
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -229,6 +229,9 @@ void Shutdown()
         if (pcoinsTip != NULL) {
             FlushStateToDisk();
         }
+        // Flush the wallet witness cache to disk (no longer done by FlushStateToDisk())
+        GetMainSignals().SetBestChain(chainActive.GetLocator());
+
         delete pcoinsTip;
         pcoinsTip = NULL;
         delete pcoinscatcher;


### PR DESCRIPTION
Closes #4596, follow-on to #4573. In addition to flushing witness data on shutdown, fix the RPC test that was preventing this change from being part of #4573.