### PR TITLE
v5 transaction format

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -20,6 +20,10 @@ static const int32_t OVERWINTER_MAX_TX_VERSION = 3;
 static const int32_t SAPLING_MIN_TX_VERSION = 4;
 /** The maximum allowed Sapling transaction version (network rule) */
 static const int32_t SAPLING_MAX_TX_VERSION = 4;
+/** The minimum allowed ZIP225 transaction version (network rule) */
+static const int32_t ZIP225_MIN_TX_VERSION = 5;
+/** The maximum allowed ZIP225 transaction version (network rule) */
+static const int32_t ZIP225_MAX_TX_VERSION = 5;
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_SIZE = 2000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -9,6 +9,66 @@
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 
+SaplingBundle::SaplingBundle(
+    const CAmount& valueBalance,
+    const std::vector<SpendDescription>& vShieldedSpend,
+    const std::vector<OutputDescription>& vShieldedOutput,
+    const binding_sig_t& bindingSig)
+        : valueBalanceSapling(valueBalance), bindingSigSapling(bindingSig)
+{
+    for (auto &spend : vShieldedSpend) {
+        vSpendsSapling.emplace_back(spend.cv, spend.nullifier, spend.rk);
+        if (anchorSapling.IsNull()) {
+            anchorSapling = spend.anchor;
+        } else {
+            assert(anchorSapling == spend.anchor);
+        }
+        vSpendProofsSapling.push_back(spend.zkproof);
+        vSpendAuthSigSapling.push_back(spend.spendAuthSig);
+    }
+    for (auto &output : vShieldedOutput) {
+        vOutputsSapling.emplace_back(
+            output.cv,
+            output.cmu,
+            output.ephemeralKey,
+            output.encCiphertext,
+            output.outCiphertext);
+        vOutputProofsSapling.push_back(output.zkproof);
+    }
+}
+
+std::vector<SpendDescription> SaplingBundle::GetV4ShieldedSpend()
+{
+    std::vector<SpendDescription> vShieldedSpend;
+    for (int i = 0; i < vSpendsSapling.size(); i++) {
+        auto spend = vSpendsSapling[i];
+        vShieldedSpend.emplace_back(
+            spend.cv,
+            anchorSapling,
+            spend.nullifier,
+            spend.rk,
+            vSpendProofsSapling[i],
+            vSpendAuthSigSapling[i]);
+    }
+    return vShieldedSpend;
+}
+
+std::vector<OutputDescription> SaplingBundle::GetV4ShieldedOutput()
+{
+    std::vector<OutputDescription> vShieldedOutput;
+    for (int i = 0; i < vOutputsSapling.size(); i++) {
+        auto output = vOutputsSapling[i];
+        vShieldedOutput.emplace_back(
+            output.cv,
+            output.cmu,
+            output.ephemeralKey,
+            output.encCiphertext,
+            output.outCiphertext,
+            vOutputProofsSapling[i]);
+    }
+    return vShieldedOutput;
+}
+
 std::string COutPoint::ToString() const
 {
     return strprintf("COutPoint(%s, %u)", hash.ToString().substr(0,10), n);
@@ -67,8 +127,10 @@ std::string CTxOut::ToString() const
 
 CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION), fOverwintered(false), nVersionGroupId(0), nExpiryHeight(0), nLockTime(0), valueBalance(0) {}
 CMutableTransaction::CMutableTransaction(const CTransaction& tx) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
+                                                                   nConsensusBranchId(tx.nConsensusBranchId),
                                                                    vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
                                                                    valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
+                                                                   orchardBundle(tx.orchardBundle),
                                                                    vJoinSplit(tx.vJoinSplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
                                                                    bindingSig(tx.bindingSig)
 {
@@ -86,14 +148,18 @@ void CTransaction::UpdateHash() const
 
 CTransaction::CTransaction() : nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION),
                                fOverwintered(false), nVersionGroupId(0), nExpiryHeight(0),
+                               nConsensusBranchId(0),
                                vin(), vout(), nLockTime(0),
                                valueBalance(0), vShieldedSpend(), vShieldedOutput(),
+                               orchardBundle(),
                                vJoinSplit(), joinSplitPubKey(), joinSplitSig(),
                                bindingSig() { }
 
 CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
+                                                            nConsensusBranchId(tx.nConsensusBranchId),
                                                             vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
                                                             valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
+                                                            orchardBundle(tx.orchardBundle),
                                                             vJoinSplit(tx.vJoinSplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
                                                             bindingSig(tx.bindingSig)
 {
@@ -105,8 +171,10 @@ CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion
 CTransaction::CTransaction(
     const CMutableTransaction &tx,
     bool evilDeveloperFlag) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
+                              nConsensusBranchId(tx.nConsensusBranchId),
                               vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
                               valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
+                              orchardBundle(tx.orchardBundle),
                               vJoinSplit(tx.vJoinSplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
                               bindingSig(tx.bindingSig)
 {
@@ -115,10 +183,12 @@ CTransaction::CTransaction(
 
 CTransaction::CTransaction(CMutableTransaction &&tx) : nVersion(tx.nVersion),
                                                        fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId),
+                                                       nConsensusBranchId(tx.nConsensusBranchId),
                                                        vin(std::move(tx.vin)), vout(std::move(tx.vout)),
                                                        nLockTime(tx.nLockTime), nExpiryHeight(tx.nExpiryHeight),
                                                        valueBalance(tx.valueBalance),
                                                        vShieldedSpend(std::move(tx.vShieldedSpend)), vShieldedOutput(std::move(tx.vShieldedOutput)),
+                                                       orchardBundle(std::move(tx.orchardBundle)),
                                                        vJoinSplit(std::move(tx.vJoinSplit)),
                                                        joinSplitPubKey(std::move(tx.joinSplitPubKey)), joinSplitSig(std::move(tx.joinSplitSig)),
                                                        bindingSig(std::move(tx.bindingSig))
@@ -130,6 +200,7 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
     *const_cast<bool*>(&fOverwintered) = tx.fOverwintered;
     *const_cast<int*>(&nVersion) = tx.nVersion;
     *const_cast<uint32_t*>(&nVersionGroupId) = tx.nVersionGroupId;
+    *const_cast<uint32_t*>(&nConsensusBranchId) = tx.nConsensusBranchId;
     *const_cast<std::vector<CTxIn>*>(&vin) = tx.vin;
     *const_cast<std::vector<CTxOut>*>(&vout) = tx.vout;
     *const_cast<unsigned int*>(&nLockTime) = tx.nLockTime;
@@ -137,6 +208,7 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
     *const_cast<CAmount*>(&valueBalance) = tx.valueBalance;
     *const_cast<std::vector<SpendDescription>*>(&vShieldedSpend) = tx.vShieldedSpend;
     *const_cast<std::vector<OutputDescription>*>(&vShieldedOutput) = tx.vShieldedOutput;
+    *const_cast<OrchardBundle*>(&orchardBundle) = tx.orchardBundle;
     *const_cast<std::vector<JSDescription>*>(&vJoinSplit) = tx.vJoinSplit;
     *const_cast<Ed25519VerificationKey*>(&joinSplitPubKey) = tx.joinSplitPubKey;
     *const_cast<Ed25519Signature*>(&joinSplitSig) = tx.joinSplitSig;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -23,6 +23,7 @@
 #include "zcash/Proof.hpp"
 
 #include <rust/ed25519/types.h>
+#include <rust/orchard.h>
 
 // Overwinter transaction version group id
 static constexpr uint32_t OVERWINTER_VERSION_GROUP_ID = 0x03C48270;
@@ -244,6 +245,122 @@ public:
     friend bool operator!=(const OutputDescription& a, const OutputDescription& b)
     {
         return !(a == b);
+    }
+};
+
+/**
+ * The Sapling component of a v5 transaction.
+ */
+class SaplingBundle
+{
+private:
+    typedef std::array<unsigned char, 64> binding_sig_t;
+
+    std::vector<SpendDescriptionV5> vSpendsSapling;
+    std::vector<OutputDescriptionV5> vOutputsSapling;
+    CAmount valueBalanceSapling;
+    uint256 anchorSapling;
+    std::vector<libzcash::GrothProof> vSpendProofsSapling;
+    std::vector<SpendDescription::spend_auth_sig_t> vSpendAuthSigSapling;
+    std::vector<libzcash::GrothProof> vOutputProofsSapling;
+    binding_sig_t bindingSigSapling = {{0}};
+
+public:
+    SaplingBundle() : valueBalanceSapling(0) {}
+
+    SaplingBundle(
+        const CAmount& valueBalance,
+        const std::vector<SpendDescription>& vShieldedSpend,
+        const std::vector<OutputDescription>& vShieldedOutput,
+        const binding_sig_t& bindingSig);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(vSpendsSapling);
+        READWRITE(vOutputsSapling);
+        READWRITE(valueBalanceSapling);
+        READWRITE(anchorSapling);
+        if (ser_action.ForRead()) {
+            for (auto &spend : vSpendsSapling) {
+                libzcash::GrothProof zkproof;
+                READWRITE(zkproof);
+                vSpendProofsSapling.push_back(zkproof);
+            }
+            for (auto &spend : vSpendsSapling) {
+                SpendDescription::spend_auth_sig_t spendAuthSig;
+                READWRITE(spendAuthSig);
+                vSpendAuthSigSapling.push_back(spendAuthSig);
+            }
+            for (auto &output : vOutputsSapling) {
+                libzcash::GrothProof zkproof;
+                READWRITE(zkproof);
+                vOutputProofsSapling.push_back(zkproof);
+            }
+        } else {
+            for (auto &zkproof : vSpendProofsSapling) {
+                READWRITE(zkproof);
+            }
+            for (auto &spendAuthSig : vSpendAuthSigSapling) {
+                READWRITE(spendAuthSig);
+            }
+            for (auto &zkproof : vOutputProofsSapling) {
+                READWRITE(zkproof);
+            }
+        }
+        READWRITE(bindingSigSapling);
+    }
+
+    std::vector<SpendDescription> GetV4ShieldedSpend();
+    std::vector<OutputDescription> GetV4ShieldedOutput();
+};
+
+/**
+ * The Orchard component of a transaction.
+ */
+class OrchardBundle
+{
+private:
+    /// An optional Orchard bundle (with `nullptr` corresponding to `None`).
+    /// Memory is allocated by Rust.
+    std::unique_ptr<OrchardBundlePtr, decltype(&orchard_bundle_free)> inner;
+
+public:
+    OrchardBundle() : inner(nullptr, orchard_bundle_free) {}
+
+    OrchardBundle(OrchardBundle&& bundle) : inner(std::move(bundle.inner)) {}
+    OrchardBundle(const OrchardBundle& bundle) : inner(orchard_bundle_clone(bundle.inner.get()), orchard_bundle_free) {}
+    OrchardBundle& operator=(OrchardBundle&& bundle)
+    {
+        if (this != &bundle) {
+            inner = std::move(bundle.inner);
+        }
+        return *this;
+    }
+    OrchardBundle& operator=(const OrchardBundle& bundle)
+    {
+        if (this != &bundle) {
+            inner.reset(orchard_bundle_clone(bundle.inner.get()));
+        }
+        return *this;
+    }
+
+    template<typename Stream>
+    void Serialize(Stream& s) const {
+        RustStream rs(s);
+        if (!orchard_bundle_serialize(inner.get(), &rs, RustStream<Stream>::write_callback)) {
+            throw std::ios_base::failure("Failed to serialize v5 Orchard bundle");
+        }
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s) {
+        RustStream rs(s);
+        inner.reset(orchard_bundle_parse(&rs, RustStream<Stream>::read_callback));
+        if (!inner) {
+            throw std::ios_base::failure("Failed to parse v5 Orchard bundle");
+        }
     }
 };
 
@@ -625,6 +742,9 @@ public:
     const bool fOverwintered;
     const int32_t nVersion;
     const uint32_t nVersionGroupId;
+    /// The consensus branch ID that this transaction commits to.
+    /// Serialized from v5 onwards.
+    const uint32_t nConsensusBranchId;
     const std::vector<CTxIn> vin;
     const std::vector<CTxOut> vout;
     const uint32_t nLockTime;
@@ -632,6 +752,7 @@ public:
     const CAmount valueBalance;
     const std::vector<SpendDescription> vShieldedSpend;
     const std::vector<OutputDescription> vShieldedOutput;
+    const OrchardBundle orchardBundle;
     const std::vector<JSDescription> vJoinSplit;
     const Ed25519VerificationKey joinSplitPubKey;
     const Ed25519Signature joinSplitSig;
@@ -674,6 +795,11 @@ public:
             nVersionGroupId == SAPLING_VERSION_GROUP_ID &&
             nVersion == SAPLING_TX_VERSION;
 
+        bool isZip225V5 =
+            fOverwintered &&
+            nVersionGroupId == ZIP225_VERSION_GROUP_ID &&
+            nVersion == ZIP225_TX_VERSION;
+
         // It is not possible to make the transaction's serialized form vary on
         // a per-enabled-feature basis. The approach here is that all
         // serialization rules for not-yet-released features must be
@@ -684,8 +810,41 @@ public:
             nVersionGroupId == ZFUTURE_VERSION_GROUP_ID &&
             nVersion == ZFUTURE_TX_VERSION;
 
-        if (fOverwintered && !(isOverwinterV3 || isSaplingV4 || isFuture)) {
+        if (fOverwintered && !(isOverwinterV3 || isSaplingV4 || isZip225V5 || isFuture)) {
             throw std::ios_base::failure("Unknown transaction format");
+        }
+
+        if (isZip225V5) {
+            // Common Transaction Fields (plus version bytes above)
+            READWRITE(*const_cast<uint32_t*>(&this->nConsensusBranchId));
+            READWRITE(*const_cast<uint32_t*>(&nLockTime));
+            READWRITE(*const_cast<uint32_t*>(&nExpiryHeight));
+
+            // Transparent Transaction Fields
+            READWRITE(*const_cast<std::vector<CTxIn>*>(&vin));
+            READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
+
+            // Sapling Transaction Fields
+            if (ser_action.ForRead()) {
+                SaplingBundle saplingBundle;
+                READWRITE(saplingBundle);
+                *const_cast<std::vector<SpendDescription>*>(&vShieldedSpend) =
+                    saplingBundle.GetV4ShieldedSpend();
+                *const_cast<std::vector<OutputDescription>*>(&vShieldedOutput) =
+                    saplingBundle.GetV4ShieldedOutput();
+            } else {
+                SaplingBundle saplingBundle(
+                    valueBalance,
+                    vShieldedSpend,
+                    vShieldedOutput,
+                    bindingSig);
+                READWRITE(saplingBundle);
+            }
+
+            // Orchard Transaction Fields
+            READWRITE(*const_cast<OrchardBundle*>(&orchardBundle));
+
+            return;
         }
 
         READWRITE(*const_cast<std::vector<CTxIn>*>(&vin));
@@ -785,6 +944,9 @@ struct CMutableTransaction
     bool fOverwintered;
     int32_t nVersion;
     uint32_t nVersionGroupId;
+    /// The consensus branch ID that this transaction commits to.
+    /// Serialized from v5 onwards.
+    uint32_t nConsensusBranchId;
     std::vector<CTxIn> vin;
     std::vector<CTxOut> vout;
     uint32_t nLockTime;
@@ -792,6 +954,7 @@ struct CMutableTransaction
     CAmount valueBalance;
     std::vector<SpendDescription> vShieldedSpend;
     std::vector<OutputDescription> vShieldedOutput;
+    OrchardBundle orchardBundle;
     std::vector<JSDescription> vJoinSplit;
     Ed25519VerificationKey joinSplitPubKey;
     Ed25519Signature joinSplitSig;
@@ -831,12 +994,47 @@ struct CMutableTransaction
             fOverwintered &&
             nVersionGroupId == SAPLING_VERSION_GROUP_ID &&
             nVersion == SAPLING_TX_VERSION;
+        bool isZip225V5 =
+            fOverwintered &&
+            nVersionGroupId == ZIP225_VERSION_GROUP_ID &&
+            nVersion == ZIP225_TX_VERSION;
         bool isFuture =
             fOverwintered &&
             nVersionGroupId == ZFUTURE_VERSION_GROUP_ID &&
             nVersion == ZFUTURE_TX_VERSION;
-        if (fOverwintered && !(isOverwinterV3 || isSaplingV4 || isFuture)) {
+        if (fOverwintered && !(isOverwinterV3 || isSaplingV4 || isZip225V5 || isFuture)) {
             throw std::ios_base::failure("Unknown transaction format");
+        }
+
+        if (isZip225V5) {
+            // Common Transaction Fields (plus version bytes above)
+            READWRITE(nConsensusBranchId);
+            READWRITE(nLockTime);
+            READWRITE(nExpiryHeight);
+
+            // Transparent Transaction Fields
+            READWRITE(vin);
+            READWRITE(vout);
+
+            // Sapling Transaction Fields
+            if (ser_action.ForRead()) {
+                SaplingBundle saplingBundle;
+                READWRITE(saplingBundle);
+                vShieldedSpend = saplingBundle.GetV4ShieldedSpend();
+                vShieldedOutput = saplingBundle.GetV4ShieldedOutput();
+            } else {
+                SaplingBundle saplingBundle(
+                    valueBalance,
+                    vShieldedSpend,
+                    vShieldedOutput,
+                    bindingSig);
+                READWRITE(saplingBundle);
+            }
+
+            // Orchard Transaction Fields
+            READWRITE(orchardBundle);
+
+            return;
         }
 
         READWRITE(vin);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -46,6 +46,18 @@ static_assert(SAPLING_TX_VERSION >= SAPLING_MIN_TX_VERSION,
 static_assert(SAPLING_TX_VERSION <= SAPLING_MAX_TX_VERSION,
     "Sapling tx version must not be higher than maximum");
 
+// ZIP225 transaction version group id
+// (defined in section 7.1 of the protocol spec)
+static constexpr uint32_t ZIP225_VERSION_GROUP_ID = 0x26A7270A;
+static_assert(ZIP225_VERSION_GROUP_ID != 0, "version group id must be non-zero as specified in ZIP 202");
+
+// ZIP225 transaction version
+static const int32_t ZIP225_TX_VERSION = 5;
+static_assert(ZIP225_TX_VERSION >= ZIP225_MIN_TX_VERSION,
+    "ZIP225 tx version must not be lower than minimum");
+static_assert(ZIP225_TX_VERSION <= ZIP225_MAX_TX_VERSION,
+    "ZIP225 tx version must not be higher than maximum");
+
 // Future transaction version group id
 static constexpr uint32_t ZFUTURE_VERSION_GROUP_ID = 0xFFFFFFFF;
 static_assert(ZFUTURE_VERSION_GROUP_ID != 0, "version group id must be non-zero as specified in ZIP 202");

--- a/src/rust/include/rust/orchard.h
+++ b/src/rust/include/rust/orchard.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#ifndef ZCASH_RUST_INCLUDE_RUST_ORCHARD_H
+#define ZCASH_RUST_INCLUDE_RUST_ORCHARD_H
+
+#include "rust/streams.h"
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct OrchardBundlePtr;
+typedef struct OrchardBundlePtr OrchardBundlePtr;
+
+/// Clones the given Orchard bundle.
+///
+/// Both bundles need to be separately freed when they go out of scope.
+OrchardBundlePtr* orchard_bundle_clone(const OrchardBundlePtr* span);
+
+/// Frees an Orchard bundle returned from `orchard_parse_bundle`.
+void orchard_bundle_free(OrchardBundlePtr *);
+
+/// Parses an authorized Orchard bundle from the given stream.
+///
+/// - If no error occurs, `bundle` will point to a Rust-allocated Orchard bundle.
+/// - If an error occurs, `bundle` will be unaltered.
+OrchardBundlePtr* orchard_bundle_parse(void* stream, read_callback_t read_cb);
+
+/// Serializes an authorized Orchard bundle to the given stream
+///
+/// If `bundle == nullptr`, this serializes `nActionsOrchard = 0`.
+bool orchard_bundle_serialize(
+    const OrchardBundlePtr* bundle,
+    void* stream,
+    write_callback_t write_cb);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ZCASH_RUST_INCLUDE_RUST_ORCHARD_H

--- a/src/rust/include/rust/streams.h
+++ b/src/rust/include/rust/streams.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#ifndef ZCASH_RUST_INCLUDE_RUST_STREAMS_H
+#define ZCASH_RUST_INCLUDE_RUST_STREAMS_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef long (*read_callback_t)(void* context, unsigned char* pch, size_t nSize);
+typedef long (*write_callback_t)(void* context, const unsigned char* pch, size_t nSize);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ZCASH_RUST_INCLUDE_RUST_STREAMS_H

--- a/src/rust/src/orchard_ffi.rs
+++ b/src/rust/src/orchard_ffi.rs
@@ -1,0 +1,59 @@
+use std::io;
+
+use libc::{c_uchar, size_t};
+use tracing::error;
+use zcash_primitives::serialize::Vector;
+
+use crate::streams_ffi::{CppStreamReader, CppStreamWriter, ReadCb, StreamObj, WriteCb};
+
+#[no_mangle]
+pub extern "C" fn orchard_bundle_clone(
+    bundle: *const orchard::Bundle<Authorized>,
+) -> *mut orchard::Bundle<Authorized> {
+    unsafe { bundle.as_ref() }
+        .map(|bundle| Box::into_raw(Box::new(bundle.clone())))
+        .unwrap_or(std::ptr::null_mut())
+}
+
+#[no_mangle]
+pub extern "C" fn orchard_bundle_free(orchard_bundle: *mut orchard::Bundle<Authorized>) {
+    if !orchard_bundle.is_null() {
+        drop(unsafe { Box::from_raw(orchard_bundle) });
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn orchard_bundle_parse(
+    stream: Option<StreamObj>,
+    read_cb: Option<ReadCb>,
+) -> *mut orchard::Bundle<Authorized> {
+    let reader = CppStreamReader::from_raw_parts(stream, read_cb.unwrap());
+
+    let bundle = ();
+    // TODO: If error occurs, log it and return nullptr.
+
+    Box::into_raw(Box::new(bundle));
+}
+
+#[no_mangle]
+pub extern "C" fn orchard_bundle_serialize(
+    orchard_bundle: *const orchard::Bundle<Authorized>,
+    stream: Option<StreamObj>,
+    write_cb: Option<WriteCb>,
+) -> bool {
+    let writer = CppStreamWriter::from_raw_parts(stream, write_cb.unwrap());
+
+    match if let Some(bundle) = unsafe { orchard_bundle.as_ref() } {
+        // TODO: Serialize bundle.
+        Err(io::Error::new(io::ErrorKind::Other, "Unimplemented"))
+    } else {
+        // No bundle; serialize an empty vector.
+        Vector::write(writer, &[], |_, _| Ok(()))
+    } {
+        Ok(()) => true,
+        Err(e) => {
+            error!("{}", e);
+            false
+        }
+    }
+}

--- a/src/rust/src/rustzcash.rs
+++ b/src/rust/src/rustzcash.rs
@@ -67,6 +67,8 @@ mod metrics_ffi;
 mod streams_ffi;
 mod tracing_ffi;
 
+mod orchard_ffi;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/rust/src/rustzcash.rs
+++ b/src/rust/src/rustzcash.rs
@@ -64,6 +64,7 @@ use zcash_history::{Entry as MMREntry, NodeData as MMRNodeData, Tree as MMRTree}
 mod blake2b;
 mod ed25519;
 mod metrics_ffi;
+mod streams_ffi;
 mod tracing_ffi;
 
 #[cfg(test)]

--- a/src/rust/src/streams_ffi.rs
+++ b/src/rust/src/streams_ffi.rs
@@ -1,0 +1,54 @@
+use std::io;
+use std::ptr::NonNull;
+
+use libc::{c_long, c_void, size_t};
+
+pub type StreamObj = NonNull<c_void>;
+pub type ReadCb =
+    unsafe extern "C" fn(obj: Option<StreamObj>, pch: *mut u8, size: size_t) -> c_long;
+pub type WriteCb =
+    unsafe extern "C" fn(obj: Option<StreamObj>, pch: *const u8, size: size_t) -> c_long;
+
+pub struct CppStreamReader {
+    inner: Option<StreamObj>,
+    cb: ReadCb,
+}
+
+impl CppStreamReader {
+    pub fn from_raw_parts(inner: Option<StreamObj>, cb: ReadCb) -> Self {
+        CppStreamReader { inner, cb }
+    }
+}
+
+impl io::Read for CppStreamReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match unsafe { (self.cb)(self.inner, buf.as_mut_ptr(), buf.len()) } {
+            -1 => Err(io::Error::new(io::ErrorKind::Other, "C++ stream error")),
+            n => Ok(n as usize),
+        }
+    }
+}
+
+pub struct CppStreamWriter {
+    inner: Option<StreamObj>,
+    cb: WriteCb,
+}
+
+impl CppStreamWriter {
+    pub fn from_raw_parts(inner: Option<StreamObj>, cb: WriteCb) -> Self {
+        CppStreamWriter { inner, cb }
+    }
+}
+
+impl io::Write for CppStreamWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match unsafe { (self.cb)(self.inner, buf.as_ptr(), buf.len()) } {
+            -1 => Err(io::Error::new(io::ErrorKind::Other, "C++ stream error")),
+            n => Ok(n as usize),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Includes a new wrapper that enables passing C++ streams across to Rust.

Closes zcash/zcash#5022.