### PR TITLE
Improvements to tracing initialization

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -170,6 +170,11 @@ bool AppInit(int argc, char* argv[])
 
         // Set this early so that parameter interactions go to console
         InitLogging();
+
+        // Now that we have logging set up, start the initialization span.
+        auto span = TracingSpan("info", "main", "Init");
+        auto spanGuard = span.Enter();
+
         InitParameterInteraction();
         fRet = AppInit2(threadGroup, scheduler);
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -808,19 +808,21 @@ void InitLogging()
     // Set up the initial filtering directive from the -debug flags.
     std::string initialFilter = LogConfigFilter();
 
-    if (fPrintToConsole) {
-        pTracingHandle = tracing_init(nullptr, 0, initialFilter.c_str(), fLogTimestamps);
-    } else {
-        boost::filesystem::path pathDebug = GetDebugLogPath();
-        const boost::filesystem::path::string_type& pathDebugStr = pathDebug.native();
-        static_assert(sizeof(boost::filesystem::path::value_type) == sizeof(codeunit),
-                      "native path has unexpected code unit size");
-        pTracingHandle = tracing_init(
-            reinterpret_cast<const codeunit*>(pathDebugStr.c_str()),
-            pathDebugStr.length(),
-            initialFilter.c_str(),
-            fLogTimestamps);
+    boost::filesystem::path pathDebug = GetDebugLogPath();
+    const boost::filesystem::path::string_type& pathDebugStr = pathDebug.native();
+    static_assert(sizeof(boost::filesystem::path::value_type) == sizeof(codeunit),
+                    "native path has unexpected code unit size");
+    const codeunit* pathDebugCStr = nullptr;
+    size_t pathDebugLen = 0;
+    if (!fPrintToConsole) {
+        pathDebugCStr = reinterpret_cast<const codeunit*>(pathDebugStr.c_str());
+        pathDebugLen = pathDebugStr.length();
     }
+
+    pTracingHandle = tracing_init(
+        pathDebugCStr, pathDebugLen,
+        initialFilter.c_str(),
+        fLogTimestamps);
 
     LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     LogPrintf("Zcash version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -177,7 +177,9 @@ void Interrupt(boost::thread_group& threadGroup)
 
 void Shutdown()
 {
-    LogPrintf("%s: In progress...\n", __func__);
+    auto span = TracingSpan("info", "main", "Shutdown");
+    auto spanGuard = span.Enter();
+
     static CCriticalSection cs_Shutdown;
     TRY_LOCK(cs_Shutdown, lockShutdown);
     if (!lockShutdown)
@@ -260,7 +262,7 @@ void Shutdown()
 #endif
     globalVerifyHandle.reset();
     ECC_Stop();
-    LogPrintf("%s: done\n", __func__);
+    TracingInfo("main", "done");
     if (pTracingHandle) {
         tracing_free(pTracingHandle);
     }


### PR DESCRIPTION
The refactor makes it easier to implement further tracing customisations.

We also now have spans for `zcashd` initialization and shutdown.