### PR TITLE
Fix an error reporting bug in "Checksum missing or mismatched ..."

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -138,7 +138,7 @@ endef
 define check_or_remove_sources
   mkdir -p $($(package)_source_dir); cd $($(package)_source_dir); \
   $(build_SHA256SUM) -c $($(package)_fetched) >/dev/null 2>/dev/null || \
-    ( ( echo $($(package)_all_sources) | xargs -n 1 test -f ) || echo "Checksum missing or mismatched for $(package) source. Forcing re-download."; \
+    ( test -z "$($(package)_all_sources)" || ( echo $($(package)_all_sources) | xargs -n 1 test ! -f ) || echo "Checksum missing or mismatched for $(package) source. Forcing re-download."; \
       rm -f $($(package)_all_sources) $($(1)_fetched))
 endef
 


### PR DESCRIPTION
The sense of the test was accidentally inverted in my change to #4733. The message should be shown if any of the files exist but have an incorrect checksum. fixes #4813

No documentation needed.
Test plan: as for #4733, and also check that there are no false positive "Checksum missing or mismatched ..." warnings.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>
