### PR TITLE
Reduce the dependencies of libzcashconsensus

### DIFF
--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -19,6 +19,51 @@
 #include <sys/endian.h>
 #endif
 
+#ifndef HAVE_CONFIG_H
+// While not technically a supported configuration, defaulting to defining these
+// DECLs when we were compiled without autotools makes it easier for other build
+// systems to build things like libbitcoinconsensus for strange targets.
+#ifdef htobe16
+#define HAVE_DECL_HTOBE16 1
+#endif
+#ifdef htole16
+#define HAVE_DECL_HTOLE16 1
+#endif
+#ifdef be16toh
+#define HAVE_DECL_BE16TOH 1
+#endif
+#ifdef le16toh
+#define HAVE_DECL_LE16TOH 1
+#endif
+
+#ifdef htobe32
+#define HAVE_DECL_HTOBE32 1
+#endif
+#ifdef htole32
+#define HAVE_DECL_HTOLE32 1
+#endif
+#ifdef be32toh
+#define HAVE_DECL_BE32TOH 1
+#endif
+#ifdef le32toh
+#define HAVE_DECL_LE32TOH 1
+#endif
+
+#ifdef htobe64
+#define HAVE_DECL_HTOBE64 1
+#endif
+#ifdef htole64
+#define HAVE_DECL_HTOLE64 1
+#endif
+#ifdef be64toh
+#define HAVE_DECL_BE64TOH 1
+#endif
+#ifdef le64toh
+#define HAVE_DECL_LE64TOH 1
+#endif
+
+#endif // HAVE_CONFIG_H
+
 #if defined(WORDS_BIGENDIAN)
 
 #if HAVE_DECL_HTOBE16 == 0

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -13,7 +13,6 @@
 #include <assert.h>
 #include <string.h>
 
-#include "sodium.h"
 #include "compat/endian.h"
 
 #if defined(NDEBUG)
@@ -83,44 +82,6 @@ void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htobe64(x);
     memcpy(ptr, (char*)&v, 8);
-}
-
-int inline init_and_check_sodium()
-{
-    if (sodium_init() == -1) {
-        return -1;
-    }
-
-    // What follows is a runtime test that ensures the version of libsodium
-    // we're linked against checks that signatures are canonical (s < L).
-    const unsigned char message[1] = { 0 };
-
-    unsigned char pk[crypto_sign_PUBLICKEYBYTES];
-    unsigned char sk[crypto_sign_SECRETKEYBYTES];
-    unsigned char sig[crypto_sign_BYTES];
-
-    crypto_sign_keypair(pk, sk);
-    crypto_sign_detached(sig, NULL, message, sizeof(message), sk);
-
-    assert(crypto_sign_verify_detached(sig, message, sizeof(message), pk) == 0);
-
-    // Copied from libsodium/crypto_sign/ed25519/ref10/open.c
-    static const unsigned char L[32] =
-      { 0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
-        0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10 };
-
-    // Add L to S, which starts at sig[32].
-    unsigned int s = 0;
-    for (size_t i = 0; i < 32; i++) {
-        s = sig[32 + i] + L[i] + (s >> 8);
-        sig[32 + i] = s & 0xff;
-    }
-
-    assert(crypto_sign_verify_detached(sig, message, sizeof(message), pk) != 0);
-
-    return 0;
 }
 
 #endif // BITCOIN_CRYPTO_COMMON_H

--- a/src/gtest/main.cpp
+++ b/src/gtest/main.cpp
@@ -1,10 +1,10 @@
 #include "gmock/gmock.h"
-#include "crypto/common.h"
 #include "key.h"
 #include "pubkey.h"
 #include "util.h"
 
 #include "librustzcash.h"
+#include <sodium.h>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
@@ -16,7 +16,7 @@ struct ECCryptoClosure
 ECCryptoClosure instance_of_eccryptoclosure;
 
 int main(int argc, char **argv) {
-  assert(init_and_check_sodium() != -1);
+  assert(sodium_init() != -1);
   ECC_Start();
 
   fs::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";

--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -826,11 +826,13 @@ TEST(ChecktransactionTests, SaplingSproutInputSumsTooLarge) {
         std::array<size_t, ZC_NUM_JS_INPUTS> inputMap;
         std::array<size_t, ZC_NUM_JS_OUTPUTS> outputMap;
 
-        auto jsdesc = JSDescription::Randomized(
+        auto jsdesc = JSDescriptionInfo(
             joinSplitPubKey, rt,
             inputs, outputs,
+            0, 0
+        ).BuildRandomized(
             inputMap, outputMap,
-            0, 0, false);
+            false);
 
         mtx.vJoinSplit.push_back(jsdesc);
     }

--- a/src/gtest/test_joinsplit.cpp
+++ b/src/gtest/test_joinsplit.cpp
@@ -10,6 +10,7 @@
 #include "serialize.h"
 #include "primitives/transaction.h"
 #include "proof_verifier.h"
+#include "transaction_builder.h"
 #include "zcash/JoinSplit.hpp"
 #include "zcash/Note.hpp"
 #include "zcash/NoteEncryption.hpp"
@@ -31,7 +32,7 @@ JSDescription makeSproutProof(
         uint64_t vpub_new,
         const uint256& rt
 ){
-    return JSDescription(joinSplitPubKey, rt, inputs, outputs, vpub_old, vpub_new);
+    return JSDescriptionInfo(joinSplitPubKey, rt, inputs, outputs, vpub_old, vpub_new).BuildDeterministic();
 }
 
 bool verifySproutProof(

--- a/src/gtest/test_joinsplit.cpp
+++ b/src/gtest/test_joinsplit.cpp
@@ -25,8 +25,8 @@ using namespace libzcash;
 // Make the Groth proof for a Sprout statement,
 // and store the result in a JSDescription object.
 JSDescription makeSproutProof(
-        const std::array<JSInput, 2>& inputs,
-        const std::array<JSOutput, 2>& outputs,
+        std::array<JSInput, 2>& inputs,
+        std::array<JSOutput, 2>& outputs,
         const Ed25519VerificationKey& joinSplitPubKey,
         uint64_t vpub_old,
         uint64_t vpub_new,

--- a/src/gtest/test_timedata.cpp
+++ b/src/gtest/test_timedata.cpp
@@ -8,6 +8,7 @@
 #include "timedata.h"
 #include "random.h"
 #include "netbase.h"
+#include "utiltime.h"
 
 using ::testing::StrictMock;
 

--- a/src/gtest/test_transaction.cpp
+++ b/src/gtest/test_transaction.cpp
@@ -2,6 +2,7 @@
 
 #include "gtest/utils.h"
 #include "primitives/transaction.h"
+#include "transaction_builder.h"
 #include "zcash/Note.hpp"
 #include "zcash/Address.hpp"
 
@@ -43,11 +44,13 @@ TEST(Transaction, JSDescriptionRandomized) {
     std::array<size_t, ZC_NUM_JS_OUTPUTS> outputMap;
 
     {
-        auto jsdesc = JSDescription::Randomized(
+        auto jsdesc = JSDescriptionInfo(
             joinSplitPubKey, rt,
             inputs, outputs,
+            0, 0
+        ).BuildRandomized(
             inputMap, outputMap,
-            0, 0, false);
+            false);
 
         std::set<size_t> inputSet(inputMap.begin(), inputMap.end());
         std::set<size_t> expectedInputSet {0, 1};
@@ -59,11 +62,13 @@ TEST(Transaction, JSDescriptionRandomized) {
     }
 
     {
-        auto jsdesc = JSDescription::Randomized(
+        auto jsdesc = JSDescriptionInfo(
             joinSplitPubKey, rt,
             inputs, outputs,
+            0, 0
+        ).BuildRandomized(
             inputMap, outputMap,
-            0, 0, false, nullptr, GenZero);
+            false, nullptr, GenZero);
 
         std::array<size_t, ZC_NUM_JS_INPUTS> expectedInputMap {1, 0};
         std::array<size_t, ZC_NUM_JS_OUTPUTS> expectedOutputMap {1, 0};
@@ -72,11 +77,13 @@ TEST(Transaction, JSDescriptionRandomized) {
     }
 
     {
-        auto jsdesc = JSDescription::Randomized(
+        auto jsdesc = JSDescriptionInfo(
             joinSplitPubKey, rt,
             inputs, outputs,
+            0, 0
+        ).BuildRandomized(
             inputMap, outputMap,
-            0, 0, false, nullptr, GenMax);
+            false, nullptr, GenMax);
 
         std::array<size_t, ZC_NUM_JS_INPUTS> expectedInputMap {0, 1};
         std::array<size_t, ZC_NUM_JS_OUTPUTS> expectedOutputMap {0, 1};

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -8,7 +8,6 @@
 #endif
 
 #include "init.h"
-#include "crypto/common.h"
 #include "addrman.h"
 #include "amount.h"
 #include "checkpoints.h"
@@ -59,6 +58,7 @@
 #include <boost/bind/bind.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/thread.hpp>
+#include <sodium.h>
 
 #if ENABLE_ZMQ
 #include "zmq/zmqnotificationinterface.h"
@@ -1158,7 +1158,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 
     // Initialize libsodium
-    if (init_and_check_sodium() == -1) {
+    if (sodium_init() == -1) {
         return false;
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -828,6 +828,20 @@ void InitLogging()
     LogPrintf("Zcash version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);
 }
 
+[[noreturn]] static void new_handler_terminate()
+{
+    // Rather than throwing std::bad-alloc if allocation fails, terminate
+    // immediately to (try to) avoid chain corruption.
+    // Since LogPrintf may itself allocate memory, set the handler directly
+    // to terminate first.
+    std::set_new_handler(std::terminate);
+    fputs("Error: Out of memory. Terminating.\n", stderr);
+    LogPrintf("Error: Out of memory. Terminating.\n");
+
+    // The log was successful, terminate now.
+    std::terminate();
+};
+
 /** Initialize bitcoin.
  *  @pre Parameters should be parsed and config file should be read.
  */

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -54,20 +54,6 @@ static FILE* fileout = NULL;
 static boost::mutex* mutexDebugLog = NULL;
 static list<string> *vMsgsBeforeOpenLog;
 
-[[noreturn]] void new_handler_terminate()
-{
-    // Rather than throwing std::bad-alloc if allocation fails, terminate
-    // immediately to (try to) avoid chain corruption.
-    // Since LogPrintf may itself allocate memory, set the handler directly
-    // to terminate first.
-    std::set_new_handler(std::terminate);
-    fputs("Error: Out of memory. Terminating.\n", stderr);
-    LogPrintf("Error: Out of memory. Terminating.\n");
-
-    // The log was successful, terminate now.
-    std::terminate();
-};
-
 static int FileWriteStr(const std::string &str, FILE *fp)
 {
     return fwrite(str.data(), 1, str.size(), fp);

--- a/src/mempool_limit.cpp
+++ b/src/mempool_limit.cpp
@@ -2,11 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-#include "core_memusage.h"
 #include "mempool_limit.h"
+
+#include "core_memusage.h"
+#include "logging.h"
 #include "random.h"
 #include "serialize.h"
 #include "timedata.h"
+#include "utiltime.h"
 #include "version.h"
 
 const TxWeight ZERO_WEIGHT = TxWeight(0, 0);

--- a/src/mempool_limit.h
+++ b/src/mempool_limit.h
@@ -5,6 +5,7 @@
 #ifndef ZCASH_MEMPOOL_LIMIT_H
 #define ZCASH_MEMPOOL_LIMIT_H
 
+#include <deque>
 #include <map>
 #include <optional>
 #include <set>

--- a/src/miner.h
+++ b/src/miner.h
@@ -12,6 +12,8 @@
 #include <stdint.h>
 #include <variant>
 
+#include <boost/shared_ptr.hpp>
+
 class CBlockIndex;
 class CChainParams;
 class CScript;

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -5,8 +5,6 @@
 #ifndef BITCOIN_PREVECTOR_H
 #define BITCOIN_PREVECTOR_H
 
-#include <util.h>
-
 #include <assert.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -177,11 +175,11 @@ private:
                     success. These should instead use an allocator or new/delete so that handlers
                     are called as necessary, but performance would be slightly degraded by doing so. */
                 _union.indirect = static_cast<char*>(realloc(_union.indirect, ((size_t)sizeof(T)) * new_capacity));
-                if (!_union.indirect) { new_handler_terminate(); }
+                assert(_union.indirect);
                 _union.capacity = new_capacity;
             } else {
                 char* new_indirect = static_cast<char*>(malloc(((size_t)sizeof(T)) * new_capacity));
-                if (!new_indirect) { new_handler_terminate(); }
+                assert(new_indirect);
                 T* src = direct_ptr(0);
                 T* dst = reinterpret_cast<T*>(new_indirect);
                 memcpy(dst, src, size() * sizeof(T));

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -9,68 +9,6 @@
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 
-JSDescription::JSDescription(
-    const Ed25519VerificationKey& joinSplitPubKey,
-    const uint256& anchor,
-    const std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS>& inputs,
-    const std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS>& outputs,
-    CAmount vpub_old,
-    CAmount vpub_new,
-    bool computeProof,
-    uint256 *esk // payment disclosure
-) : vpub_old(vpub_old), vpub_new(vpub_new), anchor(anchor)
-{
-    std::array<libzcash::SproutNote, ZC_NUM_JS_OUTPUTS> notes;
-
-    proof = ZCJoinSplit::prove(
-        inputs,
-        outputs,
-        notes,
-        ciphertexts,
-        ephemeralKey,
-        joinSplitPubKey,
-        randomSeed,
-        macs,
-        nullifiers,
-        commitments,
-        vpub_old,
-        vpub_new,
-        anchor,
-        computeProof,
-        esk // payment disclosure
-    );
-}
-
-JSDescription JSDescription::Randomized(
-    const Ed25519VerificationKey& joinSplitPubKey,
-    const uint256& anchor,
-    std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS>& inputs,
-    std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS>& outputs,
-    std::array<size_t, ZC_NUM_JS_INPUTS>& inputMap,
-    std::array<size_t, ZC_NUM_JS_OUTPUTS>& outputMap,
-    CAmount vpub_old,
-    CAmount vpub_new,
-    bool computeProof,
-    uint256 *esk, // payment disclosure
-    std::function<int(int)> gen
-)
-{
-    // Randomize the order of the inputs and outputs
-    inputMap = {0, 1};
-    outputMap = {0, 1};
-
-    assert(gen);
-
-    MappedShuffle(inputs.begin(), inputMap.begin(), ZC_NUM_JS_INPUTS, gen);
-    MappedShuffle(outputs.begin(), outputMap.begin(), ZC_NUM_JS_OUTPUTS, gen);
-
-    return JSDescription(
-        joinSplitPubKey, anchor, inputs, outputs,
-        vpub_old, vpub_new, computeProof,
-        esk // payment disclosure
-    );
-}
-
 uint256 JSDescription::h_sig(const Ed25519VerificationKey& joinSplitPubKey) const
 {
     return ZCJoinSplit::h_sig(randomSeed, nullifiers, joinSplitPubKey);

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -9,11 +9,6 @@
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 
-uint256 JSDescription::h_sig(const Ed25519VerificationKey& joinSplitPubKey) const
-{
-    return ZCJoinSplit::h_sig(randomSeed, nullifiers, joinSplitPubKey);
-}
-
 std::string COutPoint::ToString() const
 {
     return strprintf("COutPoint(%s, %u)", hash.ToString().substr(0,10), n);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -7,7 +7,6 @@
 #define BITCOIN_PRIMITIVES_TRANSACTION_H
 
 #include "amount.h"
-#include "random.h"
 #include "script/script.h"
 #include "serialize.h"
 #include "streams.h"
@@ -235,31 +234,6 @@ public:
     libzcash::SproutProof proof;
 
     JSDescription(): vpub_old(0), vpub_new(0) { }
-
-    JSDescription(
-            const Ed25519VerificationKey& joinSplitPubKey,
-            const uint256& rt,
-            const std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS>& inputs,
-            const std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS>& outputs,
-            CAmount vpub_old,
-            CAmount vpub_new,
-            bool computeProof = true, // Set to false in some tests
-            uint256 *esk = nullptr // payment disclosure
-    );
-
-    static JSDescription Randomized(
-            const Ed25519VerificationKey& joinSplitPubKey,
-            const uint256& rt,
-            std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS>& inputs,
-            std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS>& outputs,
-            std::array<size_t, ZC_NUM_JS_INPUTS>& inputMap,
-            std::array<size_t, ZC_NUM_JS_OUTPUTS>& outputMap,
-            CAmount vpub_old,
-            CAmount vpub_new,
-            bool computeProof = true, // Set to false in some tests
-            uint256 *esk = nullptr, // payment disclosure
-            std::function<int(int)> gen = GetRandInt
-    );
 
     // Returns the calculated h_sig
     uint256 h_sig(const Ed25519VerificationKey& joinSplitPubKey) const;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -19,7 +19,6 @@
 
 #include "zcash/NoteEncryption.hpp"
 #include "zcash/Zcash.h"
-#include "zcash/JoinSplit.hpp"
 #include "zcash/Proof.hpp"
 
 #include <rust/ed25519/types.h>
@@ -234,9 +233,6 @@ public:
     libzcash::SproutProof proof;
 
     JSDescription(): vpub_old(0), vpub_new(0) { }
-
-    // Returns the calculated h_sig
-    uint256 h_sig(const Ed25519VerificationKey& joinSplitPubKey) const;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -13,6 +13,7 @@
 #include "undo.h"
 #include "primitives/transaction.h"
 #include "pubkey.h"
+#include "zcash/Note.hpp"
 
 #include <vector>
 #include <map>

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -6,8 +6,6 @@
 
 #include "test_bitcoin.h"
 
-#include "crypto/common.h"
-
 #include "chainparams.h"
 #include "consensus/consensus.h"
 #include "consensus/validation.h"
@@ -28,6 +26,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
+#include <sodium.h>
 
 #include "librustzcash.h"
 
@@ -70,7 +69,7 @@ JoinSplitTestingSetup::~JoinSplitTestingSetup()
 
 BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
 {
-    assert(init_and_check_sodium() != -1);
+    assert(sodium_init() != -1);
     ECC_Start();
     SetupEnvironment();
     SetupNetworking();

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -22,6 +22,7 @@
 #include "script/sign.h"
 #include "test/test_util.h"
 #include "primitives/transaction.h"
+#include "transaction_builder.h"
 
 #include <array>
 #include <map>
@@ -321,7 +322,7 @@ BOOST_AUTO_TEST_CASE(test_basic_joinsplit_verification)
     auto verifier = ProofVerifier::Strict();
 
     {
-        JSDescription jsdesc(joinSplitPubKey, rt, inputs, outputs, 0, 0);
+        auto jsdesc = JSDescriptionInfo(joinSplitPubKey, rt, inputs, outputs, 0, 0).BuildDeterministic();
         BOOST_CHECK(verifier.VerifySprout(jsdesc, joinSplitPubKey));
 
         CDataStream ss(SER_DISK, CLIENT_VERSION);
@@ -337,13 +338,13 @@ BOOST_AUTO_TEST_CASE(test_basic_joinsplit_verification)
 
     {
         // Ensure that the balance equation is working.
-        BOOST_CHECK_THROW(JSDescription(joinSplitPubKey, rt, inputs, outputs, 10, 0), std::invalid_argument);
-        BOOST_CHECK_THROW(JSDescription(joinSplitPubKey, rt, inputs, outputs, 0, 10), std::invalid_argument);
+        BOOST_CHECK_THROW(JSDescriptionInfo(joinSplitPubKey, rt, inputs, outputs, 10, 0).BuildDeterministic(), std::invalid_argument);
+        BOOST_CHECK_THROW(JSDescriptionInfo(joinSplitPubKey, rt, inputs, outputs, 0, 10).BuildDeterministic(), std::invalid_argument);
     }
 
     {
         // Ensure that it won't verify if the root is changed.
-        auto test = JSDescription(joinSplitPubKey, rt, inputs, outputs, 0, 0);
+        auto test = JSDescriptionInfo(joinSplitPubKey, rt, inputs, outputs, 0, 0).BuildDeterministic();
         test.anchor = GetRandHash();
         BOOST_CHECK(!verifier.VerifySprout(test, joinSplitPubKey));
     }

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -634,7 +634,10 @@ void TransactionBuilder::CreateJSDescriptions()
 
             // Decrypt the change note's ciphertext to retrieve some data we need
             ZCNoteDecryption decryptor(changeKey.receiving_key());
-            auto hSig = prevJoinSplit.h_sig(mtx.joinSplitPubKey);
+            auto hSig = ZCJoinSplit::h_sig(
+                prevJoinSplit.randomSeed,
+                prevJoinSplit.nullifiers,
+                mtx.joinSplitPubKey);
             try {
                 auto plaintext = libzcash::SproutNotePlaintext::decrypt(
                     decryptor,

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -71,6 +71,57 @@ std::optional<OutputDescription> OutputDescriptionInfo::Build(void* ctx) {
     return odesc;
 }
 
+JSDescription JSDescriptionInfo::BuildDeterministic(
+    bool computeProof,
+    uint256 *esk // payment disclosure
+) {
+    JSDescription jsdesc;
+    jsdesc.vpub_old = vpub_old;
+    jsdesc.vpub_new = vpub_new;
+    jsdesc.anchor = anchor;
+
+    std::array<libzcash::SproutNote, ZC_NUM_JS_OUTPUTS> notes;
+    jsdesc.proof = ZCJoinSplit::prove(
+        inputs,
+        outputs,
+        notes,
+        jsdesc.ciphertexts,
+        jsdesc.ephemeralKey,
+        joinSplitPubKey,
+        jsdesc.randomSeed,
+        jsdesc.macs,
+        jsdesc.nullifiers,
+        jsdesc.commitments,
+        vpub_old,
+        vpub_new,
+        anchor,
+        computeProof,
+        esk // payment disclosure
+    );
+
+    return jsdesc;
+}
+
+JSDescription JSDescriptionInfo::BuildRandomized(
+    std::array<size_t, ZC_NUM_JS_INPUTS>& inputMap,
+    std::array<size_t, ZC_NUM_JS_OUTPUTS>& outputMap,
+    bool computeProof,
+    uint256 *esk, // payment disclosure
+    std::function<int(int)> gen
+)
+{
+    // Randomize the order of the inputs and outputs
+    inputMap = {0, 1};
+    outputMap = {0, 1};
+
+    assert(gen);
+
+    MappedShuffle(inputs.begin(), inputMap.begin(), ZC_NUM_JS_INPUTS, gen);
+    MappedShuffle(outputs.begin(), outputMap.begin(), ZC_NUM_JS_OUTPUTS, gen);
+
+    return BuildDeterministic(computeProof, esk);
+}
+
 TransactionBuilderResult::TransactionBuilderResult(const CTransaction& tx) : maybeTx(tx) {}
 
 TransactionBuilderResult::TransactionBuilderResult(const std::string& error) : maybeError(error) {}
@@ -714,15 +765,16 @@ void TransactionBuilder::CreateJSDescription(
 
     // Generate the proof, this can take over a minute.
     assert(mtx.fOverwintered && (mtx.nVersion >= SAPLING_TX_VERSION));
-    JSDescription jsdesc = JSDescription::Randomized(
+    JSDescription jsdesc = JSDescriptionInfo(
             mtx.joinSplitPubKey,
             vjsin[0].witness.root(),
             vjsin,
             vjsout,
+            vpub_old,
+            vpub_new
+    ).BuildRandomized(
             inputMap,
             outputMap,
-            vpub_old,
-            vpub_new,
             true, //!this->testmode,
             &esk); // parameter expects pointer to esk, so pass in address
 

--- a/src/transaction_builder.h
+++ b/src/transaction_builder.h
@@ -53,16 +53,17 @@ struct OutputDescriptionInfo {
 struct JSDescriptionInfo {
     Ed25519VerificationKey joinSplitPubKey;
     uint256 anchor;
-    std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS> inputs;
-    std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS> outputs;
+    // We store references to these so they are correctly randomised for the caller.
+    std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS>& inputs;
+    std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS>& outputs;
     CAmount vpub_old;
     CAmount vpub_new;
 
     JSDescriptionInfo(
         Ed25519VerificationKey joinSplitPubKey,
         uint256 anchor,
-        std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS> inputs,
-        std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS> outputs,
+        std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS>& inputs,
+        std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS>& outputs,
         CAmount vpub_old,
         CAmount vpub_new) : joinSplitPubKey(joinSplitPubKey), anchor(anchor), inputs(inputs), outputs(outputs), vpub_old(vpub_old), vpub_new(vpub_new) {}
 

--- a/src/transaction_builder.h
+++ b/src/transaction_builder.h
@@ -9,6 +9,7 @@
 #include "consensus/params.h"
 #include "keystore.h"
 #include "primitives/transaction.h"
+#include "random.h"
 #include "script/script.h"
 #include "script/standard.h"
 #include "uint256.h"
@@ -47,6 +48,36 @@ struct OutputDescriptionInfo {
         std::array<unsigned char, ZC_MEMO_SIZE> memo) : ovk(ovk), note(note), memo(memo) {}
 
     std::optional<OutputDescription> Build(void* ctx);
+};
+
+struct JSDescriptionInfo {
+    Ed25519VerificationKey joinSplitPubKey;
+    uint256 anchor;
+    std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS> inputs;
+    std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS> outputs;
+    CAmount vpub_old;
+    CAmount vpub_new;
+
+    JSDescriptionInfo(
+        Ed25519VerificationKey joinSplitPubKey,
+        uint256 anchor,
+        std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS> inputs,
+        std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS> outputs,
+        CAmount vpub_old,
+        CAmount vpub_new) : joinSplitPubKey(joinSplitPubKey), anchor(anchor), inputs(inputs), outputs(outputs), vpub_old(vpub_old), vpub_new(vpub_new) {}
+
+    JSDescription BuildDeterministic(
+        bool computeProof = true, // Set to false in some tests
+        uint256* esk = nullptr    // payment disclosure
+    );
+
+    JSDescription BuildRandomized(
+        std::array<size_t, ZC_NUM_JS_INPUTS>& inputMap,
+        std::array<size_t, ZC_NUM_JS_OUTPUTS>& outputMap,
+        bool computeProof = true, // Set to false in some tests
+        uint256* esk = nullptr,   // payment disclosure
+        std::function<int(int)> gen = GetRandInt
+    );
 };
 
 struct TransparentInputInfo {

--- a/src/util.h
+++ b/src/util.h
@@ -34,8 +34,6 @@ extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
 extern bool fDebug;
 extern bool fServer;
 
-[[noreturn]] extern void new_handler_terminate();
-
 extern const char * const BITCOIN_CONF_FILENAME;
 extern const char * const BITCOIN_PID_FILENAME;
 

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -114,7 +114,10 @@ CWalletTx GetInvalidCommitmentSproutReceive(
 libzcash::SproutNote GetSproutNote(const libzcash::SproutSpendingKey& sk,
                                    const CTransaction& tx, size_t js, size_t n) {
     ZCNoteDecryption decryptor {sk.receiving_key()};
-    auto hSig = tx.vJoinSplit[js].h_sig(tx.joinSplitPubKey);
+    auto hSig = ZCJoinSplit::h_sig(
+        tx.vJoinSplit[js].randomSeed,
+        tx.vJoinSplit[js].nullifiers,
+        tx.joinSplitPubKey);
     auto note_pt = libzcash::SproutNotePlaintext::decrypt(
         decryptor,
         tx.vJoinSplit[js].ciphertexts[n],

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -52,8 +52,8 @@ CMutableTransaction GetValidSproutReceiveTransaction(
 
     // Prepare JoinSplits
     uint256 rt;
-    JSDescription jsdesc {mtx.joinSplitPubKey, rt,
-                          inputs, outputs, 2*value, 0, false};
+    auto jsdesc = JSDescriptionInfo(mtx.joinSplitPubKey, rt,
+                          inputs, outputs, 2*value, 0).BuildDeterministic(false);
     mtx.vJoinSplit.push_back(jsdesc);
 
     // Consider: The following is a bit misleading (given the name of this function)
@@ -173,8 +173,8 @@ CWalletTx GetValidSproutSpend(const libzcash::SproutSpendingKey& sk,
 
     // Prepare JoinSplits
     uint256 rt = tree.root();
-    JSDescription jsdesc {mtx.joinSplitPubKey, rt,
-                          inputs, outputs, 0, value, false};
+    auto jsdesc = JSDescriptionInfo(mtx.joinSplitPubKey, rt,
+                          inputs, outputs, 0, value).BuildDeterministic(false);
     mtx.vJoinSplit.push_back(jsdesc);
 
     // Empty output script.

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -20,6 +20,7 @@
 #include "rpc/server.h"
 #include "script/interpreter.h"
 #include "timedata.h"
+#include "transaction_builder.h"
 #include "util.h"
 #include "utilmoneystr.h"
 #include "utiltime.h"
@@ -799,15 +800,16 @@ UniValue AsyncRPCOperation_mergetoaddress::perform_joinsplit(
     uint256 esk; // payment disclosure - secret
 
     assert(mtx.fOverwintered && (mtx.nVersion >= SAPLING_TX_VERSION));
-    JSDescription jsdesc = JSDescription::Randomized(
+    JSDescription jsdesc = JSDescriptionInfo(
         joinSplitPubKey_,
         anchor,
         inputs,
         outputs,
+        info.vpub_old,
+        info.vpub_new
+    ).BuildRandomized(
         inputMap,
         outputMap,
-        info.vpub_old,
-        info.vpub_new,
         !this->testmode,
         &esk); // parameter expects pointer to esk, so pass in address
     {

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -553,7 +553,10 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
 
             // Decrypt the change note's ciphertext to retrieve some data we need
             ZCNoteDecryption decryptor(changeKey.receiving_key());
-            auto hSig = prevJoinSplit.h_sig(tx_.joinSplitPubKey);
+            auto hSig = ZCJoinSplit::h_sig(
+                prevJoinSplit.randomSeed,
+                prevJoinSplit.nullifiers,
+                tx_.joinSplitPubKey);
             try {
                 SproutNotePlaintext plaintext = SproutNotePlaintext::decrypt(
                     decryptor,
@@ -857,7 +860,7 @@ UniValue AsyncRPCOperation_mergetoaddress::perform_joinsplit(
         ss2 << ((unsigned char)0x00);
         ss2 << jsdesc.ephemeralKey;
         ss2 << jsdesc.ciphertexts[0];
-        ss2 << jsdesc.h_sig(joinSplitPubKey_);
+        ss2 << ZCJoinSplit::h_sig(jsdesc.randomSeed, jsdesc.nullifiers, joinSplitPubKey_);
 
         encryptedNote1 = HexStr(ss2.begin(), ss2.end());
     }
@@ -866,7 +869,7 @@ UniValue AsyncRPCOperation_mergetoaddress::perform_joinsplit(
         ss2 << ((unsigned char)0x01);
         ss2 << jsdesc.ephemeralKey;
         ss2 << jsdesc.ciphertexts[1];
-        ss2 << jsdesc.h_sig(joinSplitPubKey_);
+        ss2 << ZCJoinSplit::h_sig(jsdesc.randomSeed, jsdesc.nullifiers, joinSplitPubKey_);
 
         encryptedNote2 = HexStr(ss2.begin(), ss2.end());
     }

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -638,7 +638,10 @@ bool AsyncRPCOperation_sendmany::main_impl() {
 
             // Decrypt the change note's ciphertext to retrieve some data we need
             ZCNoteDecryption decryptor(std::get<libzcash::SproutSpendingKey>(spendingkey_).receiving_key());
-            auto hSig = prevJoinSplit.h_sig(tx_.joinSplitPubKey);
+            auto hSig = ZCJoinSplit::h_sig(
+                prevJoinSplit.randomSeed,
+                prevJoinSplit.nullifiers,
+                tx_.joinSplitPubKey);
             try {
                 SproutNotePlaintext plaintext = SproutNotePlaintext::decrypt(
                         decryptor,
@@ -1106,7 +1109,7 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(
         ss2 << ((unsigned char) 0x00);
         ss2 << jsdesc.ephemeralKey;
         ss2 << jsdesc.ciphertexts[0];
-        ss2 << jsdesc.h_sig(joinSplitPubKey_);
+        ss2 << ZCJoinSplit::h_sig(jsdesc.randomSeed, jsdesc.nullifiers, joinSplitPubKey_);
 
         encryptedNote1 = HexStr(ss2.begin(), ss2.end());
     }
@@ -1115,7 +1118,7 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(
         ss2 << ((unsigned char) 0x01);
         ss2 << jsdesc.ephemeralKey;
         ss2 << jsdesc.ciphertexts[1];
-        ss2 << jsdesc.h_sig(joinSplitPubKey_);
+        ss2 << ZCJoinSplit::h_sig(jsdesc.randomSeed, jsdesc.nullifiers, joinSplitPubKey_);
 
         encryptedNote2 = HexStr(ss2.begin(), ss2.end());
     }

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -18,6 +18,7 @@
 #include "proof_verifier.h"
 #include "rpc/protocol.h"
 #include "rpc/server.h"
+#include "transaction_builder.h"
 #include "timedata.h"
 #include "util.h"
 #include "utilmoneystr.h"
@@ -1048,15 +1049,16 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(
     uint256 esk; // payment disclosure - secret
 
     assert(mtx.fOverwintered && (mtx.nVersion >= SAPLING_TX_VERSION));
-    JSDescription jsdesc = JSDescription::Randomized(
+    JSDescription jsdesc = JSDescriptionInfo(
             joinSplitPubKey_,
             anchor,
             inputs,
             outputs,
+            info.vpub_old,
+            info.vpub_new
+    ).BuildRandomized(
             inputMap,
             outputMap,
-            info.vpub_old,
-            info.vpub_new,
             !this->testmode,
             &esk); // parameter expects pointer to esk, so pass in address
     {

--- a/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
+++ b/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
@@ -369,7 +369,7 @@ UniValue AsyncRPCOperation_shieldcoinbase::perform_joinsplit(ShieldCoinbaseJSInf
         ss2 << ((unsigned char) 0x00);
         ss2 << jsdesc.ephemeralKey;
         ss2 << jsdesc.ciphertexts[0];
-        ss2 << jsdesc.h_sig(joinSplitPubKey_);
+        ss2 << ZCJoinSplit::h_sig(jsdesc.randomSeed, jsdesc.nullifiers, joinSplitPubKey_);
 
         encryptedNote1 = HexStr(ss2.begin(), ss2.end());
     }
@@ -378,7 +378,7 @@ UniValue AsyncRPCOperation_shieldcoinbase::perform_joinsplit(ShieldCoinbaseJSInf
         ss2 << ((unsigned char) 0x01);
         ss2 << jsdesc.ephemeralKey;
         ss2 << jsdesc.ciphertexts[1];
-        ss2 << jsdesc.h_sig(joinSplitPubKey_);
+        ss2 << ZCJoinSplit::h_sig(jsdesc.randomSeed, jsdesc.nullifiers, joinSplitPubKey_);
 
         encryptedNote2 = HexStr(ss2.begin(), ss2.end());
     }

--- a/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
+++ b/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
@@ -18,6 +18,7 @@
 #include "proof_verifier.h"
 #include "rpc/protocol.h"
 #include "rpc/server.h"
+#include "transaction_builder.h"
 #include "timedata.h"
 #include "util.h"
 #include "utilmoneystr.h"
@@ -311,15 +312,16 @@ UniValue AsyncRPCOperation_shieldcoinbase::perform_joinsplit(ShieldCoinbaseJSInf
     uint256 esk; // payment disclosure - secret
 
     assert(mtx.fOverwintered && (mtx.nVersion >= SAPLING_TX_VERSION));
-    JSDescription jsdesc = JSDescription::Randomized(
+    JSDescription jsdesc = JSDescriptionInfo(
             joinSplitPubKey_,
             anchor,
             inputs,
             outputs,
+            info.vpub_old,
+            info.vpub_new
+    ).BuildRandomized(
             inputMap,
             outputMap,
-            info.vpub_old,
-            info.vpub_new,
             !this->testmode,
             &esk); // parameter expects pointer to esk, so pass in address
     {

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -11,6 +11,7 @@
 #include "transaction_builder.h"
 #include "utiltest.h"
 #include "wallet/wallet.h"
+#include "zcash/JoinSplit.hpp"
 #include "zcash/Note.hpp"
 #include "zcash/NoteEncryption.hpp"
 
@@ -445,7 +446,10 @@ TEST(WalletTests, CheckSproutNoteCommitmentAgainstNotePlaintext) {
     auto note = GetSproutNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    auto hSig = wtx.vJoinSplit[0].h_sig(wtx.joinSplitPubKey);
+    auto hSig = ZCJoinSplit::h_sig(
+        wtx.vJoinSplit[0].randomSeed,
+        wtx.vJoinSplit[0].nullifiers,
+        wtx.joinSplitPubKey);
 
     ASSERT_THROW(wallet.GetSproutNoteNullifier(
         wtx.vJoinSplit[0],
@@ -466,7 +470,10 @@ TEST(WalletTests, GetSproutNoteNullifier) {
     auto note = GetSproutNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    auto hSig = wtx.vJoinSplit[0].h_sig(wtx.joinSplitPubKey);
+    auto hSig = ZCJoinSplit::h_sig(
+        wtx.vJoinSplit[0].randomSeed,
+        wtx.vJoinSplit[0].nullifiers,
+        wtx.joinSplitPubKey);
 
     auto ret = wallet.GetSproutNoteNullifier(
         wtx.vJoinSplit[0],

--- a/src/wallet/rpcdisclosure.cpp
+++ b/src/wallet/rpcdisclosure.cpp
@@ -15,6 +15,7 @@
 #include "wallet.h"
 #include "wallet/paymentdisclosure.h"
 #include "wallet/paymentdisclosuredb.h"
+#include "zcash/JoinSplit.hpp"
 
 #include <fstream>
 #include <stdint.h>
@@ -271,7 +272,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
         try {
             // Decrypt the note to get value and memo field
             JSDescription jsdesc = tx.vJoinSplit[pd.payload.js];
-            uint256 h_sig = jsdesc.h_sig(tx.joinSplitPubKey);
+            uint256 h_sig = ZCJoinSplit::h_sig(jsdesc.randomSeed, jsdesc.nullifiers, tx.joinSplitPubKey);
 
             ZCPaymentDisclosureNoteDecryption decrypter;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2777,10 +2777,12 @@ UniValue zc_sample_joinsplit(const UniValue& params, bool fHelp)
 
     Ed25519VerificationKey joinSplitPubKey;
     uint256 anchor = SproutMerkleTree().root();
+    std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS> inputs({JSInput(), JSInput()});
+    std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS> outputs({JSOutput(), JSOutput()});
     auto samplejoinsplit = JSDescriptionInfo(joinSplitPubKey,
                                   anchor,
-                                  {JSInput(), JSInput()},
-                                  {JSOutput(), JSOutput()},
+                                  inputs,
+                                  outputs,
                                   0,
                                   0).BuildDeterministic();
 
@@ -3152,10 +3154,12 @@ UniValue zc_raw_joinsplit(const UniValue& params, bool fHelp)
     mtx.nVersionGroupId = SAPLING_VERSION_GROUP_ID;
     mtx.joinSplitPubKey = joinSplitPubKey;
 
+    std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS> jsInputs({vjsin[0], vjsin[1]});
+    std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS> jsIutputs({vjsout[0], vjsout[1]});
     auto jsdesc = JSDescriptionInfo(joinSplitPubKey,
                          anchor,
-                         {vjsin[0], vjsin[1]},
-                         {vjsout[0], vjsout[1]},
+                         jsInputs,
+                         jsIutputs,
                          vpub_old,
                          vpub_new).BuildDeterministic();
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3196,7 +3196,7 @@ UniValue zc_raw_joinsplit(const UniValue& params, bool fHelp)
         ss2 << ((unsigned char) 0x00);
         ss2 << jsdesc.ephemeralKey;
         ss2 << jsdesc.ciphertexts[0];
-        ss2 << jsdesc.h_sig(joinSplitPubKey);
+        ss2 << ZCJoinSplit::h_sig(jsdesc.randomSeed, jsdesc.nullifiers, joinSplitPubKey);
 
         encryptedNote1 = HexStr(ss2.begin(), ss2.end());
     }
@@ -3205,7 +3205,7 @@ UniValue zc_raw_joinsplit(const UniValue& params, bool fHelp)
         ss2 << ((unsigned char) 0x01);
         ss2 << jsdesc.ephemeralKey;
         ss2 << jsdesc.ciphertexts[1];
-        ss2 << jsdesc.h_sig(joinSplitPubKey);
+        ss2 << ZCJoinSplit::h_sig(jsdesc.randomSeed, jsdesc.nullifiers, joinSplitPubKey);
 
         encryptedNote2 = HexStr(ss2.begin(), ss2.end());
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2777,12 +2777,12 @@ UniValue zc_sample_joinsplit(const UniValue& params, bool fHelp)
 
     Ed25519VerificationKey joinSplitPubKey;
     uint256 anchor = SproutMerkleTree().root();
-    JSDescription samplejoinsplit(joinSplitPubKey,
+    auto samplejoinsplit = JSDescriptionInfo(joinSplitPubKey,
                                   anchor,
                                   {JSInput(), JSInput()},
                                   {JSOutput(), JSOutput()},
                                   0,
-                                  0);
+                                  0).BuildDeterministic();
 
     CDataStream ss(SER_NETWORK, SAPLING_TX_VERSION | (1 << 31));
     ss << samplejoinsplit;
@@ -3152,12 +3152,12 @@ UniValue zc_raw_joinsplit(const UniValue& params, bool fHelp)
     mtx.nVersionGroupId = SAPLING_VERSION_GROUP_ID;
     mtx.joinSplitPubKey = joinSplitPubKey;
 
-    JSDescription jsdesc(joinSplitPubKey,
+    auto jsdesc = JSDescriptionInfo(joinSplitPubKey,
                          anchor,
                          {vjsin[0], vjsin[1]},
                          {vjsout[0], vjsout[1]},
                          vpub_old,
-                         vpub_new);
+                         vpub_new).BuildDeterministic();
 
     {
         auto verifier = ProofVerifier::Strict();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -24,6 +24,7 @@
 #include "wallet/walletdb.h"
 #include "wallet/rpcwallet.h"
 #include "zcash/Address.hpp"
+#include "zcash/Note.hpp"
 #include "base58.h"
 
 #include <algorithm>

--- a/src/zcash/Note.cpp
+++ b/src/zcash/Note.cpp
@@ -1,7 +1,9 @@
 #include "Note.hpp"
+
 #include "prf.h"
 #include "crypto/sha256.h"
 #include "consensus/consensus.h"
+#include "logging.h"
 
 #include "random.h"
 #include "version.h"
@@ -9,6 +11,8 @@
 
 #include "zcash/util.h"
 #include "librustzcash.h"
+
+#include <boost/thread/exceptions.hpp>
 
 using namespace libzcash;
 

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -23,6 +23,7 @@
 #include "rpc/server.h"
 #include "script/sign.h"
 #include "streams.h"
+#include "transaction_builder.h"
 #include "txdb.h"
 #include "utiltest.h"
 #include "wallet/wallet.h"
@@ -103,12 +104,12 @@ double benchmark_create_joinsplit()
 
     struct timeval tv_start;
     timer_start(tv_start);
-    JSDescription jsdesc(joinSplitPubKey,
+    auto jsdesc = JSDescriptionInfo(joinSplitPubKey,
                          anchor,
                          {JSInput(), JSInput()},
                          {JSOutput(), JSOutput()},
                          0,
-                         0);
+                         0).BuildDeterministic();
     double ret = timer_stop(tv_start);
 
     auto verifier = ProofVerifier::Strict();

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -101,13 +101,15 @@ double benchmark_create_joinsplit()
 
     /* Get the anchor of an empty commitment tree. */
     uint256 anchor = SproutMerkleTree().root();
+    std::array<libzcash::JSInput, ZC_NUM_JS_INPUTS> inputs({JSInput(), JSInput()});
+    std::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS> outputs({JSOutput(), JSOutput()});
 
     struct timeval tv_start;
     timer_start(tv_start);
     auto jsdesc = JSDescriptionInfo(joinSplitPubKey,
                          anchor,
-                         {JSInput(), JSInput()},
-                         {JSOutput(), JSOutput()},
+                         inputs,
+                         outputs,
                          0,
                          0).BuildDeterministic();
     double ret = timer_stop(tv_start);


### PR DESCRIPTION
This is the first of two PRs that rework the `libzcashconsensus` library
into `libzcash_script`, and enable it to be wrapped by the `zcash_script`
crate:

https://github.com/ZcashFoundation/zcash_script

Includes code cherry-picked from bitcoin/bitcoin#12998.