### PR TITLE
build: Remove Rust staticlib naming workaround

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,19 +83,7 @@ endif
 cargo-build: $(CARGO_CONFIGURED)
 	$(RUST_ENV_VARS) $(CARGO) build $(RUST_BUILD_OPTS) $(rust_verbose) --manifest-path $(top_srcdir)/Cargo.toml
 
-if TARGET_WINDOWS
-LIBRUSTZCASH_WIN=$(top_builddir)/target/$(RUST_TARGET)/release/rustzcash.lib
-
-$(LIBRUSTZCASH_WIN): cargo-build
-
-# This ensures that the Rust library is correctly linked in by libtool.
-# See https://github.com/rust-lang/rust/issues/69904 for the underlying cause.
-$(LIBRUSTZCASH): $(LIBRUSTZCASH_WIN)
-	$(AM_V_at)cp $< $@
-
-else
 $(LIBRUSTZCASH): cargo-build
-endif
 
 $(LIBSECP256K1): $(wildcard secp256k1/src/*) $(wildcard secp256k1/include/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F)


### PR DESCRIPTION
The bug this was working around was fixed in Rust 1.44.0. We now pin
Rust 1.44.1, so we no longer need the workaround (and in fact, it is
necessary to make this change, as rustc no longer generates the old
filename, causing our Windows cross-compile to fail).