### PR TITLE
allow getaddressutxos if -lightwalletd

### DIFF
--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -10,7 +10,7 @@
 #   getaddresstxids
 #   getaddressbalance
 #   getaddressdeltas
-#   getaddressutxos - available only for insightexplorer
+#   getaddressutxos
 #   getaddressmempool
 
 
@@ -338,7 +338,7 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(deltas_info['end']['hash'], block_hash)
 
         # Test getaddressutxos by comparing results with deltas
-        utxos = self.nodes[1].getaddressutxos(addr1)
+        utxos = self.nodes[3].getaddressutxos(addr1)
 
         # The value 4 note was spent, so won't show up in the utxo list,
         # so for comparison, remove the 4 (and -4 for output) from the

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -668,8 +668,8 @@ UniValue getaddressmempool(const UniValue& params, bool fHelp)
 UniValue getaddressutxos(const UniValue& params, bool fHelp)
 {
     std::string disabledMsg = "";
-    if (!fExperimentalInsightExplorer) {
-        disabledMsg = experimentalDisabledHelpMsg("getaddressutxos", {"insightexplorer"});
+    if (!(fExperimentalInsightExplorer || fExperimentalLightWalletd)) {
+        disabledMsg = experimentalDisabledHelpMsg("getaddressutxos", {"insightexplorer", "lightwalletd"});
     }
     if (fHelp || params.size() != 1)
         throw runtime_error(
@@ -719,7 +719,7 @@ UniValue getaddressutxos(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getaddressutxos", "{\"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"], \"chainInfo\": true}")
             );
 
-    if (!fExperimentalInsightExplorer) {
+    if (!(fExperimentalInsightExplorer || fExperimentalLightWalletd)) {
         throw JSONRPCError(RPC_MISC_ERROR, "Error: getaddressutxos is disabled. "
             "Run './zcash-cli help getaddressutxos' for instructions on how to enable this feature.");
     }


### PR DESCRIPTION
The wallets need to be able to retrieve, via lightwalletd, the UTXO set for a given address, see https://github.com/zcash/lightwalletd/issues/312. The `getaddressutxos` rpc that was added for Insight Explorer is perfect for this, but this rpc is disabled when only `-lightwalletd` is enabled (that is, it requires `-insightexplorer`, which is a superset of `-lightwalletd`). However, the `DB_ADDRESSUNSPENTINDEX` index that supports this rpc is present when only `-lightwalletd` is enabled. This was probably a (fortuitous, as it turns out) oversight. So all that's required is to allow this rpc when `-lightwalletd` is enabled.