### PR TITLE
depends: Postpone current and scheduled Rust releases until 2021

### DIFF
--- a/qa/zcash/postponed-updates.txt
+++ b/qa/zcash/postponed-updates.txt
@@ -5,14 +5,17 @@
 #
 
 bdb 18.1.40 2021-01-20
+
+# We currently pin Rust 1.44.1, and plan to re-evaluate this in 2021 if
+# we haven't already upgraded before then. In the meantime, postpone
+# current and scheduled subsequent releases through the end of the year.
 native_rust 1.45.0 2021-01-20
 native_rust 1.45.1 2021-01-20
 native_rust 1.45.2 2021-01-20
 native_rust 1.46.0 2021-01-20
-
-rust 1.45.0 2021-01-20
-rust 1.45.1 2021-01-20
-rust 1.45.2 2021-01-20
+native_rust 1.47.0 2021-01-20
+native_rust 1.48.0 2021-01-20
+native_rust 1.49.0 2021-01-20
 
 # Google Test 1.10.0 requires adding CMake to the depends system.
 googletest 1.10.0 2021-01-20


### PR DESCRIPTION
We don't currently have a need for newer releases, and will likely be
pinning Rust for longer periods of time once we are also pinning Clang.
Rust releases occur every six weeks, so we can pre-emptively postpone
releases through the end of this year.