### PR TITLE
build: Remove a stray -lcrypto

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -817,7 +817,7 @@ esac
 AX_CHECK_COMPILE_FLAG([-fno-strict-aliasing],[CXXFLAGS="$CXXFLAGS -fno-strict-aliasing"])
 AX_CHECK_COMPILE_FLAG([-Wno-builtin-declaration-mismatch],[CXXFLAGS="$CXXFLAGS -Wno-builtin-declaration-mismatch"],,[[$CXXFLAG_WERROR]])
 
-LIBZCASH_LIBS="$BOOST_SYSTEM_LIB -lcrypto -lsodium $RUST_LIBS"
+LIBZCASH_LIBS="$BOOST_SYSTEM_LIB -lsodium $RUST_LIBS"
 
 AC_MSG_CHECKING([whether to build bitcoind])
 AM_CONDITIONAL([BUILD_BITCOIND], [test x$build_bitcoind = xyes])


### PR DESCRIPTION
zcash/zcash#4740 removed OpenSSL from our depends system, so we were
not satisfying this linker flag intentionally. Configurations where a
target OpenSSL could not be found by the linker, such as cross-compiles
and native macOS builds, were therefore failing. However, OpenSSL is
likely available in the system for all the "supported builders" (which
are all Linux-based), so the linker was likely being satisfied by that
library, enabling the previous PR to be merged.