### PR TITLE
build: Enable cross-language ThinLTO

### DIFF
--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -27,8 +27,8 @@ OSX_SDK=$(SDK_PATH)/Xcode-$(XCODE_VERSION)-$(XCODE_BUILD_ID)-extracted-SDK-with-
 #         https://reviews.llvm.org/D64089, we should use that instead. Read the
 #         differential summary there for more details.
 #
-darwin_CC=clang -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION) -B$(build_prefix)/bin
-darwin_CXX=clang++ -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -stdlib=libc++ -mlinker-version=$(LD64_VERSION) -B$(build_prefix)/bin -nostdinc++ -isystem $(OSX_SDK)/usr/include/c++/v1
+darwin_CC=clang -target $(host) -flto=thin -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION) -B$(build_prefix)/bin
+darwin_CXX=clang++ -target $(host) -flto=thin -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -stdlib=libc++ -mlinker-version=$(LD64_VERSION) -B$(build_prefix)/bin -nostdinc++ -isystem $(OSX_SDK)/usr/include/c++/v1
 
 darwin_CFLAGS=-pipe
 darwin_CXXFLAGS=$(darwin_CFLAGS)

--- a/depends/hosts/default.mk
+++ b/depends/hosts/default.mk
@@ -5,8 +5,8 @@
 #         Explicitly point to our binaries (e.g. cctools) so that they are
 #         ensured to be found and preferred over other possibilities.
 #
-default_host_CC = clang -target $(host) -B$(build_prefix)/bin
-default_host_CXX = clang++ -target $(host) -B$(build_prefix)/bin -stdlib=libc++
+default_host_CC = clang -target $(host) -flto=thin -B$(build_prefix)/bin
+default_host_CXX = clang++ -target $(host) -flto=thin -B$(build_prefix)/bin -stdlib=libc++
 default_host_AR = llvm-ar
 default_host_RANLIB = llvm-ranlib
 default_host_STRIP = llvm-strip

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,7 +39,7 @@ if ENABLE_WALLET
 LIBBITCOIN_WALLET=libbitcoin_wallet.a
 endif
 
-RUST_ENV_VARS = RUSTC="$(RUSTC)" TERM=dumb
+RUST_ENV_VARS = RUSTC="$(RUSTC)" TERM=dumb RUSTFLAGS="-Clinker-plugin-lto"
 RUST_BUILD_OPTS = --lib --release --target $(RUST_TARGET)
 
 rust_verbose = $(rust_verbose_@AM_V@)


### PR DESCRIPTION
Causes warnings at link time due to C++ and Rust using different target
strings. These warnings do not break CI, because while we require `-Werror`
to build on Linux, that only affects compilation, not linking.

See https://github.com/rust-lang/rust/issues/33147 for more details.