### PR TITLE
Revert "tracing: Simplify init logic using optional layers"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ zcash_proofs = "0.4"
 ed25519-zebra = "2.0.0"
 
 [dependencies.tracing-subscriber]
-version = "0.2.12"
+version = "0.2"
 default-features = false
 features = ["ansi", "chrono", "env-filter"]
 


### PR DESCRIPTION
This reverts commit 5dce316f1010f7b06ad496e0d222e8f3595bdb20.

The new init logic causes zcashd to log information to stdout without the `-printtoconsole` flag being specified.

This is a partial revert of #4918