### PR TITLE
Improve logging

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1692,6 +1692,13 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         }
     }
 
+    auto txid = tx.GetHash().ToString();
+    auto poolsz = tfm::format("%u", mempool.mapTx.size());
+
+    TracingInfo("mempool", "Accepted",
+        "txid", txid.c_str(),
+        "poolsize", poolsz.c_str());
+
     return true;
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -298,6 +298,8 @@ public:
     CBloomFilter* pfilter;
     int nRefCount;
     NodeId id;
+    // Stored so we can pass a pointer to it across the Rust FFI for span.
+    std::string idStr;
 
     tracing::Span span;
 protected:
@@ -358,6 +360,10 @@ private:
     void operator=(const CNode&);
 
 public:
+
+    // Regenerate the span for this CNode. This re-queries the log filter to see
+    // if the span should be enabled, and re-collects the logged variables.
+    void ReloadTracingSpan();
 
     NodeId GetId() const {
       return id;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -269,6 +269,8 @@ UniValue setlogfilter(const UniValue& params, bool fHelp)
     }
 
     if (pTracingHandle) {
+        TracingInfo("main", "Reloading log filter", "new_filter", newFilter.c_str());
+
         if (!tracing_reload(pTracingHandle, newFilter.c_str())) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Filter reload failed; check logs");
         }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -8,6 +8,7 @@
 #include "fs.h"
 #include "init.h"
 #include "key_io.h"
+#include "net.h"
 #include "random.h"
 #include "sync.h"
 #include "ui_interface.h"
@@ -270,6 +271,14 @@ UniValue setlogfilter(const UniValue& params, bool fHelp)
     if (pTracingHandle) {
         if (!tracing_reload(pTracingHandle, newFilter.c_str())) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Filter reload failed; check logs");
+        }
+
+        // Now that we have reloaded the filter, reload any stored spans.
+        {
+            LOCK(cs_vNodes);
+            for (CNode* pnode : vNodes) {
+                pnode->ReloadTracingSpan();
+            }
         }
     }
 


### PR DESCRIPTION
- Fix logging of peer spans under `net=info`.
- Log all mempool-accepted txids under `mempool=info`.
- Log the new log filter under `main=info` when calling `setlogfilter`.