### PR TITLE
Remove 'jessie' (debian 8) from suites list in linux gitian descriptors

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -3,7 +3,6 @@ name: "zcash-3.1.0"
 enable_cache: true
 distro: "debian"
 suites:
-- "jessie"
 - "stretch"
 architectures:
 - "amd64"


### PR DESCRIPTION
Debian 8 "jessie" support reached its end-of-life on June 30, 2020
https://www.debian.org/News/2020/20200709