### PR TITLE
control-C stops zcashd more quickly during startup

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1423,10 +1423,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                         CleanupBlockRevFiles();
                 }
 
+                LogPrintf("Loading block index...");
                 if (!LoadBlockIndex()) {
                     strLoadError = _("Error loading block database");
                     break;
                 }
+                if (ShutdownRequested()) break;
 
                 // If the loaded chain has a wrong genesis, bail out immediately
                 // (we're likely using a testnet datadir, or the other way around).
@@ -1506,6 +1508,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
             fLoaded = true;
         } while(false);
+
+        if (strLoadError.empty() && fRequestShutdown) break;
 
         if (!fLoaded) {
             // first suggest a reindex

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4656,6 +4656,7 @@ bool static LoadBlockIndexDB()
     const CChainParams& chainparams = Params();
     if (!pblocktree->LoadBlockIndexGuts(InsertBlockIndex, chainparams))
         return false;
+    if (ShutdownRequested()) return true;
 
     boost::this_thread::interruption_point();
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -9,6 +9,7 @@
 #include "hash.h"
 #include "main.h"
 #include "pow.h"
+#include "init.h"
 #include "uint256.h"
 
 #include <stdint.h>
@@ -534,7 +535,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(
 
     // Load mapBlockIndex
     while (pcursor->Valid()) {
-        boost::this_thread::interruption_point();
+        if (ShutdownRequested()) break;
         std::pair<char, uint256> key;
         if (pcursor->GetKey(key) && key.first == DB_BLOCK_INDEX) {
             CDiskBlockIndex diskindex;


### PR DESCRIPTION
Stopping `zcashd` while it is loading the block index during startup has no effect until the entire index is loaded, which can take several minutes. This PR fixes that. Note that it's not possible to reproduce this problem using `zcash-cli stop` because RPC calls aren't allowed until after the block index is loaded (and other initialization is complete).