### PR TITLE
Add support for FreeBSD 12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -482,6 +482,9 @@ case $host in
    *linux*)
      LEVELDB_TARGET_FLAGS="-DOS_LINUX"
      ;;
+   *freebsd*)
+     LEVELDB_TARGET_FLAGS="-DOS_FREEBSD"
+     ;;
    *)
      OTHER_OS=`echo ${host_os} | awk '{print toupper($0)}'`
      LEVELDB_TARGET_FLAGS="-DOS_${OTHER_OS}"

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -32,7 +32,12 @@ export PKG_CONFIG_LIBDIR=$depends_prefix/lib/pkgconfig
 export PKG_CONFIG_PATH=$depends_prefix/share/pkgconfig
 
 CPPFLAGS="-I$depends_prefix/include/ $CPPFLAGS"
-LDFLAGS="-L$depends_prefix/lib $LDFLAGS -static-libstdc++ -lc++abi"
+
+if test x@host_os@ = xfreebsd; then
+  LDFLAGS="-L$depends_prefix/lib $LDFLAGS -static-libstdc++ -lcxxrt"
+else
+  LDFLAGS="-L$depends_prefix/lib $LDFLAGS -static-libstdc++ -lc++abi"
+fi
 
 CC="@CC@"
 CXX="@CXX@"

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -20,7 +20,13 @@ $(package)_config_opts_darwin=--disable-atomicsupport
 endif
 $(package)_config_opts_aarch64=--disable-atomicsupport
 $(package)_cxxflags+=-std=c++17
-$(package)_ldflags+=-static-libstdc++ -lc++abi
+
+ifeq ($(host_os),freebsd)
+  $(package)_ldflags+=-static-libstdc++ -lcxxrt
+else
+  $(package)_ldflags+=-static-libstdc++ -lc++abi
+endif
+
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -14,6 +14,7 @@ $(package)_config_opts_debug=variant=debug
 $(package)_config_opts=--layout=system
 $(package)_config_opts+=threading=multi link=static -sNO_BZIP2=1 -sNO_ZLIB=1
 $(package)_config_opts_linux=threadapi=pthread runtime-link=shared
+$(package)_config_opts_freebsd=cxxflags=-fPIC
 $(package)_config_opts_darwin=--toolset=darwin-4.2.1 runtime-link=shared
 $(package)_config_opts_mingw32=binary-format=pe target-os=windows threadapi=win32 runtime-link=static
 $(package)_config_opts_x86_64_mingw32=address-model=64
@@ -27,7 +28,13 @@ $(package)_config_libraries=chrono,filesystem,program_options,system,thread,test
 $(package)_cxxflags+=-std=c++17 -fvisibility=hidden
 $(package)_cxxflags_linux=-fPIC
 $(package)_cxxflags_freebsd=-fPIC
-$(package)_ldflags+=-static-libstdc++ -lc++abi
+
+ifeq ($(host_os),freebsd)
+  $(package)_ldflags+=-static-libstdc++ -lcxxrt
+else
+  $(package)_ldflags+=-static-libstdc++ -lc++abi
+endif
+
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/googletest.mk
+++ b/depends/packages/googletest.mk
@@ -13,7 +13,13 @@ define $(package)_set_vars
 $(package)_cxxflags+=-std=c++17
 $(package)_cxxflags_linux=-fPIC
 $(package)_cxxflags_freebsd=-fPIC
-$(package)_ldflags+=-static-libstdc++ -lc++abi
+
+ifeq ($(host_os),freebsd)
+  $(package)_ldflags+=-static-libstdc++ -lcxxrt
+else
+  $(package)_ldflags+=-static-libstdc++ -lc++abi
+endif
+
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/libcxx.mk
+++ b/depends/packages/libcxx.mk
@@ -68,6 +68,7 @@ endef
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/lib && \
   cp $(build_prefix)/lib/libc++.a $($(package)_staging_prefix_dir)/lib && \
-  cp $(build_prefix)/lib/libc++abi.a $($(package)_staging_prefix_dir)/lib
+  if [ -f "$(build_prefix)/lib/libc++abi.a" ]; then cp $(build_prefix)/lib/libc++abi.a $($(package)_staging_prefix_dir)/lib; fi
 endef
+
 endif

--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -8,6 +8,9 @@ $(package)_sha256_hash_linux=9ef854b71949f825362a119bf2597f744836cb571131ae6b721
 $(package)_download_file_darwin=clang+llvm-$($(package)_version)-x86_64-apple-darwin.tar.xz
 $(package)_file_name_darwin=clang-llvm-$($(package)_version)-x86_64-apple-darwin.tar.xz
 $(package)_sha256_hash_darwin=94ebeb70f17b6384e052c47fef24a6d70d3d949ab27b6c83d4ab7b298278ad6f
+$(package)_download_file_freebsd=clang+llvm-$($(package)_version)-amd64-unknown-freebsd11.tar.xz
+$(package)_file_name_freebsd=clang-llvm-$($(package)_version)-amd64-unknown-freebsd11.tar.xz
+$(package)_sha256_hash_freebsd=af15d14bd25e469e35ed7c43cb7e035bc1b2aa7b55d26ad597a43e72768750a8
 
 # Ensure we have clang native to the builder, not the target host
 ifneq ($(canonical_host),$(build))

--- a/depends/packages/native_rust.mk
+++ b/depends/packages/native_rust.mk
@@ -13,6 +13,7 @@ $(package)_sha256_hash_freebsd=36a14498f9d1d7fb50d6fc01740960a99aff3d4c4c3d2e4ff
 # "darwin", in which case we assume x86_64-apple-darwin.
 $(package)_rust_target_x86_64-pc-linux-gnu=x86_64-unknown-linux-gnu
 $(package)_rust_target_x86_64-w64-mingw32=x86_64-pc-windows-gnu
+$(package)_rust_target_x86_64-unknown-freebsd12.2=x86_64-unknown-freebsd
 
 # Mapping from Rust targets to SHA-256 hashes
 $(package)_rust_std_sha256_hash_aarch64-unknown-linux-gnu=666c6d1f2c65a9bb6e20ae68a6eaa1c5aadee44ff4eb43c593836fe7daba1441

--- a/depends/packages/native_rust.mk
+++ b/depends/packages/native_rust.mk
@@ -13,7 +13,6 @@ $(package)_sha256_hash_freebsd=36a14498f9d1d7fb50d6fc01740960a99aff3d4c4c3d2e4ff
 # "darwin", in which case we assume x86_64-apple-darwin.
 $(package)_rust_target_x86_64-pc-linux-gnu=x86_64-unknown-linux-gnu
 $(package)_rust_target_x86_64-w64-mingw32=x86_64-pc-windows-gnu
-$(package)_rust_target_x86_64-unknown-freebsd12.2=x86_64-unknown-freebsd
 
 # Mapping from Rust targets to SHA-256 hashes
 $(package)_rust_std_sha256_hash_aarch64-unknown-linux-gnu=666c6d1f2c65a9bb6e20ae68a6eaa1c5aadee44ff4eb43c593836fe7daba1441
@@ -21,7 +20,7 @@ $(package)_rust_std_sha256_hash_x86_64-apple-darwin=716305d18cfa88151b0446e8c142
 $(package)_rust_std_sha256_hash_x86_64-pc-windows-gnu=d82ee422b024451c0001ee4dd4282e948405df7a3c315b2791880ed68c1ff88b
 
 define rust_target
-$(if $($(1)_rust_target_$(2)),$($(1)_rust_target_$(2)),$(if $(findstring darwin,$(3)),x86_64-apple-darwin,$(2)))
+$(if $($(1)_rust_target_$(2)),$($(1)_rust_target_$(2)),$(if $(findstring darwin,$(3)),x86_64-apple-darwin,$(if $(findstring freebsd,$(3)),x86_64-unknown-freebsd,$(2))))
 endef
 
 ifneq ($(canonical_host),$(build))

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -17,7 +17,13 @@ define $(package)_set_vars
   $(package)_config_opts_linux=--with-pic
   $(package)_config_opts_freebsd=--with-pic
   $(package)_cxxflags+=-std=c++17
-  $(package)_ldflags+=-static-libstdc++ -lc++abi
+
+  ifeq ($(host_os),freebsd)
+    $(package)_ldflags+=-static-libstdc++ -lcxxrt
+  else
+    $(package)_ldflags+=-static-libstdc++ -lc++abi
+  endif
+
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/patches/zeromq/windows-unused-variables.diff
+++ b/depends/patches/zeromq/windows-unused-variables.diff
@@ -9,7 +9,7 @@ diff -ur zeromq-4.3.3-orig/src/clock.cpp zeromq-4.3.3/src/clock.cpp
  const uint64_t usecs_per_msec = 1000;
 +#endif
  const uint64_t usecs_per_sec = 1000000;
-+#ifndef ZMQ_HAVE_WINDOWS
++#if !defined ZMQ_HAVE_WINDOWS && !defined ZMQ_HAVE_FREEBSD
  const uint64_t nsecs_per_usec = 1000;
 +#endif
  

--- a/depends/patches/zeromq/windows-unused-variables.diff
+++ b/depends/patches/zeromq/windows-unused-variables.diff
@@ -9,7 +9,7 @@ diff -ur zeromq-4.3.3-orig/src/clock.cpp zeromq-4.3.3/src/clock.cpp
  const uint64_t usecs_per_msec = 1000;
 +#endif
  const uint64_t usecs_per_sec = 1000000;
-+#if !defined ZMQ_HAVE_WINDOWS && !defined ZMQ_HAVE_FREEBSD
++#if !defined(ZMQ_HAVE_WINDOWS) && !defined(ZMQ_HAVE_FREEBSD)
  const uint64_t nsecs_per_usec = 1000;
 +#endif
  


### PR DESCRIPTION
The pre-built binaries for clang 8 on FreeBSD do not ship with `libc++api`, so `libcxxrt` from the base system is used instead.