### PR TITLE
Remove workaround affecting old Boost version

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -82,18 +82,6 @@
 #include <boost/program_options/parsers.hpp>
 #include <boost/thread.hpp>
 
-// Work around clang compilation problem in Boost 1.46:
-// /usr/include/boost/program_options/detail/config_file.hpp:163:17: error: call to function 'to_internal' that is neither visible in the template definition nor found by argument-dependent lookup
-// See also: https://stackoverflow.com/questions/10020179/compilation-fail-in-boost-librairies-program-options
-//           https://clang.debian.net/status.php?version=3.0&key=CANNOT_FIND_FUNCTION
-namespace boost {
-
-    namespace program_options {
-        std::string to_internal(const std::string&);
-    }
-
-} // namespace boost
-
 using namespace std;
 
 const char * const BITCOIN_CONF_FILENAME = "zcash.conf";


### PR DESCRIPTION
Closes https://github.com/zcash/zcash/issues/4914.