### PR TITLE
Postpone Clang 12

### DIFF
--- a/qa/zcash/postponed-updates.txt
+++ b/qa/zcash/postponed-updates.txt
@@ -13,6 +13,10 @@ native_ccache 4.2.1 2021-05-01
 native_clang 11.1.0 2021-07-01
 libcxx 11.1.0 2021-07-01
 
+# LLVM 12 is postponed until Rust migrates to it.
+native_clang 12.0.0 2021-07-01
+libcxx 12.0.0 2021-07-01
+
 bdb 18.1.40 2021-07-01
 
 # Boost 1.75 starts using the statx syscall where available, which causes


### PR DESCRIPTION
We won't migrate to LLVM 12 until Rust does.