### PR TITLE
ZIP 207 and ZIP 214 NCC comments

### DIFF
--- a/src/consensus/funding.cpp
+++ b/src/consensus/funding.cpp
@@ -10,7 +10,7 @@ namespace Consensus
  * General information about each funding stream.
  * Ordered by Consensus::FundingStreamIndex.
  */
-const struct FSInfo FundingStreamInfo[Consensus::MAX_FUNDING_STREAMS] = {
+constexpr struct FSInfo FundingStreamInfo[Consensus::MAX_FUNDING_STREAMS] = {
     {
         .recipient = "Electric Coin Company",
         .specification = "https://zips.z.cash/zip-0214",
@@ -30,6 +30,16 @@ const struct FSInfo FundingStreamInfo[Consensus::MAX_FUNDING_STREAMS] = {
         .valueDenominator = 100,
     }
 };
+
+static constexpr bool validateFundingStreamInfo(uint32_t idx) {
+    return (idx >= Consensus::MAX_FUNDING_STREAMS || (
+        FundingStreamInfo[idx].valueNumerator < FundingStreamInfo[idx].valueDenominator &&
+        FundingStreamInfo[idx].valueNumerator < (INT64_MAX / MAX_MONEY) &&
+        validateFundingStreamInfo(idx + 1)));
+}
+static_assert(
+    validateFundingStreamInfo(Consensus::FIRST_FUNDING_STREAM),
+    "Invalid FundingStreamInfo");
 
 CAmount FSInfo::Value(CAmount blockSubsidy) const
 {

--- a/src/consensus/funding.h
+++ b/src/consensus/funding.h
@@ -14,8 +14,8 @@ namespace Consensus
 {
 
 struct FSInfo {
-    std::string recipient;
-    std::string specification;
+    const char* recipient;
+    const char* specification;
     uint64_t valueNumerator;
     uint64_t valueDenominator;
 

--- a/src/consensus/params.cpp
+++ b/src/consensus/params.cpp
@@ -47,6 +47,9 @@ namespace Consensus {
      * first halving.
      */
     int Params::HalvingHeight(int nHeight, int halvingIndex) const {
+        assert(nHeight >= 0);
+        assert(halvingIndex > 0);
+
         // zip208
         // HalvingHeight(i) := max({ height ⦂ N | Halving(height) < i }) + 1
         //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4181,6 +4181,10 @@ bool ContextualCheckBlock(
 
     if (consensusParams.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_CANOPY)) {
         // Funding streams are checked inside ContextualCheckTransaction.
+        // This empty conditional branch exists to enforce this ZIP 207 consensus rule:
+        //
+        //     Once the Canopy network upgrade activates, the existing consensus rule for
+        //     payment of the Founders' Reward is no longer active.
     } else if ((nHeight > 0) && (nHeight <= consensusParams.GetLastFoundersRewardBlockHeight(nHeight))) {
         // Coinbase transaction must include an output sending 20% of
         // the block subsidy to a Founders' Reward script, until the last Founders'


### PR DESCRIPTION
Changes to the ZIP 207 and ZIP 214 implementations as suggested in the NCC audit.