### PR TITLE
test: Use default shielded address in RPC tests where the type is irrelevant

### DIFF
--- a/qa/rpc-tests/regtest_signrawtransaction.py
+++ b/qa/rpc-tests/regtest_signrawtransaction.py
@@ -12,7 +12,7 @@ class RegtestSignrawtransactionTest (BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
         taddr = self.nodes[1].getnewaddress()
-        zaddr1 = self.nodes[1].z_getnewaddress('sprout')
+        zaddr1 = self.nodes[1].z_getnewaddress()
 
         self.nodes[0].sendtoaddress(taddr, 2.0)
         self.nodes[0].generate(1)

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -297,7 +297,7 @@ class WalletTest (BitcoinTestFramework):
         assert("joinSplitSig" not in mytxdetails)
 
         # z_sendmany is expected to fail if tx size breaks limit
-        myzaddr = self.nodes[0].z_getnewaddress('sprout')
+        myzaddr = self.nodes[0].z_getnewaddress()
 
         recipients = []
         num_t_recipients = 1000
@@ -308,7 +308,7 @@ class WalletTest (BitcoinTestFramework):
             newtaddr = self.nodes[2].getnewaddress()
             recipients.append({"address":newtaddr, "amount":amount_per_recipient})
         for i in range(0,num_z_recipients):
-            newzaddr = self.nodes[2].z_getnewaddress('sprout')
+            newzaddr = self.nodes[2].z_getnewaddress()
             recipients.append({"address":newzaddr, "amount":amount_per_recipient})
 
         # Issue #2759 Workaround START
@@ -327,7 +327,7 @@ class WalletTest (BitcoinTestFramework):
         assert("size of raw transaction would be larger than limit" in errorString)
 
         # add zaddr to node 2
-        myzaddr = self.nodes[2].z_getnewaddress('sprout')
+        myzaddr = self.nodes[2].z_getnewaddress()
 
         # send node 2 taddr to zaddr
         recipients = []
@@ -367,24 +367,11 @@ class WalletTest (BitcoinTestFramework):
         assert_equal(Decimal(wallet_info["shielded_unconfirmed_balance"]), Decimal('0.0'))
         assert_equal(Decimal(wallet_info["shielded_balance"]), zsendmanynotevalue)
 
-        # there should be at least one joinsplit
-        mytxdetails = self.nodes[2].gettransaction(mytxid)
-        myvjoinsplits = mytxdetails["vjoinsplit"]
-        assert_greater_than(len(myvjoinsplits), 0)
-
-        # the first (probably only) joinsplit should take in all the public value
+        # there should be at least one Sapling output
         mytxdetails = self.nodes[2].getrawtransaction(mytxid, 1)
-        myjoinsplit = mytxdetails["vjoinsplit"][0]
-        assert_equal(myjoinsplit["vpub_old"], zsendmanynotevalue)
-        assert_equal(myjoinsplit["vpub_new"], 0)
-        assert("onetimePubKey" in myjoinsplit.keys())
-        assert("randomSeed" in myjoinsplit.keys())
-        assert("ciphertexts" in myjoinsplit.keys())
-
-        assert(len(mytxdetails["joinSplitPubKey"]) == 64)
-        int(mytxdetails["joinSplitPubKey"], 16) # throws if not a hex string
-        assert(len(mytxdetails["joinSplitSig"]) == 128)
-        int(mytxdetails["joinSplitSig"], 16) # hex string
+        assert_greater_than(len(mytxdetails["vShieldedOutput"]), 0)
+        # the Sapling output should take in all the public value
+        assert_equal(mytxdetails["valueBalance"], -zsendmanynotevalue)
 
         # send from private note to node 0 and node 2
         node0balance = self.nodes[0].getbalance() # 25.99794745
@@ -441,7 +428,7 @@ class WalletTest (BitcoinTestFramework):
 
         assert_equal("not an integer" in errorString, True)
 
-        myzaddr     = self.nodes[0].z_getnewaddress('sprout')
+        myzaddr     = self.nodes[0].z_getnewaddress()
         recipients  = [ {"address": myzaddr, "amount": Decimal('0.0') } ]
         errorString = ''
 

--- a/qa/rpc-tests/wallet_1941.py
+++ b/qa/rpc-tests/wallet_1941.py
@@ -49,7 +49,7 @@ class Wallet1941RegressionTest (BitcoinTestFramework):
         self.sync_all()
 
         mytaddr = get_coinbase_address(self.nodes[0])
-        myzaddr = self.nodes[0].z_getnewaddress('sprout')
+        myzaddr = self.nodes[0].z_getnewaddress()
 
         # Send 10 coins to our zaddr.
         recipients = []
@@ -77,7 +77,7 @@ class Wallet1941RegressionTest (BitcoinTestFramework):
         # Start the new wallet
         self.add_second_node()
         self.nodes[1].getnewaddress()
-        self.nodes[1].z_getnewaddress('sprout')
+        self.nodes[1].z_getnewaddress()
         self.nodes[1].generate(101)
         self.sync_all()
 

--- a/qa/rpc-tests/wallet_anchorfork.py
+++ b/qa/rpc-tests/wallet_anchorfork.py
@@ -8,7 +8,6 @@ from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, stop_nodes, connect_nodes_bi, \
     wait_and_assert_operationid_status, wait_bitcoinds, get_coinbase_address, \
     sync_blocks, sync_mempools
-
 from decimal import Decimal
 
 class WalletAnchorForkTest (BitcoinTestFramework):
@@ -47,7 +46,7 @@ class WalletAnchorForkTest (BitcoinTestFramework):
 
         # Node 0 creates a joinsplit transaction
         mytaddr0 = get_coinbase_address(self.nodes[0])
-        myzaddr0 = self.nodes[0].z_getnewaddress('sprout')
+        myzaddr0 = self.nodes[0].z_getnewaddress()
         recipients = []
         recipients.append({"address":myzaddr0, "amount": Decimal('10.0') - Decimal('0.0001')})
         myopid = self.nodes[0].z_sendmany(mytaddr0, recipients)

--- a/qa/rpc-tests/wallet_changeindicator.py
+++ b/qa/rpc-tests/wallet_changeindicator.py
@@ -18,8 +18,8 @@ class WalletChangeIndicatorTest (BitcoinTestFramework):
     # Tests
     def run_test(self):
         taddr = self.nodes[1].getnewaddress()
-        zaddr1 = self.nodes[1].z_getnewaddress('sprout')
-        zaddr2 = self.nodes[1].z_getnewaddress('sprout')
+        zaddr1 = self.nodes[1].z_getnewaddress()
+        zaddr2 = self.nodes[1].z_getnewaddress()
 
         self.nodes[0].sendtoaddress(taddr, Decimal('1.0'))
         self.generate_and_sync()
@@ -66,12 +66,12 @@ class WalletChangeIndicatorTest (BitcoinTestFramework):
         received_node0 = self.nodes[0].z_listreceivedbyaddress(zaddr1, 0)
         assert_equal(2, len(received_node0))
         unspent_node0 = self.nodes[0].z_listunspent(1, 9999999, True)
-        assert_equal(2, len(unspent_node0))
+        # Sapling viewing keys correctly detect spends, so we only see the unspent note
+        assert_equal(1, len(unspent_node0))
         # node 0 only has a viewing key so does not see the change field
         assert_false('change' in received_node0[0])
         assert_false('change' in received_node0[1])
         assert_false('change' in unspent_node0[0])
-        assert_false('change' in unspent_node0[1])
 
 if __name__ == '__main__':
     WalletChangeIndicatorTest().main()

--- a/qa/rpc-tests/wallet_treestate.py
+++ b/qa/rpc-tests/wallet_treestate.py
@@ -35,7 +35,7 @@ class WalletTreeStateTest (BitcoinTestFramework):
         self.sync_all()
 
         mytaddr = get_coinbase_address(self.nodes[0])
-        myzaddr = self.nodes[0].z_getnewaddress('sprout')
+        myzaddr = self.nodes[0].z_getnewaddress()
 
         # Spend coinbase utxos to create three notes of 9.99990000 each
         recipients = []
@@ -66,15 +66,15 @@ class WalletTreeStateTest (BitcoinTestFramework):
 
         # Tx 1 will change the treestate while Tx 2 containing chained joinsplits is still being generated
         recipients = []
-        recipients.append({"address":self.nodes[2].z_getnewaddress('sprout'), "amount":Decimal('10.0') - Decimal('0.0001')})
+        recipients.append({"address":self.nodes[2].z_getnewaddress(), "amount":Decimal('10.0') - Decimal('0.0001')})
         myopid = self.nodes[0].z_sendmany(mytaddr, recipients)
         wait_and_assert_operationid_status(self.nodes[0], myopid)
 
         # Tx 2 will consume all three notes, which must take at least two joinsplits.  This is regardless of
         # the z_sendmany implementation because there are only two inputs per joinsplit.
         recipients = []
-        recipients.append({"address":self.nodes[2].z_getnewaddress('sprout'), "amount":Decimal('18')})
-        recipients.append({"address":self.nodes[2].z_getnewaddress('sprout'), "amount":Decimal('11.9997') - Decimal('0.0001')})
+        recipients.append({"address":self.nodes[2].z_getnewaddress(), "amount":Decimal('18')})
+        recipients.append({"address":self.nodes[2].z_getnewaddress(), "amount":Decimal('11.9997') - Decimal('0.0001')})
         myopid = self.nodes[0].z_sendmany(myzaddr, recipients)
 
         # Wait for Tx 2 to begin executing...

--- a/qa/rpc-tests/zkey_import_export.py
+++ b/qa/rpc-tests/zkey_import_export.py
@@ -54,11 +54,9 @@ class ZkeyImportExportTest (BitcoinTestFramework):
             try:
                 assert_equal(amts, [tx["amount"] for tx in txs])
                 for tx in txs:
-                    # make sure JoinSplit keys exist and have valid values
-                    assert_equal("jsindex" in tx, True)
-                    assert_equal("jsoutindex" in tx, True)
-                    assert_greater_than(tx["jsindex"], -1)
-                    assert_greater_than(tx["jsoutindex"], -1)
+                    # make sure Sapling outputs exist and have valid values
+                    assert_equal("outindex" in tx, True)
+                    assert_greater_than(tx["outindex"], -1)
             except AssertionError:
                 logging.error(
                     'Expected amounts: %r; txs: %r',
@@ -75,7 +73,7 @@ class ZkeyImportExportTest (BitcoinTestFramework):
         miner.generate(100)
         self.sync_all()
         # Shield Alice's coinbase funds to her zaddr
-        alice_zaddr = alice.z_getnewaddress('sprout')
+        alice_zaddr = alice.z_getnewaddress()
         res = alice.z_shieldcoinbase("*", alice_zaddr)
         wait_and_assert_operationid_status(alice, res['opid'])
         self.sync_all()
@@ -83,7 +81,7 @@ class ZkeyImportExportTest (BitcoinTestFramework):
         self.sync_all()
 
         # Now get a pristine z-address for receiving transfers:
-        bob_zaddr = bob.z_getnewaddress('sprout')
+        bob_zaddr = bob.z_getnewaddress()
         verify_utxos(bob, [], bob_zaddr)
         # TODO: Verify that charlie doesn't have funds in addr
         # verify_utxos(charlie, [])
@@ -117,8 +115,8 @@ class ZkeyImportExportTest (BitcoinTestFramework):
         # z_importkey should have rescanned for new key, so this should pass:
         verify_utxos(charlie, amounts[:4], ipk_zaddr["address"])
 
-        # address is sprout
-        assert_equal(ipk_zaddr["type"], "sprout")
+        # address is Sapling
+        assert_equal(ipk_zaddr["type"], "sapling")
 
         # Verify idempotent behavior:
         ipk_zaddr2 = charlie.z_importkey(bob_privkey)


### PR DESCRIPTION
This means we are running these tests against the recommended functionality,
and that these RPC tests will now use the faster Sapling addresses.