### PR TITLE
Fix death gtests on macOS by switching to the threadsafe style

### DIFF
--- a/src/gtest/main.cpp
+++ b/src/gtest/main.cpp
@@ -38,7 +38,11 @@ int main(int argc, char **argv) {
     );
 
   testing::InitGoogleMock(&argc, argv);
-  
+
+  // The "threadsafe" style is necessary for correct operation of death/exit
+  // tests on macOS (https://github.com/zcash/zcash/issues/4802).
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+
   auto ret = RUN_ALL_TESTS();
 
   ECC_Stop();


### PR DESCRIPTION
[Tested on macOS](https://github.com/zcash/zcash/issues/4802#issuecomment-714770192). fixes #4802

Signed-off-by: Daira Hopwood <daira@jacaranda.org>
