### PR TITLE
depends: Allow per-host package download paths

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -49,6 +49,7 @@ final_build_id_long+=$($(package)_build_id_long)
 $(eval $(1)_file_name=$(if $($(1)_exact_file_name),$($(1)_exact_file_name),$(if $($(1)_file_name_$(host_arch)_$(host_os)),$($(1)_file_name_$(host_arch)_$(host_os)),$(if $($(1)_file_name_$(host_os)),$($(1)_file_name_$(host_os)),$($(1)_file_name)))))
 $(eval $(1)_sha256_hash=$(if $($(1)_exact_sha256_hash),$($(1)_exact_sha256_hash),$(if $($(1)_sha256_hash_$(host_arch)_$(host_os)),$($(1)_sha256_hash_$(host_arch)_$(host_os)),$(if $($(1)_sha256_hash_$(host_os)),$($(1)_sha256_hash_$(host_os)),$($(1)_sha256_hash)))))
 $(eval $(1)_download_file=$(if $($(1)_exact_download_file),$($(1)_exact_download_file),$(if $($(1)_download_file_$(host_arch)_$(host_os)),$($(1)_download_file_$(host_arch)_$(host_os)),$(if $($(1)_download_file_$(host_os)),$($(1)_download_file_$(host_os)),$(if $($(1)_download_file),$($(1)_download_file),$($(1)_file_name))))))
+$(eval $(1)_download_path=$(if $($(1)_exact_download_path),$($(1)_exact_download_path),$(if $($(1)_download_path_$(host_arch)_$(host_os)),$($(1)_download_path_$(host_arch)_$(host_os)),$(if $($(1)_download_path_$(host_os)),$($(1)_download_path_$(host_os)),$($(1)_download_path)))))
 
 #compute package-specific paths
 $(1)_build_subdir?=.

--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -5,6 +5,7 @@ $(package)_download_path=https://github.com/llvm/llvm-project/releases/download/
 $(package)_download_file_linux=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 $(package)_file_name_linux=clang-llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 $(package)_sha256_hash_linux=67f18660231d7dd09dc93502f712613247b7b4395e6f48c11226629b250b53c5
+$(package)_download_path_darwin=https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0
 $(package)_download_file_darwin=clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz
 $(package)_file_name_darwin=clang-llvm-11.0.0-x86_64-apple-darwin.tar.xz
 $(package)_sha256_hash_darwin=b93886ab0025cbbdbb08b46e5e403a462b0ce034811c929e96ed66c2b07fe63a

--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -2,6 +2,7 @@ package=native_clang
 $(package)_major_version=11
 $(package)_version=11.0.1
 $(package)_download_path=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
+$(package)_download_path_linux=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
 $(package)_download_file_linux=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 $(package)_file_name_linux=clang-llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 $(package)_sha256_hash_linux=67f18660231d7dd09dc93502f712613247b7b4395e6f48c11226629b250b53c5
@@ -9,12 +10,14 @@ $(package)_download_path_darwin=https://github.com/llvm/llvm-project/releases/do
 $(package)_download_file_darwin=clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz
 $(package)_file_name_darwin=clang-llvm-11.0.0-x86_64-apple-darwin.tar.xz
 $(package)_sha256_hash_darwin=b93886ab0025cbbdbb08b46e5e403a462b0ce034811c929e96ed66c2b07fe63a
+$(package)_download_path_freebsd=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
 $(package)_download_file_freebsd=clang+llvm-$($(package)_version)-amd64-unknown-freebsd11.tar.xz
 $(package)_file_name_freebsd=clang-llvm-$($(package)_version)-amd64-unknown-freebsd11.tar.xz
 $(package)_sha256_hash_freebsd=cd0a6da1825bc7440c5a8dfa22add4ee91953c45aa0e5597ba1a5caf347f807d
 
 # Ensure we have clang native to the builder, not the target host
 ifneq ($(canonical_host),$(build))
+$(package)_exact_download_path=$($(package)_download_path_$(build_os))
 $(package)_exact_download_file=$($(package)_download_file_$(build_os))
 $(package)_exact_file_name=$($(package)_file_name_$(build_os))
 $(package)_exact_sha256_hash=$($(package)_sha256_hash_$(build_os))


### PR DESCRIPTION
Clang's download path includes its version, but LLVM doesn't always
publish every package for every version, so we need to support multiple
versions.

Fixes zcash/zcash#4954.