### PR TITLE
Ensure that `CONFIGURE_FLAGS=--enable-debug` correctly uses -O0 for dependencies and main build

### DIFF
--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -36,7 +36,7 @@ darwin_CXXFLAGS=$(darwin_CFLAGS)
 darwin_release_CFLAGS=-O3
 darwin_release_CXXFLAGS=$(darwin_release_CFLAGS)
 
-darwin_debug_CFLAGS=-O1
+darwin_debug_CFLAGS=-O0
 darwin_debug_CXXFLAGS=$(darwin_debug_CFLAGS)
 
 darwin_native_binutils=native_cctools

--- a/depends/hosts/freebsd.mk
+++ b/depends/hosts/freebsd.mk
@@ -4,7 +4,7 @@ freebsd_CXXFLAGS=$(freebsd_CFLAGS)
 freebsd_release_CFLAGS=-O3
 freebsd_release_CXXFLAGS=$(freebsd_release_CFLAGS)
 
-freebsd_debug_CFLAGS=-O1
+freebsd_debug_CFLAGS=-O0
 freebsd_debug_CXXFLAGS=$(freebsd_debug_CFLAGS)
 
 freebsd_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -4,7 +4,7 @@ linux_CXXFLAGS=$(linux_CFLAGS)
 linux_release_CFLAGS=-O3
 linux_release_CXXFLAGS=$(linux_release_CFLAGS)
 
-linux_debug_CFLAGS=-O1
+linux_debug_CFLAGS=-O0
 linux_debug_CXXFLAGS=$(linux_debug_CFLAGS)
 
 linux_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -6,7 +6,7 @@ mingw32_LDFLAGS?=-fuse-ld=lld
 mingw32_release_CFLAGS=-O3
 mingw32_release_CXXFLAGS=$(mingw32_release_CFLAGS)
 
-mingw32_debug_CFLAGS=-O1
+mingw32_debug_CFLAGS=-O0
 mingw32_debug_CXXFLAGS=$(mingw32_debug_CFLAGS)
 
 mingw32_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -69,7 +69,15 @@ set -x
 eval "$MAKE" --version
 as --version
 
-HOST="$HOST" BUILD="$BUILD" "$MAKE" "$@" -C ./depends/
+ENABLE_DEBUG_REGEX='^(.*\s)?--enable-debug(\s.*)?$'
+if [[ "$CONFIGURE_FLAGS" =~ $ENABLE_DEBUG_REGEX ]]
+then
+    DEBUG=1
+else
+    DEBUG=
+fi
+
+HOST="$HOST" BUILD="$BUILD" "$MAKE" "$@" -C ./depends/ DEBUG="$DEBUG"
 
 if [ "${BUILD_STAGE:-all}" = "depends" ]
 then


### PR DESCRIPTION
Test plan:
* build using `zcutil/build.sh V=1` and confirm from the build log that all dependencies and the main build use `-O1`
* run `zcutil/distclean.sh` then build using `CONFIGURE_FLAGS=--enable-debug zcutil/build.sh V=1`
* confirm from the build log that all dependencies and the main build use `-O0`
* run builds with and without `--enable-debug` under `gdb`, and find a case where local variables are usually optimized out, but not with `--enable-debug`.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>