### PR TITLE
depends download: fix a logging bug for multi-archive packages:

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -138,7 +138,7 @@ endef
 define check_or_remove_sources
   mkdir -p $($(package)_source_dir); cd $($(package)_source_dir); \
   $(build_SHA256SUM) -c $($(package)_fetched) >/dev/null 2>/dev/null || \
-    ( if test -f $($(package)_all_sources); then echo "Checksum missing or mismatched for $(package) source. Forcing re-download."; fi; \
+    ( ( echo $($(package)_all_sources) | xargs -n 1 test -f ) || echo "Checksum missing or mismatched for $(package) source. Forcing re-download."; \
       rm -f $($(package)_all_sources) $($(1)_fetched))
 endef
 


### PR DESCRIPTION
No documentation change needed.

The test plan appears below. Since this bug output should appear on all builds without a pre-existing source cache, then an easier test plan might be to verify the bug output is not present from an infrastructure build log that doesn't rely on cached sources.

# Bug Behavior

While initially fetching packages, I saw `sh: test:` error messages in the make output for only two packages. However, it appears all packages are correctly fetched.

See detailed output appendix for demonstration of the bug output and conditions compared to with this patch for the same conditions.

# Analysis

## Design Requirements

The intent of the `check_or_remove_sources` is to fetch sources if either existing archive hashes do not match or the archives aren't present.

Additionally, this should report hash mismatches and be quiet about missing files.

## Bug Source

The second design requirement goal has a bug for multi-archive packages which define `$(package)_extra_sources)` because `test -f $($(package)_all_sources)` passes more than one argument to `test -f` which is not supported. If sha256sum fails in any case for multi-archive packages, a `sh: test` error line is always printed.

Aside from this spurious output, this bug has no effect, I believe. Fortunately this bug does not bypass the hash check!

## Testing

I tested this patch manually by running the same three tests against the `v4.0.0` tag and then again repeating those same three steps with this patch. In all 6 cases I visually inspected the output.

1. Starting with a pre-downloaded source cash, run the `download` target.
2. Remove an archive from a multi-archive package, then rerun `download`.
3. Alter a hash to cause a hash mismatch condition, then rerun `download`.

I believe after each step both with and without this patch the resulting source cache should be identical (except for filesystem timestamps).

### Testing v4.0.0 without this patch

Notice in the second and third steps the same bug output:

```
/bin/sh: 1: test: rust-std-1.42.0-x86_64-apple-darwin.tar.gz: unexpected operator
```
