### PR TITLE
WIP [Do not merge] nix build of zcashd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,21 +69,45 @@ CHECK_ATOMIC
 dnl Libtool init checks.
 LT_INIT([pic-only])
 
+dnl Zcash macros for required programs. Configure exits with error if
+dnl they are not detected.
+AC_DEFUN(
+  ZC_REQUIRE_TOOL,
+  [
+    AC_PATH_TOOL($1, $2, $2_notfound)
+    if test x${$1} = x$2_notfound
+    then
+      AC_MSG_ERROR("Required tool $2 was not found")
+    fi
+  ]
+)
+
+AC_DEFUN(
+  ZC_REQUIRE_PROG,
+  [
+    AC_PATH_PROG($1, $2, $2_notfound)
+    if test x${$1} = x$2_notfound
+    then
+      AC_MSG_ERROR("Required program $2 was not found")
+    fi
+  ]
+)
+
 dnl Check/return PATH for base programs.
-AC_PATH_TOOL(AR, ar)
-AC_PATH_TOOL(RANLIB, ranlib)
-AC_PATH_TOOL(STRIP, strip)
-AC_PATH_TOOL(GCOV, gcov)
-AC_PATH_PROG(LCOV, lcov)
-AC_PATH_PROG(GENHTML, genhtml)
-AC_PATH_PROG([GIT], [git])
-AC_PATH_PROG(RUSTC, rustc)
-AC_PATH_PROG(CARGO, cargo)
-AC_PATH_PROG(CCACHE,ccache)
-AC_PATH_PROG(XGETTEXT,xgettext)
-AC_PATH_PROG(HEXDUMP,hexdump)
-AC_PATH_TOOL(READELF,readelf)
-AC_PATH_TOOL(CPPFILT,c++filt)
+dnl Required tools and programs:
+ZC_REQUIRE_TOOL(AR, ar)
+ZC_REQUIRE_TOOL(RANLIB, ranlib)
+ZC_REQUIRE_TOOL(STRIP, strip)
+ZC_REQUIRE_PROG([GIT], [git])
+ZC_REQUIRE_PROG(RUSTC, rustc)
+ZC_REQUIRE_PROG(CARGO, cargo)
+ZC_REQUIRE_PROG(XGETTEXT,xgettext)
+ZC_REQUIRE_PROG(HEXDUMP,hexdump)
+ZC_REQUIRE_TOOL(READELF,readelf)
+ZC_REQUIRE_TOOL(CPPFILT,c++filt)
+
+dnl This one is still optional and checked by complicated logic below:
+AC_PATH_PROG(CCACHE, ccache)
 
 AC_ARG_ENABLE([online-rust],
   [AS_HELP_STRING([--enable-online-rust],
@@ -350,10 +374,7 @@ case $host in
        AC_MSG_WARN("makensis not found. Cannot create installer.")
      fi
 
-     AC_PATH_TOOL(WINDRES, windres, none)
-     if test x$WINDRES = xnone; then
-       AC_MSG_ERROR("windres not found")
-     fi
+     ZC_REQUIRE_TOOL(WINDRES, windres)
 
      CPPFLAGS="$CPPFLAGS -D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB"
      LEVELDB_TARGET_FLAGS="TARGET_OS=OS_WINDOWS_CROSSCOMPILE"
@@ -452,15 +473,10 @@ if test x$use_pkgconfig = xyes; then
 fi
 
 if test x$use_lcov = xyes; then
-  if test x$LCOV = x; then
-    AC_MSG_ERROR("lcov testing requested but lcov not found")
-  fi
-  if test x$GCOV = x; then
-    AC_MSG_ERROR("lcov testing requested but gcov not found")
-  fi
-  if test x$GENHTML = x; then
-    AC_MSG_ERROR("lcov testing requested but genhtml not found")
-  fi
+  ZC_REQUIRE_TOOL(GCOV, gcov)
+  ZC_REQUIRE_PROG(LCOV, lcov)
+  ZC_REQUIRE_PROG(GENHTML, genhtml)
+
   LCOV="$LCOV --gcov-tool=$GCOV --rc lcov_branch_coverage=1"
   GENHTML="$GENHTML --branch-coverage"
   AX_CHECK_COMPILE_FLAG([--coverage],[CXXFLAGS="$CXXFLAGS --coverage"],

--- a/zcutil/nix-builder/README.md
+++ b/zcutil/nix-builder/README.md
@@ -1,0 +1,161 @@
+# Zcash nix-builder
+
+This is an alternative build system for Zcash based on [nix](https://nixos.org/).
+
+## Phase 0 TODOs
+
+See the [Proposed Roadmap] below for phase descriptions.
+
+1. Build a runnable zcashd/zcash-cli on the build platform with all non-compiler, non-crate `./depends` packages pinned to the same sources.
+2. Pin rustc and cargo as per `./depends`.
+3. Pin clang.
+4. Undo the 'cp' of patch files and refer to them directly.
+5. Remove unnecessary `builder`s where stdenv will do.
+6. General nix cleanup and factoring out common code.
+7. Add a docker wrapper.
+8. Move to `./contrib`
+9. Rebase to `master.`
+
+## Proposed Roadmap
+
+Note: This roadmap is merely a proposal by the contributors to this branch, and not necessarily adopted by the `zcashd` developers. Also, each subsequent phase becomes less certain. The end result might be no change to `zcashd` or only a subset of the phases in this proposed roadmap.
+
+### Phase 0: Proof of Concept Prototype
+
+During this phase, the nix-builder will live in a branch for those adventurous types that want to experiment with it.
+
+### Phase 1: Merged to Master
+
+#### Phase 1 Features
+
+Phase 1 provides an alternative build system to `./zcutil/build.sh` and `./depends` for non-cross linux builds.
+
+#### Phase 1 Zcash Integration
+
+In this phase the nix-builder approach will be merged to master as a `contrib` feature, meaning it must not be on any critical path for building or releasing official `zcashd` releases/packages, nor will any developer be required to use it. Instead, a subset of dev users may use this to build their own dev versions.
+
+During this phase, there's a continued risk that the official build system and the nix-builder will drift.
+
+#### Phase 1 Requirements
+
+**P1.R1.** It should be easy for any PR or code reviewer, even one unfamiliar with `./depends` or `nix`, to verify that:
+
+- Both systems appear to define the same dependencies, including identical versions, URLs, and hashes.
+- Both systems appear to define the same patches on dependencies, applied in the same order.
+- The nix build file for top-level `zcash` in `./zcash/default.nix` appears to define many build tool prerequisites that are roughly similar to the required development tool dependencies defined on [Zcash readthedocs.io](https://zcash.readthedocs.io/en/latest/).
+- The nix build appears to pin the set of `nixpkgs` packages to a specific hash.
+
+**P1.R2.** It should be possible for a focused security-aware reviewer to verify that the "appears to X" statements above do indeed hold.
+
+**P1.R3.** It should be possible for a dev not familiar with nix to build zcash with nix, either by installing nix on their dev system or by using a Docker-based wrapper.
+
+**P1.R4.** The binaries built by the PR should pass all local automated tests.
+
+### Phase 2: Continuous Integration Support
+
+#### Phase 2 Features
+
+There are no new features during this phase. Instead continuous integration support helps ensure changes to the production build system (`./zcutil/build.sh` + `./depends`) will require updating the nix build specs to match.
+
+#### Phase 2 Zcash Integration
+
+Even though the nix builder is not used in official developer flows or releases, CI support is added to ensure it is well maintained.
+
+#### Phase 2 Requirements
+
+**P2.R1.** All build and QA test automation runs against both the production `./depends` system and the nix build for `x86_64` on an officially supported linux distro.
+
+### Phase 3 Cross-Platform Support
+
+#### Phase 3 Features
+
+Cross platform builds are introduces for all officially supported Zcash targets on at least one x86_64 linux build platform.
+
+#### Phase 3 Zcash Integration
+
+CI runs automated tests on all cross-compiled targets.
+
+#### Phase 3 Requirements
+
+**P3.R1.** CI automates the build of _each_ officially supported target platform via nix from a single _build_ host based on x86_64 on a favored linux distro.
+
+**P3.R2.** CI automates running all automated single-host run-time tests for _each_ target platform using the binaries build by **P3.R1.**.
+ That involves building for each officially supported _target_ platform from a single _build_ platform, then it involves running automated tests on each _target_ platform with those results.
+
+### Phase 4: Deprecating ./depends
+
+#### Phase 4 Features
+
+This phase involves no new nix build features.
+
+#### Phase 4 Zcash Integration
+
+#### Phase 4 Requirements
+
+**P4.R1.** All of CI switches promotes the nix build as primary, and makes the `./depends` secondary. (Because earlier phases already introduced CI coverage of nix builds along side the production `./depends` CI, this change should almost be a single toggle.)
+
+**P4.R2.** Production releases switch from `./depends` to the nix build, including the gitian pipeline. Two achieve this safely a branch of `zcash-gitian` should be maintained that performs the `./depends`-based known-working build through at least two production `zcashd` releases.
+
+**P4.R3.** At least two production `zcashd` releases must successfully complete using the nix builder within gitian with no reproducibility failures and no other blocking snags.
+
+### Phase 5: Reproducible Nix Builds Belt-And-Suspenders
+
+#### Phase 5 Features
+
+The nix build constrains the build artifacts to be bytewise identical when built on any two systems from the same fresh clone of a specific `zcashd` git revision. The build streamlines signing a build artifact cryptographic hash attestation so that it is routine for many developers to create such attestations on each build.
+
+#### Phase 5 Zcash Integration
+
+Releases will still rely on gitian for artifact reproducibility checks, and the nix build attestations will provide a second layer initially.
+
+Because the build system streamlines attestations, they can & should be gathered more frequently than once-per-release, and instead zcashd developers and even a wider set of volunteers should submit them for builds of `master` frequently (ie: once per PR merge for some devs, or once per week for volunteers).
+
+#### Phase 5 Requirements
+
+**P5.R1.** There is a published set of build system constraint requirements such that reproducible builds are only supported when those requirements are met. For example, if particular versions of nix or specific underlying build platforms (ie: nix-on-windows) are known to produce results different from other systems, we may exclude those arbitrarily-but-consistently to reduce the problem space.
+
+**P5.R2.** Every build generates an unsigned build manifest for all artifacts. This includes intermediate nix derivations which are defined within the `zcashd` repository. If nix enables it, it should also encompass the entire transitive dependency graph of all derivations regardless of whether or not they are defined in the `zcashd` repo or in the upstream pinned `nixpkgs` repository.
+
+**P5.R3.** The nix build makes it convenient to force a local build of the entire transitive derivation graph without relying on binary caching of servers. (FIXME: Research nix binary reproducibility more. Can derivations be locked down to fixed-output derivations?)
+
+**P5.R4.** It's very easy and convenient for developers to opt-in to generating signed attestations of the build manifests. "very easy" means, for example, setting their GPG pubkey fingerprint in a config setting to produce this extra output. (FIXME: Research if there's a nix facility for this.)
+
+**P5.R5.** Zcash CI/CD infrastructure automatically publishes infrastructure-signed attestations of every PR merge and every release.
+
+##### Phase 5 Bonus Requirements
+
+**P5.BR1.** There's a commandline tool any developer can use to publish their attestation *without requiring any zcash-developer gatekeeping of account management*. It can either post their attestation to a well-known viewing key, and/or push a commit to a their github fork of an attestation repo, then submit a PR.
+
+**P5.BR2.** There are two tools *anyone can run* for aggregating attestations: one scans the well-known viewing key, and another searches github for all forks of a signature repo finding all attestation commits. Notice that anyone can do either **P5.BR1.** or **P5.BR2.** without relying on zcash devs and also zcash devs can't censor attestations (and github can't censor the blockchain-based attestations).
+
+### Phase 6 Retire Gitian
+
+#### Phase 6 Features
+
+No new nix features past phase 5.
+
+#### Phase 6 Zcash Integration
+
+After the nix layer of attestations have proven themselves, we can drop gitian.
+
+#### Phase 6 Requirements
+
+**P6.R1.** There have been no attestation discrepencies between the nix layer and gitian builds for two zcashd production releases.
+
+### Phase 7 End-user-package Nix Build Artifacts
+
+#### Phase 7 Features
+
+The top-level nix derivation for zcash is extended to produce end-user package artifacts. For example, debian and ubuntu `.deb` files, binary tarballs, Docker images, windows installers, mac installers.
+
+#### Phase 7 Zcash Integration
+
+As many end-user-packages as possible should be automated by nix generation, and where that's difficult, the existing package-specific approach will continue to be used.
+
+#### Phase 7 Requirements
+
+**P7.R1.** The "officially supported platforms" are extended to "officially supported packages", and each "package" format identifies a set of supported install/runtime platforms.
+
+**P7.R2.** The top-level nix build expression generates all packages for all platforms.
+
+**P7.R3.** There are more specific nix derivations for specific packages or builds, and it's easy for a dev to build just the pieces they need at the moment.

--- a/zcutil/nix-builder/pkgs-pinned.nix
+++ b/zcutil/nix-builder/pkgs-pinned.nix
@@ -1,7 +1,8 @@
 let
   # channelrev taken from https://status.nixos.org/ for nixos-20.09
-  channelrev = "61525137fd1002f6f2a5eb0ea27d480713362cd5";
+  rev = "61525137fd1002f6f2a5eb0ea27d480713362cd5";
+  sha256 = "1gzwz9jvfcf0is6zma7qlgszkngfb2aa4kam0nhs0qnwb4nqn7mg";
 
-  channelurl = "https://github.com/NixOS/nixpkgs-channels/archive/${channelrev}.tar.gz";
+  url = "https://github.com/NixOS/nixpkgs-channels/archive/${rev}.tar.gz";
 in
-  import (fetchTarball channelurl) {}
+  import (fetchTarball { inherit url sha256; }) {}

--- a/zcutil/nix-builder/pkgs-pinned.nix
+++ b/zcutil/nix-builder/pkgs-pinned.nix
@@ -1,0 +1,7 @@
+let
+  # channelrev taken from https://status.nixos.org/ for nixos-20.09
+  channelrev = "61525137fd1002f6f2a5eb0ea27d480713362cd5";
+
+  channelurl = "https://github.com/NixOS/nixpkgs-channels/archive/${channelrev}.tar.gz";
+in
+  import (fetchTarball channelurl) {}

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -1,0 +1,13 @@
+let
+  pkgs = import ./../pkgs-pinned.nix;
+in
+  with pkgs;
+  stdenv.mkDerivation {
+    pname = "zcash";
+    version = "FIXME";
+    src = ./../../..;
+    nativeBuildInputs = [
+      autoreconfHook
+      pkg-config
+    ];
+  }

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -16,6 +16,7 @@ in
       zcboost
       (import ./deps/bdb)
       (import ./deps/libevent)
+      (import ./deps/libsodium)
       (import ./deps/openssl)
     ];
 

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -9,5 +9,6 @@ in
     nativeBuildInputs = [
       autoreconfHook
       pkg-config
+      (import ./deps/bdb)
     ];
   }

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -13,6 +13,7 @@ in
 
       # Zcash-pinned dependencies:
       (import ./deps/bdb)
+      (import ./deps/boost)
       (import ./deps/libevent)
       (import ./deps/openssl)
     ];

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -8,8 +8,9 @@ in
     src = ./../../..;
     nativeBuildInputs = [
       autoreconfHook
-      pkg-config
+      file
       hexdump
+      pkg-config
 
       # Zcash-pinned dependencies:
       (import ./deps/bdb)

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -9,6 +9,10 @@ in
     nativeBuildInputs = [
       autoreconfHook
       pkg-config
+      hexdump
+
+      # Zcash-pinned dependencies:
       (import ./deps/bdb)
+      (import ./deps/openssl)
     ];
   }

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -18,6 +18,7 @@ in
       (import ./deps/libevent)
       (import ./deps/libsodium)
       (import ./deps/openssl)
+      (import ./deps/utfcpp)
     ];
 
     configureFlags = [

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -1,7 +1,7 @@
+with import ./../pkgs-pinned.nix;
 let
-  pkgs = import ./../pkgs-pinned.nix;
+  zcboost = import ./deps/boost;
 in
-  with pkgs;
   stdenv.mkDerivation {
     pname = "zcash";
     version = "FIXME";
@@ -12,10 +12,18 @@ in
       hexdump
       pkg-config
 
-      # Zcash-pinned dependencies:
+      # Zcash-custom dependencies:
+      zcboost
       (import ./deps/bdb)
-      (import ./deps/boost)
       (import ./deps/libevent)
       (import ./deps/openssl)
     ];
+
+    configureFlags = [
+      "--with-boost=${zcboost}"
+    ];
+
+    # Patch absolute paths from libtool to use nix file:
+    # See https://github.com/NixOS/nixpkgs/issues/98440
+    preConfigure = ''sed -i 's,/usr/bin/file,${file}/bin/file,g' ./configure'';
   }

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -13,6 +13,7 @@ in
 
       # Zcash-pinned dependencies:
       (import ./deps/bdb)
+      (import ./deps/libevent)
       (import ./deps/openssl)
     ];
   }

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -36,6 +36,10 @@ in
       "--with-boost=${zcboost}"
     ];
 
+    makeFlags = [
+      "--debug=verbose"
+    ];
+
     # Patch absolute paths from libtool to use nix file:
     # See https://github.com/NixOS/nixpkgs/issues/98440
     preConfigure = ''sed -i 's,/usr/bin/file,${pkgs.file}/bin/file,g' ./configure'';

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -20,6 +20,7 @@ let
       (import ./deps/native_rust)
       (import ./deps/openssl)
       (import ./deps/utfcpp)
+      (import ./deps/vendored-crates)
     ];
 in
   pkgs.stdenv.mkDerivation {

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -17,6 +17,7 @@ let
       (import ./deps/bdb)
       (import ./deps/libevent)
       (import ./deps/libsodium)
+      (import ./deps/native_rust)
       (import ./deps/openssl)
       (import ./deps/utfcpp)
     ];
@@ -26,6 +27,10 @@ in
     version = "FIXME";
     src = ./../../..;
     nativeBuildInputs = nixdeps ++ zcdeps;
+
+    CONFIG_SITE = pkgs.writeText "config.site" ''
+      RUST_TARGET='${pkgs.buildPlatform.config}'
+    '';
 
     configureFlags = [
       "--with-boost=${zcboost}"

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -1,18 +1,17 @@
-with import ./../pkgs-pinned.nix;
 let
-  zcboost = import ./deps/boost;
-in
-  stdenv.mkDerivation {
-    pname = "zcash";
-    version = "FIXME";
-    src = ./../../..;
-    nativeBuildInputs = [
+  pkgs = import ./../pkgs-pinned.nix;
+
+  # Build dependencies from nixpkgs:
+  nixdeps = with pkgs; [
       autoreconfHook
       file
       hexdump
       pkg-config
+  ];
 
-      # Zcash-custom dependencies:
+  # Zcash-custom dependencies:
+  zcboost = import ./deps/boost;
+  zcdeps = [
       zcboost
       (import ./deps/bdb)
       (import ./deps/libevent)
@@ -20,6 +19,12 @@ in
       (import ./deps/openssl)
       (import ./deps/utfcpp)
     ];
+in
+  pkgs.stdenv.mkDerivation {
+    pname = "zcash";
+    version = "FIXME";
+    src = ./../../..;
+    nativeBuildInputs = nixdeps ++ zcdeps;
 
     configureFlags = [
       "--with-boost=${zcboost}"
@@ -27,5 +32,5 @@ in
 
     # Patch absolute paths from libtool to use nix file:
     # See https://github.com/NixOS/nixpkgs/issues/98440
-    preConfigure = ''sed -i 's,/usr/bin/file,${file}/bin/file,g' ./configure'';
+    preConfigure = ''sed -i 's,/usr/bin/file,${pkgs.file}/bin/file,g' ./configure'';
   }

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -5,6 +5,7 @@ let
   nixdeps = with pkgs; [
       autoreconfHook
       file
+      git
       hexdump
       pkg-config
   ];

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -15,13 +15,14 @@ let
   zcVendoredCrates = import ./deps/vendored-crates;
   zcdeps = [
       zcboost
+      zcVendoredCrates
       (import ./deps/bdb)
+      (import ./deps/googletest)
       (import ./deps/libevent)
       (import ./deps/libsodium)
       (import ./deps/native_rust)
       (import ./deps/openssl)
       (import ./deps/utfcpp)
-      zcVendoredCrates
     ];
 in
   pkgs.stdenv.mkDerivation {

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -40,7 +40,7 @@ in
     ];
 
     makeFlags = [
-      "--debug=verbose"
+      # "--debug=verbose"
     ];
 
     # Patch absolute paths from libtool to use nix file:

--- a/zcutil/nix-builder/zcash/default.nix
+++ b/zcutil/nix-builder/zcash/default.nix
@@ -12,6 +12,7 @@ let
 
   # Zcash-custom dependencies:
   zcboost = import ./deps/boost;
+  zcVendoredCrates = import ./deps/vendored-crates;
   zcdeps = [
       zcboost
       (import ./deps/bdb)
@@ -20,7 +21,7 @@ let
       (import ./deps/native_rust)
       (import ./deps/openssl)
       (import ./deps/utfcpp)
-      (import ./deps/vendored-crates)
+      zcVendoredCrates
     ];
 in
   pkgs.stdenv.mkDerivation {
@@ -31,6 +32,7 @@ in
 
     CONFIG_SITE = pkgs.writeText "config.site" ''
       RUST_TARGET='${pkgs.buildPlatform.config}'
+      RUST_VENDORED_SOURCES='${zcVendoredCrates}'
     '';
 
     configureFlags = [

--- a/zcutil/nix-builder/zcash/deps/bdb/builder.sh
+++ b/zcutil/nix-builder/zcash/deps/bdb/builder.sh
@@ -1,0 +1,22 @@
+source "$stdenv/setup"
+trap 'ev=$?; set +x; exitHandler; exit $ev' EXIT
+set -x
+set -efuo pipefail
+
+tar -xf "$src"
+cd "db-${version}"
+
+: ./depends Preprocessing
+sed -i.old s/WinIoCtl.h/winioctl.h/g src/dbinc/win_db.h
+sed -i.old s/atomic_init/atomic_init_db/ src/dbinc/atomic.h src/mp/mp_region.c src/mp/mp_mvcc.c src/mp/mp_fget.c src/mutex/mut_method.c src/mutex/mut_tas.c
+
+: ./depends Configuring
+cd ./build_unix
+../dist/configure --prefix="$out" $configureOptions CXXFLAGS="$configureCxxflags"
+
+: ./depends Building
+make $makeTargets
+
+: ./depends Staging and Caching not necessary due to nix.
+# Nix approach:
+make install

--- a/zcutil/nix-builder/zcash/deps/bdb/default.nix
+++ b/zcutil/nix-builder/zcash/deps/bdb/default.nix
@@ -32,7 +32,6 @@ in
     builder = ./builder.sh;
     nativeBuildInputs = [
       autoreconfHook
-      #pkg-config
     ];
   }
 

--- a/zcutil/nix-builder/zcash/deps/bdb/default.nix
+++ b/zcutil/nix-builder/zcash/deps/bdb/default.nix
@@ -1,0 +1,38 @@
+let
+  pkgs = import ./../../../pkgs-pinned.nix;
+in
+  with pkgs;
+  stdenv.mkDerivation rec {
+    pname = "bdb";
+    version = "6.2.23";
+    src = fetchurl {
+      url = "https://download.oracle.com/berkeley-db/db-${version}.tar.gz";
+      sha256 = "47612c8991aa9ac2f6be721267c8d3cdccf5ac83105df8e50809daea24e95dc7";
+    };
+    
+    configureOptions = [
+      "--disable-shared"
+      "--enable-cxx"
+      "--disable-replication"
+    ] ++ [(
+      let platform_opts = {
+        mingw32 = "--enable-mingw";
+        linux = "--with-pic";
+        freebsd = "--with-pic";
+        darwin = "--disable-atomicsupport";
+        aarch64 = "--disable-atomicsupport";
+      };
+      in
+        # FIXME: figure out the nix way to query the platform:
+        platform_opts.linux
+    )];
+    configureCxxflags = "-std=c++11";
+    makeTargets = "libdb_cxx-6.2.a libdb-6.2.a";
+
+    builder = ./builder.sh;
+    nativeBuildInputs = [
+      autoreconfHook
+      #pkg-config
+    ];
+  }
+

--- a/zcutil/nix-builder/zcash/deps/bdb/default.nix
+++ b/zcutil/nix-builder/zcash/deps/bdb/default.nix
@@ -1,37 +1,46 @@
-let
-  pkgs = import ./../../../pkgs-pinned.nix;
-in
-  with pkgs;
-  stdenv.mkDerivation rec {
-    pname = "bdb";
-    version = "6.2.23";
-    src = fetchurl {
-      url = "https://download.oracle.com/berkeley-db/db-${version}.tar.gz";
-      sha256 = "47612c8991aa9ac2f6be721267c8d3cdccf5ac83105df8e50809daea24e95dc7";
-    };
-    
-    configureOptions = [
+with import ./../../../pkgs-pinned.nix;
+with import ./../utils.nix;
+stdenv.mkDerivation rec {
+  pname = "bdb";
+  version = "6.2.23";
+  src = fetchurl {
+    url = "https://download.oracle.com/berkeley-db/db-${version}.tar.gz";
+    sha256 = "47612c8991aa9ac2f6be721267c8d3cdccf5ac83105df8e50809daea24e95dc7";
+  };
+
+  configureOptions = selectByHostPlatform [
+    [ # All hosts:
       "--disable-shared"
       "--enable-cxx"
       "--disable-replication"
-    ] ++ [(
-      let platform_opts = {
-        mingw32 = "--enable-mingw";
-        linux = "--with-pic";
-        freebsd = "--with-pic";
-        darwin = "--disable-atomicsupport";
-        aarch64 = "--disable-atomicsupport";
-      };
-      in
-        # FIXME: figure out the nix way to query the platform:
-        platform_opts.linux
-    )];
-    configureCxxflags = "-std=c++11";
-    makeTargets = "libdb_cxx-6.2.a libdb-6.2.a";
+    ]
+    # FIXME: mingw32 support dropped in this branch. :-/
+    # mingw32 = "--enable-mingw";
+    {
+      kernel = "linux";
+      values = ["--with-pic"];
+    }
+    {
+      kernel = "freebsd";
+      values = ["--with-pic"];
+    }
+    {
+      kernel = "freebsd";
+      values = ["--disable-atomicsupport"];
+    }
+    {
+      # FIXME: Is this really a CPU type?
+      cpu = "aarch64";
+      values = ["--disable-atomicsupport"];
+    }
+  ];
 
-    builder = ./builder.sh;
-    nativeBuildInputs = [
-      autoreconfHook
-    ];
-  }
+  configureCxxflags = "-std=c++11";
+  makeTargets = "libdb_cxx-6.2.a libdb-6.2.a";
+
+  builder = ./builder.sh;
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+}
 

--- a/zcutil/nix-builder/zcash/deps/boost/builder.sh
+++ b/zcutil/nix-builder/zcash/deps/boost/builder.sh
@@ -1,0 +1,26 @@
+source "$stdenv/setup"
+trap 'ev=$?; set +x; exitHandler; exit $ev' EXIT
+set -x
+set -efuo pipefail
+
+tar -xf "$src"
+cd "${pname}_${version_}"
+
+: ./depends Preprocessing
+for patch in $(ls "$patches")
+do
+  echo "Applying patch: $patch"
+  patch -p1 < "$patches/$patch"
+done
+
+: ./depends Configuring
+./bootstrap.sh --without-icu --with-libraries="$boostlibs"
+
+# FIXME: port this patch from ./depends:
+#sed -i -e "s|using gcc ;|using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;|" project-config.jam
+
+: ./depends Building
+./b2 -d2 -j2 -d1 --prefix="$out" $configureOptions stage
+
+: ./depends Staging
+./b2 -d0 -j4 --prefix="$out" $configureOptions install

--- a/zcutil/nix-builder/zcash/deps/boost/default.nix
+++ b/zcutil/nix-builder/zcash/deps/boost/default.nix
@@ -1,0 +1,95 @@
+with import ./../../../pkgs-pinned.nix;
+with import ./../utils.nix;
+stdenv.mkDerivation rec {
+  pname = "boost";
+  version = "1.70.0";
+
+  # The underscored version used in filenames and elsewhere:
+  version_ =
+    with lib.strings;
+    concatStringsSep "_" (splitString "." version);
+
+  src = fetchurl {
+    url = "https://dl.bintray.com/boostorg/release/${version}/source/${pname}_${version_}.tar.bz2";
+    sha256 = "430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778";
+  };
+
+  boostlibs = "chrono,filesystem,program_options,system,thread,test";
+  configureOptions = selectByHostPlatform [
+    [
+      "variant=release" # FIXME: un-hardcode variant?
+      "--layout=system"
+      "threading=multi"
+      "link=static"
+      "-sNO_BZIP2=1"
+      "-sNO_ZLIB=1"
+    ]
+    {
+      kernel = "linux";
+      values = [
+        "threadapi=pthread"
+        "runtime-link=shared"
+      ];
+    }
+    {
+      kernel = "linux";
+      cpu = "i686";
+      values = [
+        "address-model=32"
+        "architecture=x86"
+      ];
+    }
+    {
+      # FIXME: Is darwin a kernel?
+      kernel = "darwin";
+      values = [
+        "--toolset=darwin-4.2.1"
+        "runtime-link=shared"
+      ];
+    }
+    #{
+    #  # FIXME: We don't know what mingw is.
+    #  ??? = "mingw32";
+    #  values = [
+    #    "binary-format=pe"
+    #    "target-os=windows"
+    #    "threadapi=win32"
+    #    "runtime-link=static"
+    #  ];
+    #}
+    #{
+    #  # FIXME: We don't know what mingw is.
+    #  ??? = "mingw32";
+    #  cpu = "x86_64";
+    #  values = ["address-model=64"];
+    #}
+    #{
+    #  # FIXME: We don't know what mingw is.
+    #  ??? = "mingw32";
+    #  cpu = "i686";
+    #  values = ["address-model=32"];
+    #}
+  ];
+
+  cxxflags = selectByHostPlatform [
+    [
+      "-std=c++11"
+      "-fvisibility=hidden"
+    ]
+    {
+      kernel = "linux";
+      values = ["-fPIC"];
+    }
+    {
+      kernel = "freebsd";
+      values = ["-fPIC"];
+    }
+  ];
+
+  patches = ./patches;
+  builder = ./builder.sh;
+  nativeBuildInputs = [
+    which
+  ];
+}
+

--- a/zcutil/nix-builder/zcash/deps/boost/patches/darwin.diff
+++ b/zcutil/nix-builder/zcash/deps/boost/patches/darwin.diff
@@ -1,0 +1,27 @@
+diff --git a/darwin.jam b/darwin.jam
+index 8d47741..641d8bb 100644
+--- a/tools/build/src/tools/darwin.jam
++++ b/tools/build/src/tools/darwin.jam
+@@ -138,14 +138,14 @@ rule init ( version ? : command * : options * : requirement * )
+     common.handle-options darwin : $(condition) : $(command) : $(options) ;
+     
+     # - GCC 4.0 and higher in Darwin does not have -fcoalesce-templates.
+-    if $(real-version) < "4.0.0"
+-    {
+-        flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
+-    }
++#    if $(real-version) < "4.0.0"
++#    {
++#        flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
++#    }
+     # - GCC 4.2 and higher in Darwin does not have -Wno-long-double.
+-    if $(real-version) < "4.2.0"
+-    {
+-        flags darwin.compile OPTIONS $(condition) : -Wno-long-double ;
+-    }
++#    if $(real-version) < "4.2.0"
++#    {
++#        flags darwin.compile OPTIONS $(condition) : -Wno-long-double ;
++#    }
+     # - GCC on Darwin with -pedantic, suppress unsupported long long warning
+     flags darwin.compile OPTIONS $(condition)/<warnings>all : -Wno-long-long ;

--- a/zcutil/nix-builder/zcash/deps/googletest/builder.sh
+++ b/zcutil/nix-builder/zcash/deps/googletest/builder.sh
@@ -1,0 +1,16 @@
+source "$zcbuildutil"
+
+tar -xf "$src"
+cd "${pname}-release-${version}"
+mkdir -p "$out/lib"
+
+function makeinst
+{
+  echo "making & installing ${2@Q}"
+  make -C "$1/make" "$2"
+  cp "$1/make/$2" "$out/lib/lib$2"
+  cp -a "$1/include" "$out/"
+}
+
+makeinst googlemock gmock.a
+makeinst googletest gtest.a

--- a/zcutil/nix-builder/zcash/deps/googletest/default.nix
+++ b/zcutil/nix-builder/zcash/deps/googletest/default.nix
@@ -1,0 +1,39 @@
+with {
+  inherit (import ./../../zcstd.nix)
+    attrNames
+    buildPlatform
+    concatStrings
+    fetchurl
+    getAttr
+    importTOML
+    lib
+    mkDerivation
+    zcname
+    zcsrc
+    zcversion
+    zcbuildutil
+  ; 
+};
+mkDerivation rec {
+  pname = "googletest";
+  version = "1.8.0";
+  src = fetchurl {
+    url = "https://github.com/google/${pname}/archive/${pname}-${version}.tar.gz";
+    sha256 = "58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8";
+  };
+
+  cxxflags = [
+    "-std=c++11" 
+  ] ++ (getAttr buildPlatform.parsed.kernel.name {
+    "linux" = ["-fPIC"];
+    "freebsd" = ["-fPIC"];
+  });
+
+  nativeBuildInputs = [
+  ];
+
+  inherit zcbuildutil;
+  builder = ./builder.sh;
+}
+
+

--- a/zcutil/nix-builder/zcash/deps/libevent/builder.sh
+++ b/zcutil/nix-builder/zcash/deps/libevent/builder.sh
@@ -1,0 +1,22 @@
+source "$stdenv/setup"
+trap 'ev=$?; set +x; exitHandler; exit $ev' EXIT
+set -x
+set -efuo pipefail
+
+tar -xf "$src"
+cd "${pname}-release-${version}-stable"
+
+: ./depends Preprocessing
+for patch in $(ls "$patches")
+do
+  echo "Applying patch: $patch"
+  patch -p1 < "$patches/$patch"
+done
+
+: ./depends Configuring
+./autogen.sh
+./configure --prefix="$out" $configureOptions
+
+: ./depends Building
+make
+make install

--- a/zcutil/nix-builder/zcash/deps/libevent/default.nix
+++ b/zcutil/nix-builder/zcash/deps/libevent/default.nix
@@ -1,0 +1,39 @@
+let
+  pkgs = import ./../../../pkgs-pinned.nix;
+in
+  with pkgs;
+  stdenv.mkDerivation rec {
+    pname = "libevent";
+    version = "2.1.8";
+    src = fetchurl {
+      url = "https://github.com/libevent/libevent/archive/${pname}-${version}.tar.gz";
+      sha256 = "316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d";
+    };
+    
+    configureOptions = [
+      "--disable-shared"
+      "--disable-openssl"
+      "--disable-libevent-regress"
+    ] ++ (
+      # Platform/Architecture specific opts:
+      let
+        # FIXME: don't hardcode platform/arch:
+        platform = "linux";
+        release = true;
+
+        releaseOpts = ["--disable-debug-mode"];
+        platformOpts = {
+          linux = ["--with-pic"];
+          freebsd = ["--with-pic"];
+        };
+      in
+        platformOpts.${platform} ++ (if release then releaseOpts else [])
+    );
+
+    patches = ./patches;
+    builder = ./builder.sh;
+    nativeBuildInputs = [
+      autoreconfHook
+    ];
+  }
+

--- a/zcutil/nix-builder/zcash/deps/libevent/default.nix
+++ b/zcutil/nix-builder/zcash/deps/libevent/default.nix
@@ -1,39 +1,37 @@
-let
-  pkgs = import ./../../../pkgs-pinned.nix;
-in
-  with pkgs;
-  stdenv.mkDerivation rec {
-    pname = "libevent";
-    version = "2.1.8";
-    src = fetchurl {
-      url = "https://github.com/libevent/libevent/archive/${pname}-${version}.tar.gz";
-      sha256 = "316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d";
-    };
-    
-    configureOptions = [
+with import ./../../../pkgs-pinned.nix;
+with import ./../utils.nix;
+stdenv.mkDerivation rec {
+  pname = "libevent";
+  version = "2.1.8";
+  src = fetchurl {
+    url = "https://github.com/libevent/libevent/archive/${pname}-${version}.tar.gz";
+    sha256 = "316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d";
+  };
+
+  configureOptions = selectByHostPlatform [
+    [
       "--disable-shared"
       "--disable-openssl"
       "--disable-libevent-regress"
-    ] ++ (
-      # Platform/Architecture specific opts:
-      let
-        # FIXME: don't hardcode platform/arch:
-        platform = "linux";
-        release = true;
+    ]
+    {
+      kernel = "linux";
+      values = ["--with-pic"];
+    }
+    {
+      kernel = "freebsd";
+      values = ["--with-pic"];
+    }
+    [
+      # FIXME: handle removing this hardcoding to match ./depends?
+      "--disable-debug-mode"
+    ]
+  ];
 
-        releaseOpts = ["--disable-debug-mode"];
-        platformOpts = {
-          linux = ["--with-pic"];
-          freebsd = ["--with-pic"];
-        };
-      in
-        platformOpts.${platform} ++ (if release then releaseOpts else [])
-    );
-
-    patches = ./patches;
-    builder = ./builder.sh;
-    nativeBuildInputs = [
-      autoreconfHook
-    ];
-  }
+  patches = ./patches;
+  builder = ./builder.sh;
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+}
 

--- a/zcutil/nix-builder/zcash/deps/libevent/patches/0.detect-arch4random_addrandom.patch
+++ b/zcutil/nix-builder/zcash/deps/libevent/patches/0.detect-arch4random_addrandom.patch
@@ -1,0 +1,77 @@
+From 6541168d7037457b8e5c51cc354f11bd94e618b6 Mon Sep 17 00:00:00 2001
+From: Marek Sebera <marek.sebera@gmail.com>
+Date: Mon, 6 Mar 2017 00:55:16 +0300
+Subject: [PATCH] Detect arch4random_addrandom() existence
+
+Refs: #370
+Refs: #475
+---
+ CMakeLists.txt        | 1 +
+ configure.ac          | 1 +
+ evutil_rand.c         | 2 ++
+ include/event2/util.h | 2 ++
+ 4 files changed, 6 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a861e7d96..f609d02d0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -338,6 +338,7 @@ CHECK_FUNCTION_EXISTS_EX(sysctl EVENT__HAVE_SYSCTL)
+ CHECK_FUNCTION_EXISTS_EX(accept4 EVENT__HAVE_ACCEPT4)
+ CHECK_FUNCTION_EXISTS_EX(arc4random EVENT__HAVE_ARC4RANDOM)
+ CHECK_FUNCTION_EXISTS_EX(arc4random_buf EVENT__HAVE_ARC4RANDOM_BUF)
++CHECK_FUNCTION_EXISTS_EX(arc4random_addrandom EVENT__HAVE_ARC4RANDOM_ADDRANDOM)
+ CHECK_FUNCTION_EXISTS_EX(epoll_create1 EVENT__HAVE_EPOLL_CREATE1)
+ CHECK_FUNCTION_EXISTS_EX(getegid EVENT__HAVE_GETEGID)
+ CHECK_FUNCTION_EXISTS_EX(geteuid EVENT__HAVE_GETEUID)
+diff --git a/configure.ac b/configure.ac
+index a127bbc91..e73c29b14 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -342,6 +342,7 @@ AC_CHECK_FUNCS([ \
+   accept4 \
+   arc4random \
+   arc4random_buf \
++  arc4random_addrandom \
+   eventfd \
+   epoll_create1 \
+   fcntl \
+diff --git a/evutil_rand.c b/evutil_rand.c
+index 046a14b07..4be0b1c5e 100644
+--- a/evutil_rand.c
++++ b/evutil_rand.c
+@@ -192,12 +192,14 @@ evutil_secure_rng_get_bytes(void *buf, size_t n)
+ 	ev_arc4random_buf(buf, n);
+ }
+ 
++#if !defined(EVENT__HAVE_ARC4RANDOM) || defined(EVENT__HAVE_ARC4RANDOM_ADDRANDOM)
+ void
+ evutil_secure_rng_add_bytes(const char *buf, size_t n)
+ {
+ 	arc4random_addrandom((unsigned char*)buf,
+ 	    n>(size_t)INT_MAX ? INT_MAX : (int)n);
+ }
++#endif
+ 
+ void
+ evutil_free_secure_rng_globals_(void)
+diff --git a/include/event2/util.h b/include/event2/util.h
+index dd4bbb69d..c4af2bd60 100644
+--- a/include/event2/util.h
++++ b/include/event2/util.h
+@@ -842,6 +842,7 @@ int evutil_secure_rng_init(void);
+ EVENT2_EXPORT_SYMBOL
+ int evutil_secure_rng_set_urandom_device_file(char *fname);
+ 
++#ifdef EVENT__HAVE_ARC4RANDOM_ADDRANDOM
+ /** Seed the random number generator with extra random bytes.
+ 
+     You should almost never need to call this function; it should be
+@@ -858,6 +859,7 @@ int evutil_secure_rng_set_urandom_device_file(char *fname);
+  */
+ EVENT2_EXPORT_SYMBOL
+ void evutil_secure_rng_add_bytes(const char *dat, size_t datlen);
++#endif
+ 
+ #ifdef __cplusplus
+ }

--- a/zcutil/nix-builder/zcash/deps/libevent/patches/1.detect-arch4random_addrandom-fix.patch
+++ b/zcutil/nix-builder/zcash/deps/libevent/patches/1.detect-arch4random_addrandom-fix.patch
@@ -1,0 +1,43 @@
+From 266f43af7798befa3d27bfabaa9ae699259c3924 Mon Sep 17 00:00:00 2001
+From: Azat Khuzhin <a3at.mail@gmail.com>
+Date: Mon, 27 Mar 2017 15:50:23 +0300
+Subject: [PATCH] Fix arc4random_addrandom() detecting and fallback
+ (regression)
+
+But this is kind of hot-fix, we definitelly need more sane arc4random
+compat layer.
+
+Fixes: #488
+Introduced-in: 6541168 ("Detect arch4random_addrandom() existence")
+---
+ event-config.h.cmake  | 3 +++
+ include/event2/util.h | 2 +-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/event-config.h.cmake b/event-config.h.cmake
+index b7f0be57c..5c233a3d9 100644
+--- a/event-config.h.cmake
++++ b/event-config.h.cmake
+@@ -53,6 +53,9 @@
+ /* Define to 1 if you have the `arc4random_buf' function. */
+ #cmakedefine EVENT__HAVE_ARC4RANDOM_BUF 1
+ 
++/* Define to 1 if you have the `arc4random_addrandom' function. */
++#cmakedefine EVENT__HAVE_ARC4RANDOM_ADDRANDOM 1
++
+ /* Define if clock_gettime is available in libc */
+ #cmakedefine EVENT__DNS_USE_CPU_CLOCK_FOR_ID 1
+ 
+diff --git a/include/event2/util.h b/include/event2/util.h
+index c4af2bd60..ca4048944 100644
+--- a/include/event2/util.h
++++ b/include/event2/util.h
+@@ -842,7 +842,7 @@ int evutil_secure_rng_init(void);
+ EVENT2_EXPORT_SYMBOL
+ int evutil_secure_rng_set_urandom_device_file(char *fname);
+ 
+-#ifdef EVENT__HAVE_ARC4RANDOM_ADDRANDOM
++#if !defined(EVENT__HAVE_ARC4RANDOM) || defined(EVENT__HAVE_ARC4RANDOM_ADDRANDOM)
+ /** Seed the random number generator with extra random bytes.
+ 
+     You should almost never need to call this function; it should be

--- a/zcutil/nix-builder/zcash/deps/librustzcash/default.nix
+++ b/zcutil/nix-builder/zcash/deps/librustzcash/default.nix
@@ -1,0 +1,25 @@
+with import ./../../../pkgs-pinned.nix;
+let
+  reporoot = ./../../../../..;
+  cargoinfo =
+    with builtins;
+    let
+      cargopath = "${reporoot}/Cargo.toml";
+      toml = fromTOML (readFile cargopath);
+    in toml.package;
+in
+  rustPlatform.buildRustPackage rec {
+    pname = cargoinfo.name;
+    version = cargoinfo.version;
+    src = reporoot;
+    cargoSha256 = "sha256:1n2gl25qfw1q9my9qdg3y98vpsiqn06pmza0dhg1y0f7shri67xs";
+    verifyCargoDeps = true;
+
+    meta = with stdenv.lib; {
+      description = cargoinfo.description;
+      homepage = cargoinfo.homepage;
+      license = cargoinfo.license;
+      maintainers = [ maintainers.tailhook ];
+      platforms = platforms.all;
+    };
+  }

--- a/zcutil/nix-builder/zcash/deps/libsodium/default.nix
+++ b/zcutil/nix-builder/zcash/deps/libsodium/default.nix
@@ -1,0 +1,24 @@
+with import ./../../../pkgs-pinned.nix;
+with import ./../utils.nix;
+stdenv.mkDerivation rec {
+  pname = "libsodium";
+  version = "1.0.18";
+  src = fetchurl {
+    url = "https://download.libsodium.org/libsodium/releases/${pname}-${version}.tar.gz";
+    sha256 = "6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1";
+  };
+
+  patches = [
+    ./../../../../../depends/patches/libsodium/1.0.15-pubkey-validation.diff
+    ./../../../../../depends/patches/libsodium/1.0.15-signature-validation.diff
+  ];
+
+  configureOptions = [
+    "--enable-static"
+    "--disable-shared"
+  ];
+
+  nativeBuildInputs = [
+  ];
+}
+

--- a/zcutil/nix-builder/zcash/deps/native_rust/builder.sh
+++ b/zcutil/nix-builder/zcash/deps/native_rust/builder.sh
@@ -1,6 +1,18 @@
-source "$stdenv/setup"
+source "$zcbuildutil"
+
 tar -xf "$src" --strip-components=1 --one-top-level="."
 bash ./install.sh \
   --destdir="$out" \
   --prefix='/' \
   --disable-ldconfig
+
+# Ref: https://nixos.wiki/wiki/Packaging/Binaries#The_Dynamic_Loader
+for bin in "$out"/bin/*
+do
+  if file "$bin" | sed "s,$bin: *,," | grep -q '^ELF'
+  then
+    basebin="$(basename "$bin")"
+    echo "patchelf on ${basebin@Q}."
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$bin"
+  fi
+done

--- a/zcutil/nix-builder/zcash/deps/native_rust/builder.sh
+++ b/zcutil/nix-builder/zcash/deps/native_rust/builder.sh
@@ -1,0 +1,6 @@
+source "$stdenv/setup"
+tar -xf "$src" --strip-components=1 --one-top-level="."
+bash ./install.sh \
+  --destdir="$out" \
+  --prefix='/' \
+  --disable-ldconfig

--- a/zcutil/nix-builder/zcash/deps/native_rust/default.nix
+++ b/zcutil/nix-builder/zcash/deps/native_rust/default.nix
@@ -1,0 +1,21 @@
+# FIXME: This version does not support cross-builds.
+let
+  pkgs = import ./../../../pkgs-pinned.nix;
+  pname = "rust";
+  version = "1.44.1";
+  buildPlatform = pkgs.buildPlatform.config;
+in
+  pkgs.stdenv.mkDerivation rec {
+    name = "${pname}-${version}-${buildPlatform}";
+    src = pkgs.fetchurl {
+      url = "https://static.rust-lang.org/dist/${name}.tar.gz";
+
+      # BUG: I've only tested on "x86_64-unknown-linux-gnu"
+      sha256 = builtins.getAttr buildPlatform {
+        "x86_64-unknown-linux-gnu" = "a41df89a461a580536aeb42755e43037556fba2e527dd13a1e1bb0749de28202";
+        "x86_64-apple-darwin" = "a5464e7bcbce9647607904a4afa8362382f1fc55d39e7bbaf4483ac00eb5d56a";
+        "x86_64-unknown-freebsd" = "36a14498f9d1d7fb50d6fc01740960a99aff3d4c4c3d2e4fff2795ac8042c957";
+      };
+    };
+    builder = ./builder.sh;
+  }

--- a/zcutil/nix-builder/zcash/deps/native_rust/default.nix
+++ b/zcutil/nix-builder/zcash/deps/native_rust/default.nix
@@ -1,21 +1,32 @@
 # FIXME: This version does not support cross-builds.
+with {
+  inherit (import ./../../zcstd.nix)
+    buildPlatform
+    fetchurl
+    getAttr
+    mkDerivation
+    pkgs
+    zcbuildutil
+  ; 
+};
 let
-  pkgs = import ./../../../pkgs-pinned.nix;
   pname = "rust";
   version = "1.44.1";
-  buildPlatform = pkgs.buildPlatform.config;
+  platform = buildPlatform.config;
 in
-  pkgs.stdenv.mkDerivation rec {
-    name = "${pname}-${version}-${buildPlatform}";
-    src = pkgs.fetchurl {
+  mkDerivation rec {
+    name = "${pname}-${version}-${platform}";
+    src = fetchurl {
       url = "https://static.rust-lang.org/dist/${name}.tar.gz";
 
       # BUG: I've only tested on "x86_64-unknown-linux-gnu"
-      sha256 = builtins.getAttr buildPlatform {
+      sha256 = getAttr platform {
         "x86_64-unknown-linux-gnu" = "a41df89a461a580536aeb42755e43037556fba2e527dd13a1e1bb0749de28202";
         "x86_64-apple-darwin" = "a5464e7bcbce9647607904a4afa8362382f1fc55d39e7bbaf4483ac00eb5d56a";
         "x86_64-unknown-freebsd" = "36a14498f9d1d7fb50d6fc01740960a99aff3d4c4c3d2e4fff2795ac8042c957";
       };
     };
+    inherit zcbuildutil;
+    nativeBuildInputs = [ pkgs.file ];
     builder = ./builder.sh;
   }

--- a/zcutil/nix-builder/zcash/deps/openssl/builder.sh
+++ b/zcutil/nix-builder/zcash/deps/openssl/builder.sh
@@ -1,0 +1,24 @@
+source "$stdenv/setup"
+trap 'ev=$?; set +x; exitHandler; exit $ev' EXIT
+set -x
+set -efuo pipefail
+
+tar -xf "$src"
+cd "${pname}-${version}"
+set +x
+patchShebangs --build ./Configure
+set -x
+
+: ./depends Preprocessing
+sed -i.old 's/built on: $$$$date/built on: date not available/' util/mkbuildinf.pl && \
+sed -i.old "s|\"engines\", \"apps\", \"test\"|\"engines\"|" Configure
+
+: ./depends Configuring
+# What about --openssldir=$out/etc/openssl ?
+./Configure --prefix="$out" $configureOptions
+
+: ./depends Building
+make install_sw
+
+: ./depends Staging/Caching not necessary due to nix.
+rm -rf "$out"/{share,bin,etc}

--- a/zcutil/nix-builder/zcash/deps/openssl/default.nix
+++ b/zcutil/nix-builder/zcash/deps/openssl/default.nix
@@ -1,0 +1,142 @@
+let
+  pkgs = import ./../../../pkgs-pinned.nix;
+in
+  with pkgs;
+  stdenv.mkDerivation rec {
+    pname = "openssl";
+    version = "1.1.1a";
+    src = fetchurl {
+      url = "https://www.openssl.org/source/old/1.1.1/${pname}-${version}.tar.gz";
+      sha256 = "fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41";
+    };
+    
+    configureOptions = [
+      "no-afalgeng"
+      "no-asm"
+      "no-async"
+      "no-bf"
+      "no-blake2"
+      "no-camellia"
+      "no-capieng"
+      "no-cast"
+      "no-chacha"
+      "no-cmac"
+      "no-cms"
+      "no-comp"
+      "no-crypto-mdebug"
+      "no-crypto-mdebug-backtrace"
+      "no-ct"
+      "no-des"
+      "no-dgram"
+      "no-dsa"
+      "no-dso"
+      "no-dtls"
+      "no-dtls1"
+      "no-dtls1-method"
+      "no-dynamic-engine"
+      "no-ec2m"
+      "no-ec_nistp_64_gcc_128"
+      "no-egd"
+      "no-engine"
+      "no-err"
+      "no-gost"
+      "no-heartbeats"
+      "no-idea"
+      "no-md2"
+      "no-md4"
+      "no-mdc2"
+      "no-multiblock"
+      "no-nextprotoneg"
+      "no-ocb"
+      "no-ocsp"
+      "no-poly1305"
+      "no-posix-io"
+      "no-psk"
+      "no-rc2"
+      "no-rc4"
+      "no-rc5"
+      "no-rdrand"
+      "no-rfc3779"
+      "no-rmd160"
+      "no-scrypt"
+      "no-sctp"
+      "no-seed"
+      "no-shared"
+      "no-sock"
+      "no-srp"
+      "no-srtp"
+      "no-ssl"
+      "no-ssl3"
+      "no-ssl3-method"
+      "no-ssl-trace"
+      "no-stdio"
+      "no-tls"
+      "no-tls1"
+      "no-tls1-method"
+      "no-ts"
+      "no-ui"
+      "no-unit-test"
+      "no-weak-ssl-ciphers"
+      "no-whirlpool"
+      "no-zlib"
+      "no-zlib-dynamic"
+      # $($(package)_cflags) $($(package)_cppflags)
+      "-DPURIFY"
+    ] ++ (
+      # Platform/Architecture specific opts:
+      let
+        # FIXME: don't hardcode platform/arch:
+        platform = "linux";
+        arch = "x86_64";
+
+        platformTables = {
+          darwin = {
+            x86_64 = ["darwin64-x86_64-cc"];
+          };
+          freebsd = {
+            all = [
+              "-fPIC"
+              "-Wa,--noexecstack"
+            ];
+            i686 = ["BSD-generic32"];
+            x86_64 = ["BSD-x86_64"];
+          };
+          linux = {
+            all = [
+              "-fPIC"
+              "-Wa,--noexecstack"
+            ];
+            aarch64 = ["linux-generic64"];
+            arm = ["linux-generic32"];
+            i686 = ["linux-generic32"];
+            mips = ["linux-generic32"];
+            mipsel = ["linux-generic32"];
+            powerpc = ["linux-generic32"];
+            x86_64 = ["linux-x86_64"];
+          };
+          mingw32 = {
+            i686 = "mingw";
+            x86_64 = "mingw64";
+          };
+        };
+
+        platformTable = platformTables.${platform};
+        platformOpts = platformTable.all or [];
+        platArchOpts = platformTable.${arch} or [];
+      in
+        platformOpts ++ platArchOpts
+    );
+
+    makeTargets = [
+      "build_libs"
+      "libcrypto.pc"
+      "libssl.pc"
+      "openssl.pc"
+    ];
+
+    builder = ./builder.sh;
+    nativeBuildInputs = [
+      perl
+    ];
+  }
+

--- a/zcutil/nix-builder/zcash/deps/utfcpp/builder.sh
+++ b/zcutil/nix-builder/zcash/deps/utfcpp/builder.sh
@@ -1,0 +1,5 @@
+source "$stdenv/setup"
+set -efuo pipefail
+mkdir "$out"
+tar -xf "$src"
+mv "${pname}-${version}/source" "$out/include"

--- a/zcutil/nix-builder/zcash/deps/utfcpp/default.nix
+++ b/zcutil/nix-builder/zcash/deps/utfcpp/default.nix
@@ -1,0 +1,12 @@
+with import ./../../../pkgs-pinned.nix;
+with import ./../utils.nix;
+stdenv.mkDerivation rec {
+  pname = "utfcpp";
+  version = "3.1";
+  src = fetchurl {
+    url = "https://github.com/nemtrif/$(package)/archive/${pname}-${version}.tar.gz";
+    sha256 = "ab531c3fd5d275150430bfaca01d7d15e017a188183be932322f2f651506b096";
+  };
+
+  builder = ./builder.sh;
+}

--- a/zcutil/nix-builder/zcash/deps/utils.nix
+++ b/zcutil/nix-builder/zcash/deps/utils.nix
@@ -1,0 +1,39 @@
+with import ./../../pkgs-pinned.nix;
+{
+  # Given a list of "selections" return the flattened result of selecting
+  # them by hostPlatform details. This is used heavily for example to
+  # select ./configure options by hostPlatform.
+  selectByHostPlatform = lib.lists.concatMap (elem:
+    with hostPlatform.parsed;
+    let
+      hostCPU = cpu.name;
+      hostVendor = vendor.name;
+      hostKernel = kernel.name;
+      hostABI = abi.name;
+
+      tj = builtins.toJSON;
+
+      select = ({ vendor ? hostVendor, cpu ? hostCPU, kernel ? hostKernel, abi ? hostABI, values }:
+        let
+          mismatched = (
+            candidate: target:
+            !(builtins.isNull candidate || candidate == target)
+          );
+        in if mismatched vendor hostVendor
+        then []
+        else if mismatched cpu hostCPU
+        then []
+        else if mismatched kernel hostKernel
+        then []
+        else if mismatched abi hostABI
+        then []
+        # Everything matches:
+        else values
+      );
+    in select (
+      if builtins.isList elem # A list is shorthand for all platforms:
+      then { values = elem; }
+      else elem
+    )
+  );
+}

--- a/zcutil/nix-builder/zcash/deps/vendored-crates/builder.sh
+++ b/zcutil/nix-builder/zcash/deps/vendored-crates/builder.sh
@@ -1,7 +1,6 @@
 source "$zcbuildutil"
 
-dst="$out/vendored-sources"
-mkdir -p "$dst"
+mkdir -p "$out"
 
 for cratepath in $crates
 do
@@ -10,9 +9,9 @@ do
   cat > "${cratename}/.cargo-checksum.json" <<__EOF
     {
       "package": "$(sha256sum "${cratepath}" | sed 's/ .*$//')",
-      "files" {}
+      "files": {}
     }
 __EOF
-  mv "${cratename}" "${dst}/${cratename}"
+  mv "${cratename}" "${out}/${cratename}"
   echo "nix-vendored: ${cratename@Q}"
 done

--- a/zcutil/nix-builder/zcash/deps/vendored-crates/builder.sh
+++ b/zcutil/nix-builder/zcash/deps/vendored-crates/builder.sh
@@ -1,0 +1,16 @@
+source "$zcbuildutil"
+
+dst="$out/vendored-sources"
+mkdir -p "$dst"
+
+for crate in $crates
+do
+  tar -xf "$crate" --one-top-level='./crate'
+  cratedir="$(ls ./crate)"
+  pkgname="$(
+    grep ^name "./crate/$cratedir/Cargo.toml" | \
+    sed 's/name = "//; s/".*$//'
+  )"
+  echo "$cratedir -> $dst/$pkgname"
+  mv "./crate/$cratedir" "$dst/$pkgname"
+done

--- a/zcutil/nix-builder/zcash/deps/vendored-crates/builder.sh
+++ b/zcutil/nix-builder/zcash/deps/vendored-crates/builder.sh
@@ -3,14 +3,16 @@ source "$zcbuildutil"
 dst="$out/vendored-sources"
 mkdir -p "$dst"
 
-for crate in $crates
+for cratepath in $crates
 do
-  tar -xf "$crate" --one-top-level='./crate'
-  cratedir="$(ls ./crate)"
-  pkgname="$(
-    grep ^name "./crate/$cratedir/Cargo.toml" | \
-    sed 's/name = "//; s/".*$//'
-  )"
-  echo "$cratedir -> $dst/$pkgname"
-  mv "./crate/$cratedir" "$dst/$pkgname"
+  cratename="$(basename "$cratepath" | sed 's/^[^-]*-//; s/\.crate$//')"
+  tar -xf "${cratepath}"
+  cat > "${cratename}/.cargo-checksum.json" <<__EOF
+    {
+      "package": "$(sha256sum "${cratepath}" | sed 's/ .*$//')",
+      "files" {}
+    }
+__EOF
+  mv "${cratename}" "${dst}/${cratename}"
+  echo "nix-vendored: ${cratename@Q}"
 done

--- a/zcutil/nix-builder/zcash/deps/vendored-crates/default.nix
+++ b/zcutil/nix-builder/zcash/deps/vendored-crates/default.nix
@@ -1,0 +1,27 @@
+# FIXME: This version does not support cross-builds.
+with {
+  inherit (import ./../../zcstd.nix)
+    attrNames
+    fetchurl
+    importTOML
+    lib
+    mkDerivation
+    zcname
+    zcsrc
+    zcversion
+    zcbuildutil
+  ; 
+};
+let
+  fetchCrate = import ./fetch-crate.nix;
+  rustpkgname = (importTOML "${zcsrc}/Cargo.toml").package.name;
+  rustpkgs = (importTOML "${zcsrc}/Cargo.lock").package;
+  externalpkgs =
+    lib.lists.filter ({name, ...}: name != rustpkgname) rustpkgs;
+in
+  mkDerivation {
+    name = "${zcname}-${zcversion}-vendored-crates";
+    crates = map fetchCrate externalpkgs;
+    builder = ./builder.sh;
+    zcbuildutil = zcbuildutil;
+  }

--- a/zcutil/nix-builder/zcash/deps/vendored-crates/fetch-crate.nix
+++ b/zcutil/nix-builder/zcash/deps/vendored-crates/fetch-crate.nix
@@ -1,0 +1,20 @@
+with {
+  inherit (import ./../../zcstd.nix)
+    fetchurl
+    lib
+  ; 
+};
+let
+  hardcodedSource = "registry+https://github.com/rust-lang/crates.io-index";
+in
+  { name, version, checksum, source, dependencies ? null }:
+    # Caution: dependencies are ignored!
+
+    assert (source == hardcodedSource);
+
+    # FIXME: This endpoint is potentially unstable.
+    # Ref: https://github.com/rust-lang/crates.io/issues/65
+    fetchurl {
+      url = "https://crates.io/api/v1/crates/${name}/${version}/download";
+      sha256 = checksum;
+    }

--- a/zcutil/nix-builder/zcash/deps/vendored-crates/fetch-crate.nix
+++ b/zcutil/nix-builder/zcash/deps/vendored-crates/fetch-crate.nix
@@ -15,6 +15,7 @@ in
     # FIXME: This endpoint is potentially unstable.
     # Ref: https://github.com/rust-lang/crates.io/issues/65
     fetchurl {
+      name = "${name}-${version}.crate";
       url = "https://crates.io/api/v1/crates/${name}/${version}/download";
       sha256 = checksum;
     }

--- a/zcutil/nix-builder/zcash/zc-build-util.sh
+++ b/zcutil/nix-builder/zcash/zc-build-util.sh
@@ -12,3 +12,6 @@ then
   trap 'zc-build-util-cleanup; exitHandler' EXIT
   set -x
 fi
+
+set -euo pipefail
+

--- a/zcutil/nix-builder/zcash/zc-build-util.sh
+++ b/zcutil/nix-builder/zcash/zc-build-util.sh
@@ -1,0 +1,14 @@
+source "$stdenv/setup"
+
+# Set ZC_TRACE=1 in a derivation to see clean xtrace.
+if [ -n "${ZC_TRACE:-}" ]
+then
+  function zc-build-util-cleanup {
+    local ecode=$?;
+    set +x
+    return $ecode;
+  }
+
+  trap 'zc-build-util-cleanup; exitHandler' EXIT
+  set -x
+fi

--- a/zcutil/nix-builder/zcash/zcstd.nix
+++ b/zcutil/nix-builder/zcash/zcstd.nix
@@ -11,6 +11,7 @@ rec {
   pkgs = import ./../pkgs-pinned.nix;
   inherit (pkgs) lib buildPlatform fetchurl stdenv;
   inherit (stdenv) mkDerivation;
+  inherit (lib.strings) concatStrings;
 
   # Our own utilities:
   fnCompose = f: g: arg: f (g arg);

--- a/zcutil/nix-builder/zcash/zcstd.nix
+++ b/zcutil/nix-builder/zcash/zcstd.nix
@@ -6,7 +6,7 @@ rec {
   zcsrc = ./../../..;
 
   # Frequently used libraries:
-  inherit (builtins) attrNames;
+  inherit (builtins) attrNames getAttr;
   
   pkgs = import ./../pkgs-pinned.nix;
   inherit (pkgs) lib buildPlatform fetchurl stdenv;

--- a/zcutil/nix-builder/zcash/zcstd.nix
+++ b/zcutil/nix-builder/zcash/zcstd.nix
@@ -1,0 +1,21 @@
+# Common definitions used across Zcash derivations:
+rec {
+  # High-level Zcash parameters:
+  zcname = "zcash";
+  zcversion = "FIXME";
+  zcsrc = ./../../..;
+
+  # Frequently used libraries:
+  inherit (builtins) attrNames;
+  
+  pkgs = import ./../pkgs-pinned.nix;
+  inherit (pkgs) lib buildPlatform fetchurl stdenv;
+  inherit (stdenv) mkDerivation;
+
+  # Our own utilities:
+  fnCompose = f: g: arg: f (g arg);
+  importTOML = with builtins; fnCompose fromTOML readFile;
+
+  # Useful builder script utilities:
+  zcbuildutil = ./zc-build-util.sh;
+}


### PR DESCRIPTION
This branch should not be merged. I'm creating this PR to document this proof-of-concept milestone, get early review for anyone interested, and document next steps to make a mergable PR.

PoC features:

- This branch succeeds in building zcash via nix.
- It pins all of the dependencies that have been ported to nix from `./depends` to the same hashes.
- It has not ported `ccache`, `cctools`, or `zeromq`.
- It pins all nix dependencies (including the complete build toolchain, I believe) to the latest stable release of nixpkgs as of about a week ago.
- It builds with the nix-pinned C/C++ tool chain rather than `clang`.
- It uses the pinned `native_rust` for building `librustzcash` and dependencies.
- It emulates `cargo vendor` in the nix language, fetching crates by the hashes listed in `Cargo.lock` automagically. This seems to work but may be brittle if `Cargo` formats change or we begin using new cargo features.
- It probably doesn't support cross-compiling well at all yet (this seems fairly feasible in the future).