### PR TITLE
depends: Use patch rather than sed in bdb package

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -4,6 +4,7 @@ $(package)_download_path=https://download.oracle.com/berkeley-db
 $(package)_file_name=db-$($(package)_version).tar.gz
 $(package)_sha256_hash=47612c8991aa9ac2f6be721267c8d3cdccf5ac83105df8e50809daea24e95dc7
 $(package)_build_subdir=build_unix
+$(package)_patches=winioctl-and-atomic_init_db.patch
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared --enable-cxx --disable-replication --enable-option-checking
@@ -18,8 +19,7 @@ $(package)_cxxflags=-std=c++11
 endef
 
 define $(package)_preprocess_cmds
-  sed -i.old 's/WinIoCtl.h/winioctl.h/g' src/dbinc/win_db.h && \
-  sed -i.old 's/atomic_init/atomic_init_db/' src/dbinc/atomic.h src/mp/mp_region.c src/mp/mp_mvcc.c src/mp/mp_fget.c src/mutex/mut_method.c src/mutex/mut_tas.c
+  patch -p1 <$($(package)_patch_dir)/winioctl-and-atomic_init_db.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/bdb/winioctl-and-atomic_init_db.patch
+++ b/depends/patches/bdb/winioctl-and-atomic_init_db.patch
@@ -1,0 +1,136 @@
+diff --git a/src/dbinc/atomic.h b/src/dbinc/atomic.h
+index e4420aa..4799b5f 100644
+--- a/src/dbinc/atomic.h
++++ b/src/dbinc/atomic.h
+@@ -70,7 +70,7 @@ typedef struct {
+  * These have no memory barriers; the caller must include them when necessary.
+  */
+ #define	atomic_read(p)		((p)->value)
+-#define	atomic_init(p, val)	((p)->value = (val))
++#define	atomic_init_db(p, val)	((p)->value = (val))
+ 
+ #ifdef HAVE_ATOMIC_SUPPORT
+ 
+@@ -225,7 +225,7 @@ static inline int __atomic_compare_exchange_int(
+ #define	atomic_dec(env, p)	(--(p)->value)
+ #define	atomic_compare_exchange(env, p, oldval, newval)		\
+ 	(DB_ASSERT(env, atomic_read(p) == (oldval)),		\
+-	atomic_init(p, (newval)), 1)
++	atomic_init_db(p, (newval)), 1)
+ #else
+ #define	atomic_inc(env, p)	__atomic_inc_int(env, p)
+ #define	atomic_dec(env, p)	__atomic_dec_int(env, p)
+diff --git a/src/dbinc/win_db.h b/src/dbinc/win_db.h
+index f5228f4..6e44659 100644
+--- a/src/dbinc/win_db.h
++++ b/src/dbinc/win_db.h
+@@ -51,7 +51,7 @@
+ #include <windows.h>
+ #include <winsock2.h>
+ #ifndef DB_WINCE
+-#include <WinIoCtl.h>
++#include <winioctl.h>
+ #endif
+ 
+ #ifdef HAVE_GETADDRINFO
+diff --git a/src/mp/mp_fget.c b/src/mp/mp_fget.c
+index 59fe9fe..fa4ced7 100644
+--- a/src/mp/mp_fget.c
++++ b/src/mp/mp_fget.c
+@@ -654,7 +654,7 @@ alloc:		/* Allocate a new buffer header and data space. */
+ 
+ 		/* Initialize enough so we can call __memp_bhfree. */
+ 		alloc_bhp->flags = 0;
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ #ifdef DIAGNOSTIC
+ 		if ((uintptr_t)alloc_bhp->buf & (sizeof(size_t) - 1)) {
+ 			__db_errx(env, DB_STR("3025",
+@@ -969,7 +969,7 @@ alloc:		/* Allocate a new buffer header and data space. */
+ 			MVCC_MPROTECT(bhp->buf, mfp->pagesize,
+ 			    PROT_READ);
+ 
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ 		MUTEX_LOCK(env, alloc_bhp->mtx_buf);
+ 		alloc_bhp->priority = bhp->priority;
+ 		alloc_bhp->pgno = bhp->pgno;
+diff --git a/src/mp/mp_mvcc.c b/src/mp/mp_mvcc.c
+index 83c4d72..0a47202 100644
+--- a/src/mp/mp_mvcc.c
++++ b/src/mp/mp_mvcc.c
+@@ -281,7 +281,7 @@ __memp_bh_freeze(dbmp, infop, hp, bhp, need_frozenp)
+ #else
+ 	memcpy(frozen_bhp, bhp, SSZA(BH, buf));
+ #endif
+-	atomic_init(&frozen_bhp->ref, 0);
++	atomic_init_db(&frozen_bhp->ref, 0);
+ 	if (mutex != MUTEX_INVALID)
+ 		frozen_bhp->mtx_buf = mutex;
+ 	else if ((ret = __mutex_alloc(env, MTX_MPOOL_BH,
+@@ -440,7 +440,7 @@ __memp_bh_thaw(dbmp, infop, hp, frozen_bhp, alloc_bhp)
+ #endif
+ 		alloc_bhp->mtx_buf = mutex;
+ 		MUTEX_LOCK(env, alloc_bhp->mtx_buf);
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ 		F_CLR(alloc_bhp, BH_FROZEN);
+ 	}
+ 
+diff --git a/src/mp/mp_region.c b/src/mp/mp_region.c
+index 4d95e4f..e97459c 100644
+--- a/src/mp/mp_region.c
++++ b/src/mp/mp_region.c
+@@ -278,7 +278,7 @@ __memp_init(env, dbmp, reginfo_off, htab_buckets, max_nreg)
+ 			     MTX_MPOOL_FILE_BUCKET, 0, &htab[i].mtx_hash)) != 0)
+ 				return (ret);
+ 			SH_TAILQ_INIT(&htab[i].hash_bucket);
+-			atomic_init(&htab[i].hash_page_dirty, 0);
++			atomic_init_db(&htab[i].hash_page_dirty, 0);
+ 		}
+ 
+ 		mtx_base = mtx_prev = MUTEX_INVALID;
+@@ -332,7 +332,7 @@ no_prealloc:
+ 		    DB_MUTEX_SHARED, &hp->mtx_hash)) != 0)
+ 			return (ret);
+ 		SH_TAILQ_INIT(&hp->hash_bucket);
+-		atomic_init(&hp->hash_page_dirty, 0);
++		atomic_init_db(&hp->hash_page_dirty, 0);
+ #ifdef HAVE_STATISTICS
+ 		hp->hash_io_wait = 0;
+ 		hp->hash_frozen = hp->hash_thawed = hp->hash_frozen_freed = 0;
+diff --git a/src/mutex/mut_method.c b/src/mutex/mut_method.c
+index 72b34de..a9f9868 100644
+--- a/src/mutex/mut_method.c
++++ b/src/mutex/mut_method.c
+@@ -501,7 +501,7 @@ __atomic_compare_exchange_int(env, v, oldval, newval)
+ 	MUTEX_LOCK(env, mtx);
+ 	ret = atomic_read(v) == oldval;
+ 	if (ret)
+-		atomic_init(v, newval);
++		atomic_init_db(v, newval);
+ 	MUTEX_UNLOCK(env, mtx);
+ 
+ 	return (ret);
+diff --git a/src/mutex/mut_tas.c b/src/mutex/mut_tas.c
+index 7899c4b..d9420fa 100644
+--- a/src/mutex/mut_tas.c
++++ b/src/mutex/mut_tas.c
+@@ -47,7 +47,7 @@ __db_tas_mutex_init(env, mutex, flags)
+ 
+ #ifdef HAVE_SHARED_LATCHES
+ 	if (F_ISSET(mutexp, DB_MUTEX_SHARED))
+-		atomic_init(&mutexp->sharecount, 0);
++		atomic_init_db(&mutexp->sharecount, 0);
+ 	else
+ #endif
+ 	if (MUTEX_INIT(&mutexp->tas)) {
+@@ -643,7 +643,7 @@ was_not_locked:
+ 			F_CLR(mutexp, DB_MUTEX_LOCKED);
+ 			/* Flush flag update before zeroing count */
+ 			MEMBAR_EXIT();
+-			atomic_init(&mutexp->sharecount, 0);
++			atomic_init_db(&mutexp->sharecount, 0);
+ 		} else {
+ 			DB_ASSERT(env, sharecount > 0);
+ 			MEMBAR_EXIT();


### PR DESCRIPTION
This converts a sed command within a makefile into a static patch file in the
`./depends` system for `bdb`. We use `sed` in some dependencies to replace
some "dynamic" stuff, where regular expressions are necessary (such as to
remove build-non-reproducibility, I believe). However, whenever we can use a
patchfile, I feel that's superior because it's easier to manually read a patch
file and it's known that the change is "static".

Equivalent to the first commit in https://github.com/bitcoin/bitcoin/pull/19761