### PR TITLE
depends: Revert to using upstreams as primary download paths

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -4,7 +4,7 @@ SOURCES_PATH ?= $(BASEDIR)/sources
 BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
 NO_WALLET ?=
-PRIORITY_DOWNLOAD_PATH ?= https://download.z.cash/depends-sources
+FALLBACK_DOWNLOAD_PATH ?= https://download.z.cash/depends-sources
 
 BUILD ?= $(shell ./config.guess)
 HOST ?= $(BUILD)

--- a/depends/README.md
+++ b/depends/README.md
@@ -33,7 +33,7 @@ The following can be set when running make: make FOO=bar
     SOURCES_PATH: downloaded sources will be placed here
     BASE_CACHE: built packages will be placed here
     SDK_PATH: Path where sdk's can be found (used by OSX)
-    PRIORITY_DOWNLOAD_PATH: Try fetching source files from here before using their own URLs
+    FALLBACK_DOWNLOAD_PATH: If a source file can't be fetched, try here before giving up
     NO_WALLET: Don't download/build/cache libs needed to enable the wallet
     DEBUG: disable some optimizations and enable more runtime checking
     LIBRUSTZCASH_OVERRIDE: Path to a local librustzcash repository

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -22,7 +22,7 @@ endef
 define fetch_file
 (test -f $$($(1)_source_dir)/$(4) || \
   ( mkdir -p $$($(1)_download_dir) && echo Fetching $(1)... && \
-  ( $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(PRIORITY_DOWNLOAD_PATH)/$(4)" || \
+  ( $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(FALLBACK_DOWNLOAD_PATH)/$(4)" || \
     $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(2)/$(3)" ) && \
     echo "$(5)  $$($(1)_download_dir)/$(4).temp" > $$($(1)_download_dir)/.$(4).hash && \
     $(build_SHA256SUM) -c $$($(1)_download_dir)/.$(4).hash && \

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -19,13 +19,15 @@ define int_get_all_dependencies
 $(sort $(foreach dep,$(2),$(2) $(call int_get_all_dependencies,$(1),$($(dep)_dependencies))))
 endef
 
+define download_and_check_file
+($(build_DOWNLOAD) "$(1)/$(2).temp" $(3) && echo "$(4)  $(1)/$(2).temp" > $(1)/.$(2).hash && $(build_SHA256SUM) -c $(1)/.$(2).hash)
+endef
+
 define fetch_file
 (test -f $$($(1)_source_dir)/$(4) || \
   ( mkdir -p $$($(1)_download_dir) && echo Fetching $(1)... && \
-  ( $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(2)/$(3)" || \
-    $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(FALLBACK_DOWNLOAD_PATH)/$(4)" ) && \
-    echo "$(5)  $$($(1)_download_dir)/$(4).temp" > $$($(1)_download_dir)/.$(4).hash && \
-    $(build_SHA256SUM) -c $$($(1)_download_dir)/.$(4).hash && \
+  ( $(call download_and_check_file,$$($(1)_download_dir),$(4),"$(2)/$(3)",$(5)) || \
+    $(call download_and_check_file,$$($(1)_download_dir),$(4),"$(FALLBACK_DOWNLOAD_PATH)/$(4)",$(5)) ) && \
     mv $$($(1)_download_dir)/$(4).temp $$($(1)_source_dir)/$(4) && \
     rm -rf $$($(1)_download_dir) ))
 endef

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -22,8 +22,8 @@ endef
 define fetch_file
 (test -f $$($(1)_source_dir)/$(4) || \
   ( mkdir -p $$($(1)_download_dir) && echo Fetching $(1)... && \
-  ( $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(FALLBACK_DOWNLOAD_PATH)/$(4)" || \
-    $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(2)/$(3)" ) && \
+  ( $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(2)/$(3)" || \
+    $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(FALLBACK_DOWNLOAD_PATH)/$(4)" ) && \
     echo "$(5)  $$($(1)_download_dir)/$(4).temp" > $$($(1)_download_dir)/.$(4).hash && \
     $(build_SHA256SUM) -c $$($(1)_download_dir)/.$(4).hash && \
     mv $$($(1)_download_dir)/$(4).temp $$($(1)_source_dir)/$(4) && \

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -149,7 +149,6 @@ def rust_test():
 #
 
 STAGES = [
-    'check-depends',
     'rust-test',
     'btest',
     'gtest',
@@ -162,7 +161,6 @@ STAGES = [
 ]
 
 STAGE_COMMANDS = {
-    'check-depends': ['qa/zcash/test-depends-sources-mirror.py'],
     'rust-test': rust_test,
     'btest': [repofile('src/test/test_bitcoin'), '-p'],
     'gtest': [repofile('src/zcash-gtest')],


### PR DESCRIPTION
We use the depends system for vendoring `zcashd` dependencies, pinning them
with SHA-256 hashes. It supports fetching dependencies from both their
upstream archive source, and a mirror operated by ECC.

In #816, we switched to the ECC mirror as the primary source, due to an
unreliable upstream (SourceForge). However, this only addressed the symptom
(that dependency builds would reliably fail with an unreliable upstream that
was serving incorrect files). In particular, if the ECC mirror were to become
similarly unreliable, the issue would return.

This PR fixes the core problem, by downloading dependencies and checking
their hashes as an atomic operation. This gives us greater resiliency, as
both the primary and fallback would need to fail in order to halt the build.
Having addressed this problem, we also switch back to using upstreams as
primary download paths.