### PR TITLE
Fix build regression by adding #include <atomic>

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -23,6 +23,7 @@
 
 #include <deque>
 #include <stdint.h>
+#include <atomic>
 
 #ifndef WIN32
 #include <arpa/inet.h>


### PR DESCRIPTION
This fixes #5014, a build regression on Nix introduced in e286250ce49309bfa931b622fabfc37100246266 .

Signed-off-by: Daira Hopwood <daira@jacaranda.org>