### PR TITLE
Debug messages for zecwallet Windows Heartwood bug

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2976,6 +2976,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         // - If the previous block is in this epoch, this block would affect
         //   this epoch's tree root, but as we haven't updated the tree for this
         //   block yet, view.GetHistoryRoot() returns the root we need.
+        LogPrintf("block.hashLightClientRoot: %s\n", block.hashLightClientRoot.GetHex());
+        LogPrintf("view.GetHistoryRoot: %s\n", view.GetHistoryRoot(prevConsensusBranchId).GetHex());
+        LogPrintf("prevConsensusBranchId: %x\n", prevConsensusBranchId);
         if (block.hashLightClientRoot != view.GetHistoryRoot(prevConsensusBranchId)) {
             return state.DoS(100,
                 error("ConnectBlock(): block's hashLightClientRoot is incorrect (should be history tree root)"),


### PR DESCRIPTION
Purpose of debug messages: to identify how the wrong `view.GetHistoryRoot()` is being computed at Block 903002.