### PR TITLE
Fix a new warning about use of boost::bind placeholders after updating Boost

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -56,7 +56,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/thread.hpp>
 
@@ -67,6 +67,7 @@
 #include "librustzcash.h"
 
 using namespace std;
+using namespace boost::placeholders;
 
 extern void ThreadSendAlert();
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -18,7 +18,7 @@
 
 #include <univalue.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 #include <boost/iostreams/concepts.hpp>
@@ -32,6 +32,7 @@
 
 using namespace RPCServer;
 using namespace std;
+using namespace boost::placeholders;
 
 static bool fRPCRunning = false;
 static bool fRPCInWarmup = true;

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -14,7 +14,7 @@
 #include <set>
 #include <stdlib.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -27,6 +27,8 @@
 #include <event2/util.h>
 #include <event2/event.h>
 #include <event2/thread.h>
+
+using namespace boost::placeholders;
 
 /** Default control port */
 const std::string DEFAULT_TOR_CONTROL = "127.0.0.1:9051";


### PR DESCRIPTION
closes #4774

Signed-off-by: Daira Hopwood <daira@jacaranda.org>