### PR TITLE
Improve reject reasons for unmet shielded requirements

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -447,6 +447,14 @@ public:
     friend class CCoinsViewCache;
 };
 
+/** The set of shielded requirements that might be unsatisfied. */
+enum class UnsatisfiedShieldedReq {
+    SproutDuplicateNullifier,
+    SproutUnknownAnchor,
+    SaplingDuplicateNullifier,
+    SaplingUnknownAnchor,
+};
+
 /** CCoinsView that adds a memory cache for transactions to another CCoinsView */
 class CCoinsViewCache : public CCoinsViewBacked
 {
@@ -566,7 +574,7 @@ public:
     bool HaveInputs(const CTransaction& tx) const;
 
     //! Check whether all joinsplit and sapling spend requirements (anchors/nullifiers) are satisfied
-    bool HaveShieldedRequirements(const CTransaction& tx) const;
+    std::optional<UnsatisfiedShieldedReq> HaveShieldedRequirements(const CTransaction& tx) const;
 
     //! Return priority of tx at height nHeight
     double GetPriority(const CTransaction &tx, int nHeight) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1567,10 +1567,14 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         // Are the shielded spends' requirements met?
         auto unmetShieldedReq = view.HaveShieldedRequirements(tx);
         if (unmetShieldedReq) {
+            auto txid = tx.GetHash().ToString();
             auto rejectCode = ShieldedReqRejectCode(*unmetShieldedReq);
             auto rejectReason = ShieldedReqRejectReason(*unmetShieldedReq);
-            return state.Invalid(error("AcceptToMemoryPool: shielded requirements not met (%s)", rejectReason),
-                                 rejectCode, rejectReason);
+            TracingError(
+                "main", "AcceptToMemoryPool(): shielded requirements not met",
+                "txid", txid.c_str(),
+                "reason", rejectReason.c_str());
+            return state.Invalid(false, rejectCode, rejectReason);
         }
 
         // Bring the best block into scope
@@ -2205,10 +2209,14 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
         // Are the shielded spends' requirements met?
         auto unmetShieldedReq = inputs.HaveShieldedRequirements(tx);
         if (unmetShieldedReq) {
+            auto txid = tx.GetHash().ToString();
             auto rejectCode = ShieldedReqRejectCode(*unmetShieldedReq);
             auto rejectReason = ShieldedReqRejectReason(*unmetShieldedReq);
-            return state.Invalid(error("CheckInputs(): %s shielded requirements not met (%s)", tx.GetHash().ToString(), rejectReason),
-                                 rejectCode, rejectReason);
+            TracingError(
+                "main", "CheckInputs(): shielded requirements not met",
+                "txid", txid.c_str(),
+                "reason", rejectReason.c_str());
+            return state.Invalid(false, rejectCode, rejectReason);
         }
 
         CAmount nValueIn = 0;
@@ -2895,10 +2903,14 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             // Are the shielded spends' requirements met?
             auto unmetShieldedReq = view.HaveShieldedRequirements(tx);
             if (unmetShieldedReq) {
+                auto txid = tx.GetHash().ToString();
                 auto rejectCode = ShieldedReqRejectCode(*unmetShieldedReq);
                 auto rejectReason = ShieldedReqRejectReason(*unmetShieldedReq);
-                return state.DoS(100, error("ConnectBlock(): shielded requirements not met (%s)", rejectReason),
-                                 rejectCode, rejectReason);
+                TracingError(
+                    "main", "ConnectBlock(): shielded requirements not met",
+                    "txid", txid.c_str(),
+                    "reason", rejectReason.c_str());
+                return state.DoS(100, false, rejectCode, rejectReason);
             }
 
             // insightexplorer

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,6 +117,28 @@ const string strMessageMagic = "Zcash Signed Message:\n";
 // Internal stuff
 namespace {
 
+    unsigned char ShieldedReqRejectCode(UnsatisfiedShieldedReq shieldedReq)
+    {
+        switch (shieldedReq) {
+            case UnsatisfiedShieldedReq::SproutDuplicateNullifier:
+            case UnsatisfiedShieldedReq::SaplingDuplicateNullifier:
+                return REJECT_DUPLICATE;
+            case UnsatisfiedShieldedReq::SproutUnknownAnchor:
+            case UnsatisfiedShieldedReq::SaplingUnknownAnchor:
+                return REJECT_INVALID;
+        }
+    }
+
+    std::string ShieldedReqRejectReason(UnsatisfiedShieldedReq shieldedReq)
+    {
+        switch (shieldedReq) {
+            case UnsatisfiedShieldedReq::SproutDuplicateNullifier:  return "bad-txns-sprout-duplicate-nullifier";
+            case UnsatisfiedShieldedReq::SproutUnknownAnchor:       return "bad-txns-sprout-unknown-anchor";
+            case UnsatisfiedShieldedReq::SaplingDuplicateNullifier: return "bad-txns-sapling-duplicate-nullifier";
+            case UnsatisfiedShieldedReq::SaplingUnknownAnchor:      return "bad-txns-sapling-unknown-anchor";
+        }
+    }
+
     /** Abort with a message */
     bool AbortNode(const std::string& strMessage, const std::string& userMessage="")
     {
@@ -1542,10 +1564,14 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             return state.Invalid(error("AcceptToMemoryPool: inputs already spent"),
                                  REJECT_DUPLICATE, "bad-txns-inputs-spent");
 
-        // are the joinsplits' and sapling spends' requirements met in tx(valid anchors/nullifiers)?
-        if (!view.HaveShieldedRequirements(tx))
-            return state.Invalid(error("AcceptToMemoryPool: shielded requirements not met"),
-                                 REJECT_DUPLICATE, "bad-txns-shielded-requirements-not-met");
+        // Are the shielded spends' requirements met?
+        auto unmetShieldedReq = view.HaveShieldedRequirements(tx);
+        if (unmetShieldedReq) {
+            auto rejectCode = ShieldedReqRejectCode(*unmetShieldedReq);
+            auto rejectReason = ShieldedReqRejectReason(*unmetShieldedReq);
+            return state.Invalid(error("AcceptToMemoryPool: shielded requirements not met (%s)", rejectReason),
+                                 rejectCode, rejectReason);
+        }
 
         // Bring the best block into scope
         view.GetBestBlock();
@@ -2176,9 +2202,14 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
         if (!inputs.HaveInputs(tx))
             return state.Invalid(error("CheckInputs(): %s inputs unavailable", tx.GetHash().ToString()));
 
-        // are the JoinSplit's requirements met?
-        if (!inputs.HaveShieldedRequirements(tx))
-            return state.Invalid(error("CheckInputs(): %s JoinSplit requirements not met", tx.GetHash().ToString()));
+        // Are the shielded spends' requirements met?
+        auto unmetShieldedReq = inputs.HaveShieldedRequirements(tx);
+        if (unmetShieldedReq) {
+            auto rejectCode = ShieldedReqRejectCode(*unmetShieldedReq);
+            auto rejectReason = ShieldedReqRejectReason(*unmetShieldedReq);
+            return state.Invalid(error("CheckInputs(): %s shielded requirements not met (%s)", tx.GetHash().ToString(), rejectReason),
+                                 rejectCode, rejectReason);
+        }
 
         CAmount nValueIn = 0;
         CAmount nFees = 0;
@@ -2861,10 +2892,14 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 return state.DoS(100, error("ConnectBlock(): inputs missing/spent"),
                                  REJECT_INVALID, "bad-txns-inputs-missingorspent");
 
-            // are the JoinSplit's requirements met?
-            if (!view.HaveShieldedRequirements(tx))
-                return state.DoS(100, error("ConnectBlock(): JoinSplit requirements not met"),
-                                 REJECT_INVALID, "bad-txns-joinsplit-requirements-not-met");
+            // Are the shielded spends' requirements met?
+            auto unmetShieldedReq = view.HaveShieldedRequirements(tx);
+            if (unmetShieldedReq) {
+                auto rejectCode = ShieldedReqRejectCode(*unmetShieldedReq);
+                auto rejectReason = ShieldedReqRejectReason(*unmetShieldedReq);
+                return state.DoS(100, error("ConnectBlock(): shielded requirements not met (%s)", rejectReason),
+                                 rejectCode, rejectReason);
+            }
 
             // insightexplorer
             // https://github.com/bitpay/bitcoin/commit/017f548ea6d89423ef568117447e61dd5707ec42#diff-7ec3c68a81efff79b6ca22ac1f1eabbaR2597

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -644,7 +644,7 @@ BOOST_AUTO_TEST_CASE(chained_joinsplits)
         CMutableTransaction mtx;
         mtx.vJoinSplit.push_back(js2);
 
-        BOOST_CHECK(!cache.HaveShieldedRequirements(mtx));
+        BOOST_CHECK(cache.HaveShieldedRequirements(mtx) == std::optional(UnsatisfiedShieldedReq::SproutUnknownAnchor));
     }
 
     {
@@ -654,7 +654,7 @@ BOOST_AUTO_TEST_CASE(chained_joinsplits)
         mtx.vJoinSplit.push_back(js2);
         mtx.vJoinSplit.push_back(js1);
 
-        BOOST_CHECK(!cache.HaveShieldedRequirements(mtx));
+        BOOST_CHECK(cache.HaveShieldedRequirements(mtx) == std::optional(UnsatisfiedShieldedReq::SproutUnknownAnchor));
     }
 
     {
@@ -662,7 +662,7 @@ BOOST_AUTO_TEST_CASE(chained_joinsplits)
         mtx.vJoinSplit.push_back(js1);
         mtx.vJoinSplit.push_back(js2);
 
-        BOOST_CHECK(cache.HaveShieldedRequirements(mtx));
+        BOOST_CHECK(cache.HaveShieldedRequirements(mtx) == std::nullopt);
     }
 
     {
@@ -671,7 +671,7 @@ BOOST_AUTO_TEST_CASE(chained_joinsplits)
         mtx.vJoinSplit.push_back(js2);
         mtx.vJoinSplit.push_back(js3);
 
-        BOOST_CHECK(cache.HaveShieldedRequirements(mtx));
+        BOOST_CHECK(cache.HaveShieldedRequirements(mtx) == std::nullopt);
     }
 
     {
@@ -681,7 +681,7 @@ BOOST_AUTO_TEST_CASE(chained_joinsplits)
         mtx.vJoinSplit.push_back(js2);
         mtx.vJoinSplit.push_back(js3);
 
-        BOOST_CHECK(cache.HaveShieldedRequirements(mtx));
+        BOOST_CHECK(cache.HaveShieldedRequirements(mtx) == std::nullopt);
     }
 }
 


### PR DESCRIPTION
These reject messages end up bubbling up to users via the RPC interface.
Distinguishing between the various failure cases will help users figure
out why their transaction is being rejected.

Closes zcash/zcash#3114.