### PR TITLE
Beef up the CoC to address use of dog-whistles

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -13,6 +13,10 @@ body size, race, ethnicity, age, religion, or nationality.
 Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery
+* The use of language or imagery that originates with, or has been
+  adopted as a symbol or "dog-whistle" for, any of: right-wing extremism,
+  anti-Semitism, Islamophobia, white supremacism, eugenics, homophobia, or
+  transphobia (whether or not the use by itself falls into those categories)
 * Personal attacks
 * Trolling or insulting/derogatory comments
 * Public or private harassment


### PR DESCRIPTION
This will make it easier to put a stop to the shitty alt-right memes (for example, [Clown World](https://rationalwiki.org/wiki/Clown_World) and similar memes) posted by a small minority of forum users. The problem is that these memes are specifically designed for plausible deniability. Therefore it may be difficult to prove intent — and the harm to contributors from affected groups is done regardless of intent.

Note: use of alt-right dog-whistles is a problem that we actually have. Memes used by tankies aren't great either but that's not a problem we have (and we could add something to address that if we ever did).

Signed-off-by: Daira Hopwood <daira@jacaranda.org>
