### PR TITLE
Fix "--disable-mining" build regression 

### DIFF
--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -16,45 +16,50 @@
 #include "config/bitcoin-config.h"
 #endif
 
-#ifdef ENABLE_MINING
-
 #include "compat/endian.h"
 #include "crypto/equihash.h"
 #include "util.h"
 
-#include <algorithm>
-#include <iostream>
-#include <stdexcept>
 
-#include <boost/optional.hpp>
+// Used in TestEquihashValidator.
 
-static EhSolverCancelledException solver_cancelled;
-
-template<unsigned int N, unsigned int K>
-int Equihash<N,K>::InitialiseState(eh_HashState& base_state)
+void CompressArray(const unsigned char* in, size_t in_len,
+                   unsigned char* out, size_t out_len,
+                   size_t bit_len, size_t byte_pad)
 {
-    uint32_t le_N = htole32(N);
-    uint32_t le_K = htole32(K);
-    unsigned char personalization[crypto_generichash_blake2b_PERSONALBYTES] = {};
-    memcpy(personalization, "ZcashPoW", 8);
-    memcpy(personalization+8,  &le_N, 4);
-    memcpy(personalization+12, &le_K, 4);
-    return crypto_generichash_blake2b_init_salt_personal(&base_state,
-                                                         NULL, 0, // No key.
-                                                         (512/N)*N/8,
-                                                         NULL,    // No salt.
-                                                         personalization);
-}
+    assert(bit_len >= 8);
+    assert(8*sizeof(uint32_t) >= 7+bit_len);
 
-void GenerateHash(const eh_HashState& base_state, eh_index g,
-                  unsigned char* hash, size_t hLen)
-{
-    eh_HashState state;
-    state = base_state;
-    eh_index lei = htole32(g);
-    crypto_generichash_blake2b_update(&state, (const unsigned char*) &lei,
-                                      sizeof(eh_index));
-    crypto_generichash_blake2b_final(&state, hash, hLen);
+    size_t in_width { (bit_len+7)/8 + byte_pad };
+    assert(out_len == bit_len*in_len/(8*in_width));
+
+    uint32_t bit_len_mask { ((uint32_t)1 << bit_len) - 1 };
+
+    // The acc_bits least-significant bits of acc_value represent a bit sequence
+    // in big-endian order.
+    size_t acc_bits = 0;
+    uint32_t acc_value = 0;
+
+    size_t j = 0;
+    for (size_t i = 0; i < out_len; i++) {
+        // When we have fewer than 8 bits left in the accumulator, read the next
+        // input element.
+        if (acc_bits < 8) {
+            acc_value = acc_value << bit_len;
+            for (size_t x = byte_pad; x < in_width; x++) {
+                acc_value = acc_value | (
+                    (
+                        // Apply bit_len_mask across byte boundaries
+                        in[j+x] & ((bit_len_mask >> (8*(in_width-x-1))) & 0xFF)
+                    ) << (8*(in_width-x-1))); // Big-endian
+            }
+            j += in_width;
+            acc_bits += bit_len;
+        }
+
+        acc_bits -= 8;
+        out[i] = (acc_value >> acc_bits) & 0xFF;
+    }
 }
 
 void ExpandArray(const unsigned char* in, size_t in_len,
@@ -100,45 +105,6 @@ void ExpandArray(const unsigned char* in, size_t in_len,
     }
 }
 
-void CompressArray(const unsigned char* in, size_t in_len,
-                   unsigned char* out, size_t out_len,
-                   size_t bit_len, size_t byte_pad)
-{
-    assert(bit_len >= 8);
-    assert(8*sizeof(uint32_t) >= 7+bit_len);
-
-    size_t in_width { (bit_len+7)/8 + byte_pad };
-    assert(out_len == bit_len*in_len/(8*in_width));
-
-    uint32_t bit_len_mask { ((uint32_t)1 << bit_len) - 1 };
-
-    // The acc_bits least-significant bits of acc_value represent a bit sequence
-    // in big-endian order.
-    size_t acc_bits = 0;
-    uint32_t acc_value = 0;
-
-    size_t j = 0;
-    for (size_t i = 0; i < out_len; i++) {
-        // When we have fewer than 8 bits left in the accumulator, read the next
-        // input element.
-        if (acc_bits < 8) {
-            acc_value = acc_value << bit_len;
-            for (size_t x = byte_pad; x < in_width; x++) {
-                acc_value = acc_value | (
-                    (
-                        // Apply bit_len_mask across byte boundaries
-                        in[j+x] & ((bit_len_mask >> (8*(in_width-x-1))) & 0xFF)
-                    ) << (8*(in_width-x-1))); // Big-endian
-            }
-            j += in_width;
-            acc_bits += bit_len;
-        }
-
-        acc_bits -= 8;
-        out[i] = (acc_value >> acc_bits) & 0xFF;
-    }
-}
-
 // Big-endian so that lexicographic array comparison is equivalent to integer
 // comparison
 void EhIndexToArray(const eh_index i, unsigned char* array)
@@ -146,6 +112,61 @@ void EhIndexToArray(const eh_index i, unsigned char* array)
     BOOST_STATIC_ASSERT(sizeof(eh_index) == 4);
     eh_index bei = htobe32(i);
     memcpy(array, &bei, sizeof(eh_index));
+}
+
+std::vector<unsigned char> GetMinimalFromIndices(std::vector<eh_index> indices,
+                                                 size_t cBitLen)
+{
+    assert(((cBitLen+1)+7)/8 <= sizeof(eh_index));
+    size_t lenIndices { indices.size()*sizeof(eh_index) };
+    size_t minLen { (cBitLen+1)*lenIndices/(8*sizeof(eh_index)) };
+    size_t bytePad { sizeof(eh_index) - ((cBitLen+1)+7)/8 };
+    std::vector<unsigned char> array(lenIndices);
+    for (int i = 0; i < indices.size(); i++) {
+        EhIndexToArray(indices[i], array.data()+(i*sizeof(eh_index)));
+    }
+    std::vector<unsigned char> ret(minLen);
+    CompressArray(array.data(), lenIndices,
+                  ret.data(), minLen, cBitLen+1, bytePad);
+    return ret;
+}
+
+#ifdef ENABLE_MINING
+
+
+#include <algorithm>
+#include <iostream>
+#include <stdexcept>
+
+#include <boost/optional.hpp>
+
+static EhSolverCancelledException solver_cancelled;
+
+template<unsigned int N, unsigned int K>
+int Equihash<N,K>::InitialiseState(eh_HashState& base_state)
+{
+    uint32_t le_N = htole32(N);
+    uint32_t le_K = htole32(K);
+    unsigned char personalization[crypto_generichash_blake2b_PERSONALBYTES] = {};
+    memcpy(personalization, "ZcashPoW", 8);
+    memcpy(personalization+8,  &le_N, 4);
+    memcpy(personalization+12, &le_K, 4);
+    return crypto_generichash_blake2b_init_salt_personal(&base_state,
+                                                         NULL, 0, // No key.
+                                                         (512/N)*N/8,
+                                                         NULL,    // No salt.
+                                                         personalization);
+}
+
+void GenerateHash(const eh_HashState& base_state, eh_index g,
+                  unsigned char* hash, size_t hLen)
+{
+    eh_HashState state;
+    state = base_state;
+    eh_index lei = htole32(g);
+    crypto_generichash_blake2b_update(&state, (const unsigned char*) &lei,
+                                      sizeof(eh_index));
+    crypto_generichash_blake2b_final(&state, hash, hLen);
 }
 
 // Big-endian so that lexicographic array comparison is equivalent to integer
@@ -184,23 +205,6 @@ std::vector<eh_index> GetIndicesFromMinimal(std::vector<unsigned char> minimal,
     for (int i = 0; i < lenIndices; i += sizeof(eh_index)) {
         ret.push_back(ArrayToEhIndex(array.data()+i));
     }
-    return ret;
-}
-
-std::vector<unsigned char> GetMinimalFromIndices(std::vector<eh_index> indices,
-                                                 size_t cBitLen)
-{
-    assert(((cBitLen+1)+7)/8 <= sizeof(eh_index));
-    size_t lenIndices { indices.size()*sizeof(eh_index) };
-    size_t minLen { (cBitLen+1)*lenIndices/(8*sizeof(eh_index)) };
-    size_t bytePad { sizeof(eh_index) - ((cBitLen+1)+7)/8 };
-    std::vector<unsigned char> array(lenIndices);
-    for (int i = 0; i < indices.size(); i++) {
-        EhIndexToArray(indices[i], array.data()+(i*sizeof(eh_index)));
-    }
-    std::vector<unsigned char> ret(minLen);
-    CompressArray(array.data(), lenIndices,
-                  ret.data(), minLen, cBitLen+1, bytePad);
     return ret;
 }
 

--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -6,10 +6,25 @@
 #ifndef BITCOIN_EQUIHASH_H
 #define BITCOIN_EQUIHASH_H
 
+#include <memory>
+#include <vector>
 
 inline constexpr size_t equihash_solution_size(unsigned int N, unsigned int K) {
     return (1 << K)*(N/(K+1)+1)/8;
 }
+
+typedef uint32_t eh_index;
+typedef uint8_t eh_trunc;
+
+std::vector<unsigned char> GetMinimalFromIndices(std::vector<eh_index> indices,
+                                                 size_t cBitLen);
+void CompressArray(const unsigned char* in, size_t in_len,
+                   unsigned char* out, size_t out_len,
+                   size_t bit_len, size_t byte_pad=0);
+void ExpandArray(const unsigned char* in, size_t in_len,
+                 unsigned char* out, size_t out_len,
+                 size_t bit_len, size_t byte_pad=0);
+void EhIndexToArray(const eh_index i, unsigned char* array);
 
 
 #ifdef ENABLE_MINING
@@ -23,30 +38,17 @@ inline constexpr size_t equihash_solution_size(unsigned int N, unsigned int K) {
 #include <exception>
 #include <stdexcept>
 #include <functional>
-#include <memory>
 #include <set>
-#include <vector>
 
 #include <boost/static_assert.hpp>
 
 typedef crypto_generichash_blake2b_state eh_HashState;
-typedef uint32_t eh_index;
-typedef uint8_t eh_trunc;
-
-void ExpandArray(const unsigned char* in, size_t in_len,
-                 unsigned char* out, size_t out_len,
-                 size_t bit_len, size_t byte_pad=0);
-void CompressArray(const unsigned char* in, size_t in_len,
-                   unsigned char* out, size_t out_len,
-                   size_t bit_len, size_t byte_pad=0);
 
 eh_index ArrayToEhIndex(const unsigned char* array);
 eh_trunc TruncateIndex(const eh_index i, const unsigned int ilen);
 
 std::vector<eh_index> GetIndicesFromMinimal(std::vector<unsigned char> minimal,
                                             size_t cBitLen);
-std::vector<unsigned char> GetMinimalFromIndices(std::vector<eh_index> indices,
-                                                 size_t cBitLen);
 
 template<size_t WIDTH>
 class StepRow

--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -5,6 +5,13 @@
 
 #ifndef BITCOIN_EQUIHASH_H
 #define BITCOIN_EQUIHASH_H
+
+
+inline constexpr size_t equihash_solution_size(unsigned int N, unsigned int K) {
+    return (1 << K)*(N/(K+1)+1)/8;
+}
+
+
 #ifdef ENABLE_MINING
 
 #include "crypto/sha256.h"
@@ -156,10 +163,6 @@ class EhSolverCancelledException : public std::exception
 };
 
 inline constexpr const size_t max(const size_t A, const size_t B) { return A > B ? A : B; }
-
-inline constexpr size_t equihash_solution_size(unsigned int N, unsigned int K) {
-    return (1 << K)*(N/(K+1)+1)/8;
-}
 
 template<unsigned int N, unsigned int K>
 class Equihash

--- a/src/gtest/test_equihash.cpp
+++ b/src/gtest/test_equihash.cpp
@@ -7,6 +7,7 @@
 
 #include "crypto/equihash.h"
 #include "uint256.h"
+#include "utilstrencodings.h"
 
 void TestExpandAndCompress(const std::string &scope, size_t bit_len, size_t byte_pad,
                            std::vector<unsigned char> compact,
@@ -50,7 +51,9 @@ void TestMinimalSolnRepr(const std::string &scope, size_t cBitLen,
 {
     SCOPED_TRACE(scope);
 
+#if ENABLE_MINING
     EXPECT_EQ(indices, GetIndicesFromMinimal(minimal, cBitLen));
+#endif
     EXPECT_EQ(minimal, GetMinimalFromIndices(indices, cBitLen));
 }
 
@@ -70,6 +73,7 @@ TEST(EquihashTests, MinimalSolutionRepresentation) {
                         ParseHex("000220000a7ffffe004d10014c800ffc00002fffff"));
 }
 
+#if ENABLE_MINING
 TEST(EquihashTests, IsProbablyDuplicate) {
     std::shared_ptr<eh_trunc> p1 (new eh_trunc[4] {0, 1, 2, 3}, std::default_delete<eh_trunc[]>());
     std::shared_ptr<eh_trunc> p2 (new eh_trunc[4] {0, 1, 1, 3}, std::default_delete<eh_trunc[]>());
@@ -80,7 +84,6 @@ TEST(EquihashTests, IsProbablyDuplicate) {
     ASSERT_TRUE(IsProbablyDuplicate<4>(p3, 4));
 }
 
-#ifdef ENABLE_MINING
 TEST(EquihashTests, CheckBasicSolverCancelled) {
     Equihash<48,5> Eh48_5;
     crypto_generichash_blake2b_state state;

--- a/src/gtest/test_miner.cpp
+++ b/src/gtest/test_miner.cpp
@@ -1,3 +1,4 @@
+#if ENABLE_MINING
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -119,3 +120,4 @@ TEST(Miner, GetMinerAddress) {
         EXPECT_FALSE(IsValidMinerAddress(minerAddress));
     }
 }
+#endif // ENABLE_MINING


### PR DESCRIPTION
closes #4634

Test by building with:
* `CONFIGURE_FLAGS="--disable-tests --disable-mining --disable-bench" zcutil/build.sh`
* `zcutil/distclean.sh`
* `CONFIGURE_FLAGS="--disable-mining" zcutil/build.sh`

After the second build, run `qa/zcash/full-test-suite.py`. Stop when it gets to the RPC tests, which will hang. The preceding parts of the test suite are all expected to pass.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>
