### PR TITLE
[Feature] Include transaction hex in verbose getblock output

### DIFF
--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -85,6 +85,9 @@ class RawTransactionsTest(BitcoinTestFramework):
         gottx = self.nodes[0].getrawtransaction(tx, 1)
         assert_equal(gottx['txid'], tx)
         assert 'in_active_chain' not in gottx
+        # We should have hex for the transaction from the getblock and getrawtransaction calls.
+        blk = self.nodes[0].getblock(block1, 2)
+        assert_equal(gottx['hex'], blk['tx'][1]['hex'])
         # We should not get the tx if we provide an unrelated block
         assert_raises(JSONRPCException, self.nodes[0].getrawtransaction, tx, 1, block2)
         # An invalid block hash should raise errors

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -164,6 +164,8 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
         entry.pushKV("expiryheight", (int64_t)tx.nExpiryHeight);
     }
 
+    entry.pushKV("hex", EncodeHexTx(tx));
+
     KeyIO keyIO(Params());
     UniValue vin(UniValue::VARR);
     BOOST_FOREACH(const CTxIn& txin, tx.vin) {


### PR DESCRIPTION
This fixes https://github.com/zcash/zcash/issues/4888 and actually makes it so the existing documentation is correct!

I also added a small test to make sure the transaction hex is returned correctly in verbose (2) `getblock` calls, and matches the value in `getrawtransaction`.