### PR TITLE
Remove reference to cargo-checksum.sh

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -81,7 +81,7 @@ packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(wallet_
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
 all_packages = $(packages) $(native_packages)
 
-meta_depends = Makefile funcs.mk builders/default.mk hosts/default.mk hosts/$(host_os).mk builders/$(build_os).mk cargo-checksum.sh
+meta_depends = Makefile funcs.mk builders/default.mk hosts/default.mk hosts/$(host_os).mk builders/$(build_os).mk
 
 $(host_arch)_$(host_os)_native_binutils?=$($(host_os)_native_binutils)
 $(host_arch)_$(host_os)_native_toolchain?=$($(host_os)_native_toolchain)


### PR DESCRIPTION
Leftover after merging https://github.com/zcash/zcash/pull/4743.

Caused compilation warnings of the form:

```
shasum: cargo-checksum.sh: No such file or directory
```