### PR TITLE
add more version information to getinfo rpc

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -82,6 +82,8 @@ UniValue getinfo(const UniValue& params, bool fHelp)
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("version", CLIENT_VERSION);
+    obj.pushKV("build", FormatFullVersion());
+    obj.pushKV("subversion", strSubVersion);
     obj.pushKV("protocolversion", PROTOCOL_VERSION);
 #ifdef ENABLE_WALLET
     if (pwalletMain) {


### PR DESCRIPTION
Needed for https://github.com/zcash/lightwalletd/issues/319, lightwalletd's `GetLightdInfo` grpc would like to return the zcashd version and commit hash.