### PR TITLE
preserve debian stretch

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -32,12 +32,12 @@ files: []
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-linux-gnu"
-  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --enable-hardening"
+  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --enable-hardening --enable-werror"
   MAKEOPTS="V=1"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="date ar ranlib nm strip objcopy"
-  HOST_CFLAGS="-fwrapv -fno-strict-aliasing -Werror -g"
-  HOST_CXXFLAGS="-fwrapv -fno-strict-aliasing -Werror -g"
+  HOST_CFLAGS=""
+  HOST_CXXFLAGS=""
   HOST_LDFLAGS=-static-libstdc++
 
   export QT_RCC_TEST=0


### PR DESCRIPTION
Fix to resolve v4.1.0-rc1 Gitian issues found:

```
--- !!omap
- out_manifest: |
    0ffb45d3ec21d91882cc5289fbef2bcf23d9ab4c77f53e6a01a2bcf8acf9270b  src/zcash-4.1.0-rc1.tar.gz
    fd8f42257e4c1abe50d0137d97b8b9a6ce89d62c1f5f3f0ef8dfffb594a5e089  zcash-4.1.0-rc1-linux64-debug.tar.gz
    58d07602ac3542091e1dcc487c422aefd7b04bf0fa173d390bd7b3e7e710a857  zcash-4.1.0-rc1-linux64.tar.gz
- in_manifest: |-
    1dc9912ff646b37318859230f6377ff1501a9d8104fbf74102ab319db21f57fb  zcash-4.1.0-rc1-desc.yml
    git:498598d56ac549828c2ac5236b4341ebb3ef4310 zcash
- base_manifests: !!omap
  - stretch-amd64: |
```