### PR TITLE
./depends/zcutil scripts for extracting url/hash info for dependencies and checking downloadability.

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -55,4 +55,4 @@ Additional targets:
 
 - [description.md](description.md): General description of the depends system
 - [packages.md](packages.md): Steps for adding packages
-
+- [zcutil/README.md](./zcutil/README.md): Zcash auxillary tools

--- a/depends/zcutil/README.md
+++ b/depends/zcutil/README.md
@@ -1,0 +1,19 @@
+# Zcash auxillary tools
+
+This directory has "auxillary" utilities for managing the depends system
+and dependencies.
+
+Specifically "auxillary" means *none of these should be required
+for developer or release builds*, but instead may be used by other
+infrastructure such as tarball link checking, caching, etc…
+
+## utilities
+
+### parse-dependency-urls.py
+
+Parse out package source URL and hashes from the makefiles. It follows
+convention and can't do sophisticated make interpretation.
+
+### download-and-check.sh
+
+Download and check sources based on output of `parse-dependency-urls.py`.

--- a/depends/zcutil/download-and-check.sh
+++ b/depends/zcutil/download-and-check.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Attempt to download all the files and check their hashes against the
+# expected hashes.
+
+set -efuo pipefail
+
+ZCUTIL="$(dirname "$(readlink -f "$0")")"
+OUTDIR="$(mktemp --directory --tmpdir 'zc-dep-sources.XXX')"
+
+echo "Downloading to: $OUTDIR"
+cd "$OUTDIR"
+
+for entry in $("$ZCUTIL/parse-dependency-urls.py" | jq -c '.[]')
+do
+    url="$(echo "$entry" | jq -r .url)"  
+    fname="$(echo "$url" | sed 's,^.*/\([^/]*\)$,\1,')"
+    sha256="$(echo "$entry" | jq -r .sha256)"  
+
+    echo "= Downloading: $url -> $fname"
+    echo "${sha256}  ${fname}" >> sha256sums.txt
+    wget "$url" || echo "Warning: failed to download $url"
+    echo
+done
+
+echo "Checking sha256sums.txt:"
+sha256sum --check --quiet ./sha256sums.txt

--- a/depends/zcutil/download-and-check.sh
+++ b/depends/zcutil/download-and-check.sh
@@ -23,5 +23,5 @@ do
     echo
 done
 
-echo "Checking sha256sums.txt:"
+echo "Checking sha256sums.txt..."
 sha256sum --check --quiet ./sha256sums.txt

--- a/depends/zcutil/parse-dependency-urls.py
+++ b/depends/zcutil/parse-dependency-urls.py
@@ -13,10 +13,9 @@ SKIP = ['packages.mk', 'vendorcrate.mk']
 def main():
     result = []
 
-    zcutil = Path(sys.argv[0]).resolve().parent
-    depends = (zcutil / '..' / 'depends' / 'packages').resolve()
+    dependsdir = Path(sys.argv[0]).parent.parent.resolve()
     #info(f'Scanning packages: {depends}')
-    for p in depends.glob('*.mk'):
+    for p in (dependsdir / 'packages').glob('*.mk'):
         if p.name in SKIP:
             continue
 

--- a/depends/zcutil/parse-dependency-urls.py
+++ b/depends/zcutil/parse-dependency-urls.py
@@ -50,23 +50,26 @@ def extract_source_info(path):
         suffix = '' if platform == 'default' else f'_{platform}'
  
         try:
-            urlfile = resolver[f'$(package)_file_name{suffix}']
+            urlfile = resolver[f'$(package)_download_file{suffix}']
         except KeyError:
-            pass
-        else:
             try:
-                sha256 = resolver[f'$(package)_sha256_hash{suffix}']
-            except KeyError as e:
-                e.args += (f'Found url for {platform!r} but no sha256 hash.',)
-                raise
-            else:
-                found = True
-                yield {
-                    'package': f'{pkgbase}{suffix}',
-                    'version': version,
-                    'url': f'{urlbase}/{urlfile}',
-                    'sha256': sha256,
-                }
+                urlfile = resolver[f'$(package)_file_name{suffix}']
+            except KeyError:
+                continue
+
+        try:
+            sha256 = resolver[f'$(package)_sha256_hash{suffix}']
+        except KeyError as e:
+            e.args += (f'Found url for {platform!r} but no sha256 hash.',)
+            raise
+        else:
+            found = True
+            yield {
+                'package': f'{pkgbase}{suffix}',
+                'version': version,
+                'url': f'{urlbase}/{urlfile}',
+                'sha256': sha256,
+            }
 
     assert found, 'Could not find $(package)_file_name* make variables'
 

--- a/zcutil/parse-dependency-urls.py
+++ b/zcutil/parse-dependency-urls.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+"""
+Parse dependency name, version, url, and sha256 from `./depends` makefiles.
+"""
 
 import re
 import sys

--- a/zcutil/parse-dependency-urls.py
+++ b/zcutil/parse-dependency-urls.py
@@ -42,7 +42,7 @@ def extract_source_info(path):
 
     resolver = Resolver(rawparams)
 
-    urlbase = resolver['$(package)_download_path']
+    urlbase = resolver['$(package)_download_path'].rstrip('/')
 
     urlhashes = {}
     for platform in ['default', 'linux', 'darwin', 'freebsd']:

--- a/zcutil/parse-dependency-urls.py
+++ b/zcutil/parse-dependency-urls.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+import json
+from pathlib import Path
+
+SKIP = ['packages.mk', 'vendorcrate.mk']
+
+def main():
+    result = {}
+
+    zcutil = Path(sys.argv[0]).resolve().parent
+    depends = (zcutil / '..' / 'depends' / 'packages').resolve()
+    #info(f'Scanning packages: {depends}')
+    for p in depends.glob('*.mk'):
+        if p.name in SKIP:
+            continue
+
+        #info(f'Parsing: {p}')
+        try:
+            pkginfo = extract_source_info(p)
+        except Exception as e:
+            warn(f'Skipping {p}: {e}')
+            raise
+        else:
+            result[pkginfo['package']] = pkginfo
+
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+
+
+def extract_source_info(path):
+    paramrgx = re.compile(r'^(?P<key>\S+)=(?P<value>.*)$')
+    rawparams = {}
+    for line in path.open('r'):
+        m = paramrgx.match(line)
+        if m:
+            rawparams[m.group('key')] = m.group('value') 
+
+    resolver = Resolver(rawparams)
+
+    urlbase = resolver['$(package)_download_path']
+
+    urlhashes = {}
+    for platform in ['default', 'linux', 'darwin', 'freebsd']:
+        suffix = '' if platform == 'default' else f'_{platform}'
+ 
+        try:
+            urlfile = resolver[f'$(package)_file_name{suffix}']
+        except KeyError:
+            pass
+        else:
+            try:
+                sha256 = resolver[f'$(package)_sha256_hash{suffix}']
+            except KeyError as e:
+                e.args += (f'Found url for {platform!r} but no sha256 hash.',)
+                raise
+            else:
+                urlhashes[platform] = {
+                    'url': f'{urlbase}/{urlfile}',
+                    'sha256': sha256,
+                }
+
+    assert len(urlhashes) > 0, 'Could not find $(package)_file_name* make variables'
+
+    return {
+        'package': resolver['package'],
+        'version': resolver['$(package)_version'],
+        'urls': urlhashes,
+    }
+
+
+class Resolver:
+    def __init__(self, rawparams):
+        self._rp = rawparams
+
+    def __getitem__(self, key):
+        # truly awful hack
+        try:
+            rawval = self._rp[key]
+        except KeyError as e:
+            e.args += (f'Missing key {key!r} in params {self._rp.keys()}',)
+            raise
+        else:
+            return self._cook(rawval)
+
+    def _cook(self, rawval):
+        cooked = ''
+        state = 'base'
+        depth = None
+        key = None
+        for i, c in enumerate(rawval):
+            if state == 'base':
+                if c == '$':
+                    state = 'expecting-expansion'
+                else:
+                    cooked += c
+            elif state == 'expecting-expansion':
+                assert c == '(', f"expected '(', found {c!r} at col {i+1} in {rawval!r}; cooked: {cooked!r}"
+                state = 'expansion' 
+                depth = 1
+                key = ''
+            elif state == 'expansion':
+                assert isinstance(depth, int), repr(locals())
+                assert isinstance(key, str), repr(locals())
+                if c == '(':
+                    depth += 1
+                    key += c
+                elif c == ')':
+                    depth -= 1
+                    if depth == 0:
+                        try:
+                            cooked += self._rp[key]
+                        except KeyError as e:
+                            e.args += (f'rawval: {rawval!r}; cooked: {cooked!r}; key: {key!r}',)
+                            raise
+                        state = 'base'
+                        depth = None
+                        key = None
+                    else:
+                        key += c
+                else:
+                    key += c
+
+        return cooked
+            
+
+def info(msg):
+    sys.stderr.write(f'{msg}\n')
+
+
+def warn(s):
+    info(f'WARNING: {s}')
+    
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds two scripts inside a new ./depends/zcutil directory: one extracts the URL/hash information for all dependencies. The other one uses that to download them all and check the hashes.

This is redundant with the ./depends makefile system, but it's a pain to extract the urls and hashes, which is useful in other contexts like caching docker layers, alternative build systems, etc…

I personally made these as a transition step on a Fun Friday project to replace the depends system.

> Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the > PR creator and by anyone who reviews the PR.
> * [ ] Relevant documentation for this PR has to be completed and reviewed by @mdr0id before the PR can be merged

I'm not sure what this relevant documentation requirement is. This PR updates `./depends/README.md` with a link then it adds `./depends/zcutil/README.md` which specifies a *requirement* that nothing in the build or packaging pipeline must depend on these utilities.

> * [ ] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release

A basic test plan (which could be automated but isn't currently):

- Ensure that `./depends/zcutil/parse-dependency-urls.py` executes with a 0 exit status. If any dependency makefiles change to break the assumptions of this python script, it will probably throw an exception. Note that this test should be fully reproducible because it only parses the depends makefiles, and the output should always match the input files.
- Ensure that `./depends/zcutil/download-and-check.sh` exits with a 0 exit status. This would ensure every dependency's *primary* url can be fetched and that the hashes match.

> As a note, all buildbot tests need to be passing and all appropriate code reviews need to be done before this PR can be merged
