### PR TITLE
Dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,15 +178,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-
-[[package]]
-name = "cc"
-version = "1.0.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "cfg-if"
@@ -341,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest",
@@ -452,19 +446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -511,12 +492,6 @@ name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
-
-[[package]]
-name = "itoa"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jubjub"
@@ -540,9 +515,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "librustzcash"
@@ -569,24 +544,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
-dependencies = [
- "cfg-if 0.1.10",
- "generator",
- "scoped-tls",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -654,6 +616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "ppv-lite86"
@@ -765,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "regex-syntax",
 ]
@@ -784,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rust-argon2"
@@ -801,76 +769,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "974ef1bd2ad8a507599b336595454081ff68a9599b4890af7643c0c0ed73a62c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "8dee1f300f838c8ac340ecb0112b3ac472464fa67e87292bdb3dfc9c49128e17"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -888,12 +809,11 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
 dependencies = [
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -904,9 +824,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.57"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -935,11 +855,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,10 +1,10 @@
 package=boost
-$(package)_version=1_75_0
+$(package)_version=1_74_0
 $(package)_download_path=https://dl.bintray.com/boostorg/release/$(subst _,.,$($(package)_version))/source/
 $(package)_file_name=boost_$($(package)_version).tar.bz2
-$(package)_sha256_hash=953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb
+$(package)_sha256_hash=83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1
 $(package)_dependencies=native_b2
-$(package)_patches=deprecated-two-arg-allocate.diff
+$(package)_patches=iostreams-106.patch signals2-noise.patch deprecated-two-arg-allocate.diff
 
 ifneq ($(host_os),darwin)
 $(package)_dependencies+=libcxx
@@ -42,6 +42,8 @@ endif
 endef
 
 define $(package)_preprocess_cmds
+  patch -p2 < $($(package)_patch_dir)/iostreams-106.patch && \
+  patch -p2 < $($(package)_patch_dir)/signals2-noise.patch && \
   patch -p2 < $($(package)_patch_dir)/deprecated-two-arg-allocate.diff && \
   echo "using $($(package)_toolset_$(host_os)) : : $($(package)_cxx) : <cflags>\"$($(package)_cflags)\" <cxxflags>\"$($(package)_cxxflags)\" <compileflags>\"$($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$($(package)_ar)\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,8 +1,8 @@
 package=zeromq
-$(package)_version=4.3.3
+$(package)_version=4.3.4
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=9d9285db37ae942ed0780c016da87060497877af45094ff9e1a1ca736e3875a2
+$(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
 $(package)_patches=windows-unused-variables.diff
 
 ifneq ($(host_os),darwin)

--- a/depends/patches/boost/iostreams-106.patch
+++ b/depends/patches/boost/iostreams-106.patch
@@ -1,0 +1,25 @@
+From 4e76f73826fd0a7067b837e4850a9051436f5ec5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jean-Micha=C3=ABl=20Celerier?=
+ <jeanmichael.celerier+github@gmail.com>
+Date: Sun, 22 Dec 2019 10:26:38 +0100
+Subject: [PATCH] Fix build on windows with libc++
+
+Proposed by @SquallATF in #67
+---
+ include/boost/iostreams/detail/config/fpos.hpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/include/boost/iostreams/detail/config/fpos.hpp b/include/boost/iostreams/detail/config/fpos.hpp
+index c5dc6cf59..a5835421f 100644
+--- a/include/boost/iostreams/detail/config/fpos.hpp
++++ b/include/boost/iostreams/detail/config/fpos.hpp
+@@ -26,7 +26,8 @@
+ 
+ # if (defined(_YVALS) || defined(_CPPLIB_VER)) && !defined(__SGI_STL_PORT) && \
+      !defined(_STLPORT_VERSION) && !defined(__QNX__) && !defined(_VX_CPU) && !defined(__VXWORKS__) \
+-     && !((defined(BOOST_MSVC) || defined(BOOST_CLANG)) && _MSVC_STL_VERSION >= 141)
++     && !((defined(BOOST_MSVC) || defined(BOOST_CLANG)) && _MSVC_STL_VERSION >= 141) \
++     && !defined(_LIBCPP_VERSION)
+      /**/
+ 
+ #include <boost/iostreams/detail/ios.hpp>

--- a/depends/patches/boost/signals2-noise.patch
+++ b/depends/patches/boost/signals2-noise.patch
@@ -1,0 +1,23 @@
+From fd27423fea5537bc857c1fa14bb0c25b994f77b3 Mon Sep 17 00:00:00 2001
+From: Frank Mori Hess <fmh6jj@gmail.com>
+Date: Mon, 20 Jul 2020 14:17:05 -0400
+Subject: [PATCH] Fix warning about deprecated
+ boost/function_output_iterator.hpp
+
+---
+ include/boost/signals2/detail/null_output_iterator.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/boost/signals2/detail/null_output_iterator.hpp b/include/boost/signals2/detail/null_output_iterator.hpp
+index 9e986959..dee4373c 100644
+--- a/include/boost/signals2/detail/null_output_iterator.hpp
++++ b/include/boost/signals2/detail/null_output_iterator.hpp
+@@ -11,7 +11,7 @@
+ #ifndef BOOST_SIGNALS2_NULL_OUTPUT_ITERATOR_HPP
+ #define BOOST_SIGNALS2_NULL_OUTPUT_ITERATOR_HPP
+ 
+-#include <boost/function_output_iterator.hpp>
++#include <boost/iterator/function_output_iterator.hpp>
+ 
+ namespace boost
+ {

--- a/qa/zcash/postponed-updates.txt
+++ b/qa/zcash/postponed-updates.txt
@@ -4,7 +4,9 @@
 # bdb 18.1.40 2020-09-01
 #
 
-native_ccache 4.0 2021-01-20
+# Ccache 4.0 requires adding CMake to the depends system.
+native_ccache 4.0 2021-03-01
+native_ccache 4.1 2021-03-01
 
 bdb 18.1.40 2021-07-01
 
@@ -16,4 +18,4 @@ boost 1.75.0 2021-03-01
 native_b2 1.75.0 2021-03-01
 
 # Google Test 1.10.0 requires adding CMake to the depends system.
-googletest 1.10.0 2021-01-20
+googletest 1.10.0 2021-03-01

--- a/qa/zcash/postponed-updates.txt
+++ b/qa/zcash/postponed-updates.txt
@@ -24,6 +24,13 @@ native_ccache 4.0 2021-01-20
 
 bdb 18.1.40 2021-01-20
 
+# Boost 1.75 starts using the statx syscall where available, which causes
+# permission errors in some environments.
+# https://github.com/zcash/zcash/issues/4945
+# native_b2 is pinned to the same version as Boost.
+boost 1.75.0 2021-03-01
+native_b2 1.75.0 2021-03-01
+
 # Google Test 1.10.0 requires adding CMake to the depends system.
 googletest 1.10.0 2021-01-20
 

--- a/qa/zcash/postponed-updates.txt
+++ b/qa/zcash/postponed-updates.txt
@@ -7,21 +7,20 @@
 # Clang is pinned to a version that matches the Rust version.
 # This would be Clang 9, but for 4.1.0 we are using Clang 8 and postponing the upgrade.
 # libc++ is pinned to the same version as Clang.
-native_clang 8.0.1 2021-01-20
-native_clang 9.0.0 2021-01-20
-native_clang 9.0.1 2021-01-20
+native_clang 8.0.1 2020-12-01
+native_clang 9.0.0 2020-12-01
+native_clang 9.0.1 2020-12-01
 native_clang 10.0.0 2021-01-20
 native_clang 10.0.1 2021-01-20
 native_clang 11.0.0 2021-01-20
-libcxx 8.0.1 2021-01-20
-libcxx 9.0.0 2021-01-20
-libcxx 9.0.1 2021-01-20
+libcxx 8.0.1 2020-12-01
+libcxx 9.0.0 2020-12-01
+libcxx 9.0.1 2020-12-01
 libcxx 10.0.0 2021-01-20
 libcxx 10.0.1 2021-01-20
 libcxx 11.0.0 2021-01-20
 
 native_ccache 4.0 2021-01-20
-native_ccache 4.1 2021-01-20
 
 bdb 18.1.40 2021-01-20
 

--- a/qa/zcash/postponed-updates.txt
+++ b/qa/zcash/postponed-updates.txt
@@ -4,22 +4,6 @@
 # bdb 18.1.40 2020-09-01
 #
 
-# Clang is pinned to a version that matches the Rust version.
-# This would be Clang 9, but for 4.1.0 we are using Clang 8 and postponing the upgrade.
-# libc++ is pinned to the same version as Clang.
-native_clang 8.0.1 2020-12-01
-native_clang 9.0.0 2020-12-01
-native_clang 9.0.1 2020-12-01
-native_clang 10.0.0 2021-01-20
-native_clang 10.0.1 2021-01-20
-native_clang 11.0.0 2021-01-20
-libcxx 8.0.1 2020-12-01
-libcxx 9.0.0 2020-12-01
-libcxx 9.0.1 2020-12-01
-libcxx 10.0.0 2021-01-20
-libcxx 10.0.1 2021-01-20
-libcxx 11.0.0 2021-01-20
-
 native_ccache 4.0 2021-01-20
 
 bdb 18.1.40 2021-01-20
@@ -33,64 +17,3 @@ native_b2 1.75.0 2021-03-01
 
 # Google Test 1.10.0 requires adding CMake to the depends system.
 googletest 1.10.0 2021-01-20
-
-# The aes crate depends on "aesni ^0.8"
-crate_aesni 0.9.0 2020-11-01
-
-# The bigint crate depends on "crunchy ^0.1.5"
-crate_crunchy 0.2.1 2020-11-01
-crate_crunchy 0.2.2 2020-11-01
-
-# These are being deferred until after 4.0.0 to avoid blocking the release.
-crate_time 0.1.44 2021-01-20
-crate_redox_users 0.3.5 2021-01-20
-
-# The chrono crate depends on "time ^0.1.43", and is highly unlikely to
-# upgrade to v0.2: https://github.com/chronotope/chrono/issues/400
-crate_time 0.2.0 2021-02-01
-crate_time 0.2.1 2021-02-01
-crate_time 0.2.2 2021-02-01
-crate_time 0.2.3 2021-02-01
-crate_time 0.2.4 2021-02-01
-crate_time 0.2.5 2021-02-01
-crate_time 0.2.6 2021-02-01
-crate_time 0.2.7 2021-02-01
-crate_time 0.2.8 2021-02-01
-crate_time 0.2.9 2021-02-01
-crate_time 0.2.10 2021-02-01
-crate_time 0.2.11 2021-02-01
-crate_time 0.2.12 2021-02-01
-crate_time 0.2.13 2021-02-01
-crate_time 0.2.14 2021-02-01
-crate_time 0.2.15 2021-02-01
-crate_time 0.2.16 2021-02-01
-
-# The futures-cpupool crate depends on "futures ^0.1", which was last
-# updated 3 years ago. We plan to move away from it when we refactor
-# bellman's multicore support.
-crate_futures 0.2.0 2021-02-01
-crate_futures 0.2.1 2021-02-01
-crate_futures 0.3.0 2021-02-01
-crate_futures 0.3.1 2021-02-01
-crate_futures 0.3.2 2021-02-01
-crate_futures 0.3.3 2021-02-01
-crate_futures 0.3.4 2021-02-01
-crate_futures 0.3.5 2021-02-01
-
-# The redox_users crate depends on:
-# - "redox_syscall ^0.1"
-# - "rust-argon2 ^0.7", which in turn depends on "base64 ^0.11"
-#
-# redox_users 0.3.5 depends on rust-argon2 ^0.8 which will address some of this.
-crate_base64 0.12.0 2020-11-01
-crate_base64 0.12.1 2020-11-01
-crate_base64 0.12.2 2020-11-01
-crate_base64 0.12.3 2020-11-01
-crate_redox_syscall 0.2.0 2020-11-01
-crate_redox_syscall 0.2.1 2020-11-01
-crate_rust_argon2 0.8.0 2020-11-01
-crate_rust_argon2 0.8.1 2020-11-01
-crate_rust_argon2 0.8.2 2020-11-01
-
-# tracing 0.1.20 was yanked.
-crate_tracing 0.1.20 9999-12-31

--- a/qa/zcash/postponed-updates.txt
+++ b/qa/zcash/postponed-updates.txt
@@ -6,7 +6,7 @@
 
 native_ccache 4.0 2021-01-20
 
-bdb 18.1.40 2021-01-20
+bdb 18.1.40 2021-07-01
 
 # Boost 1.75 starts using the statx syscall where available, which causes
 # permission errors in some environments.

--- a/qa/zcash/updatecheck.py
+++ b/qa/zcash/updatecheck.py
@@ -70,6 +70,11 @@ def get_dependency_list():
             GithubTagReleaseLister("jedisct1", "libsodium", "^(\d+)\.(\d+)\.(\d+)$",
                 { "1.0.17": (1, 0, 17) }),
             DependsVersionGetter("libsodium")),
+        # b2 matches the Boost version
+        Dependency("native_b2",
+            GithubTagReleaseLister("boostorg", "boost", "^boost-(\d+)\.(\d+)\.(\d+)$",
+                { "boost-1.69.0": (1, 69, 0), "boost-1.69.0-beta1": None }),
+            DependsVersionGetter("boost")),
         Dependency("native_ccache",
             GithubTagReleaseLister("ccache", "ccache", "^v?(\d+)\.(\d+)(?:\.(\d+))?$",
                 { "v3.5.1": (3, 5, 1), "v3.6": (3, 6)}),


### PR DESCRIPTION
Boost is reverted to 1.74 to mitigate #4945 until a fix is found.