### PR TITLE
FFI: Merge librustzcash_init_zksnark_params variants into one function

### DIFF
--- a/src/rust/src/rustzcash.rs
+++ b/src/rust/src/rustzcash.rs
@@ -96,65 +96,54 @@ fn fixed_scalar_mult(from: &[u8; 32], p_g: &jubjub::SubgroupPoint) -> jubjub::Su
 
 /// Loads the zk-SNARK parameters into memory and saves paths as necessary.
 /// Only called once.
-#[cfg(not(target_os = "windows"))]
 #[no_mangle]
 pub extern "C" fn librustzcash_init_zksnark_params(
-    spend_path: *const u8,
+    #[cfg(not(target_os = "windows"))] spend_path: *const u8,
+    #[cfg(target_os = "windows")] spend_path: *const u16,
     spend_path_len: usize,
-    output_path: *const u8,
+    #[cfg(not(target_os = "windows"))] output_path: *const u8,
+    #[cfg(target_os = "windows")] output_path: *const u16,
     output_path_len: usize,
-    sprout_path: *const u8,
+    #[cfg(not(target_os = "windows"))] sprout_path: *const u8,
+    #[cfg(target_os = "windows")] sprout_path: *const u16,
     sprout_path_len: usize,
 ) {
-    let spend_path = Path::new(OsStr::from_bytes(unsafe {
-        slice::from_raw_parts(spend_path, spend_path_len)
-    }));
-    let output_path = Path::new(OsStr::from_bytes(unsafe {
-        slice::from_raw_parts(output_path, output_path_len)
-    }));
-    let sprout_path = if sprout_path.is_null() {
-        None
-    } else {
-        Some(Path::new(OsStr::from_bytes(unsafe {
-            slice::from_raw_parts(sprout_path, sprout_path_len)
-        })))
+    #[cfg(not(target_os = "windows"))]
+    let (spend_path, output_path, sprout_path) = {
+        (
+            OsStr::from_bytes(unsafe { slice::from_raw_parts(spend_path, spend_path_len) }),
+            OsStr::from_bytes(unsafe { slice::from_raw_parts(output_path, output_path_len) }),
+            if sprout_path.is_null() {
+                None
+            } else {
+                Some(OsStr::from_bytes(unsafe {
+                    slice::from_raw_parts(sprout_path, sprout_path_len)
+                }))
+            },
+        )
     };
 
-    init_zksnark_params(spend_path, output_path, sprout_path)
-}
-
-/// Loads the zk-SNARK parameters into memory and saves paths as necessary.
-/// Only called once.
-#[cfg(target_os = "windows")]
-#[no_mangle]
-pub extern "C" fn librustzcash_init_zksnark_params(
-    spend_path: *const u16,
-    spend_path_len: usize,
-    output_path: *const u16,
-    output_path_len: usize,
-    sprout_path: *const u16,
-    sprout_path_len: usize,
-) {
-    let spend_path =
-        OsString::from_wide(unsafe { slice::from_raw_parts(spend_path, spend_path_len) });
-    let output_path =
-        OsString::from_wide(unsafe { slice::from_raw_parts(output_path, output_path_len) });
-    let sprout_path = if sprout_path.is_null() {
-        None
-    } else {
-        Some(OsString::from_wide(unsafe {
-            slice::from_raw_parts(sprout_path, sprout_path_len)
-        }))
+    #[cfg(target_os = "windows")]
+    let (spend_path, output_path, sprout_path) = {
+        (
+            OsString::from_wide(unsafe { slice::from_raw_parts(spend_path, spend_path_len) }),
+            OsString::from_wide(unsafe { slice::from_raw_parts(output_path, output_path_len) }),
+            if sprout_path.is_null() {
+                None
+            } else {
+                Some(OsString::from_wide(unsafe {
+                    slice::from_raw_parts(sprout_path, sprout_path_len)
+                }))
+            },
+        )
     };
 
-    init_zksnark_params(
+    let (spend_path, output_path, sprout_path) = (
         Path::new(&spend_path),
         Path::new(&output_path),
         sprout_path.as_ref().map(|p| Path::new(p)),
-    )
-}
+    );
 
-fn init_zksnark_params(spend_path: &Path, output_path: &Path, sprout_path: Option<&Path>) {
     // Load params
     let (spend_params, spend_vk, output_params, output_vk, sprout_vk) =
         load_parameters(spend_path, output_path, sprout_path);


### PR DESCRIPTION
Rust 1.39.0 added support for attributes on function parameters.

Closes #4651.