### PR TITLE
Correctly report founder's reward amount in getblocktemplate prior to Canopy

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -417,6 +417,8 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
             "It returns data needed to construct a block to work on.\n"
             "See https://en.bitcoin.it/wiki/BIP_0022 for full specification.\n"
 
+            "\nTo obtain information about founder's reward or funding stream amounts, use 'getblocksubsidy $(getblocktemplate)[\"height\"]'.\n"
+
             "\nArguments:\n"
             "1. \"jsonrequestobject\"       (string, optional) A json object in the following spec\n"
             "     {\n"

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -417,7 +417,9 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
             "It returns data needed to construct a block to work on.\n"
             "See https://en.bitcoin.it/wiki/BIP_0022 for full specification.\n"
 
-            "\nTo obtain information about founder's reward or funding stream amounts, use 'getblocksubsidy $(getblocktemplate)[\"height\"]'.\n"
+            "\nTo obtain information about founder's reward or funding stream\n"
+            "amounts, use 'getblocksubsidy HEIGHT' passing in the height returned\n"
+            "by this API.\n"
 
             "\nArguments:\n"
             "1. \"jsonrequestobject\"       (string, optional) A json object in the following spec\n"


### PR DESCRIPTION
Previously this would return incorrect results in the case that the
miner reward was sent to a shielded address. Post-Canopy, the
foundersreward field is removed; this information should be obtained
from getblocksubsidy instead.
