### PR TITLE
Don't compile ehHashState::* if mining is disabled

### DIFF
--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -20,7 +20,7 @@
 #include "crypto/equihash.h"
 #include "util.h"
 
-
+#ifdef ENABLE_MINING
 void eh_HashState::Update(const unsigned char *input, size_t inputLen)
 {
     blake2b_update(inner.get(), input, inputLen);
@@ -30,6 +30,7 @@ void eh_HashState::Finalize(unsigned char *hash, size_t hLen)
 {
     blake2b_finalize(inner.get(), hash, hLen);
 }
+#endif
 
 // Used in TestEquihashValidator.
 


### PR DESCRIPTION
Compile currently fails if using `CONFIGURE_FLAGS=--disable-mining`, because the `ehHashState::*` functions inadvertently get included. 