### PR TITLE
Fix integer types in DisplayDuration

### DIFF
--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -209,10 +209,10 @@ void ConnectMetricsScreen()
 
 std::string DisplayDuration(int64_t time, DurationFormat format)
 {
-    int days =  time / (24 * 60 * 60);
-    int hours = (time - (days * 24 * 60 * 60)) / (60 * 60);
-    int minutes = (time - (((days * 24) + hours) * 60 * 60)) / 60;
-    int seconds = time - (((((days * 24) + hours) * 60) + minutes) * 60);
+    int64_t days =  time / (24 * 60 * 60);
+    int64_t hours = (time - (days * 24 * 60 * 60)) / (60 * 60);
+    int64_t minutes = (time - (((days * 24) + hours) * 60 * 60)) / 60;
+    int64_t seconds = time - (((((days * 24) + hours) * 60) + minutes) * 60);
 
     std::string strDuration;
     if (format == DurationFormat::REDUCED) {

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -207,12 +207,12 @@ void ConnectMetricsScreen()
     uiInterface.InitMessage.connect(metrics_InitMessage);
 }
 
-std::string DisplayDuration(int64_t time, DurationFormat format)
+std::string DisplayDuration(int64_t duration, DurationFormat format)
 {
-    int64_t days =  time / (24 * 60 * 60);
-    int64_t hours = (time - (days * 24 * 60 * 60)) / (60 * 60);
-    int64_t minutes = (time - (((days * 24) + hours) * 60 * 60)) / 60;
-    int64_t seconds = time - (((((days * 24) + hours) * 60) + minutes) * 60);
+    int64_t days =  duration / (24 * 60 * 60);
+    int64_t hours = (duration - (days * 24 * 60 * 60)) / (60 * 60);
+    int64_t minutes = (duration - (((days * 24) + hours) * 60 * 60)) / 60;
+    int64_t seconds = duration - (((((days * 24) + hours) * 60) + minutes) * 60);
 
     std::string strDuration;
     if (format == DurationFormat::REDUCED) {


### PR DESCRIPTION
After this, `src/zcash-gtest --gtest_filter='Metrics*'` passes on a native macOS build.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>
