### PR TITLE
depends: Move to Clang 11

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -4,6 +4,7 @@ $(package)_download_path=https://dl.bintray.com/boostorg/release/$(subst _,.,$($
 $(package)_file_name=boost_$($(package)_version).tar.bz2
 $(package)_sha256_hash=953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb
 $(package)_dependencies=native_b2
+$(package)_patches=deprecated-two-arg-allocate.diff
 
 ifneq ($(host_os),darwin)
 $(package)_dependencies+=libcxx
@@ -41,6 +42,7 @@ endif
 endef
 
 define $(package)_preprocess_cmds
+  patch -p2 < $($(package)_patch_dir)/deprecated-two-arg-allocate.diff && \
   echo "using $($(package)_toolset_$(host_os)) : : $($(package)_cxx) : <cflags>\"$($(package)_cflags)\" <cxxflags>\"$($(package)_cxxflags)\" <compileflags>\"$($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$($(package)_ar)\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 

--- a/depends/packages/libcxx.mk
+++ b/depends/packages/libcxx.mk
@@ -5,13 +5,13 @@ ifneq ($(canonical_host),$(build))
 ifneq ($(host_os),mingw32)
 # Clang is provided pre-compiled for a bunch of targets; fetch the one we need
 # and stage its copies of the static libraries.
-$(package)_download_path=https://releases.llvm.org/$($(package)_version)
+$(package)_download_path=$(native_clang_download_path)
 $(package)_download_file_aarch64_linux=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
 $(package)_file_name_aarch64_linux=clang-llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
-$(package)_sha256_hash_aarch64_linux=998e9ae6e89bd3f029ed031ad9355c8b43441302c0e17603cf1de8ee9939e5c9
-$(package)_download_file_linux=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-$(package)_file_name_linux=clang-llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-$(package)_sha256_hash_linux=9ef854b71949f825362a119bf2597f744836cb571131ae6b721cd102ffea8cd0
+$(package)_sha256_hash_aarch64_linux=39b3d3e3b534e327d90c77045058e5fc924b1a81d349eac2be6fb80f4a0e40d4
+$(package)_download_file_linux=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+$(package)_file_name_linux=clang-llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+$(package)_sha256_hash_linux=67f18660231d7dd09dc93502f712613247b7b4395e6f48c11226629b250b53c5
 
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/lib && \
@@ -22,13 +22,13 @@ endef
 else
 # For Windows cross-compilation, use the MSYS2 binaries.
 $(package)_download_path=https://repo.msys2.org/mingw/x86_64
-$(package)_download_file=mingw-w64-x86_64-libc++-9.0.1-1-any.pkg.tar.xz
-$(package)_file_name=mingw-w64-x86_64-libcxx-9.0.1-1-any.pkg.tar.xz
-$(package)_sha256_hash=04e77c5d0e3a9efc9cc8ca3b6549af9a9eef6e20d53076295efbdfba76c5f5de
+$(package)_download_file=mingw-w64-x86_64-libc++-11.0.0-5-any.pkg.tar.zst
+$(package)_file_name=mingw-w64-x86_64-libcxx-11.0.0-5-any.pkg.tar.zst
+$(package)_sha256_hash=f12d5c51f6bfd9b59148e6ccece8d355b7bd5d4f8ee1fadb96d8d51930af2c6e
 
-$(package)_libcxxabi_download_file=mingw-w64-x86_64-libc++abi-9.0.1-1-any.pkg.tar.xz
-$(package)_libcxxabi_file_name=mingw-w64-x86_64-libc++abi-9.0.1-1-any.pkg.tar.xz
-$(package)_libcxxabi_sha256_hash=e8a38084dc05c9f6bd4ded4fe1cdbbe16f7280d66426a76b2c3c23d0575aad5c
+$(package)_libcxxabi_download_file=mingw-w64-x86_64-libc++abi-11.0.0-5-any.pkg.tar.zst
+$(package)_libcxxabi_file_name=mingw-w64-x86_64-libcxxabi-11.0.0-5-any.pkg.tar.zst
+$(package)_libcxxabi_sha256_hash=ecb590d2d208ab870452f8fa541d0d1aa599bd58e37a891c69fdf75e83ae13a6
 
 $(package)_extra_sources += $($(package)_libcxxabi_file_name)
 

--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -1,16 +1,16 @@
 package=native_clang
-$(package)_major_version=8
-$(package)_version=8.0.0
-$(package)_download_path=https://releases.llvm.org/$($(package)_version)
-$(package)_download_file_linux=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-$(package)_file_name_linux=clang-llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-$(package)_sha256_hash_linux=9ef854b71949f825362a119bf2597f744836cb571131ae6b721cd102ffea8cd0
-$(package)_download_file_darwin=clang+llvm-$($(package)_version)-x86_64-apple-darwin.tar.xz
-$(package)_file_name_darwin=clang-llvm-$($(package)_version)-x86_64-apple-darwin.tar.xz
-$(package)_sha256_hash_darwin=94ebeb70f17b6384e052c47fef24a6d70d3d949ab27b6c83d4ab7b298278ad6f
+$(package)_major_version=11
+$(package)_version=11.0.1
+$(package)_download_path=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
+$(package)_download_file_linux=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+$(package)_file_name_linux=clang-llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+$(package)_sha256_hash_linux=67f18660231d7dd09dc93502f712613247b7b4395e6f48c11226629b250b53c5
+$(package)_download_file_darwin=clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz
+$(package)_file_name_darwin=clang-llvm-11.0.0-x86_64-apple-darwin.tar.xz
+$(package)_sha256_hash_darwin=b93886ab0025cbbdbb08b46e5e403a462b0ce034811c929e96ed66c2b07fe63a
 $(package)_download_file_freebsd=clang+llvm-$($(package)_version)-amd64-unknown-freebsd11.tar.xz
 $(package)_file_name_freebsd=clang-llvm-$($(package)_version)-amd64-unknown-freebsd11.tar.xz
-$(package)_sha256_hash_freebsd=af15d14bd25e469e35ed7c43cb7e035bc1b2aa7b55d26ad597a43e72768750a8
+$(package)_sha256_hash_freebsd=cd0a6da1825bc7440c5a8dfa22add4ee91953c45aa0e5597ba1a5caf347f807d
 
 # Ensure we have clang native to the builder, not the target host
 ifneq ($(canonical_host),$(build))

--- a/depends/patches/boost/deprecated-two-arg-allocate.diff
+++ b/depends/patches/boost/deprecated-two-arg-allocate.diff
@@ -1,0 +1,102 @@
+diff -ur orig/include/boost/core/allocator_access.hpp patched/include/boost/core/allocator_access.hpp
+--- orig/include/boost/core/allocator_access.hpp	2021-01-18 21:42:05.926895400 +0000
++++ patched/include/boost/core/allocator_access.hpp	2021-01-18 21:44:26.426895400 +0000
+@@ -11,7 +11,7 @@
+ #include <boost/config.hpp>
+ #if !defined(BOOST_NO_CXX11_ALLOCATOR)
+ #include <boost/core/pointer_traits.hpp>
+-#if !defined(BOOST_MSVC)
++#if !defined(BOOST_MSVC) && !defined(BOOST_CLANG)
+ #include <limits>
+ #else
+ #include <memory>
+@@ -49,7 +49,7 @@
+ struct allocator_pointer {
+     typedef typename A::pointer type;
+ };
+-#elif defined(BOOST_MSVC)
++#elif defined(BOOST_MSVC) || defined(BOOST_CLANG)
+ template<class A>
+ struct allocator_pointer {
+     typedef typename std::allocator_traits<A>::pointer type;
+@@ -72,7 +72,7 @@
+ struct allocator_const_pointer {
+     typedef typename A::const_pointer type;
+ };
+-#elif defined(BOOST_MSVC)
++#elif defined(BOOST_MSVC) || defined(BOOST_CLANG)
+ template<class A>
+ struct allocator_const_pointer {
+     typedef typename std::allocator_traits<A>::const_pointer type;
+@@ -137,7 +137,7 @@
+ struct allocator_difference_type {
+     typedef typename A::difference_type type;
+ };
+-#elif defined(BOOST_MSVC)
++#elif defined(BOOST_MSVC) || defined(BOOST_CLANG)
+ template<class A>
+ struct allocator_difference_type {
+     typedef typename std::allocator_traits<A>::difference_type type;
+@@ -161,7 +161,7 @@
+ struct allocator_size_type {
+     typedef typename A::size_type type;
+ };
+-#elif defined(BOOST_MSVC)
++#elif defined(BOOST_MSVC) || defined(BOOST_CLANG)
+ template<class A>
+ struct allocator_size_type {
+     typedef typename std::allocator_traits<A>::size_type type;
+@@ -260,7 +260,7 @@
+ struct allocator_rebind {
+     typedef typename A::template rebind<T>::other type;
+ };
+-#elif defined(BOOST_MSVC)
++#elif defined(BOOST_MSVC) || defined(BOOST_CLANG)
+ template<class A, class T>
+ struct allocator_rebind {
+     typedef typename std::allocator_traits<A>::template rebind_alloc<T> type;
+@@ -313,7 +313,7 @@
+ {
+     return a.allocate(n, h);
+ }
+-#elif defined(BOOST_MSVC)
++#elif defined(BOOST_MSVC) || defined(BOOST_CLANG)
+ template<class A>
+ inline typename allocator_pointer<A>::type
+ allocator_allocate(A& a, typename allocator_size_type<A>::type n,
+@@ -400,7 +400,7 @@
+     ::new((void*)p) T(v);
+ }
+ #endif
+-#elif defined(BOOST_MSVC)
++#elif defined(BOOST_MSVC) || defined(BOOST_CLANG)
+ template<class A, class T, class... Args>
+ inline void
+ allocator_construct(A& a, T* p, Args&&... args)
+@@ -449,7 +449,7 @@
+     p->~T();
+     (void)p;
+ }
+-#elif defined(BOOST_MSVC)
++#elif defined(BOOST_MSVC) || defined(BOOST_CLANG)
+ template<class A, class T>
+ inline void
+ allocator_destroy(A& a, T* p)
+@@ -496,7 +496,7 @@
+ {
+     return a.max_size();
+ }
+-#elif defined(BOOST_MSVC)
++#elif defined(BOOST_MSVC) || defined(BOOST_CLANG)
+ template<class A>
+ inline typename allocator_size_type<A>::type
+ allocator_max_size(const A& a)
+@@ -545,7 +545,7 @@
+ {
+     return a;
+ }
+-#elif defined(BOOST_MSVC)
++#elif defined(BOOST_MSVC) || defined(BOOST_CLANG)
+ template<class A>
+ inline A
+ allocator_select_on_container_copy_construction(const A& a)


### PR DESCRIPTION
Most platforms are on 11.0.1; Darwin and Windows are both on 11.0.0
because that is the latest that binaries are provided for.

Requires `zstd` to cross-compile Windows binaries.