### PR TITLE
depends: Move to Clang 9.0.1

### DIFF
--- a/depends/packages/libcxx.mk
+++ b/depends/packages/libcxx.mk
@@ -5,13 +5,13 @@ ifneq ($(canonical_host),$(build))
 ifneq ($(host_os),mingw32)
 # Clang is provided pre-compiled for a bunch of targets; fetch the one we need
 # and stage its copies of the static libraries.
-$(package)_download_path=https://releases.llvm.org/$($(package)_version)
+$(package)_download_path=$(native_clang_download_path)
 $(package)_download_file_aarch64_linux=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
 $(package)_file_name_aarch64_linux=clang-llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
-$(package)_sha256_hash_aarch64_linux=998e9ae6e89bd3f029ed031ad9355c8b43441302c0e17603cf1de8ee9939e5c9
-$(package)_download_file_linux=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-$(package)_file_name_linux=clang-llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-$(package)_sha256_hash_linux=9ef854b71949f825362a119bf2597f744836cb571131ae6b721cd102ffea8cd0
+$(package)_sha256_hash_aarch64_linux=84023d5309646e1f56beed056ab7d7ecf92d03b26e87917deb8e7fc191805d15
+$(package)_download_file_linux=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+$(package)_file_name_linux=clang-llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+$(package)_sha256_hash_linux=1af280e96fec62acf5f3bb525e36baafe09f95f940dc9806e22809a83dfff4f8
 
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/lib && \
@@ -22,12 +22,12 @@ endef
 else
 # For Windows cross-compilation, use the MSYS2 binaries.
 $(package)_download_path=https://repo.msys2.org/mingw/x86_64
-$(package)_download_file=mingw-w64-x86_64-libc++-9.0.1-1-any.pkg.tar.xz
-$(package)_file_name=mingw-w64-x86_64-libcxx-9.0.1-1-any.pkg.tar.xz
+$(package)_download_file=mingw-w64-x86_64-libc++-$($(package)_version)-1-any.pkg.tar.xz
+$(package)_file_name=mingw-w64-x86_64-libcxx-$($(package)_version)-1-any.pkg.tar.xz
 $(package)_sha256_hash=04e77c5d0e3a9efc9cc8ca3b6549af9a9eef6e20d53076295efbdfba76c5f5de
 
-$(package)_libcxxabi_download_file=mingw-w64-x86_64-libc++abi-9.0.1-1-any.pkg.tar.xz
-$(package)_libcxxabi_file_name=mingw-w64-x86_64-libc++abi-9.0.1-1-any.pkg.tar.xz
+$(package)_libcxxabi_download_file=mingw-w64-x86_64-libc++abi-$($(package)_version)-1-any.pkg.tar.xz
+$(package)_libcxxabi_file_name=mingw-w64-x86_64-libc++abi-$($(package)_version)-1-any.pkg.tar.xz
 $(package)_libcxxabi_sha256_hash=e8a38084dc05c9f6bd4ded4fe1cdbbe16f7280d66426a76b2c3c23d0575aad5c
 
 $(package)_extra_sources += $($(package)_libcxxabi_file_name)

--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -1,16 +1,16 @@
 package=native_clang
-$(package)_major_version=8
-$(package)_version=8.0.0
-$(package)_download_path=https://releases.llvm.org/$($(package)_version)
-$(package)_download_file_linux=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-$(package)_file_name_linux=clang-llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-$(package)_sha256_hash_linux=9ef854b71949f825362a119bf2597f744836cb571131ae6b721cd102ffea8cd0
+$(package)_major_version=9
+$(package)_version=9.0.1
+$(package)_download_path=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
+$(package)_download_file_linux=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+$(package)_file_name_linux=clang-llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+$(package)_sha256_hash_linux=1af280e96fec62acf5f3bb525e36baafe09f95f940dc9806e22809a83dfff4f8
 $(package)_download_file_darwin=clang+llvm-$($(package)_version)-x86_64-apple-darwin.tar.xz
 $(package)_file_name_darwin=clang-llvm-$($(package)_version)-x86_64-apple-darwin.tar.xz
-$(package)_sha256_hash_darwin=94ebeb70f17b6384e052c47fef24a6d70d3d949ab27b6c83d4ab7b298278ad6f
+$(package)_sha256_hash_darwin=2fdb7c04fefa4cc651a8b96a5d72311efe6b4be845a08c921166dc9883b0c5b9
 $(package)_download_file_freebsd=clang+llvm-$($(package)_version)-amd64-unknown-freebsd11.tar.xz
 $(package)_file_name_freebsd=clang-llvm-$($(package)_version)-amd64-unknown-freebsd11.tar.xz
-$(package)_sha256_hash_freebsd=af15d14bd25e469e35ed7c43cb7e035bc1b2aa7b55d26ad597a43e72768750a8
+$(package)_sha256_hash_freebsd=4e23de41f67c26f67077e24cf8009e42c59c52c41e930faebfc112a63f7dfd57
 
 # Ensure we have clang native to the builder, not the target host
 ifneq ($(canonical_host),$(build))


### PR DESCRIPTION
Closes #4801.

Clang 9 status as of 2d74d8273c1675761f0e1dfe542836644fb2878f:
| Platform | Native/Cross | Builds? | Notes |
|---|---|---|---|
| Linux | Native | ✔️ |
| macOS | Native | ✔️❔ |
| macOS | Cross | ❌ | Boost: Uses `g++` instead of `clang` (which it pulls from the system), then `libtool: not found` (which system doesn't have) |
| Windows | Cross | ❌ | Fails final link: `lld-link: error: duplicate symbol: _ZTSSt9exception in zcash_cli-bitcoin-cli.o and in libc++abi.a(stdlib_stdexcept.cpp.obj)` etc. |
| aarch64 | Cross | ✔️ |

Clang 10 status (trying it locally, Ubuntu 16.04 reaches EoS in April 2021 so we could jump):
| Platform | Native/Cross | Builds? | Notes |
|---|---|---|---|
| Linux | Native | ✔️ |
| macOS | Native | ❔ |
| macOS | Cross | ❌ | Same Boost problem as with 9 |
| Windows | Cross | ❌ | [1] |
| aarch64 | Cross | ✔️ |

[1]
```
lld-link: error: duplicate symbol: typeinfo name for std::exception
>>> defined at zcash_cli-bitcoin-cli.o
>>> defined at libc++abi.a(stdlib_stdexcept.cpp.obj)
```

Clang 11 status after #4950 (it has Ubuntu 16.04 binaries? cool):
| Platform | Native/Cross | Builds? | Notes |
|---|---|---|---|
| Linux | Native | ✔️ |
| macOS | Native | ❔ |
| macOS | Cross | ✔️ |
| Windows | Cross | ✔️ | Requires `zstd` package. |
| aarch64 | Cross | ✔️ |