### PR TITLE
Replace libsodium BLAKE2b usage with blake2b_simd crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,7 @@ name = "librustzcash"
 version = "0.2.0"
 dependencies = [
  "bellman",
+ "blake2b_simd",
  "blake2s_simd",
  "bls12_381",
  "ed25519-zebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 bellman = "0.8"
+blake2b_simd = "0.5"
 blake2s_simd = "0.5"
 bls12_381 = "0.3"
 group = "0.8"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -593,7 +593,7 @@ endif
 
 libzcashconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
 libzcashconsensus_la_LIBADD = $(LIBSECP256K1)
-libzcashconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
+libzcashconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/rust/include -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
 libzcashconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
 endif

--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -21,6 +21,16 @@
 #include "util.h"
 
 
+void eh_HashState::Update(const unsigned char *input, size_t inputLen)
+{
+    blake2b_update(inner.get(), input, inputLen);
+}
+
+void eh_HashState::Finalize(unsigned char *hash, size_t hLen)
+{
+    blake2b_finalize(inner.get(), hash, hLen);
+}
+
 // Used in TestEquihashValidator.
 
 void CompressArray(const unsigned char* in, size_t in_len,
@@ -143,30 +153,24 @@ std::vector<unsigned char> GetMinimalFromIndices(std::vector<eh_index> indices,
 static EhSolverCancelledException solver_cancelled;
 
 template<unsigned int N, unsigned int K>
-int Equihash<N,K>::InitialiseState(eh_HashState& base_state)
+void Equihash<N,K>::InitialiseState(eh_HashState& base_state)
 {
     uint32_t le_N = htole32(N);
     uint32_t le_K = htole32(K);
-    unsigned char personalization[crypto_generichash_blake2b_PERSONALBYTES] = {};
+    unsigned char personalization[BLAKE2bPersonalBytes] = {};
     memcpy(personalization, "ZcashPoW", 8);
     memcpy(personalization+8,  &le_N, 4);
     memcpy(personalization+12, &le_K, 4);
-    return crypto_generichash_blake2b_init_salt_personal(&base_state,
-                                                         NULL, 0, // No key.
-                                                         (512/N)*N/8,
-                                                         NULL,    // No salt.
-                                                         personalization);
+    base_state = eh_HashState((512/N)*N/8, personalization);
 }
 
 void GenerateHash(const eh_HashState& base_state, eh_index g,
                   unsigned char* hash, size_t hLen)
 {
-    eh_HashState state;
-    state = base_state;
+    eh_HashState state(base_state);
     eh_index lei = htole32(g);
-    crypto_generichash_blake2b_update(&state, (const unsigned char*) &lei,
-                                      sizeof(eh_index));
-    crypto_generichash_blake2b_final(&state, hash, hLen);
+    state.Update((const unsigned char*) &lei, sizeof(eh_index));
+    state.Finalize(hash, hLen);
 }
 
 // Big-endian so that lexicographic array comparison is equivalent to integer
@@ -724,7 +728,7 @@ invalidsolution:
 }
 
 // Explicit instantiations for Equihash<96,3>
-template int Equihash<96,3>::InitialiseState(eh_HashState& base_state);
+template void Equihash<96,3>::InitialiseState(eh_HashState& base_state);
 template bool Equihash<96,3>::BasicSolve(const eh_HashState& base_state,
                                          const std::function<bool(std::vector<unsigned char>)> validBlock,
                                          const std::function<bool(EhSolverCancelCheck)> cancelled);
@@ -733,7 +737,7 @@ template bool Equihash<96,3>::OptimisedSolve(const eh_HashState& base_state,
                                              const std::function<bool(EhSolverCancelCheck)> cancelled);
 
 // Explicit instantiations for Equihash<200,9>
-template int Equihash<200,9>::InitialiseState(eh_HashState& base_state);
+template void Equihash<200,9>::InitialiseState(eh_HashState& base_state);
 template bool Equihash<200,9>::BasicSolve(const eh_HashState& base_state,
                                           const std::function<bool(std::vector<unsigned char>)> validBlock,
                                           const std::function<bool(EhSolverCancelCheck)> cancelled);
@@ -742,7 +746,7 @@ template bool Equihash<200,9>::OptimisedSolve(const eh_HashState& base_state,
                                               const std::function<bool(EhSolverCancelCheck)> cancelled);
 
 // Explicit instantiations for Equihash<96,5>
-template int Equihash<96,5>::InitialiseState(eh_HashState& base_state);
+template void Equihash<96,5>::InitialiseState(eh_HashState& base_state);
 template bool Equihash<96,5>::BasicSolve(const eh_HashState& base_state,
                                          const std::function<bool(std::vector<unsigned char>)> validBlock,
                                          const std::function<bool(EhSolverCancelCheck)> cancelled);
@@ -751,7 +755,7 @@ template bool Equihash<96,5>::OptimisedSolve(const eh_HashState& base_state,
                                              const std::function<bool(EhSolverCancelCheck)> cancelled);
 
 // Explicit instantiations for Equihash<48,5>
-template int Equihash<48,5>::InitialiseState(eh_HashState& base_state);
+template void Equihash<48,5>::InitialiseState(eh_HashState& base_state);
 template bool Equihash<48,5>::BasicSolve(const eh_HashState& base_state,
                                          const std::function<bool(std::vector<unsigned char>)> validBlock,
                                          const std::function<bool(EhSolverCancelCheck)> cancelled);

--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -32,8 +32,6 @@ void EhIndexToArray(const eh_index i, unsigned char* array);
 #include "crypto/sha256.h"
 #include "utilstrencodings.h"
 
-#include "sodium.h"
-
 #include <cstring>
 #include <exception>
 #include <stdexcept>
@@ -41,8 +39,35 @@ void EhIndexToArray(const eh_index i, unsigned char* array);
 #include <set>
 
 #include <boost/static_assert.hpp>
+#include <rust/blake2b.h>
 
-typedef crypto_generichash_blake2b_state eh_HashState;
+struct eh_HashState {
+    std::unique_ptr<BLAKE2bState, decltype(&blake2b_free)> inner;
+
+    eh_HashState() : inner(nullptr, blake2b_free) {}
+
+    eh_HashState(size_t length, unsigned char personalization[BLAKE2bPersonalBytes]) : inner(blake2b_init(length, personalization), blake2b_free) {}
+
+    eh_HashState(eh_HashState&& baseState) : inner(std::move(baseState.inner)) {}
+    eh_HashState(const eh_HashState& baseState) : inner(blake2b_clone(baseState.inner.get()), blake2b_free) {}
+    eh_HashState& operator=(eh_HashState&& baseState)
+    {
+        if (this != &baseState) {
+            inner = std::move(baseState.inner);
+        }
+        return *this;
+    }
+    eh_HashState& operator=(const eh_HashState& baseState)
+    {
+        if (this != &baseState) {
+            inner.reset(blake2b_clone(baseState.inner.get()));
+        }
+        return *this;
+    }
+
+    void Update(const unsigned char *input, size_t inputLen);
+    void Finalize(unsigned char *hash, size_t hLen);
+};
 
 eh_index ArrayToEhIndex(const unsigned char* array);
 eh_trunc TruncateIndex(const eh_index i, const unsigned int ilen);
@@ -188,7 +213,7 @@ public:
 
     Equihash() { }
 
-    int InitialiseState(eh_HashState& base_state);
+    void InitialiseState(eh_HashState& base_state);
     bool BasicSolve(const eh_HashState& base_state,
                     const std::function<bool(std::vector<unsigned char>)> validBlock,
                     const std::function<bool(EhSolverCancelCheck)> cancelled);

--- a/src/gtest/test_equihash.cpp
+++ b/src/gtest/test_equihash.cpp
@@ -86,10 +86,10 @@ TEST(EquihashTests, IsProbablyDuplicate) {
 
 TEST(EquihashTests, CheckBasicSolverCancelled) {
     Equihash<48,5> Eh48_5;
-    crypto_generichash_blake2b_state state;
+    eh_HashState state;
     Eh48_5.InitialiseState(state);
     uint256 V = uint256S("0x00");
-    crypto_generichash_blake2b_update(&state, V.begin(), V.size());
+    state.Update(V.begin(), V.size());
 
     {
         ASSERT_NO_THROW(Eh48_5.BasicSolve(state, [](std::vector<unsigned char> soln) {
@@ -190,10 +190,10 @@ TEST(EquihashTests, CheckBasicSolverCancelled) {
 
 TEST(EquihashTests, CheckOptimisedSolverCancelled) {
     Equihash<48,5> Eh48_5;
-    crypto_generichash_blake2b_state state;
+    eh_HashState state;
     Eh48_5.InitialiseState(state);
     uint256 V = uint256S("0x00");
-    crypto_generichash_blake2b_update(&state, V.begin(), V.size());
+    state.Update(V.begin(), V.size());
 
     {
         ASSERT_NO_THROW(Eh48_5.OptimisedSolve(state, [](std::vector<unsigned char> soln) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -35,7 +35,6 @@
 #include "validationinterface.h"
 
 #include <librustzcash.h>
-#include "sodium.h"
 
 #include <boost/thread.hpp>
 #include <boost/tuple/tuple.hpp>
@@ -796,7 +795,7 @@ void static BitcoinMiner(const CChainParams& chainparams)
 
             while (true) {
                 // Hash state
-                crypto_generichash_blake2b_state state;
+                eh_HashState state;
                 EhInitialiseState(n, k, state);
 
                 // I = the block header minus nonce and solution.
@@ -805,14 +804,12 @@ void static BitcoinMiner(const CChainParams& chainparams)
                 ss << I;
 
                 // H(I||...
-                crypto_generichash_blake2b_update(&state, (unsigned char*)&ss[0], ss.size());
+                state.Update((unsigned char*)&ss[0], ss.size());
 
                 // H(I||V||...
-                crypto_generichash_blake2b_state curr_state;
+                eh_HashState curr_state;
                 curr_state = state;
-                crypto_generichash_blake2b_update(&curr_state,
-                                                  pblock->nNonce.begin(),
-                                                  pblock->nNonce.size());
+                curr_state.Update(pblock->nNonce.begin(), pblock->nNonce.size());
 
                 // (x_1, x_2, ...) = A(I, V, n, k)
                 LogPrint("pow", "Running Equihash solver \"%s\" with nNonce = %s\n",
@@ -860,7 +857,7 @@ void static BitcoinMiner(const CChainParams& chainparams)
                 if (solver == "tromp") {
                     // Create solver and initialize it.
                     equi eq(1);
-                    eq.setstate(&curr_state);
+                    eq.setstate(curr_state.inner.get());
 
                     // Initialization done, start algo driver.
                     eq.digit0(0);

--- a/src/rust/include/rust/blake2b.h
+++ b/src/rust/include/rust/blake2b.h
@@ -41,8 +41,8 @@ void blake2b_update(
 
 /// Finalizes the `state` and stores the result in `output`.
 ///
-/// `output_len` MUST be the same value as was passed as the first parameter to
-/// `blake2b_init`.
+/// `output_len` MUST be less than or equal to the value that was passed as the
+/// first parameter to `blake2b_init`.
 ///
 /// This method is idempotent, and calling it multiple times will give the same
 /// result. It's also possible to call `blake2b_update` with more input in

--- a/src/rust/include/rust/blake2b.h
+++ b/src/rust/include/rust/blake2b.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#ifndef BLAKE2B_INCLUDE_H_
+#define BLAKE2B_INCLUDE_H_
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct BLAKE2bState;
+typedef struct BLAKE2bState BLAKE2bState;
+#define BLAKE2bPersonalBytes 16U
+
+/// Initializes a BLAKE2b state with no key and no salt.
+///
+/// `personalization` MUST be a pointer to a 16-byte array.
+///
+/// Please free this with `blake2b_free` when you are done.
+BLAKE2bState* blake2b_init(
+    size_t output_len,
+    const unsigned char* personalization);
+
+/// Clones the given BLAKE2b state.
+///
+/// Both states need to be separately freed with `blake2b_free` when you are
+/// done.
+BLAKE2bState* blake2b_clone(const BLAKE2bState* state);
+
+/// Frees a BLAKE2b state returned by `blake2b_init`.
+void blake2b_free(BLAKE2bState* state);
+
+/// Adds input to the hash. You can call this any number of times.
+void blake2b_update(
+    BLAKE2bState* state,
+    const unsigned char* input,
+    size_t input_len);
+
+/// Finalizes the `state` and stores the result in `output`.
+///
+/// `output_len` MUST be the same value as was passed as the first parameter to
+/// `blake2b_init`.
+///
+/// This method is idempotent, and calling it multiple times will give the same
+/// result. It's also possible to call `blake2b_update` with more input in
+/// between.
+void blake2b_finalize(
+    BLAKE2bState* state,
+    unsigned char* output,
+    size_t output_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BLAKE2B_INCLUDE_H_

--- a/src/rust/include/tracing.h
+++ b/src/rust/include/tracing.h
@@ -221,9 +221,9 @@ public:
     /// Use the `TracingSpan` macro instead of calling this constructor directly.
     Span(const TracingCallsite* callsite, const char* const* field_values, size_t fields_len) : inner(tracing_span_create(callsite, field_values, fields_len), tracing_span_free) {}
 
-    Span(Span& span) : inner(std::move(span.inner)) {}
+    Span(Span&& span) : inner(std::move(span.inner)) {}
     Span(const Span& span) : inner(tracing_span_clone(span.inner.get()), tracing_span_free) {}
-    Span& operator=(Span& span)
+    Span& operator=(Span&& span)
     {
         if (this != &span) {
             inner = std::move(span.inner);

--- a/src/rust/src/blake2b.rs
+++ b/src/rust/src/blake2b.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+use blake2b_simd::{State, PERSONALBYTES};
+use libc::{c_uchar, size_t};
+use std::ptr;
+use std::slice;
+
+#[no_mangle]
+pub extern "C" fn blake2b_init(
+    output_len: size_t,
+    personalization: *const [c_uchar; PERSONALBYTES],
+) -> *mut State {
+    let personalization = unsafe { personalization.as_ref().unwrap() };
+
+    Box::into_raw(Box::new(
+        blake2b_simd::Params::new()
+            .hash_length(output_len)
+            .personal(personalization)
+            .to_state(),
+    ))
+}
+
+#[no_mangle]
+pub extern "C" fn blake2b_clone(state: *const State) -> *mut State {
+    unsafe { state.as_ref() }
+        .map(|state| Box::into_raw(Box::new(state.clone())))
+        .unwrap_or(ptr::null_mut())
+}
+
+#[no_mangle]
+pub extern "C" fn blake2b_free(state: *mut State) {
+    if !state.is_null() {
+        drop(unsafe { Box::from_raw(state) });
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn blake2b_update(state: *mut State, input: *const c_uchar, input_len: size_t) {
+    let state = unsafe { state.as_mut().unwrap() };
+    let input = unsafe { slice::from_raw_parts(input, input_len) };
+
+    state.update(input);
+}
+
+#[no_mangle]
+pub extern "C" fn blake2b_finalize(state: *mut State, output: *mut c_uchar, output_len: size_t) {
+    let state = unsafe { state.as_mut().unwrap() };
+    let output = unsafe { slice::from_raw_parts_mut(output, output_len) };
+
+    output.copy_from_slice(state.finalize().as_bytes());
+}

--- a/src/rust/src/blake2b.rs
+++ b/src/rust/src/blake2b.rs
@@ -49,5 +49,8 @@ pub extern "C" fn blake2b_finalize(state: *mut State, output: *mut c_uchar, outp
     let state = unsafe { state.as_mut().unwrap() };
     let output = unsafe { slice::from_raw_parts_mut(output, output_len) };
 
-    output.copy_from_slice(state.finalize().as_bytes());
+    // Allow consuming only part of the output.
+    let hash = state.finalize();
+    assert!(output_len <= hash.as_bytes().len());
+    output.copy_from_slice(&hash.as_bytes()[..output_len]);
 }

--- a/src/rust/src/rustzcash.rs
+++ b/src/rust/src/rustzcash.rs
@@ -61,6 +61,7 @@ use zcash_proofs::{
 
 use zcash_history::{Entry as MMREntry, NodeData as MMRNodeData, Tree as MMRTree};
 
+mod blake2b;
 mod ed25519;
 mod tracing_ffi;
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -14,6 +14,8 @@
 #include "script/script.h"
 #include "uint256.h"
 
+#include <librustzcash.h>
+
 using namespace std;
 
 typedef vector<unsigned char> valtype;
@@ -1057,17 +1059,17 @@ public:
     }
 };
 
-const unsigned char ZCASH_PREVOUTS_HASH_PERSONALIZATION[crypto_generichash_blake2b_PERSONALBYTES] =
+const unsigned char ZCASH_PREVOUTS_HASH_PERSONALIZATION[BLAKE2bPersonalBytes] =
     {'Z','c','a','s','h','P','r','e','v','o','u','t','H','a','s','h'};
-const unsigned char ZCASH_SEQUENCE_HASH_PERSONALIZATION[crypto_generichash_blake2b_PERSONALBYTES] =
+const unsigned char ZCASH_SEQUENCE_HASH_PERSONALIZATION[BLAKE2bPersonalBytes] =
     {'Z','c','a','s','h','S','e','q','u','e','n','c','H','a','s','h'};
-const unsigned char ZCASH_OUTPUTS_HASH_PERSONALIZATION[crypto_generichash_blake2b_PERSONALBYTES] =
+const unsigned char ZCASH_OUTPUTS_HASH_PERSONALIZATION[BLAKE2bPersonalBytes] =
     {'Z','c','a','s','h','O','u','t','p','u','t','s','H','a','s','h'};
-const unsigned char ZCASH_JOINSPLITS_HASH_PERSONALIZATION[crypto_generichash_blake2b_PERSONALBYTES] =
+const unsigned char ZCASH_JOINSPLITS_HASH_PERSONALIZATION[BLAKE2bPersonalBytes] =
     {'Z','c','a','s','h','J','S','p','l','i','t','s','H','a','s','h'};
-const unsigned char ZCASH_SHIELDED_SPENDS_HASH_PERSONALIZATION[crypto_generichash_blake2b_PERSONALBYTES] =
+const unsigned char ZCASH_SHIELDED_SPENDS_HASH_PERSONALIZATION[BLAKE2bPersonalBytes] =
     {'Z','c','a','s','h','S','S','p','e','n','d','s','H','a','s','h'};
-const unsigned char ZCASH_SHIELDED_OUTPUTS_HASH_PERSONALIZATION[crypto_generichash_blake2b_PERSONALBYTES] =
+const unsigned char ZCASH_SHIELDED_OUTPUTS_HASH_PERSONALIZATION[BLAKE2bPersonalBytes] =
     {'Z','c','a','s','h','S','O','u','t','p','u','t','H','a','s','h'};
 
 uint256 GetPrevoutHash(const CTransaction& txTo) {

--- a/src/test/equihash_tests.cpp
+++ b/src/test/equihash_tests.cpp
@@ -13,8 +13,6 @@
 #include "test/test_bitcoin.h"
 #include "uint256.h"
 
-#include "sodium.h"
-
 #include "librustzcash.h"
 
 #include <sstream>
@@ -49,12 +47,12 @@ void PrintSolutions(std::stringstream &strm, std::set<std::vector<uint32_t>> sol
 #ifdef ENABLE_MINING
 void TestEquihashSolvers(unsigned int n, unsigned int k, const std::string &I, const arith_uint256 &nonce, const std::set<std::vector<uint32_t>> &solns) {
     size_t cBitLen { n/(k+1) };
-    crypto_generichash_blake2b_state state;
+    eh_HashState state;
     EhInitialiseState(n, k, state);
     uint256 V = ArithToUint256(nonce);
     BOOST_TEST_MESSAGE("Running solver: n = " << n << ", k = " << k << ", I = " << I << ", V = " << V.GetHex());
-    crypto_generichash_blake2b_update(&state, (unsigned char*)&I[0], I.size());
-    crypto_generichash_blake2b_update(&state, V.begin(), V.size());
+    state.Update((unsigned char*)&I[0], I.size());
+    state.Update(V.begin(), V.size());
 
     // First test the basic solver
     std::set<std::vector<uint32_t>> ret;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         unsigned int k = Params().GetConsensus().nEquihashK;
 
         // Hash state
-        crypto_generichash_blake2b_state eh_state;
+        eh_HashState eh_state;
         EhInitialiseState(n, k, eh_state);
 
         // I = the block header minus nonce and solution.
@@ -208,21 +208,18 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         ss << I;
 
         // H(I||...
-        crypto_generichash_blake2b_update(&eh_state, (unsigned char*)&ss[0], ss.size());
+        eh_state.Update((unsigned char*)&ss[0], ss.size());
 
         while (true) {
             pblock->nNonce = ArithToUint256(try_nonce);
 
             // H(I||V||...
-            crypto_generichash_blake2b_state curr_state;
-            curr_state = eh_state;
-            crypto_generichash_blake2b_update(&curr_state,
-                                              pblock->nNonce.begin(),
-                                              pblock->nNonce.size());
+            eh_HashState curr_state(eh_state);
+            curr_state.Update(pblock->nNonce.begin(), pblock->nNonce.size());
 
             // Create solver and initialize it.
             equi eq(1);
-            eq.setstate(&curr_state);
+            eq.setstate(curr_state.state);
 
             // Intialization done, start algo driver.
             eq.digit0(0);

--- a/src/zcash/JoinSplit.cpp
+++ b/src/zcash/JoinSplit.cpp
@@ -1,6 +1,5 @@
 #include "JoinSplit.hpp"
 #include "prf.h"
-#include "sodium.h"
 
 #include "zcash/util.h"
 
@@ -17,6 +16,8 @@
 #include "librustzcash.h"
 #include "streams.h"
 #include "version.h"
+
+#include <rust/blake2b.h>
 
 namespace libzcash {
 
@@ -207,7 +208,7 @@ uint256 JoinSplit<NumInputs, NumOutputs>::h_sig(
     const std::array<uint256, NumInputs>& nullifiers,
     const Ed25519VerificationKey& joinSplitPubKey
 ) {
-    const unsigned char personalization[crypto_generichash_blake2b_PERSONALBYTES]
+    const unsigned char personalization[BLAKE2bPersonalBytes]
         = {'Z','c','a','s','h','C','o','m','p','u','t','e','h','S','i','g'};
 
     std::vector<unsigned char> block(randomSeed.begin(), randomSeed.end());
@@ -220,15 +221,10 @@ uint256 JoinSplit<NumInputs, NumOutputs>::h_sig(
 
     uint256 output;
 
-    if (crypto_generichash_blake2b_salt_personal(output.begin(), 32,
-                                                 &block[0], block.size(),
-                                                 NULL, 0, // No key.
-                                                 NULL,    // No salt.
-                                                 personalization
-                                                ) != 0)
-    {
-        throw std::logic_error("hash function failure");
-    }
+    auto state = blake2b_init(32, personalization);
+    blake2b_update(state, &block[0], block.size());
+    blake2b_finalize(state, output.begin(), 32);
+    blake2b_free(state);
 
     return output;
 }

--- a/src/zcash/address/sapling.cpp
+++ b/src/zcash/address/sapling.cpp
@@ -13,7 +13,7 @@
 
 namespace libzcash {
 
-const unsigned char ZCASH_SAPLING_FVFP_PERSONALIZATION[crypto_generichash_blake2b_PERSONALBYTES] =
+const unsigned char ZCASH_SAPLING_FVFP_PERSONALIZATION[BLAKE2bPersonalBytes] =
     {'Z', 'c', 'a', 's', 'h', 'S', 'a', 'p', 'l', 'i', 'n', 'g', 'F', 'V', 'F', 'P'};
 
 //! Sapling

--- a/src/zcash/address/zip32.cpp
+++ b/src/zcash/address/zip32.cpp
@@ -11,12 +11,12 @@
 #include "zcash/prf.h"
 
 #include <librustzcash.h>
-#include <sodium.h>
+#include <rust/blake2b.h>
 
-const unsigned char ZCASH_HD_SEED_FP_PERSONAL[crypto_generichash_blake2b_PERSONALBYTES] =
+const unsigned char ZCASH_HD_SEED_FP_PERSONAL[BLAKE2bPersonalBytes] =
     {'Z', 'c', 'a', 's', 'h', '_', 'H', 'D', '_', 'S', 'e', 'e', 'd', '_', 'F', 'P'};
 
-const unsigned char ZCASH_TADDR_OVK_PERSONAL[crypto_generichash_blake2b_PERSONALBYTES] =
+const unsigned char ZCASH_TADDR_OVK_PERSONAL[BLAKE2bPersonalBytes] =
     {'Z', 'c', 'T', 'a', 'd', 'd', 'r', 'T', 'o', 'S', 'a', 'p', 'l', 'i', 'n', 'g'};
 
 HDSeed HDSeed::Random(size_t len)
@@ -38,16 +38,11 @@ uint256 ovkForShieldingFromTaddr(HDSeed& seed) {
     auto rawSeed = seed.RawSeed();
 
     // I = BLAKE2b-512("ZcTaddrToSapling", seed)
-    crypto_generichash_blake2b_state state;
-    assert(crypto_generichash_blake2b_init_salt_personal(
-        &state,
-        NULL, 0, // No key.
-        64,
-        NULL,    // No salt.
-        ZCASH_TADDR_OVK_PERSONAL) == 0);
-    crypto_generichash_blake2b_update(&state, rawSeed.data(), rawSeed.size());
+    auto state = blake2b_init(64, ZCASH_TADDR_OVK_PERSONAL);
+    blake2b_update(state, rawSeed.data(), rawSeed.size());
     auto intermediate = std::array<unsigned char, 64>();
-    crypto_generichash_blake2b_final(&state, intermediate.data(), 64);
+    blake2b_finalize(state, intermediate.data(), 64);
+    blake2b_free(state);
 
     // I_L = I[0..32]
     uint256 intermediate_L;

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -23,7 +23,6 @@
 #include "random.h"
 #include "rpc/server.h"
 #include "script/sign.h"
-#include "sodium.h"
 #include "streams.h"
 #include "txdb.h"
 #include "utiltest.h"
@@ -160,14 +159,12 @@ double benchmark_solve_equihash()
     auto params = Params(CBaseChainParams::MAIN).GetConsensus();
     unsigned int n = params.nEquihashN;
     unsigned int k = params.nEquihashK;
-    crypto_generichash_blake2b_state eh_state;
+    eh_HashState eh_state;
     EhInitialiseState(n, k, eh_state);
-    crypto_generichash_blake2b_update(&eh_state, (unsigned char*)&ss[0], ss.size());
+    eh_state.Update((unsigned char*)&ss[0], ss.size());
 
     uint256 nonce = GetRandHash();
-    crypto_generichash_blake2b_update(&eh_state,
-                                    nonce.begin(),
-                                    nonce.size());
+    eh_state.Update(nonce.begin(), nonce.size());
 
     struct timeval tv_start;
     timer_start(tv_start);


### PR DESCRIPTION
Extracted from zcash/zcash#4654.

Also fixes a bug in the `tracing::Span` C++ class.