### PR TITLE
Update IPFS_HASH

### DIFF
--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -14,7 +14,7 @@ SAPLING_SPEND_NAME='sapling-spend.params'
 SAPLING_OUTPUT_NAME='sapling-output.params'
 SAPLING_SPROUT_GROTH16_NAME='sprout-groth16.params'
 DOWNLOAD_URL="https://download.z.cash/downloads"
-IPFS_HASH="/ipfs/QmXRHVGLQBiKwvNq7c2vPxAKz1zRVmMYbmt7G5TQss7tY7"
+IPFS_HASH="/ipfs/QmUSFo5zgPPXXejidzFWZcxVyF3AJH6Pr9br6Xisdww1r1"
 
 SHA256CMD="$(command -v sha256sum || echo shasum)"
 SHA256ARGS="$(command -v sha256sum >/dev/null || echo '-a 256')"


### PR DESCRIPTION
The content available at this hash can be viewed via IPFS gateway urls. For example:

https://ipfs.io/ipfs/QmUSFo5zgPPXXejidzFWZcxVyF3AJH6Pr9br6Xisdww1r1
https://ipfs.eternum.io/ipfs/QmUSFo5zgPPXXejidzFWZcxVyF3AJH6Pr9br6Xisdww1r1