### PR TITLE
add zstd package to support Windows cross compile

### DIFF
--- a/contrib/ci-builders/apt-package-list.txt
+++ b/contrib/ci-builders/apt-package-list.txt
@@ -20,3 +20,4 @@ python3-dev
 python3-venv
 valgrind
 wget
+zstd


### PR DESCRIPTION
Once the v4.3.0 release is stable, we will need to go rebuild/deploy this builder with a couple other updates so that windows can gracefully cross compile again.
