### PR TITLE
Update other incorrect uses of `python` instead of `python3`

### DIFF
--- a/zcutil/make-release.py
+++ b/zcutil/make-release.py
@@ -274,7 +274,6 @@ def build():
         'Staging boost...',
         'Staging libevent...',
         'Staging zeromq...',
-        'Staging libgmp...',
         'Staging libsodium...',
         "Leaving directory '%s'" % depends_dir,
         'config.status: creating libzcashconsensus.pc',
@@ -297,7 +296,6 @@ def gen_manpages():
 @phase('Generating release notes.')
 def gen_release_notes(release, releasefrom):
     release_notes = [
-        'python',
         './zcutil/release-notes.py',
         '--version',
         release.novtext,

--- a/zcutil/make-release.py
+++ b/zcutil/make-release.py
@@ -128,9 +128,10 @@ def verify_dependencies(dependencies):
 
 @phase('Checking dependency updates.')
 def verify_dependency_updates():
-    status = subprocess.call(['python', 'qa/zcash/updatecheck.py'])
-    if status != 0:
-        raise SystemExit("Dependency update check did not pass.")
+    try:
+        sh_log('./qa/zcash/updatecheck.py')
+    except SystemExit:
+        raise SystemExit("Dependency update check found updates that have not been correctly postponed.")
 
 @phase('Checking tags.')
 def verify_tags(releaseprev, releasefrom):

--- a/zcutil/release-notes.py
+++ b/zcutil/release-notes.py
@@ -66,7 +66,7 @@ def alias_authors_in_release_notes(line):
 ## Returns dict of {'author': #_of_commits} from a release note
 def authors_in_release_notes(filename):
     note = os.path.join(doc_dir, 'release-notes', filename)
-    with open(note, 'r') as f:
+    with open(note, mode='r', encoding="utf-8", errors="replace") as f:
         authors = {}
         line = f.readline()
         first_name, commits = parse_authors(line)
@@ -82,7 +82,7 @@ def authors_in_release_notes(filename):
 def document_authors():
     print("Writing contributors documented in release-notes directory to authors.md.")
     authors_file = os.path.join(doc_dir, 'authors.md')
-    with open(authors_file, 'w') as f:
+    with open(authors_file, mode='w', encoding="utf-8", errors="replace") as f:
         f.write('Zcash Contributors\n==================\n\n')
         total_contrib = {}
         for notes in os.listdir(os.path.join(doc_dir, 'release-notes')):
@@ -114,10 +114,10 @@ def generate_release_note(version, prev, clear):
         latest_tag = subprocess.Popen(['git describe --abbrev=0'], shell=True, stdout=subprocess.PIPE).communicate()[0].strip()
     print("Previous release tag: ", latest_tag)
     notes = subprocess.Popen(['git shortlog --no-merges {0}..HEAD'.format(latest_tag)], shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE).communicate()[0]
-    lines = notes.decode().split('\n')
+    lines = notes.decode("utf-8", "replace").split('\n')
     lines = [alias_authors_in_release_notes(line) for line in lines]
     temp_release_note = os.path.join(doc_dir, 'release-notes.md')
-    with open(temp_release_note, 'r') as f:
+    with open(temp_release_note, mode='r', encoding="utf-8", errors="replace") as f:
         notable_changes = f.readlines()
         # Assumes that all notable changes are appended to the default header
         if len(notable_changes) > 6:
@@ -125,13 +125,13 @@ def generate_release_note(version, prev, clear):
         else:
             notable_changes = []
     release_note = os.path.join(doc_dir, 'release-notes', filename)
-    with open(release_note, 'w') as f:
+    with open(release_note, mode='w', encoding="utf-8", errors="replace") as f:
         f.writelines(notable_changes)
         f.writelines(RELEASE_NOTES_CHANGELOG_HEADING)
         f.writelines('\n'.join(lines))
     if clear:
         # Clear temporary release notes file
-        with open(temp_release_note, 'w') as f:
+        with open(temp_release_note, mode='w', encoding="utf-8", errors="replace") as f:
             f.writelines(TEMP_RELEASE_NOTES_HEADER)
 
 def main(version, prev, clear):


### PR DESCRIPTION
This also adds explicit replacement of invalid characters in file read/write operations.