### PR TITLE
Rename the FS_ZIP214_ECC funding stream to FS_ZIP214_BP

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -208,7 +208,7 @@ public:
 
             consensus.AddZIP207FundingStream(
                 keyConstants,
-                Consensus::FS_ZIP214_ECC,
+                Consensus::FS_ZIP214_BP,
                 consensus.vUpgrades[Consensus::UPGRADE_CANOPY].nActivationHeight, 2726400,
                 ecc_addresses);
             consensus.AddZIP207FundingStream(
@@ -492,7 +492,7 @@ public:
 
             consensus.AddZIP207FundingStream(
                 keyConstants,
-                Consensus::FS_ZIP214_ECC,
+                Consensus::FS_ZIP214_BP,
                 consensus.vUpgrades[Consensus::UPGRADE_CANOPY].nActivationHeight, 2796000,
                 ecc_addresses);
             consensus.AddZIP207FundingStream(

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -89,12 +89,12 @@ typedef boost::variant<libzcash::SaplingPaymentAddress, CScript> FundingStreamAd
  * Being array indices, these MUST be numbered consecutively.
  */
 enum FundingStreamIndex : uint32_t {
-    FS_ZIP214_ECC,
+    FS_ZIP214_BP,
     FS_ZIP214_ZF,
     FS_ZIP214_MG,
     MAX_FUNDING_STREAMS,
 };
-const auto FIRST_FUNDING_STREAM = FS_ZIP214_ECC;
+const auto FIRST_FUNDING_STREAM = FS_ZIP214_BP;
 
 enum FundingStreamError {
     CANOPY_NOT_ACTIVE,


### PR DESCRIPTION
See also https://github.com/zcash/zips/pull/412 .

Signed-off-by: Daira Hopwood <daira@jacaranda.org>
