### PR TITLE
Implement Orchard signature validation consensus rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=3915abd0a1ee5b7e757c3fec0509d71f5e08fdfb#3915abd0a1ee5b7e757c3fec0509d71f5e08fdfb"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d88e40113c8dadea751dfcdd72ee90868f9655ff#d88e40113c8dadea751dfcdd72ee90868f9655ff"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "halo2"
 version = "0.0.1"
-source = "git+https://github.com/zcash/halo2.git?rev=32cdcfa66fbc4ca3103115518d374f4cfe6c3b7a#32cdcfa66fbc4ca3103115518d374f4cfe6c3b7a"
+source = "git+https://github.com/zcash/halo2.git?rev=d04b532368d05b505e622f8cac4c0693574fbd93#d04b532368d05b505e622f8cac4c0693574fbd93"
 dependencies = [
  "blake2b_simd",
  "crossbeam-utils 0.8.5",
@@ -1030,7 +1030,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.0.0"
-source = "git+https://github.com/zcash/orchard.git?rev=cd1e72bbcd9f2e873408aa365537c89824cb7430#cd1e72bbcd9f2e873408aa365537c89824cb7430"
+source = "git+https://github.com/zcash/orchard.git?rev=63ca1f8d3aaa5bdf136f8ab8e6fab26af1d73002#63ca1f8d3aaa5bdf136f8ab8e6fab26af1d73002"
 dependencies = [
  "aes",
  "arrayvec 0.7.0",
@@ -1040,11 +1040,13 @@ dependencies = [
  "fpe",
  "group",
  "halo2",
+ "lazy_static",
  "nonempty",
  "pasta_curves",
  "rand",
  "reddsa",
  "subtle",
+ "zcash_note_encryption 0.0.0 (git+https://github.com/zcash/librustzcash.git?rev=cc533a9da4f6a7209a7be05f82b12a03969152c9)",
 ]
 
 [[package]]
@@ -1686,7 +1688,21 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=3915abd0a1ee5b7e757c3fec0509d71f5e08fdfb#3915abd0a1ee5b7e757c3fec0509d71f5e08fdfb"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cc533a9da4f6a7209a7be05f82b12a03969152c9#cc533a9da4f6a7209a7be05f82b12a03969152c9"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "crypto_api_chachapoly",
+ "ff",
+ "group",
+ "rand_core 0.6.2",
+ "subtle",
+]
+
+[[package]]
+name = "zcash_note_encryption"
+version = "0.0.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d88e40113c8dadea751dfcdd72ee90868f9655ff#d88e40113c8dadea751dfcdd72ee90868f9655ff"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1700,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=3915abd0a1ee5b7e757c3fec0509d71f5e08fdfb#3915abd0a1ee5b7e757c3fec0509d71f5e08fdfb"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d88e40113c8dadea751dfcdd72ee90868f9655ff#d88e40113c8dadea751dfcdd72ee90868f9655ff"
 dependencies = [
  "aes",
  "bitvec",
@@ -1724,13 +1740,13 @@ dependencies = [
  "rand_core 0.6.2",
  "sha2",
  "subtle",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.0.0 (git+https://github.com/zcash/librustzcash.git?rev=d88e40113c8dadea751dfcdd72ee90868f9655ff)",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=3915abd0a1ee5b7e757c3fec0509d71f5e08fdfb#3915abd0a1ee5b7e757c3fec0509d71f5e08fdfb"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d88e40113c8dadea751dfcdd72ee90868f9655ff#d88e40113c8dadea751dfcdd72ee90868f9655ff"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.0.0"
-source = "git+https://github.com/zcash/orchard.git?rev=63ca1f8d3aaa5bdf136f8ab8e6fab26af1d73002#63ca1f8d3aaa5bdf136f8ab8e6fab26af1d73002"
+source = "git+https://github.com/zcash/orchard.git?rev=f7c64e0437040d831e61711cd9e5695b001cb5cb#f7c64e0437040d831e61711cd9e5695b001cb5cb"
 dependencies = [
  "aes",
  "arrayvec 0.7.0",
@@ -1046,7 +1046,7 @@ dependencies = [
  "rand",
  "reddsa",
  "subtle",
- "zcash_note_encryption 0.0.0 (git+https://github.com/zcash/librustzcash.git?rev=cc533a9da4f6a7209a7be05f82b12a03969152c9)",
+ "zcash_note_encryption",
 ]
 
 [[package]]
@@ -1688,20 +1688,6 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cc533a9da4f6a7209a7be05f82b12a03969152c9#cc533a9da4f6a7209a7be05f82b12a03969152c9"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "crypto_api_chachapoly",
- "ff",
- "group",
- "rand_core 0.6.2",
- "subtle",
-]
-
-[[package]]
-name = "zcash_note_encryption"
-version = "0.0.0"
 source = "git+https://github.com/zcash/librustzcash.git?rev=d88e40113c8dadea751dfcdd72ee90868f9655ff#d88e40113c8dadea751dfcdd72ee90868f9655ff"
 dependencies = [
  "blake2b_simd",
@@ -1740,7 +1726,7 @@ dependencies = [
  "rand_core 0.6.2",
  "sha2",
  "subtle",
- "zcash_note_encryption 0.0.0 (git+https://github.com/zcash/librustzcash.git?rev=d88e40113c8dadea751dfcdd72ee90868f9655ff)",
+ "zcash_note_encryption",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,6 @@ codegen-units = 1
 
 [patch.crates-io]
 ed25519-zebra = { git = "https://github.com/ZcashFoundation/ed25519-zebra.git", rev = "d3512400227a362d08367088ffaa9bd4142a69c7" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "cd1e72bbcd9f2e873408aa365537c89824cb7430" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "3915abd0a1ee5b7e757c3fec0509d71f5e08fdfb" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "3915abd0a1ee5b7e757c3fec0509d71f5e08fdfb" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "63ca1f8d3aaa5bdf136f8ab8e6fab26af1d73002" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "d88e40113c8dadea751dfcdd72ee90868f9655ff" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "d88e40113c8dadea751dfcdd72ee90868f9655ff" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ codegen-units = 1
 
 [patch.crates-io]
 ed25519-zebra = { git = "https://github.com/ZcashFoundation/ed25519-zebra.git", rev = "d3512400227a362d08367088ffaa9bd4142a69c7" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "63ca1f8d3aaa5bdf136f8ab8e6fab26af1d73002" }
+halo2 = { git = "https://github.com/zcash/halo2.git", rev = "d04b532368d05b505e622f8cac4c0693574fbd93" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "f7c64e0437040d831e61711cd9e5695b001cb5cb" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "d88e40113c8dadea751dfcdd72ee90868f9655ff" }
 zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "d88e40113c8dadea751dfcdd72ee90868f9655ff" }
 zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "d88e40113c8dadea751dfcdd72ee90868f9655ff" }

--- a/src/gtest/test_checkblock.cpp
+++ b/src/gtest/test_checkblock.cpp
@@ -7,6 +7,8 @@
 #include "utiltest.h"
 #include "zcash/Proof.hpp"
 
+#include <rust/orchard.h>
+
 class MockCValidationState : public CValidationState {
 public:
     MOCK_METHOD5(DoS, bool(int level, bool ret,
@@ -26,13 +28,14 @@ public:
 
 TEST(CheckBlock, VersionTooLow) {
     auto verifier = ProofVerifier::Strict();
+    auto orchardAuth = orchard::AuthValidator::Batch();
 
     CBlock block;
     block.nVersion = 1;
 
     MockCValidationState state;
     EXPECT_CALL(state, DoS(100, false, REJECT_INVALID, "version-too-low", false)).Times(1);
-    EXPECT_FALSE(CheckBlock(block, state, Params(), verifier, false, false, true));
+    EXPECT_FALSE(CheckBlock(block, state, Params(), verifier, orchardAuth, false, false, true));
 }
 
 
@@ -72,9 +75,10 @@ TEST(CheckBlock, BlockSproutRejectsBadVersion) {
     CBlockIndex indexPrev {Params().GenesisBlock()};
 
     auto verifier = ProofVerifier::Strict();
+    auto orchardAuth = orchard::AuthValidator::Batch();
 
     EXPECT_CALL(state, DoS(100, false, REJECT_INVALID, "bad-txns-version-too-low", false)).Times(1);
-    EXPECT_FALSE(CheckBlock(block, state, Params(), verifier, false, false, true));
+    EXPECT_FALSE(CheckBlock(block, state, Params(), verifier, orchardAuth, false, false, true));
 }
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -42,6 +42,8 @@
 #include <utility>
 #include <vector>
 
+#include <rust/orchard.h>
+
 #include <boost/unordered_map.hpp>
 
 class CBlockIndex;
@@ -358,7 +360,8 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, ProofVerifier& verifier);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state,
+                      ProofVerifier& verifier, orchard::AuthValidator& orchardAuth);
 bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidationState &state);
 
 namespace Consensus {
@@ -464,6 +467,7 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state,
 bool CheckBlock(const CBlock& block, CValidationState& state,
                 const CChainParams& chainparams,
                 ProofVerifier& verifier,
+                orchard::AuthValidator& orchardAuth,
                 bool fCheckPOW,
                 bool fCheckMerkleRoot,
                 bool fCheckTransactions);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -374,6 +374,15 @@ public:
         }
         inner.reset(bundle);
     }
+
+    /// Queues this bundle's signatures for validation.
+    ///
+    /// `txid` must be for the transaction this bundle is within.
+    void QueueSignatureValidation(
+        orchard::AuthValidator& batch, const uint256& txid) const
+    {
+        batch.Queue(inner.get(), txid.begin());
+    }
 };
 
 template <typename Stream>

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -11,6 +11,8 @@
 #include "utiltime.h"
 #include "zcash/Proof.hpp"
 
+#include <rust/orchard.h>
+
 #include <cstdio>
 
 #include <boost/test/unit_test.hpp>
@@ -57,7 +59,8 @@ BOOST_AUTO_TEST_CASE(May15)
         // After May 15'th, big blocks are OK:
         forkingBlock.nTime = tMay15; // Invalidates PoW
         auto verifier = ProofVerifier::Strict();
-        BOOST_CHECK(CheckBlock(forkingBlock, state, Params(), verifier, false, false, true));
+        auto orchardAuth = orchard::AuthValidator::Disabled(); // Block is before NU5
+        BOOST_CHECK(CheckBlock(forkingBlock, state, Params(), verifier, orchardAuth, false, false, true));
     }
 
     SetMockTime(0);


### PR DESCRIPTION
Implemented via an `AuthValidator` class that internally uses batch validation.

- Currently, only RedPallas signatures are batch-validated. We can extend
  this validator to cover Halo 2 proofs in the future.

- Signatures in a batch are not retried individually if the batch fails:
  - For per-transaction batching (when adding to the mempool), we don't
    care which signature within the transaction failed.
  - For per-block batching, we currently don't care which transaction
    failed. We might do so in future, at which point this behaviour can
    be easily changed.

Closes zcash/zcash#5194.