### PR TITLE
Microsecond log timestamps

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2145,7 +2145,7 @@ void CNode::AskFor(const CInv& inv)
         nRequestTime = it->second;
     else
         nRequestTime = 0;
-    LogPrint("net", "askfor %s  %d (%s) peer=%d\n", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000), id);
+    LogPrint("net", "askfor %s  %d (%s) peer=%d\n", inv.ToString(), nRequestTime, DateTimeStrFormatMicros("%H:%M:%S.%f", nRequestTime), id);
 
     // Make sure not to reuse time indexes to keep things in the same order
     int64_t nNow = GetTimeMicros() - 1000000;

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -96,6 +96,17 @@ BOOST_AUTO_TEST_CASE(util_DateTimeStrFormat)
     BOOST_CHECK_EQUAL(DateTimeStrFormat("%a, %d %b %Y %H:%M:%S +0000", 1317425777), "Fri, 30 Sep 2011 23:36:17 +0000");
 }
 
+BOOST_AUTO_TEST_CASE(util_DateTimeStrFormatMicros)
+{
+    BOOST_CHECK_EQUAL(DateTimeStrFormatMicros("%Y-%m-%d %H:%M:%S.%f", 0), "1970-01-01 00:00:00.000000");
+    BOOST_CHECK_EQUAL(DateTimeStrFormatMicros("%Y-%m-%d %H:%M:%S.%f", 1000000 * UINT64_C(0x7FFFFFFF)), "2038-01-19 03:14:07.000000");
+    BOOST_CHECK_EQUAL(DateTimeStrFormatMicros("%Y-%m-%d %H:%M:%S.%f", INT64_MAX), "+infinity");
+    BOOST_CHECK_EQUAL(DateTimeStrFormatMicros("%Y-%m-%d %H:%M:%S.%f", 1317425777123456), "2011-09-30 23:36:17.123456");
+    BOOST_CHECK_EQUAL(DateTimeStrFormatMicros("%Y-%m-%d %H:%M:%S", 1317425777123456), "2011-09-30 23:36:17");
+    BOOST_CHECK_EQUAL(DateTimeStrFormatMicros("%Y-%m-%d %H:%M", 1317425777123456), "2011-09-30 23:36");
+    BOOST_CHECK_EQUAL(DateTimeStrFormatMicros("%a, %d %b %Y %H:%M:%S.%f +0000", 1317425777123456), "Fri, 30 Sep 2011 23:36:17.123456 +0000");
+}
+
 BOOST_AUTO_TEST_CASE(util_ParseParameters)
 {
     const char *argv_test[] = {"-ignored", "-a", "-b", "-ccc=argument", "-ccc=multiple", "f", "-d=e"};

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -319,7 +319,7 @@ int LogPrintStr(const std::string &str)
         ret = FileWriteStr(strTimestamped, stdout);
         fflush(stdout);
     }
-    else if (fPrintToDebugLog)
+    if (fPrintToDebugLog)
     {
         // buffer if we haven't opened the log yet
         if (fileout == NULL) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -289,7 +289,7 @@ static std::string LogTimestampStr(const std::string &str, bool *fStartedNewLine
         return str;
 
     if (*fStartedNewLine)
-        strStamped =  DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) + ' ' + str;
+        strStamped = DateTimeStrFormatMicros("%Y-%m-%d %H:%M:%S.%f", GetTimeMicros()) + ' ' + str;
     else
         strStamped = str;
 

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -48,12 +48,24 @@ void MilliSleep(int64_t n)
     boost::this_thread::sleep_for(boost::chrono::milliseconds(n));
 }
 
-std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)
+std::string DateTimeStrFormatPtime(const char* pszFormat, boost::posix_time::ptime theTime)
 {
     // std::locale takes ownership of the pointer
     std::locale loc(std::locale::classic(), new boost::posix_time::time_facet(pszFormat));
     std::stringstream ss;
     ss.imbue(loc);
-    ss << boost::posix_time::from_time_t(nTime);
+    ss << theTime;
     return ss.str();
+}
+
+std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)
+{
+    return DateTimeStrFormatPtime(pszFormat, boost::posix_time::from_time_t(nTime));
+}
+
+std::string DateTimeStrFormatMicros(const char* pszFormat, int64_t nTimeMicros)
+{
+    static const boost::posix_time::ptime unix_epoch(boost::gregorian::date(1970, 1, 1));
+
+    return DateTimeStrFormatPtime(pszFormat, unix_epoch + boost::posix_time::microseconds(nTimeMicros));
 }

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -16,5 +16,6 @@ void SetMockTime(int64_t nMockTimeIn);
 void MilliSleep(int64_t n);
 
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);
+std::string DateTimeStrFormatMicros(const char* pszFormat, int64_t nTimeMicros);
 
 #endif // BITCOIN_UTILTIME_H


### PR DESCRIPTION
This includes microseconds in the timestamps logged to `debug.log`, and also adds timestamps to the output of `-printtoconsole`.
In addition, `-printtoconsole` will no longer inhibit logging to `debug.log`.