### PR TITLE
Check Orchard bundle-specific consensus rules, i.e. proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13#fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13"
+source = "git+https://github.com/zcash/librustzcash.git?rev=02052526925fba9389f1428d6df254d4dec967e6#02052526925fba9389f1428d6df254d4dec967e6"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1030,7 +1030,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.0.0"
-source = "git+https://github.com/zcash/orchard.git?rev=f7c64e0437040d831e61711cd9e5695b001cb5cb#f7c64e0437040d831e61711cd9e5695b001cb5cb"
+source = "git+https://github.com/zcash/orchard.git?rev=93a7f1db228479228f768e9d86dd5868e4c2ff1e#93a7f1db228479228f768e9d86dd5868e4c2ff1e"
 dependencies = [
  "aes",
  "arrayvec 0.7.0",
@@ -1677,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13#fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13"
+source = "git+https://github.com/zcash/librustzcash.git?rev=02052526925fba9389f1428d6df254d4dec967e6#02052526925fba9389f1428d6df254d4dec967e6"
 dependencies = [
  "bigint",
  "blake2b_simd",
@@ -1687,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13#fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13"
+source = "git+https://github.com/zcash/librustzcash.git?rev=02052526925fba9389f1428d6df254d4dec967e6#02052526925fba9389f1428d6df254d4dec967e6"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1701,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13#fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13"
+source = "git+https://github.com/zcash/librustzcash.git?rev=02052526925fba9389f1428d6df254d4dec967e6#02052526925fba9389f1428d6df254d4dec967e6"
 dependencies = [
  "aes",
  "bitvec",
@@ -1731,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13#fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13"
+source = "git+https://github.com/zcash/librustzcash.git?rev=02052526925fba9389f1428d6df254d4dec967e6#02052526925fba9389f1428d6df254d4dec967e6"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,8 @@ codegen-units = 1
 [patch.crates-io]
 ed25519-zebra = { git = "https://github.com/ZcashFoundation/ed25519-zebra.git", rev = "d3512400227a362d08367088ffaa9bd4142a69c7" }
 halo2 = { git = "https://github.com/zcash/halo2.git", rev = "d04b532368d05b505e622f8cac4c0693574fbd93" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "f7c64e0437040d831e61711cd9e5695b001cb5cb" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13" }
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "fe4b63c8fe7300ebc9cd7a1242867525ccfe1e13" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "93a7f1db228479228f768e9d86dd5868e4c2ff1e" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "02052526925fba9389f1428d6df254d4dec967e6" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "02052526925fba9389f1428d6df254d4dec967e6" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "02052526925fba9389f1428d6df254d4dec967e6" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "02052526925fba9389f1428d6df254d4dec967e6" }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -737,7 +737,7 @@ static void ZC_LoadParams(
 
     gettimeofday(&tv_end, 0);
     elapsed = float(tv_end.tv_sec-tv_start.tv_sec) + (tv_end.tv_usec-tv_start.tv_usec)/float(1000000);
-    LogPrintf("Loaded Sapling parameters in %fs seconds.\n", elapsed);
+    LogPrintf("Loaded proof system parameters in %fs seconds.\n", elapsed);
 }
 
 bool AppInitServers(boost::thread_group& threadGroup)

--- a/src/primitives/orchard.h
+++ b/src/primitives/orchard.h
@@ -66,6 +66,15 @@ public:
         return orchard_bundle_value_balance(inner.get());
     }
 
+    /// Returns true if this Orchard bundle satisfies the bundle-specific consensus rules,
+    /// or if this does not contain an Orchard bundle.
+    ///
+    /// This does not validate the bundle's signatures; use `QueueSignatureValidation` for
+    /// those checks.
+    bool CheckBundleSpecificConsensusRules() const {
+        return orchard_bundle_validate(inner.get());
+    }
+
     /// Queues this bundle's signatures for validation.
     ///
     /// `txid` must be for the transaction this bundle is within.

--- a/src/rust/include/rust/orchard.h
+++ b/src/rust/include/rust/orchard.h
@@ -49,6 +49,21 @@ bool orchard_bundle_serialize(
 /// A transaction with no Orchard component has a value balance of zero.
 int64_t orchard_bundle_value_balance(const OrchardBundlePtr* bundle);
 
+/// Validates the given Orchard bundle against bundle-specific consensus rules.
+///
+/// If `bundle == nullptr`, this returns `true`.
+///
+/// ## Consensus rules
+///
+/// [§4.6](https://zips.z.cash/protocol/protocol.pdf#actiondesc):
+/// - Canonical element encodings are enforced by `orchard_bundle_parse`.
+/// - SpendAuthSig^Orchard validity is enforced by `orchard_batch_validate`.
+/// - Proof validity is enforced here.
+///
+/// [§7.1](https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus):
+/// - `bindingSigOrchard` validity is enforced by `orchard_batch_validate`.
+bool orchard_bundle_validate(const OrchardBundlePtr* bundle);
+
 /// Initializes a new Orchard batch validator.
 ///
 /// Please free this with `orchard_batch_validation_free` when you are done with

--- a/src/rust/src/orchard_ffi.rs
+++ b/src/rust/src/orchard_ffi.rs
@@ -83,6 +83,39 @@ pub extern "C" fn orchard_bundle_value_balance(bundle: *const Bundle<Authorized,
         .unwrap_or(0)
 }
 
+/// Validates the given Orchard bundle against bundle-specific consensus rules.
+///
+/// If `bundle == nullptr`, this returns `true`.
+///
+/// ## Consensus rules
+///
+/// [§4.6](https://zips.z.cash/protocol/protocol.pdf#actiondesc):
+/// - Canonical element encodings are enforced by [`orchard_bundle_parse`].
+/// - SpendAuthSig^Orchard validity is enforced by [`BatchValidator`] via
+///   [`orchard_batch_validate`].
+/// - Proof validity is enforced here.
+///
+/// [§7.1](https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus):
+/// - `bindingSigOrchard` validity is enforced by [`BatchValidator`] via
+///   [`orchard_batch_validate`].
+#[no_mangle]
+pub extern "C" fn orchard_bundle_validate(bundle: *const Bundle<Authorized, Amount>) -> bool {
+    if let Some(bundle) = unsafe { bundle.as_ref() } {
+        let vk = unsafe { crate::ORCHARD_VK.as_ref() }.unwrap();
+
+        if bundle.verify_proof(vk).is_err() {
+            error!("Invalid Orchard proof");
+            return false;
+        }
+
+        true
+    } else {
+        // The Orchard component of a transaction without an Orchard bundle is by
+        // definition valid.
+        true
+    }
+}
+
 /// A signature within an authorized Orchard bundle.
 #[derive(Debug)]
 struct BundleSignature {


### PR DESCRIPTION
This obviously doesn't check the correct proofs yet, but this adds the consensus rule machinery so that when the circuit is implemented, we just need to upgrade the `orchard` dependency.

Closes zcash/zcash#5195.