### PR TITLE
Add support for logging fields in spans and events

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -131,7 +131,7 @@ License: Expat
 
 Files: src/rust/include/tracing/map.h
 Copyright: Copyright (c) 2012 William Swanson
-License: X11
+License: Expat-with-advertising-clause
 
 Files: src/secp256k1/*
 Copyright: Copyright (c) 2013 Pieter Wuille
@@ -1245,7 +1245,7 @@ Comment:
  The "special exception" is extended to the versions of files covered by
  this license that are distributed with this software.
 
-License: X11
+License: Expat-with-advertising-clause
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation
  files (the "Software"), to deal in the Software without

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -124,6 +124,15 @@ Files: src/crypto/ctaes/*
 Copyright: Copyright (c) 2016 Pieter Wuille
 License: Expat
 
+Files: src/rust/include/tracing.h
+ src/rust/src/tracing_ffi.rs
+Copyright: Copyright (c) 2020 Jack Grigg
+License: Expat
+
+Files: src/rust/include/tracing/map.h
+Copyright: Copyright (c) 2012 William Swanson
+License: X11
+
 Files: src/secp256k1/*
 Copyright: Copyright (c) 2013 Pieter Wuille
 License: Expat
@@ -1235,3 +1244,28 @@ License: GPLv3-or-later-with-Autoconf-exception
 Comment:
  The "special exception" is extended to the versions of files covered by
  this license that are distributed with this software.
+
+License: X11
+ Permission is hereby granted, free of charge, to any person
+ obtaining a copy of this software and associated documentation
+ files (the "Software"), to deal in the Software without
+ restriction, including without limitation the rights to use, copy,
+ modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ Except as contained in this notice, the names of the authors or
+ their institutions shall not be used in advertising or otherwise to
+ promote the sale, use or other dealings in this Software without
+ prior written authorization from the authors.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3232,11 +3232,24 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
     nTimeBestReceived = GetTime();
     mempool.AddTransactionsUpdated(1);
 
-    LogPrintf("%s: new best=%s  height=%d bits=%d log2_work=%.8g  tx=%lu  date=%s progress=%f  cache=%.1fMiB(%utx)\n", __func__,
-      chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(), chainActive.Tip()->nBits,
-      log(chainActive.Tip()->nChainWork.getdouble())/log(2.0), (unsigned long)chainActive.Tip()->nChainTx,
-      DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
-      Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip()), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
+    auto hash = tfm::format("%s", chainActive.Tip()->GetBlockHash().ToString());
+    auto height = tfm::format("%d", chainActive.Height());
+    auto bits = tfm::format("%d", chainActive.Tip()->nBits);
+    auto log2_work = tfm::format("%.8g", log(chainActive.Tip()->nChainWork.getdouble())/log(2.0));
+    auto tx = tfm::format("%lu", (unsigned long)chainActive.Tip()->nChainTx);
+    auto date = DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime());
+    auto progress = tfm::format("%f", Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip()));
+    auto cache = tfm::format("%.1fMiB(%utx)", pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
+
+    TracingInfo("main", "UpdateTip: new best",
+        "hash", hash.c_str(),
+        "height", height.c_str(),
+        "bits", bits.c_str(),
+        "log2_work", log2_work.c_str(),
+        "tx", tx.c_str(),
+        "date", date.c_str(),
+        "progress", progress.c_str(),
+        "cache", cache.c_str());
 
     cvBlockChange.notify_all();
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2108,7 +2108,12 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     nPingUsecTime = 0;
     fPingQueued = false;
     nMinPingUsecTime = std::numeric_limits<int64_t>::max();
-    span = TracingSpan("info", "net", "CNode");
+
+    if (fLogIPs) {
+        span = TracingSpanFields("info", "net", "CNode", "addr", addrName.c_str());
+    } else {
+        span = TracingSpan("info", "net", "CNode");
+    }
     auto spanGuard = span.Enter();
 
     {

--- a/src/rust/include/tracing/map.h
+++ b/src/rust/include/tracing/map.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2012 William Swanson
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the names of the authors or
+ * their institutions shall not be used in advertising or otherwise to
+ * promote the sale, use or other dealings in this Software without
+ * prior written authorization from the authors.
+ */
+
+#ifndef MAP_H_INCLUDED
+#define MAP_H_INCLUDED
+
+#define EVAL0(...) __VA_ARGS__
+#define EVAL1(...) EVAL0(EVAL0(EVAL0(__VA_ARGS__)))
+#define EVAL2(...) EVAL1(EVAL1(EVAL1(__VA_ARGS__)))
+#define EVAL3(...) EVAL2(EVAL2(EVAL2(__VA_ARGS__)))
+#define EVAL4(...) EVAL3(EVAL3(EVAL3(__VA_ARGS__)))
+#define EVAL(...)  EVAL4(EVAL4(EVAL4(__VA_ARGS__)))
+
+#define MAP_END(...)
+#define MAP_OUT
+#define MAP_COMMA ,
+
+#define MAP_GET_END2() 0, MAP_END
+#define MAP_GET_END1(...) MAP_GET_END2
+#define MAP_GET_END(...) MAP_GET_END1
+#define MAP_NEXT0(test, next, ...) next MAP_OUT
+#define MAP_NEXT1(test, next) MAP_NEXT0(test, next, 0)
+#define MAP_NEXT(test, next)  MAP_NEXT1(MAP_GET_END test, next)
+
+#define MAP0(f, x, peek, ...) f(x) MAP_NEXT(peek, MAP1)(f, peek, __VA_ARGS__)
+#define MAP1(f, x, peek, ...) f(x) MAP_NEXT(peek, MAP0)(f, peek, __VA_ARGS__)
+
+#define MAP_LIST_NEXT1(test, next) MAP_NEXT0(test, MAP_COMMA next, 0)
+#define MAP_LIST_NEXT(test, next)  MAP_LIST_NEXT1(MAP_GET_END test, next)
+
+#define MAP_LIST0(f, x, peek, ...) f(x) MAP_LIST_NEXT(peek, MAP_LIST1)(f, peek, __VA_ARGS__)
+#define MAP_LIST1(f, x, peek, ...) f(x) MAP_LIST_NEXT(peek, MAP_LIST0)(f, peek, __VA_ARGS__)
+
+/**
+ * Applies the function macro `f` to each of the remaining parameters.
+ */
+#define MAP(f, ...) EVAL(MAP1(f, __VA_ARGS__, ()()(), ()()(), ()()(), 0))
+
+/**
+ * Applies the function macro `f` to each of the remaining parameters and
+ * inserts commas between the results.
+ */
+#define MAP_LIST(f, ...) EVAL(MAP_LIST1(f, __VA_ARGS__, ()()(), ()()(), ()()(), 0))
+
+#endif

--- a/src/rust/src/tracing_ffi.rs
+++ b/src/rust/src/tracing_ffi.rs
@@ -456,6 +456,7 @@ pub extern "C" fn tracing_span_create(
             .map(|&p| unsafe { CStr::from_ptr(p) })
             .map(|cs| cs.to_string_lossy());
 
+        use tracing::field::display;
         macro_rules! new_span {
             ($n:tt) => {
                 Span::new(
@@ -464,7 +465,7 @@ pub extern "C" fn tracing_span_create(
                         $n,
                         (
                             &fi.next().unwrap(),
-                            Some(&vi.next().unwrap().as_ref() as &dyn Value)
+                            Some(&display(vi.next().unwrap().as_ref()) as &dyn Value)
                         )
                     )),
                 )
@@ -562,6 +563,7 @@ pub extern "C" fn tracing_log(
             .map(|&p| unsafe { CStr::from_ptr(p) })
             .map(|cs| cs.to_string_lossy());
 
+        use tracing::field::display;
         macro_rules! dispatch {
             ($n:tt) => {
                 Event::dispatch(
@@ -570,7 +572,7 @@ pub extern "C" fn tracing_log(
                         $n,
                         (
                             &fi.next().unwrap(),
-                            Some(&vi.next().unwrap().as_ref() as &dyn Value)
+                            Some(&display(vi.next().unwrap().as_ref()) as &dyn Value)
                         )
                     )),
                 )

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -230,10 +230,10 @@ std::string LogConfigFilter()
     std::set<std::string> setCategories(categories.begin(), categories.end());
     if (setCategories.count(string("")) != 0 || setCategories.count(string("1")) != 0) {
         // Turn on the firehose!
-        filter = "info";
+        filter = "debug";
     } else {
         for (auto category : setCategories) {
-            filter += "," + category + "=info";
+            filter += "," + category + "=debug";
         }
     }
 

--- a/src/util.h
+++ b/src/util.h
@@ -79,17 +79,18 @@ std::string LogConfigFilter();
 /** Return true if log accepts specified category */
 bool LogAcceptCategory(const char* category);
 
-#define LogPrintf(...) LogPrint(NULL, __VA_ARGS__)
+/** Print to debug.log with level INFO and category "main". */
+#define LogPrintf(...) LogPrintInner("info", "main", __VA_ARGS__)
 
-/**   Print to debug.log if -debug=category switch is given OR category is NULL. */
-#define LogPrint(category, ...) do {                       \
+/** Print to debug.log with level DEBUG. */
+#define LogPrint(category, ...) LogPrintInner("debug", category, __VA_ARGS__)
+
+#define LogPrintInner(level, category, ...) do {           \
     std::string T_MSG = tfm::format(__VA_ARGS__);          \
     if (!T_MSG.empty() && T_MSG[T_MSG.size()-1] == '\n') { \
         T_MSG.erase(T_MSG.size()-1);                       \
     }                                                      \
-    TracingInfo(                                           \
-        category == NULL ? "main" : category,              \
-        T_MSG.c_str());                                    \
+    TracingLog(level, category, T_MSG.c_str());            \
 } while(0)
 
 #define LogError(category, ...) ([&]() {          \


### PR DESCRIPTION
Field values must be pointers to C strings, which in practice means that they
cannot be formatted inline (as the pointer must remain valid across the FFI).
This might be improved by future iterations of the macros.

`LogPrint()` is also moved to the DEBUG level, leaving `LogPrintf()` at INFO.