### PR TITLE
Add logging when we receive an invalid note plaintext (using the "receiveunsafe" log category)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -423,7 +423,7 @@ std::string HelpMessage(HelpMessageMode mode)
                 "Use given addresses for block subsidy share paid to the funding stream with id <streamId> (regtest-only)");
     }
     string debugCategories = "addrman, alert, bench, coindb, db, estimatefee, http, libevent, lock, mempool, net, partitioncheck, pow, proxy, prune, "
-                             "rand, reindex, rpc, selectcoins, tor, zmq, zrpc, zrpcunsafe (implies zrpc)"; // Don't translate these
+                             "rand, receiveunsafe, reindex, rpc, selectcoins, tor, zmq, zrpc, zrpcunsafe (implies zrpc)"; // Don't translate these
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +
         _("If <category> is not supplied or if <category> = 1, output all debugging information.") + " " + _("<category> can be:") + " " + debugCategories + ". " + 
         _("For multiple specific categories use -debug=<category> multiple times."));

--- a/src/zcash/Note.cpp
+++ b/src/zcash/Note.cpp
@@ -229,6 +229,8 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
 
         // Check leadbyte is allowed at block height
         if (!plaintext_version_is_valid(params, height, plaintext.get_leadbyte())) {
+            LogPrint("receiveunsafe", "Received note plaintext with invalid lead byte %d at height %d",
+                     plaintext.get_leadbyte(), height);
             return boost::none;
         }
 
@@ -328,6 +330,8 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
 
         // Check leadbyte is allowed at block height
         if (!plaintext_version_is_valid(params, height, plaintext.get_leadbyte())) {
+            LogPrint("receiveunsafe", "Received note plaintext with invalid lead byte %d at height %d",
+                     plaintext.get_leadbyte(), height);
             return boost::none;
         }
 


### PR DESCRIPTION
fixes #4735

Signed-off-by: Daira Hopwood <daira@jacaranda.org>
