### PR TITLE
#4624 improve IBD sync by eliminating getheaders requests

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6239,6 +6239,18 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             return true;
         }
 
+        // If we already know the last header in the message, then it contains
+        // no new information for us.  In this case, we do not request
+        // more headers later.  This prevents multiple chains of redundant
+        // getheader requests from running in parallel if triggered by incoming
+        // blocks while the node is still in initial headers sync.
+        //
+        // (Allow disabling optimization in case there are unexpected problems.)
+        bool hasNewHeaders = true;
+        if (GetBoolArg("-optimize-getheaders", true) && IsInitialBlockDownload(chainparams.GetConsensus())) {
+            hasNewHeaders = (mapBlockIndex.count(headers.back().GetHash()) == 0);
+        }
+
         CBlockIndex *pindexLast = NULL;
         for (const CBlockHeader& header : headers) {
             CValidationState state;
@@ -6259,7 +6271,12 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
         if (pindexLast)
             UpdateBlockAvailability(pfrom->GetId(), pindexLast->GetBlockHash());
 
-        if (nCount == MAX_HEADERS_RESULTS && pindexLast) {
+        // Temporary, until we're sure the optimization works
+        if (nCount == MAX_HEADERS_RESULTS && pindexLast && !hasNewHeaders) {
+            LogPrint("net", "NO more getheaders (%d) to send to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->id, pfrom->nStartingHeight);
+        }
+
+        if (nCount == MAX_HEADERS_RESULTS && pindexLast && hasNewHeaders) {
             // Headers message had its maximum size; the peer may have more headers.
             // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
             // from there instead.


### PR DESCRIPTION
Closes #4624. Don't issue redundant `getheaders` P2P requests.

It's not certain that this is a safe change or the best way to solve the problem, but it does dramatically decrease IBD time and network (read) usage. The corresponding upstream code has become quite different, so it's not clear how this problem is solved there. (In my testing, the problem did not occur there; the node seemed to download the minimum amount of data from the network.)

There's no behavior change after IBD completes, so perhaps the only problem with this change (the only way it might be unsafe) is if IBD stalls completely (due to `getheaders` not being sent when necessary). That hasn't happened in my testing so far (I'll continue testing).