### PR TITLE
Build zcash on any system w/ Docker+bash via `./contrib/dev-docker/run.sh`.

### DIFF
--- a/contrib/dev-docker/Dockerfile
+++ b/contrib/dev-docker/Dockerfile
@@ -1,0 +1,26 @@
+# Reference: https://zcash.readthedocs.io/en/latest/rtd_pages/Debian-Ubuntu-build.html "building from source"
+
+FROM debian:stretch
+
+RUN DEBIAN_FRONTEND=noninteractive \
+        apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+        apt-get install -qq \
+            autoconf \
+            automake \
+            bsdmainutils \
+            build-essential \
+            curl \
+            g++-multilib \
+            git \
+            libc6-dev \
+            libtool \
+            m4 \
+            ncurses-dev \
+            pkg-config \
+            python3 \
+            python3-zmq \
+            unzip \
+            zlib1g-dev
+
+ENTRYPOINT ["/workspace/zcutil/build.sh"]

--- a/contrib/dev-docker/README.md
+++ b/contrib/dev-docker/README.md
@@ -1,0 +1,7 @@
+# zcash development Dockerfile
+
+This Dockerfile provides the build toolchain for building zcashd via `/zcutil/build.sh'. The entrypoint is that build script, so that anyone with docker can do development builds without installing the dev toolchain directly.
+
+## Wrapper script
+
+A wrapper script `./run.sh` will build and run the image with the appropriate bind mount and other settings so that the resulting change to the repo directory is the same as if a user had run `./zcutil/build.sh` with the dev toolchain installed locally.

--- a/contrib/dev-docker/run.sh
+++ b/contrib/dev-docker/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -efuxo pipefail
+
+# cd to the repo root:
+cd "$(readlink -f "$0/../../../")"
+docker build -t zcash-dev-docker ./contrib/dev-docker/
+exec docker run -v "$(pwd)/:/workspace" zcash-dev-docker "$@"


### PR DESCRIPTION
> Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.
> * [ ] Relevant documentation for this PR has to be completed and reviewed by @mdr0id before the PR can be merged

The documentation lives in `./contrib/dev/docker/README.md`.

> * [ ] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release

**Test plan A:**

1. Make two clones of the same `zcashd` revision which has this `./contrib/dev-docker` feature on a Debian/Ubuntu dev machine which also has docker installed.
2. In the first run `./zcutil/build.sh`.
3. In the second, run `./contrib/dev-docker/run.sh`
4. Compare the results.

Ideally the results would be byte-wise binary compatible but that's very likely not to be the case. At the very least, both should produce all the same file names, and the full test suite should run on both, and the `zcashd --version` output of both builds should match.

**Test Plan B**

Do the same as Test Plan A, except on the first "direct" build, do it on a system without docker, and on the second docker build, do it on a non-debian/non-ubuntu linux system with docker, then compare the results in the same manner.

*What this demonstrates:* This shows that building with this `dev-docker` approach allows anyone with docker to build without installing the dev toolchain directly onto their host system.
