### PR TITLE
gtest/test_mempoollimit: the test failed to properly ensure that the "low fee penalty" threshold matches the new ZIP 313 fee

### DIFF
--- a/qa/rpc-tests/wallet_listnotes.py
+++ b/qa/rpc-tests/wallet_listnotes.py
@@ -134,12 +134,12 @@ class WalletListNotes(BitcoinTestFramework):
         assert_equal(sproutzaddr,       unspent_tx[2]['address'])
         assert_equal(change_amount_9,   unspent_tx[2]['amount'])
 
-        unspent_tx_filter = self.nodes[0].z_listunspent(0, 999, False, [saplingzaddr])
+        unspent_tx_filter = self.nodes[0].z_listunspent(0, 9999, False, [saplingzaddr])
         assert_equal(1, len(unspent_tx_filter))
         assert_equal(unspent_tx[1], unspent_tx_filter[0])
 
         # test that pre- and post-sapling can be filtered in a single call
-        unspent_tx_filter = self.nodes[0].z_listunspent(0, 999, False,
+        unspent_tx_filter = self.nodes[0].z_listunspent(0, 9999, False,
             [sproutzaddr, saplingzaddr])
         assert_equal(2, len(unspent_tx_filter))
         unspent_tx_filter = sorted(unspent_tx_filter, key=lambda k: k['amount'])
@@ -147,7 +147,7 @@ class WalletListNotes(BitcoinTestFramework):
         assert_equal(unspent_tx[2], unspent_tx_filter[1])
 
         # so far, this node has no watchonly addresses, so results are the same
-        unspent_tx_watchonly = self.nodes[0].z_listunspent(0, 999, True)
+        unspent_tx_watchonly = self.nodes[0].z_listunspent(0, 9999, True)
         unspent_tx_watchonly = sorted(unspent_tx_watchonly, key=lambda k: k['amount'])
         assert_equal(unspent_tx, unspent_tx_watchonly)
 

--- a/src/gtest/test_mempoollimit.cpp
+++ b/src/gtest/test_mempoollimit.cpp
@@ -123,7 +123,7 @@ TEST(MempoolLimitTests, WeightedTxInfoFromTx)
         builder.AddSaplingSpend(sk.expanded_spending_key(), testNote.note, testNote.tree.root(), testNote.tree.witness());
         builder.AddSaplingOutput(sk.full_viewing_key().ovk, sk.default_address(), 25000, {});
 
-        WeightedTxInfo info = WeightedTxInfo::from(builder.Build().GetTxOrThrow(), 10000);
+        WeightedTxInfo info = WeightedTxInfo::from(builder.Build().GetTxOrThrow(), DEFAULT_FEE);
         EXPECT_EQ(MIN_TX_COST, info.txWeight.cost);
         EXPECT_EQ(MIN_TX_COST, info.txWeight.evictionWeight);
     }
@@ -133,9 +133,9 @@ TEST(MempoolLimitTests, WeightedTxInfoFromTx)
         auto builder = TransactionBuilder(consensusParams, 1);
         builder.AddSaplingSpend(sk.expanded_spending_key(), testNote.note, testNote.tree.root(), testNote.tree.witness());
         builder.AddSaplingOutput(sk.full_viewing_key().ovk, sk.default_address(), 25000, {});
-        builder.SetFee(9999);
-
         static_assert(DEFAULT_FEE == 1000);
+        builder.SetFee(DEFAULT_FEE-1);
+
         WeightedTxInfo info = WeightedTxInfo::from(builder.Build().GetTxOrThrow(), DEFAULT_FEE-1);
         EXPECT_EQ(MIN_TX_COST, info.txWeight.cost);
         EXPECT_EQ(MIN_TX_COST + LOW_FEE_PENALTY, info.txWeight.evictionWeight);
@@ -154,7 +154,7 @@ TEST(MempoolLimitTests, WeightedTxInfoFromTx)
         if (result.IsError()) {
             std::cerr << result.GetError() << std::endl;
         }
-        WeightedTxInfo info = WeightedTxInfo::from(result.GetTxOrThrow(), 10000);
+        WeightedTxInfo info = WeightedTxInfo::from(result.GetTxOrThrow(), DEFAULT_FEE);
         EXPECT_EQ(5168, info.txWeight.cost);
         EXPECT_EQ(5168, info.txWeight.evictionWeight);
     }


### PR DESCRIPTION
The test passed, and the code under test was correct; nevertheless the test was not testing the right thing. refs #4916

Signed-off-by: Daira Hopwood <daira@jacaranda.org>