### PR TITLE
Windows cross-build generates .lib files, which should be ignored by git and removed by clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ src/univalue/gen
 *.o-*
 .zcash
 *.a
+*.lib
 *.pb.cc
 *.pb.h
 .vscode

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -593,6 +593,7 @@ clean-local:
 	rm -f fuzz.cpp
 	rm -rf fuzzing/*/output
 	-rm -f config.h
+	-rm -f *.lib bench/*.lib test/*.lib
 
 .rc.o:
 	@test -f $(WINDRES)

--- a/zcutil/clean.sh
+++ b/zcutil/clean.sh
@@ -32,7 +32,7 @@ rm -rf cache
 rm -rf target
 rm -rf depends/work
 
-find src -type f -and \( -name '*.Po' -or -name '*.Plo' -or -name '*.o' -or -name '*.a' -or -name '*.la' -or -name '*.lo' -or -name '*.lai' -or -name '*.pc' -or -name '.dirstamp' -or -name '*.gcda' -or -name '*.gcno' -or -name '*.sage.py' -or -name '*.trs' \) -delete
+find src -type f -and \( -name '*.Po' -or -name '*.Plo' -or -name '*.o' -or -name '*.a' -or -name '*.lib' -or -name '*.la' -or -name '*.lo' -or -name '*.lai' -or -name '*.pc' -or -name '.dirstamp' -or -name '*.gcda' -or -name '*.gcno' -or -name '*.sage.py' -or -name '*.trs' \) -delete
 
 clean_dirs()
 {


### PR DESCRIPTION
Signed-off-by: Daira Hopwood <daira@jacaranda.org>
