### PR TITLE
WIP: wasm32 compatibility for librustzcash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +530,7 @@ dependencies = [
  "tracing-appender",
  "tracing-core",
  "tracing-subscriber",
+ "wasm-bindgen",
  "zcash_history",
  "zcash_primitives",
  "zcash_proofs",
@@ -934,6 +941,60 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,13 +450,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -521,9 +522,11 @@ dependencies = [
  "blake2s_simd",
  "bls12_381",
  "ed25519-zebra",
+ "getrandom",
  "group",
  "jubjub",
  "libc",
+ "rand",
  "rand_core",
  "subtle",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,10 @@ group = "0.7"
 libc = "0.2"
 jubjub = "0.4"
 subtle = "2.2"
+rand = { version = "0.7", features = ["wasm-bindgen"] }
 rand_core = "0.5.1"
+# 0.2.0 fails to build
+getrandom = { version = "=0.1.15", features = ["wasm-bindgen"] }
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-appender = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,9 @@ lto = true
 panic = 'abort'
 codegen-units = 1
 
-
 [features]
-
 wasm = ["wasm-bindgen"]
+
+# Deactivate optimisation. Fail otherwise
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 [lib]
 name = "rustzcash"
 path = "src/rust/src/rustzcash.rs"
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dependencies]
 bellman = "0.7"
@@ -36,6 +36,8 @@ zcash_primitives = "0.3"
 zcash_proofs = "0.3"
 ed25519-zebra = "2.0.0"
 
+wasm-bindgen = { version = "*", optional = true }
+
 [dependencies.tracing-subscriber]
 version = "0.2"
 default-features = false
@@ -45,3 +47,8 @@ features = ["ansi", "chrono", "env-filter"]
 lto = true
 panic = 'abort'
 codegen-units = 1
+
+
+[features]
+
+wasm = ["wasm-bindgen"]

--- a/src/rust/src/ed25519.rs
+++ b/src/rust/src/ed25519.rs
@@ -3,7 +3,18 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 use ed25519_zebra::{Signature, SigningKey, VerificationKey};
+
+#[cfg(feature = "wasm")]
+#[allow(non_camel_case_types)]
+#[cfg(feature = "wasm")]
+type c_uchar = u8;
+#[cfg(feature = "wasm")]
+#[allow(non_camel_case_types)]
+type size_t = usize;
+
+#[cfg(not(feature = "wasm"))]
 use libc::{c_uchar, size_t};
+
 use rand_core::OsRng;
 use std::convert::TryFrom;
 use std::slice;

--- a/src/rust/src/rustzcash.rs
+++ b/src/rust/src/rustzcash.rs
@@ -119,7 +119,6 @@ fn fixed_scalar_mult(from: &[u8; 32], p_g: &jubjub::SubgroupPoint) -> jubjub::Su
 /// Only called once.
 #[cfg(not(feature = "wasm"))]
 #[cfg(not(target_os = "windows"))]
-#[cfg(not(target_os = "windows"))]
 #[no_mangle]
 pub extern "C" fn librustzcash_init_zksnark_params(
     spend_path: *const u8,
@@ -574,7 +573,6 @@ const GROTH_PROOF_SIZE: usize = 48 // π_A
 /// commitment into the context.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_sapling_check_spend(
     ctx: *mut SaplingVerificationContext,
     cv: *const [c_uchar; 32],
@@ -632,7 +630,6 @@ pub extern "C" fn librustzcash_sapling_check_spend(
 /// commitment into the context.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_sapling_check_output(
     ctx: *mut SaplingVerificationContext,
     cv: *const [c_uchar; 32],
@@ -678,7 +675,6 @@ pub extern "C" fn librustzcash_sapling_check_output(
 /// valueBalance and the binding signature.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_sapling_final_check(
     ctx: *mut SaplingVerificationContext,
     value_balance: i64,
@@ -702,7 +698,6 @@ pub extern "C" fn librustzcash_sapling_final_check(
 /// Sprout JoinSplit proof generation.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_sprout_prove(
     proof_out: *mut [c_uchar; GROTH_PROOF_SIZE],
 
@@ -786,7 +781,6 @@ pub extern "C" fn librustzcash_sprout_prove(
 /// Sprout JoinSplit proof verification.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_sprout_verify(
     proof: *const [c_uchar; GROTH_PROOF_SIZE],
     rt: *const [c_uchar; 32],
@@ -820,7 +814,6 @@ pub extern "C" fn librustzcash_sprout_verify(
 /// the necessary witness information. It outputs `cv` and the `zkproof`.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_sapling_output_proof(
     ctx: *mut SaplingProvingContext,
     esk: *const [c_uchar; 32],
@@ -875,7 +868,6 @@ pub extern "C" fn librustzcash_sapling_output_proof(
 /// This function will fail if the provided `ask` or `ar` are invalid.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_sapling_spend_sig(
     ask: *const [c_uchar; 32],
     ar: *const [c_uchar; 32],
@@ -913,7 +905,6 @@ pub extern "C" fn librustzcash_sapling_spend_sig(
 /// consistency.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_sapling_binding_sig(
     ctx: *const SaplingProvingContext,
     value_balance: i64,
@@ -943,7 +934,6 @@ pub extern "C" fn librustzcash_sapling_binding_sig(
 /// `rk` (so that you don't have to compute it) along with the proof.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_sapling_spend_proof(
     ctx: *mut SaplingProvingContext,
     ak: *const [c_uchar; 32],
@@ -1044,7 +1034,6 @@ pub extern "C" fn librustzcash_sapling_spend_proof(
 /// Creates a Sapling proving context. Please free this when you're done.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_sapling_proving_ctx_init() -> *mut SaplingProvingContext {
     let ctx = Box::new(SaplingProvingContext::new());
 
@@ -1055,7 +1044,6 @@ pub extern "C" fn librustzcash_sapling_proving_ctx_init() -> *mut SaplingProving
 /// [`librustzcash_sapling_proving_ctx_init`].
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_sapling_proving_ctx_free(ctx: *mut SaplingProvingContext) {
     drop(unsafe { Box::from_raw(ctx) });
 }
@@ -1063,7 +1051,6 @@ pub extern "C" fn librustzcash_sapling_proving_ctx_free(ctx: *mut SaplingProving
 /// Derive the master ExtendedSpendingKey from a seed.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_zip32_xsk_master(
     seed: *const c_uchar,
     seedlen: size_t,
@@ -1080,7 +1067,6 @@ pub extern "C" fn librustzcash_zip32_xsk_master(
 /// Derive a child ExtendedSpendingKey from a parent.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_zip32_xsk_derive(
     xsk_parent: *const [c_uchar; 169],
     i: u32,
@@ -1099,7 +1085,6 @@ pub extern "C" fn librustzcash_zip32_xsk_derive(
 /// Derive a child ExtendedFullViewingKey from a parent.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_zip32_xfvk_derive(
     xfvk_parent: *const [c_uchar; 169],
     i: u32,
@@ -1123,7 +1108,6 @@ pub extern "C" fn librustzcash_zip32_xfvk_derive(
 /// Derive a PaymentAddress from an ExtendedFullViewingKey.
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_zip32_xfvk_address(
     xfvk: *const [c_uchar; 169],
     j: *const [c_uchar; 11],
@@ -1188,7 +1172,6 @@ fn construct_mmr_tree(
 
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "system" fn librustzcash_mmr_append(
     // Consensus branch id
     cbranch: u32,
@@ -1262,7 +1245,6 @@ pub extern "system" fn librustzcash_mmr_append(
 
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "system" fn librustzcash_mmr_delete(
     // Consensus branch id
     cbranch: u32,
@@ -1306,7 +1288,6 @@ pub extern "system" fn librustzcash_mmr_delete(
 
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "system" fn librustzcash_mmr_hash_node(
     cbranch: u32,
     n_ptr: *const [u8; zcash_history::MAX_NODE_DATA_SIZE],
@@ -1333,7 +1314,6 @@ pub extern "system" fn librustzcash_mmr_hash_node(
 
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "C" fn librustzcash_getrandom(buf: *mut u8, buf_len: usize) {
     let buf = unsafe { slice::from_raw_parts_mut(buf, buf_len) };
     OsRng.fill_bytes(buf);
@@ -1347,7 +1327,6 @@ const LIBSODIUM_ERROR: isize = -1;
 
 #[cfg_attr(not(feature = "wasm"), no_mangle)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-
 pub extern "system" fn librustzcash_zebra_crypto_sign_verify_detached(
     sig: *const [u8; 64],
     m: *const u8,

--- a/src/rust/src/tracing_ffi.rs
+++ b/src/rust/src/tracing_ffi.rs
@@ -1,4 +1,14 @@
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(feature = "wasm")]
+#[allow(non_camel_case_types)]
+#[cfg(feature = "wasm")]
+type c_char = i8;
+
+#[cfg(not(feature = "wasm"))]
 use libc::c_char;
+
 use std::ffi::CStr;
 use std::path::Path;
 use std::slice;
@@ -23,8 +33,10 @@ use tracing_subscriber::{
 };
 
 #[cfg(not(target_os = "windows"))]
+#[cfg(not(feature = "wasm"))]
 use std::ffi::OsStr;
 #[cfg(not(target_os = "windows"))]
+#[cfg(not(feature = "wasm"))]
 use std::os::unix::ffi::OsStrExt;
 
 #[cfg(target_os = "windows")]
@@ -52,6 +64,7 @@ pub struct TracingHandle {
 }
 
 #[no_mangle]
+#[cfg(not(feature = "wasm"))]
 pub extern "C" fn tracing_init(
     #[cfg(not(target_os = "windows"))] log_path: *const u8,
     #[cfg(target_os = "windows")] log_path: *const u16,
@@ -162,7 +175,8 @@ pub extern "C" fn tracing_free(handle: *mut TracingHandle) {
     drop(unsafe { Box::from_raw(handle) });
 }
 
-#[no_mangle]
+#[cfg_attr(not(feature = "wasm"), no_mangle)]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub extern "C" fn tracing_reload(handle: *mut TracingHandle, new_filter: *const c_char) -> bool {
     let handle = unsafe { &mut *handle };
 
@@ -247,7 +261,8 @@ impl Callsite for FfiCallsite {
     }
 }
 
-#[no_mangle]
+#[cfg_attr(not(feature = "wasm"), no_mangle)]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub extern "C" fn tracing_callsite(
     name: *const c_char,
     target: *const c_char,


### PR DESCRIPTION
This is an attempt of making librustzcash compatible with the target wasm32, to be used further in the browser or node, using [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen).
At the time of writing, tests are in progress. I opened this PR to get feedback and to know if it is a feature requested. 
Experimentations are going to be shared here.
Partially related to https://github.com/zcash/zcash/issues/3102 and https://github.com/zcash/zcash/projects/25#card-16748555

## Description

Export librustzcash functions in wasm/JS.

## TODO

- [ ] `librustzcash_init_zksnark_params` is not yet exported

## How to test

First, install [wasm-pack](https://github.com/rustwasm/wasm-pack) to ease the building process and get interesting ready NPM packages for NodeJS and the browser
Let's compile for use in NodeJS
```shell
wasm-pack build --target nodejs --out-dir nodejs -- --features wasm
```
In the directory `nodejs`, a NPM package has been created with the wasm code. You can play with the package in Node using
```shell
node --experimental-modules --experimental-wasm-modules
```

```javascript
var f = require("./rustzcash.js");
[...]
```

`wasm-pack` also provides a bundler ready package to be used in the browser after `webpack`:
```shell
wasm-pack build --target bundler --out-dir bundler -- --features wasm
```

## Example

- https://gitlab.com/dannywillems/librustzcash-browser (WIP)