### PR TITLE
native_rust: don't install Rust docs

### DIFF
--- a/depends/packages/native_rust.mk
+++ b/depends/packages/native_rust.mk
@@ -47,12 +47,12 @@ define $(package)_extract_cmds
 endef
 
 define $(package)_stage_cmds
-  bash ./install.sh --destdir=$($(package)_staging_dir) --prefix=$(build_prefix) --disable-ldconfig && \
+  bash ./install.sh --without=rust-docs --destdir=$($(package)_staging_dir) --prefix=$(build_prefix) --disable-ldconfig && \
   ../$(canonical_host)/install.sh --destdir=$($(package)_staging_dir) --prefix=$(build_prefix) --disable-ldconfig
 endef
 else
 
 define $(package)_stage_cmds
-  bash ./install.sh --destdir=$($(package)_staging_dir) --prefix=$(build_prefix) --disable-ldconfig
+  bash ./install.sh --without=rust-docs --destdir=$($(package)_staging_dir) --prefix=$(build_prefix) --disable-ldconfig
 endef
 endif


### PR DESCRIPTION
This speeds up builds, especially native builds on macOS. fixes #5042

Signed-off-by: Daira Hopwood <daira@jacaranda.org>
