### PR TITLE
Implement consensus checks for Orchard shielded coinbase outputs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=02052526925fba9389f1428d6df254d4dec967e6#02052526925fba9389f1428d6df254d4dec967e6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3cab105c9c3bf4ba31f779095d939ad0c7057539#3cab105c9c3bf4ba31f779095d939ad0c7057539"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -634,12 +634,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -729,12 +723,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -937,7 +931,7 @@ dependencies = [
  "crossbeam-epoch 0.9.5",
  "crossbeam-utils 0.8.5",
  "dashmap",
- "hashbrown 0.11.2",
+ "hashbrown",
  "indexmap",
  "metrics",
  "num_cpus",
@@ -982,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa586da3e43cc7df44aae0e21ed2e743218b876de3f38035683d30bd8a3828e"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
 name = "ntapi"
@@ -1050,7 +1044,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.0.0"
-source = "git+https://github.com/zcash/orchard.git?rev=1f861423c2d8e4d1f8415f9a634084fc5ca608da#1f861423c2d8e4d1f8415f9a634084fc5ca608da"
+source = "git+https://github.com/zcash/orchard.git?rev=21b77d6ec56fc7e37aab9da68e88bc5dd754fe10#21b77d6ec56fc7e37aab9da68e88bc5dd754fe10"
 dependencies = [
  "aes",
  "arrayvec 0.7.1",
@@ -1700,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=02052526925fba9389f1428d6df254d4dec967e6#02052526925fba9389f1428d6df254d4dec967e6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3cab105c9c3bf4ba31f779095d939ad0c7057539#3cab105c9c3bf4ba31f779095d939ad0c7057539"
 dependencies = [
  "bigint",
  "blake2b_simd",
@@ -1710,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=02052526925fba9389f1428d6df254d4dec967e6#02052526925fba9389f1428d6df254d4dec967e6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3cab105c9c3bf4ba31f779095d939ad0c7057539#3cab105c9c3bf4ba31f779095d939ad0c7057539"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1724,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=02052526925fba9389f1428d6df254d4dec967e6#02052526925fba9389f1428d6df254d4dec967e6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3cab105c9c3bf4ba31f779095d939ad0c7057539#3cab105c9c3bf4ba31f779095d939ad0c7057539"
 dependencies = [
  "aes",
  "bitvec",
@@ -1754,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=02052526925fba9389f1428d6df254d4dec967e6#02052526925fba9389f1428d6df254d4dec967e6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3cab105c9c3bf4ba31f779095d939ad0c7057539#3cab105c9c3bf4ba31f779095d939ad0c7057539"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ group = "0.10"
 incrementalmerkletree = "0.1"
 libc = "0.2"
 jubjub = "0.7"
-nonempty = "0.6"
+nonempty = "0.7"
 orchard = "0.0"
 subtle = "2.2"
 rand_core = "0.6"
@@ -65,8 +65,8 @@ codegen-units = 1
 ed25519-zebra = { git = "https://github.com/ZcashFoundation/ed25519-zebra.git", rev = "d3512400227a362d08367088ffaa9bd4142a69c7" }
 halo2 = { git = "https://github.com/zcash/halo2.git", rev = "d04b532368d05b505e622f8cac4c0693574fbd93" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "8b59049f1746827ffa3763efa8af948f680491d0" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "1f861423c2d8e4d1f8415f9a634084fc5ca608da" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "02052526925fba9389f1428d6df254d4dec967e6" }
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "02052526925fba9389f1428d6df254d4dec967e6" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "02052526925fba9389f1428d6df254d4dec967e6" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "02052526925fba9389f1428d6df254d4dec967e6" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "21b77d6ec56fc7e37aab9da68e88bc5dd754fe10" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "3cab105c9c3bf4ba31f779095d939ad0c7057539" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "3cab105c9c3bf4ba31f779095d939ad0c7057539" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "3cab105c9c3bf4ba31f779095d939ad0c7057539" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "3cab105c9c3bf4ba31f779095d939ad0c7057539" }

--- a/src/coins.h
+++ b/src/coins.h
@@ -326,6 +326,9 @@ struct CNullifiersCacheEntry
     CNullifiersCacheEntry() : entered(false), flags(0) {}
 };
 
+/// These identify the value pool, and as such, Canopy (for example)
+/// isn't here, since value created during the Canopy network upgrade
+/// is part of the Saplingn pool.
 enum ShieldedType
 {
     SPROUT,

--- a/src/coins.h
+++ b/src/coins.h
@@ -328,7 +328,7 @@ struct CNullifiersCacheEntry
 
 /// These identify the value pool, and as such, Canopy (for example)
 /// isn't here, since value created during the Canopy network upgrade
-/// is part of the Saplingn pool.
+/// is part of the Sapling pool.
 enum ShieldedType
 {
     SPROUT,

--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -58,7 +58,6 @@ public:
 
 void CreateJoinSplitSignature(CMutableTransaction& mtx, uint32_t consensusBranchId);
 
-// TODO If creating a zip225 (v5) tx, we need to be told whether to create sprout elements or orchard elements.
 CMutableTransaction GetValidTransaction(uint32_t consensusBranchId=SPROUT_BRANCH_ID) {
     CMutableTransaction mtx;
     if (consensusBranchId == NetworkUpgradeInfo[Consensus::UPGRADE_OVERWINTER].nBranchId) {
@@ -69,11 +68,6 @@ CMutableTransaction GetValidTransaction(uint32_t consensusBranchId=SPROUT_BRANCH
         mtx.fOverwintered = true;
         mtx.nVersionGroupId = SAPLING_VERSION_GROUP_ID;
         mtx.nVersion = SAPLING_TX_VERSION;
-    } else if (consensusBranchId == NetworkUpgradeInfo[Consensus::UPGRADE_NU5].nBranchId) {
-        mtx.fOverwintered = true;
-        mtx.nVersionGroupId = ZIP225_VERSION_GROUP_ID;
-        mtx.nVersion = ZIP225_TX_VERSION;
-        mtx.nConsensusBranchId = consensusBranchId; // XXX should this be moved outside the conditional?
     } else if (consensusBranchId != SPROUT_BRANCH_ID) {
         // Unsupported consensus branch ID
         assert(false);
@@ -130,8 +124,6 @@ void CreateJoinSplitSignature(CMutableTransaction& mtx, uint32_t consensusBranch
 TEST(ChecktransactionTests, ValidTransaction) {
     CMutableTransaction mtx = GetValidTransaction();
     CTransaction tx(mtx);
-    EXPECT_FALSE(tx.GetOrchardBundle().OutputsEnabled());
-    EXPECT_FALSE(tx.GetOrchardBundle().SpendsEnabled());
     MockCValidationState state;
     EXPECT_TRUE(CheckTransactionWithoutProofVerification(tx, state));
 }

--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -324,7 +324,7 @@ TEST(ChecktransactionTests, BadTxnsTxouttotalToolargeOutputs) {
 
 TEST(ChecktransactionTests, ValueBalanceNonZero) {
     CMutableTransaction mtx = GetValidTransaction();
-    mtx.valueBalance = 10;
+    mtx.valueBalanceSapling = 10;
 
     CTransaction tx(mtx);
 
@@ -336,7 +336,7 @@ TEST(ChecktransactionTests, ValueBalanceNonZero) {
 TEST(ChecktransactionTests, PositiveValueBalanceTooLarge) {
     CMutableTransaction mtx = GetValidTransaction();
     mtx.vShieldedSpend.resize(1);
-    mtx.valueBalance = MAX_MONEY + 1;
+    mtx.valueBalanceSapling = MAX_MONEY + 1;
 
     CTransaction tx(mtx);
 
@@ -348,7 +348,7 @@ TEST(ChecktransactionTests, PositiveValueBalanceTooLarge) {
 TEST(ChecktransactionTests, NegativeValueBalanceTooLarge) {
     CMutableTransaction mtx = GetValidTransaction();
     mtx.vShieldedSpend.resize(1);
-    mtx.valueBalance = -(MAX_MONEY + 1);
+    mtx.valueBalanceSapling = -(MAX_MONEY + 1);
 
     CTransaction tx(mtx);
 
@@ -361,7 +361,7 @@ TEST(ChecktransactionTests, ValueBalanceOverflowsTotal) {
     CMutableTransaction mtx = GetValidTransaction();
     mtx.vShieldedSpend.resize(1);
     mtx.vout[0].nValue = 1;
-    mtx.valueBalance = -MAX_MONEY;
+    mtx.valueBalanceSapling = -MAX_MONEY;
 
     CTransaction tx(mtx);
 
@@ -859,7 +859,7 @@ TEST(ChecktransactionTests, SaplingSproutInputSumsTooLarge) {
         EXPECT_TRUE(CheckTransactionWithoutProofVerification(tx, state));
     }
 
-    mtx.valueBalance = (MAX_MONEY / 2) + 10;
+    mtx.valueBalanceSapling = (MAX_MONEY / 2) + 10;
 
     {
         UNSAFE_CTransaction tx(mtx);
@@ -1221,7 +1221,7 @@ TEST(ChecktransactionTests, HeartwoodAcceptsShieldedCoinbase) {
     RegtestDeactivateHeartwood();
 }
 
-// Check that the consensus rules relevant to valueBalance, vShieldedOutput, and
+// Check that the consensus rules relevant to valueBalanceSapling, vShieldedOutput, and
 // bindingSig from https://zips.z.cash/protocol/protocol.pdf#txnencoding are
 // applied to coinbase transactions.
 TEST(ChecktransactionTests, HeartwoodEnforcesSaplingRulesOnShieldedCoinbase) {
@@ -1242,10 +1242,10 @@ TEST(ChecktransactionTests, HeartwoodEnforcesSaplingRulesOnShieldedCoinbase) {
     mtx.vin[0].prevout.SetNull();
     mtx.vin[0].scriptSig << 123;
     mtx.vJoinSplit.resize(0);
-    mtx.valueBalance = -1000;
+    mtx.valueBalanceSapling = -1000;
 
     // Coinbase transaction should fail non-contextual checks with no shielded
-    // outputs and non-zero valueBalance.
+    // outputs and non-zero valueBalanceSapling.
     {
         CTransaction tx(mtx);
         EXPECT_TRUE(tx.IsCoinBase());
@@ -1261,10 +1261,10 @@ TEST(ChecktransactionTests, HeartwoodEnforcesSaplingRulesOnShieldedCoinbase) {
     librustzcash_sapling_proving_ctx_free(ctx);
     mtx.vShieldedOutput.push_back(odesc);
 
-    // Coinbase transaction should fail non-contextual checks with valueBalance
+    // Coinbase transaction should fail non-contextual checks with valueBalanceSapling
     // out of range.
     {
-        mtx.valueBalance = MAX_MONEY + 1;
+        mtx.valueBalanceSapling = MAX_MONEY + 1;
         EXPECT_THROW((CTransaction(mtx)), std::ios_base::failure);
         UNSAFE_CTransaction tx(mtx);
         EXPECT_TRUE(tx.IsCoinBase());
@@ -1274,7 +1274,7 @@ TEST(ChecktransactionTests, HeartwoodEnforcesSaplingRulesOnShieldedCoinbase) {
         EXPECT_FALSE(CheckTransactionWithoutProofVerification(tx, state));
     }
     {
-        mtx.valueBalance = -MAX_MONEY - 1;
+        mtx.valueBalanceSapling = -MAX_MONEY - 1;
         EXPECT_THROW((CTransaction(mtx)), std::ios_base::failure);
         UNSAFE_CTransaction tx(mtx);
         EXPECT_TRUE(tx.IsCoinBase());
@@ -1284,7 +1284,7 @@ TEST(ChecktransactionTests, HeartwoodEnforcesSaplingRulesOnShieldedCoinbase) {
         EXPECT_FALSE(CheckTransactionWithoutProofVerification(tx, state));
     }
 
-    mtx.valueBalance = -1000;
+    mtx.valueBalanceSapling = -1000;
     CTransaction tx(mtx);
     EXPECT_TRUE(tx.IsCoinBase());
 

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -102,7 +102,7 @@ TEST(TransactionBuilder, TransparentToSapling)
     EXPECT_EQ(tx.vJoinSplit.size(), 0);
     EXPECT_EQ(tx.vShieldedSpend.size(), 0);
     EXPECT_EQ(tx.vShieldedOutput.size(), 1);
-    EXPECT_EQ(tx.valueBalance, -40000);
+    EXPECT_EQ(tx.valueBalanceSapling, -40000);
 
     CValidationState state;
     EXPECT_TRUE(ContextualCheckTransaction(tx, state, Params(), 2, true));
@@ -139,7 +139,7 @@ TEST(TransactionBuilder, SaplingToSapling) {
     EXPECT_EQ(tx.vJoinSplit.size(), 0);
     EXPECT_EQ(tx.vShieldedSpend.size(), 1);
     EXPECT_EQ(tx.vShieldedOutput.size(), 2);
-    EXPECT_EQ(tx.valueBalance, 10000);
+    EXPECT_EQ(tx.valueBalanceSapling, 10000);
 
     CValidationState state;
     EXPECT_TRUE(ContextualCheckTransaction(tx, state, Params(), 3, true));
@@ -177,7 +177,7 @@ TEST(TransactionBuilder, SaplingToSprout) {
     EXPECT_EQ(tx.vJoinSplit[0].vpub_new, 0);
     EXPECT_EQ(tx.vShieldedSpend.size(), 1);
     EXPECT_EQ(tx.vShieldedOutput.size(), 1);
-    EXPECT_EQ(tx.valueBalance, 35000);
+    EXPECT_EQ(tx.valueBalanceSapling, 35000);
 
     CValidationState state;
     EXPECT_TRUE(ContextualCheckTransaction(tx, state, Params(), 3, true));
@@ -238,7 +238,7 @@ TEST(TransactionBuilder, SproutToSproutAndSapling) {
     EXPECT_EQ(tx.vJoinSplit[2].vpub_new, 10000);
     EXPECT_EQ(tx.vShieldedSpend.size(), 0);
     EXPECT_EQ(tx.vShieldedOutput.size(), 1);
-    EXPECT_EQ(tx.valueBalance, -5000);
+    EXPECT_EQ(tx.valueBalanceSapling, -5000);
 
     CValidationState state;
     EXPECT_TRUE(ContextualCheckTransaction(tx, state, Params(), 4, true));
@@ -365,7 +365,7 @@ TEST(TransactionBuilder, ChangeOutput)
         EXPECT_EQ(tx.vJoinSplit.size(), 0);
         EXPECT_EQ(tx.vShieldedSpend.size(), 1);
         EXPECT_EQ(tx.vShieldedOutput.size(), 1);
-        EXPECT_EQ(tx.valueBalance, -15000);
+        EXPECT_EQ(tx.valueBalanceSapling, -15000);
     }
 
     // Change to a Sapling address
@@ -380,7 +380,7 @@ TEST(TransactionBuilder, ChangeOutput)
         EXPECT_EQ(tx.vJoinSplit.size(), 0);
         EXPECT_EQ(tx.vShieldedSpend.size(), 0);
         EXPECT_EQ(tx.vShieldedOutput.size(), 1);
-        EXPECT_EQ(tx.valueBalance, -15000);
+        EXPECT_EQ(tx.valueBalanceSapling, -15000);
     }
 
     // Change to a transparent address
@@ -395,7 +395,7 @@ TEST(TransactionBuilder, ChangeOutput)
         EXPECT_EQ(tx.vJoinSplit.size(), 0);
         EXPECT_EQ(tx.vShieldedSpend.size(), 0);
         EXPECT_EQ(tx.vShieldedOutput.size(), 0);
-        EXPECT_EQ(tx.valueBalance, 0);
+        EXPECT_EQ(tx.valueBalanceSapling, 0);
         EXPECT_EQ(tx.vout[0].nValue, 15000);
     }
 
@@ -427,7 +427,7 @@ TEST(TransactionBuilder, SetFee)
         EXPECT_EQ(tx.vJoinSplit.size(), 0);
         EXPECT_EQ(tx.vShieldedSpend.size(), 1);
         EXPECT_EQ(tx.vShieldedOutput.size(), 2);
-        EXPECT_EQ(tx.valueBalance, 10000);
+        EXPECT_EQ(tx.valueBalanceSapling, 10000);
     }
 
     // Configured fee
@@ -443,7 +443,7 @@ TEST(TransactionBuilder, SetFee)
         EXPECT_EQ(tx.vJoinSplit.size(), 0);
         EXPECT_EQ(tx.vShieldedSpend.size(), 1);
         EXPECT_EQ(tx.vShieldedOutput.size(), 2);
-        EXPECT_EQ(tx.valueBalance, 20000);
+        EXPECT_EQ(tx.valueBalanceSapling, 20000);
     }
 
     // Revert to default

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -102,7 +102,7 @@ TEST(TransactionBuilder, TransparentToSapling)
     EXPECT_EQ(tx.vJoinSplit.size(), 0);
     EXPECT_EQ(tx.vShieldedSpend.size(), 0);
     EXPECT_EQ(tx.vShieldedOutput.size(), 1);
-    EXPECT_EQ(tx.valueBalanceSapling, -40000);
+    EXPECT_EQ(tx.GetValueBalanceSapling(), -40000);
 
     CValidationState state;
     EXPECT_TRUE(ContextualCheckTransaction(tx, state, Params(), 2, true));
@@ -139,7 +139,7 @@ TEST(TransactionBuilder, SaplingToSapling) {
     EXPECT_EQ(tx.vJoinSplit.size(), 0);
     EXPECT_EQ(tx.vShieldedSpend.size(), 1);
     EXPECT_EQ(tx.vShieldedOutput.size(), 2);
-    EXPECT_EQ(tx.valueBalanceSapling, 10000);
+    EXPECT_EQ(tx.GetValueBalanceSapling(), 10000);
 
     CValidationState state;
     EXPECT_TRUE(ContextualCheckTransaction(tx, state, Params(), 3, true));
@@ -177,7 +177,7 @@ TEST(TransactionBuilder, SaplingToSprout) {
     EXPECT_EQ(tx.vJoinSplit[0].vpub_new, 0);
     EXPECT_EQ(tx.vShieldedSpend.size(), 1);
     EXPECT_EQ(tx.vShieldedOutput.size(), 1);
-    EXPECT_EQ(tx.valueBalanceSapling, 35000);
+    EXPECT_EQ(tx.GetValueBalanceSapling(), 35000);
 
     CValidationState state;
     EXPECT_TRUE(ContextualCheckTransaction(tx, state, Params(), 3, true));
@@ -238,7 +238,7 @@ TEST(TransactionBuilder, SproutToSproutAndSapling) {
     EXPECT_EQ(tx.vJoinSplit[2].vpub_new, 10000);
     EXPECT_EQ(tx.vShieldedSpend.size(), 0);
     EXPECT_EQ(tx.vShieldedOutput.size(), 1);
-    EXPECT_EQ(tx.valueBalanceSapling, -5000);
+    EXPECT_EQ(tx.GetValueBalanceSapling(), -5000);
 
     CValidationState state;
     EXPECT_TRUE(ContextualCheckTransaction(tx, state, Params(), 4, true));
@@ -365,7 +365,7 @@ TEST(TransactionBuilder, ChangeOutput)
         EXPECT_EQ(tx.vJoinSplit.size(), 0);
         EXPECT_EQ(tx.vShieldedSpend.size(), 1);
         EXPECT_EQ(tx.vShieldedOutput.size(), 1);
-        EXPECT_EQ(tx.valueBalanceSapling, -15000);
+        EXPECT_EQ(tx.GetValueBalanceSapling(), -15000);
     }
 
     // Change to a Sapling address
@@ -380,7 +380,7 @@ TEST(TransactionBuilder, ChangeOutput)
         EXPECT_EQ(tx.vJoinSplit.size(), 0);
         EXPECT_EQ(tx.vShieldedSpend.size(), 0);
         EXPECT_EQ(tx.vShieldedOutput.size(), 1);
-        EXPECT_EQ(tx.valueBalanceSapling, -15000);
+        EXPECT_EQ(tx.GetValueBalanceSapling(), -15000);
     }
 
     // Change to a transparent address
@@ -395,7 +395,7 @@ TEST(TransactionBuilder, ChangeOutput)
         EXPECT_EQ(tx.vJoinSplit.size(), 0);
         EXPECT_EQ(tx.vShieldedSpend.size(), 0);
         EXPECT_EQ(tx.vShieldedOutput.size(), 0);
-        EXPECT_EQ(tx.valueBalanceSapling, 0);
+        EXPECT_EQ(tx.GetValueBalanceSapling(), 0);
         EXPECT_EQ(tx.vout[0].nValue, 15000);
     }
 
@@ -427,7 +427,7 @@ TEST(TransactionBuilder, SetFee)
         EXPECT_EQ(tx.vJoinSplit.size(), 0);
         EXPECT_EQ(tx.vShieldedSpend.size(), 1);
         EXPECT_EQ(tx.vShieldedOutput.size(), 2);
-        EXPECT_EQ(tx.valueBalanceSapling, 10000);
+        EXPECT_EQ(tx.GetValueBalanceSapling(), 10000);
     }
 
     // Configured fee
@@ -443,7 +443,7 @@ TEST(TransactionBuilder, SetFee)
         EXPECT_EQ(tx.vJoinSplit.size(), 0);
         EXPECT_EQ(tx.vShieldedSpend.size(), 1);
         EXPECT_EQ(tx.vShieldedOutput.size(), 2);
-        EXPECT_EQ(tx.valueBalanceSapling, 20000);
+        EXPECT_EQ(tx.GetValueBalanceSapling(), 20000);
     }
 
     // Revert to default

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1126,7 +1126,12 @@ bool ContextualCheckTransaction(
         }
 
         if (tx.IsCoinBase()) {
-            // Check that Orchard coinbase outputs can be decrypted with the all-zeros OVK
+            if (!orchard_bundle.HasValidCoinbaseOutputs()) {
+                return state.DoS(
+                    DOS_LEVEL_BLOCK,
+                    error("ContextualCheckTransaction(): Orchard coinbase action has invalid ciphertext"),
+                    REJECT_INVALID, "bad-cb-action-invalid-ciphertext");
+            }
         }
     } else {
         // Rules that apply generally before Nu5. These were

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1291,7 +1291,7 @@ bool ContextualCheckTransaction(
 
         if (!librustzcash_sapling_final_check(
             ctx,
-            tx.valueBalanceSapling,
+            tx.GetValueBalanceSapling(),
             tx.bindingSig.begin(),
             dataToBeSigned.begin()
         ))
@@ -1451,20 +1451,20 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
     }
 
     // Check for non-zero valueBalanceSapling when there are no Sapling inputs or outputs
-    if (tx.vShieldedSpend.empty() && tx.vShieldedOutput.empty() && tx.valueBalanceSapling != 0) { // XXX value balance ffi
+    if (tx.vShieldedSpend.empty() && tx.vShieldedOutput.empty() && tx.GetValueBalanceSapling() != 0) { // XXX value balance ffi
         return state.DoS(100, error("CheckTransaction(): tx.valueBalanceSapling has no sources or sinks"),
                             REJECT_INVALID, "bad-txns-valuebalance-nonzero");
     }
 
     // Check for overflow valueBalanceSapling XXX rename to sapling value balance, add orchard value balance checks
-    if (tx.valueBalanceSapling > MAX_MONEY || tx.valueBalanceSapling < -MAX_MONEY) { // XXX need value balance ffi
+    if (tx.GetValueBalanceSapling() > MAX_MONEY || tx.GetValueBalanceSapling() < -MAX_MONEY) { // XXX need value balance ffi
         return state.DoS(100, error("CheckTransaction(): abs(tx.valueBalanceSapling) too large"),
                             REJECT_INVALID, "bad-txns-valuebalance-toolarge");
     }
 
-    if (tx.valueBalanceSapling <= 0) {
+    if (tx.GetValueBalanceSapling() <= 0) {
         // NB: negative valueBalanceSapling "takes" money from the transparent value pool just as outputs do
-        nValueOut += -tx.valueBalanceSapling;
+        nValueOut += -tx.GetValueBalanceSapling();
 
         if (!MoneyRange(nValueOut)) {
             return state.DoS(100, error("CheckTransaction(): txout total out of range"),
@@ -1524,9 +1524,9 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
         }
 
         // Also check for Sapling
-        if (tx.valueBalanceSapling >= 0) {
+        if (tx.GetValueBalanceSapling() >= 0) {
             // NB: positive valueBalanceSapling "adds" money to the transparent value pool, just as inputs do
-            nValueIn += tx.valueBalanceSapling;
+            nValueIn += tx.GetValueBalanceSapling();
 
             if (!MoneyRange(nValueIn)) {
                 return state.DoS(100, error("CheckTransaction(): txin total out of range"),
@@ -4256,7 +4256,7 @@ bool ReceivedBlockTransactions(
         // and adds it to the Sapling value pool. Positive valueBalanceSapling "gives"
         // money to the transparent value pool, removing from the Sapling value
         // pool. So we invert the sign here.
-        saplingValue += -tx.valueBalanceSapling;
+        saplingValue += -tx.GetValueBalanceSapling();
 
         // Orchard valueBalanceSapling behaves the same way as Sapling valueBalanceSapling.
         orchardValue += -tx.GetOrchardBundle().GetValueBalance();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1143,6 +1143,7 @@ bool ContextualCheckTransaction(
     uint256 dataToBeSigned;
     uint256 prevDataToBeSigned;
 
+    // Create signature hashes for shielded components.
     if (!tx.vJoinSplit.empty() ||
         !tx.vShieldedSpend.empty() ||
         !tx.vShieldedOutput.empty() ||
@@ -1250,9 +1251,7 @@ bool ContextualCheckTransaction(
 
         librustzcash_sapling_verification_ctx_free(ctx);
     }
-    if (orchard_bundle.IsPresent()) {
-        // XXX add similar block for orchard checks
-    }
+
     return true;
 }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -126,13 +126,13 @@ class AddFundingStreamValueToTx
 {
 private:
     CMutableTransaction &mtx;
-    void* ctx; 
+    void* ctx;
     const CAmount fundingStreamValue;
     const libzcash::Zip212Enabled zip212Enabled;
 public:
     AddFundingStreamValueToTx(
-            CMutableTransaction &mtx, 
-            void* ctx, 
+            CMutableTransaction &mtx,
+            void* ctx,
             const CAmount fundingStreamValue,
             const libzcash::Zip212Enabled zip212Enabled): mtx(mtx), ctx(ctx), fundingStreamValue(fundingStreamValue), zip212Enabled(zip212Enabled) {}
 
@@ -144,7 +144,7 @@ public:
         auto odesc = output.Build(ctx);
         if (odesc) {
             mtx.vShieldedOutput.push_back(odesc.value());
-            mtx.valueBalance -= fundingStreamValue;
+            mtx.valueBalanceSapling -= fundingStreamValue;
             return true;
         } else {
             return false;
@@ -231,7 +231,7 @@ public:
 
         bool success = librustzcash_sapling_binding_sig(
             ctx,
-            mtx.valueBalance,
+            mtx.valueBalanceSapling,
             dataToBeSigned.begin(),
             mtx.bindingSig.data());
 
@@ -248,7 +248,7 @@ public:
         auto ctx = librustzcash_sapling_proving_ctx_init();
 
         auto miner_reward = SetFoundersRewardAndGetMinerValue(ctx);
-        mtx.valueBalance -= miner_reward;
+        mtx.valueBalanceSapling -= miner_reward;
 
         uint256 ovk;
 
@@ -543,7 +543,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const MinerAddre
                 CAmount saplingValueDummy = saplingValue;
                 CAmount orchardValueDummy = orchardValue;
 
-                saplingValueDummy += -tx.valueBalance;
+                saplingValueDummy += -tx.valueBalanceSapling;
                 orchardValueDummy += -tx.GetOrchardBundle().GetValueBalance();
 
                 for (auto js : tx.vJoinSplit) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -543,7 +543,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const MinerAddre
                 CAmount saplingValueDummy = saplingValue;
                 CAmount orchardValueDummy = orchardValue;
 
-                saplingValueDummy += -tx.valueBalanceSapling;
+                saplingValueDummy += -tx.GetValueBalanceSapling();
                 orchardValueDummy += -tx.GetOrchardBundle().GetValueBalance();
 
                 for (auto js : tx.vJoinSplit) {

--- a/src/primitives/orchard.h
+++ b/src/primitives/orchard.h
@@ -93,6 +93,10 @@ public:
         batch.Queue(inner.get(), txid.begin());
     }
 
+    const size_t GetNumActions() const {
+        return orchard_bundle_actions_len(inner.get());
+    }
+
     const std::vector<uint256> GetNullifiers() const {
         size_t actions_len = orchard_bundle_actions_len(inner.get());
         std::vector<uint256> result(actions_len);

--- a/src/primitives/orchard.h
+++ b/src/primitives/orchard.h
@@ -120,6 +120,10 @@ public:
     bool SpendsEnabled() const {
         return inner && orchard_bundle_spends_enabled(inner.get());
     }
+
+    bool HasValidCoinbaseOutputs() const {
+        return inner && orchard_bundle_has_valid_coinbase_outputs(inner.get());
+    }
 };
 
 #endif // ZCASH_PRIMITIVES_ORCHARD_H

--- a/src/primitives/orchard.h
+++ b/src/primitives/orchard.h
@@ -108,6 +108,14 @@ public:
             return std::nullopt;
         }
     }
+
+    bool OutputsEnabled() const {
+        return inner && orchard_bundle_outputs_enabled(inner.get());
+    }
+
+    bool SpendsEnabled() const {
+        return inner && orchard_bundle_spends_enabled(inner.get());
+    }
 };
 
 #endif // ZCASH_PRIMITIVES_ORCHARD_H

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -14,9 +14,9 @@
 SaplingBundle::SaplingBundle(
     const std::vector<SpendDescription>& vShieldedSpend,
     const std::vector<OutputDescription>& vShieldedOutput,
-    const CAmount& valueBalance,
+    const CAmount& valueBalanceSapling,
     const binding_sig_t& bindingSig)
-        : valueBalanceSapling(valueBalance), bindingSigSapling(bindingSig)
+        : valueBalanceSapling(valueBalanceSapling), bindingSigSapling(bindingSig)
 {
     for (auto &spend : vShieldedSpend) {
         vSpendsSapling.emplace_back(spend.cv, spend.nullifier, spend.rk);
@@ -127,11 +127,11 @@ std::string CTxOut::ToString() const
 }
 
 
-CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION), fOverwintered(false), nVersionGroupId(0), nExpiryHeight(0), nLockTime(0), valueBalance(0) {}
+CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION), fOverwintered(false), nVersionGroupId(0), nExpiryHeight(0), nLockTime(0), valueBalanceSapling(0) {}
 CMutableTransaction::CMutableTransaction(const CTransaction& tx) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
                                                                    nConsensusBranchId(tx.GetConsensusBranchId()),
                                                                    vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
-                                                                   valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
+                                                                   valueBalanceSapling(tx.valueBalanceSapling), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
                                                                    orchardBundle(tx.GetOrchardBundle()),
                                                                    vJoinSplit(tx.vJoinSplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
                                                                    bindingSig(tx.bindingSig)
@@ -188,7 +188,7 @@ CTransaction::CTransaction() : nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION
                                fOverwintered(false), nVersionGroupId(0), nExpiryHeight(0),
                                nConsensusBranchId(0),
                                vin(), vout(), nLockTime(0),
-                               valueBalance(0), vShieldedSpend(), vShieldedOutput(),
+                               valueBalanceSapling(0), vShieldedSpend(), vShieldedOutput(),
                                orchardBundle(),
                                vJoinSplit(), joinSplitPubKey(), joinSplitSig(),
                                bindingSig() { }
@@ -196,7 +196,7 @@ CTransaction::CTransaction() : nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION
 CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
                                                             nConsensusBranchId(tx.nConsensusBranchId),
                                                             vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
-                                                            valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
+                                                            valueBalanceSapling(tx.valueBalanceSapling), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
                                                             orchardBundle(tx.orchardBundle),
                                                             vJoinSplit(tx.vJoinSplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
                                                             bindingSig(tx.bindingSig)
@@ -211,7 +211,7 @@ CTransaction::CTransaction(
     bool evilDeveloperFlag) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
                               nConsensusBranchId(tx.nConsensusBranchId),
                               vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
-                              valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
+                              valueBalanceSapling(tx.valueBalanceSapling), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
                               orchardBundle(tx.orchardBundle),
                               vJoinSplit(tx.vJoinSplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
                               bindingSig(tx.bindingSig)
@@ -224,7 +224,7 @@ CTransaction::CTransaction(CMutableTransaction &&tx) : nVersion(tx.nVersion),
                                                        nConsensusBranchId(tx.nConsensusBranchId),
                                                        vin(std::move(tx.vin)), vout(std::move(tx.vout)),
                                                        nLockTime(tx.nLockTime), nExpiryHeight(tx.nExpiryHeight),
-                                                       valueBalance(tx.valueBalance),
+                                                       valueBalanceSapling(tx.valueBalanceSapling),
                                                        vShieldedSpend(std::move(tx.vShieldedSpend)), vShieldedOutput(std::move(tx.vShieldedOutput)),
                                                        orchardBundle(std::move(tx.orchardBundle)),
                                                        vJoinSplit(std::move(tx.vJoinSplit)),
@@ -243,7 +243,7 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
     *const_cast<std::vector<CTxOut>*>(&vout) = tx.vout;
     *const_cast<unsigned int*>(&nLockTime) = tx.nLockTime;
     *const_cast<uint32_t*>(&nExpiryHeight) = tx.nExpiryHeight;
-    *const_cast<CAmount*>(&valueBalance) = tx.valueBalance;
+    *const_cast<CAmount*>(&valueBalanceSapling) = tx.valueBalanceSapling;
     *const_cast<std::vector<SpendDescription>*>(&vShieldedSpend) = tx.vShieldedSpend;
     *const_cast<std::vector<OutputDescription>*>(&vShieldedOutput) = tx.vShieldedOutput;
     orchardBundle = tx.orchardBundle;
@@ -266,11 +266,11 @@ CAmount CTransaction::GetValueOut() const
             throw std::runtime_error("CTransaction::GetValueOut(): value out of range");
     }
 
-    if (valueBalance <= 0) {
-        // NB: negative valueBalance "takes" money from the transparent value pool just as outputs do
-        nValueOut += -valueBalance;
+    if (valueBalanceSapling <= 0) {
+        // NB: negative valueBalanceSapling "takes" money from the transparent value pool just as outputs do
+        nValueOut += -valueBalanceSapling;
 
-        if (!MoneyRange(-valueBalance) || !MoneyRange(nValueOut)) {
+        if (!MoneyRange(-valueBalanceSapling) || !MoneyRange(nValueOut)) {
             throw std::runtime_error("CTransaction::GetValueOut(): value out of range");
         }
     }
@@ -290,11 +290,11 @@ CAmount CTransaction::GetShieldedValueIn() const
 {
     CAmount nValue = 0;
 
-    if (valueBalance >= 0) {
-        // NB: positive valueBalance "gives" money to the transparent value pool just as inputs do
-        nValue += valueBalance;
+    if (valueBalanceSapling >= 0) {
+        // NB: positive valueBalanceSapling "gives" money to the transparent value pool just as inputs do
+        nValue += valueBalanceSapling;
 
-        if (!MoneyRange(valueBalance) || !MoneyRange(nValue)) {
+        if (!MoneyRange(valueBalanceSapling) || !MoneyRange(nValue)) {
             throw std::runtime_error("CTransaction::GetShieldedValueIn(): value out of range");
         }
     }
@@ -348,7 +348,7 @@ std::string CTransaction::ToString() const
             vout.size(),
             nLockTime);
     } else if (nVersion >= SAPLING_MIN_TX_VERSION) {
-        str += strprintf("CTransaction(hash=%s, ver=%d, fOverwintered=%d, nVersionGroupId=%08x, vin.size=%u, vout.size=%u, nLockTime=%u, nExpiryHeight=%u, valueBalance=%u, vShieldedSpend.size=%u, vShieldedOutput.size=%u)\n",
+        str += strprintf("CTransaction(hash=%s, ver=%d, fOverwintered=%d, nVersionGroupId=%08x, vin.size=%u, vout.size=%u, nLockTime=%u, nExpiryHeight=%u, valueBalanceSapling=%u, vShieldedSpend.size=%u, vShieldedOutput.size=%u)\n",
             GetHash().ToString().substr(0,10),
             nVersion,
             fOverwintered,
@@ -357,7 +357,7 @@ std::string CTransaction::ToString() const
             vout.size(),
             nLockTime,
             nExpiryHeight,
-            valueBalance,
+            valueBalanceSapling,
             vShieldedSpend.size(),
             vShieldedOutput.size());
     } else if (nVersion >= 3) {

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -131,7 +131,7 @@ CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::SPROUT_MIN_C
 CMutableTransaction::CMutableTransaction(const CTransaction& tx) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
                                                                    nConsensusBranchId(tx.GetConsensusBranchId()),
                                                                    vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
-                                                                   valueBalanceSapling(tx.valueBalanceSapling), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
+                                                                   valueBalanceSapling(tx.GetValueBalanceSapling()), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
                                                                    orchardBundle(tx.GetOrchardBundle()),
                                                                    vJoinSplit(tx.vJoinSplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
                                                                    bindingSig(tx.bindingSig)

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -659,7 +659,7 @@ class CTransaction
 private:
     /// The consensus branch ID that this transaction commits to.
     /// Serialized from v5 onwards.
-    uint32_t nConsensusBranchId;
+    std::optional<uint32_t> nConsensusBranchId;
     OrchardBundle orchardBundle;
 
     /** Memory only. */
@@ -781,7 +781,7 @@ public:
 
         if (isZip225V5) {
             // Common Transaction Fields (plus version bytes above)
-            READWRITE(nConsensusBranchId);
+            READWRITE(*nConsensusBranchId);
             READWRITE(*const_cast<uint32_t*>(&nLockTime));
             READWRITE(*const_cast<uint32_t*>(&nExpiryHeight));
 
@@ -870,7 +870,7 @@ public:
         return header;
     }
 
-    uint32_t GetConsensusBranchId() const {
+    std::optional<uint32_t> GetConsensusBranchId() const {
         return nConsensusBranchId;
     }
 
@@ -929,7 +929,7 @@ struct CMutableTransaction
     uint32_t nVersionGroupId;
     /// The consensus branch ID that this transaction commits to.
     /// Serialized from v5 onwards.
-    uint32_t nConsensusBranchId;
+    std::optional<uint32_t> nConsensusBranchId;
     std::vector<CTxIn> vin;
     std::vector<CTxOut> vout;
     uint32_t nLockTime;
@@ -991,7 +991,7 @@ struct CMutableTransaction
 
         if (isZip225V5) {
             // Common Transaction Fields (plus version bytes above)
-            READWRITE(nConsensusBranchId);
+            READWRITE(*nConsensusBranchId);
             READWRITE(nLockTime);
             READWRITE(nExpiryHeight);
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -660,6 +660,7 @@ private:
     /// The consensus branch ID that this transaction commits to.
     /// Serialized from v5 onwards.
     std::optional<uint32_t> nConsensusBranchId;
+    CAmount valueBalanceSapling;
     OrchardBundle orchardBundle;
 
     /** Memory only. */
@@ -715,7 +716,6 @@ public:
     const std::vector<CTxOut> vout;
     const uint32_t nLockTime;
     const uint32_t nExpiryHeight;
-    const CAmount valueBalanceSapling;
     const std::vector<SpendDescription> vShieldedSpend;
     const std::vector<OutputDescription> vShieldedOutput;
     const std::vector<JSDescription> vJoinSplit;
@@ -797,7 +797,7 @@ public:
                     saplingBundle.GetV4ShieldedSpend();
                 *const_cast<std::vector<OutputDescription>*>(&vShieldedOutput) =
                     saplingBundle.GetV4ShieldedOutput();
-                *const_cast<CAmount*>(&valueBalanceSapling) = saplingBundle.valueBalanceSapling;
+                valueBalanceSapling = saplingBundle.valueBalanceSapling;
                 *const_cast<binding_sig_t*>(&bindingSig) = saplingBundle.bindingSigSapling;
             } else {
                 SaplingBundle saplingBundle(
@@ -819,7 +819,7 @@ public:
                 READWRITE(*const_cast<uint32_t*>(&nExpiryHeight));
             }
             if (isSaplingV4 || isFuture) {
-                READWRITE(*const_cast<CAmount*>(&valueBalanceSapling));
+                READWRITE(valueBalanceSapling);
                 READWRITE(*const_cast<std::vector<SpendDescription>*>(&vShieldedSpend));
                 READWRITE(*const_cast<std::vector<OutputDescription>*>(&vShieldedOutput));
             }
@@ -874,6 +874,16 @@ public:
         return nConsensusBranchId;
     }
 
+    /**
+     * Returns the Sapling value balance for the transaction.
+     */
+    const CAmount& GetValueBalanceSapling() const {
+        return valueBalanceSapling;
+    }
+
+    /**
+     * Returns the Orchard bundle for the transaction.
+     */
     const OrchardBundle& GetOrchardBundle() const {
         return orchardBundle;
     }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -715,7 +715,7 @@ public:
     const std::vector<CTxOut> vout;
     const uint32_t nLockTime;
     const uint32_t nExpiryHeight;
-    const CAmount valueBalance;
+    const CAmount valueBalanceSapling;
     const std::vector<SpendDescription> vShieldedSpend;
     const std::vector<OutputDescription> vShieldedOutput;
     const std::vector<JSDescription> vJoinSplit;
@@ -797,13 +797,13 @@ public:
                     saplingBundle.GetV4ShieldedSpend();
                 *const_cast<std::vector<OutputDescription>*>(&vShieldedOutput) =
                     saplingBundle.GetV4ShieldedOutput();
-                *const_cast<CAmount*>(&valueBalance) = saplingBundle.valueBalanceSapling;
+                *const_cast<CAmount*>(&valueBalanceSapling) = saplingBundle.valueBalanceSapling;
                 *const_cast<binding_sig_t*>(&bindingSig) = saplingBundle.bindingSigSapling;
             } else {
                 SaplingBundle saplingBundle(
                     vShieldedSpend,
                     vShieldedOutput,
-                    valueBalance,
+                    valueBalanceSapling,
                     bindingSig);
                 READWRITE(saplingBundle);
             }
@@ -819,7 +819,7 @@ public:
                 READWRITE(*const_cast<uint32_t*>(&nExpiryHeight));
             }
             if (isSaplingV4 || isFuture) {
-                READWRITE(*const_cast<CAmount*>(&valueBalance));
+                READWRITE(*const_cast<CAmount*>(&valueBalanceSapling));
                 READWRITE(*const_cast<std::vector<SpendDescription>*>(&vShieldedSpend));
                 READWRITE(*const_cast<std::vector<OutputDescription>*>(&vShieldedOutput));
             }
@@ -885,16 +885,16 @@ public:
      * it is (e.g. if vpub_new is non-zero the joinSplit is "giving value" to
      * the outputs in the transaction). Similarly, we can think of the Sapling
      * shielded part of the transaction as an input or output according to
-     * whether valueBalance - the sum of shielded input values minus the sum of
+     * whether valueBalanceSapling - the sum of shielded input values minus the sum of
      * shielded output values - is positive or negative.
      */
 
-    // Return sum of txouts, (negative valueBalance or zero) and JoinSplit vpub_old.
+    // Return sum of txouts, (negative valueBalanceSapling or zero) and JoinSplit vpub_old.
     CAmount GetValueOut() const;
     // GetValueIn() is a method on CCoinsViewCache, because
     // inputs must be known to compute value in.
 
-    // Return sum of (positive valueBalance or zero) and JoinSplit vpub_new
+    // Return sum of (positive valueBalanceSapling or zero) and JoinSplit vpub_new
     CAmount GetShieldedValueIn() const;
 
     // Compute priority, given priority of inputs and (optionally) tx size
@@ -934,7 +934,7 @@ struct CMutableTransaction
     std::vector<CTxOut> vout;
     uint32_t nLockTime;
     uint32_t nExpiryHeight;
-    CAmount valueBalance;
+    CAmount valueBalanceSapling;
     std::vector<SpendDescription> vShieldedSpend;
     std::vector<OutputDescription> vShieldedOutput;
     OrchardBundle orchardBundle;
@@ -1005,13 +1005,13 @@ struct CMutableTransaction
                 READWRITE(saplingBundle);
                 vShieldedSpend = saplingBundle.GetV4ShieldedSpend();
                 vShieldedOutput = saplingBundle.GetV4ShieldedOutput();
-                valueBalance = saplingBundle.valueBalanceSapling;
+                valueBalanceSapling = saplingBundle.valueBalanceSapling;
                 bindingSig = saplingBundle.bindingSigSapling;
             } else {
                 SaplingBundle saplingBundle(
                     vShieldedSpend,
                     vShieldedOutput,
-                    valueBalance,
+                    valueBalanceSapling,
                     bindingSig);
                 READWRITE(saplingBundle);
             }
@@ -1027,7 +1027,7 @@ struct CMutableTransaction
                 READWRITE(nExpiryHeight);
             }
             if (isSaplingV4 || isFuture) {
-                READWRITE(valueBalance);
+                READWRITE(valueBalanceSapling);
                 READWRITE(vShieldedSpend);
                 READWRITE(vShieldedOutput);
             }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -227,8 +227,8 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     entry.pushKV("vjoinsplit", vjoinsplit);
 
     if (tx.fOverwintered && tx.nVersion >= SAPLING_TX_VERSION) {
-        entry.pushKV("valueBalance", ValueFromAmount(tx.valueBalanceSapling));
-        entry.pushKV("valueBalanceZat", tx.valueBalanceSapling);
+        entry.pushKV("valueBalance", ValueFromAmount(tx.GetValueBalanceSapling()));
+        entry.pushKV("valueBalanceZat", tx.GetValueBalanceSapling());
         UniValue vspenddesc = TxShieldedSpendsToJSON(tx);
         entry.pushKV("vShieldedSpend", vspenddesc);
         UniValue voutputdesc = TxShieldedOutputsToJSON(tx);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -227,8 +227,8 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     entry.pushKV("vjoinsplit", vjoinsplit);
 
     if (tx.fOverwintered && tx.nVersion >= SAPLING_TX_VERSION) {
-        entry.pushKV("valueBalance", ValueFromAmount(tx.valueBalance));
-        entry.pushKV("valueBalanceZat", tx.valueBalance);
+        entry.pushKV("valueBalance", ValueFromAmount(tx.valueBalanceSapling));
+        entry.pushKV("valueBalanceZat", tx.valueBalanceSapling);
         UniValue vspenddesc = TxShieldedSpendsToJSON(tx);
         entry.pushKV("vShieldedSpend", vspenddesc);
         UniValue voutputdesc = TxShieldedOutputsToJSON(tx);
@@ -594,7 +594,7 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, locktime out of range");
         rawTx.nLockTime = nLockTime;
     }
-    
+
     if (params.size() > 3 && !params[3].isNull()) {
         if (Params().GetConsensus().NetworkUpgradeActive(nextBlockHeight, Consensus::UPGRADE_OVERWINTER)) {
             int64_t nExpiryHeight = params[3].get_int64();
@@ -1017,7 +1017,7 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
     }
 
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);
-    // Use the approximate release height if it is greater so offline nodes 
+    // Use the approximate release height if it is greater so offline nodes
     // have a better estimation of the current height and will be more likely to
     // determine the correct consensus branch ID.  Regtest mode ignores release height.
     int chainHeight = chainActive.Height() + 1;
@@ -1032,8 +1032,8 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
         if (!IsConsensusBranchId(consensusBranchId)) {
             throw runtime_error(params[4].get_str() + " is not a valid consensus branch id");
         }
-    } 
-    
+    }
+
     // Script verification errors
     UniValue vErrors(UniValue::VARR);
 

--- a/src/rust/include/rust/orchard.h
+++ b/src/rust/include/rust/orchard.h
@@ -117,6 +117,10 @@ bool orchard_bundle_outputs_enabled(const OrchardBundlePtr* bundle);
 /// are enabled.
 bool orchard_bundle_spends_enabled(const OrchardBundlePtr* bundle);
 
+/// Returns whether all actions contained in the Orchard bundle
+/// can be decrypted with the all-zeros OVK.
+bool orchard_bundle_has_valid_coinbase_outputs(const OrchardBundlePtr* bundle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rust/include/rust/orchard.h
+++ b/src/rust/include/rust/orchard.h
@@ -108,6 +108,15 @@ void orchard_batch_add_bundle(
 ///
 /// Returns false if any item in the batch is invalid.
 bool orchard_batch_validate(const OrchardBatchValidatorPtr* batch);
+
+/// Returns whether the orchard bundle is present and outputs
+/// are enabled.
+bool orchard_bundle_outputs_enabled(const OrchardBundlePtr* bundle);
+
+/// Returns whether the orchard bundle is present and spends
+/// are enabled.
+bool orchard_bundle_spends_enabled(const OrchardBundlePtr* bundle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rust/src/orchard_ffi.rs
+++ b/src/rust/src/orchard_ffi.rs
@@ -271,3 +271,19 @@ pub extern "C" fn orchard_batch_validate(batch: *const BatchValidator) -> bool {
         true
     }
 }
+
+#[no_mangle]
+pub extern "C" fn orchard_bundle_outputs_enabled(
+    bundle: *const Bundle<Authorized, Amount>,
+) -> bool {
+    let bundle = unsafe { bundle.as_ref() };
+    bundle.map(|b| b.flags().outputs_enabled()).unwrap_or(false)
+}
+
+#[no_mangle]
+pub extern "C" fn orchard_bundle_spends_enabled(
+    bundle: *const Bundle<Authorized, Amount>,
+) -> bool {
+    let bundle = unsafe { bundle.as_ref() };
+    bundle.map(|b| b.flags().spends_enabled()).unwrap_or(false)
+}

--- a/src/rust/src/orchard_ffi.rs
+++ b/src/rust/src/orchard_ffi.rs
@@ -2,11 +2,13 @@ use std::ptr;
 
 use orchard::{
     bundle::Authorized,
+    keys::OutgoingViewingKey,
     primitives::redpallas::{self, Binding, SpendAuth},
-    Bundle,
+    Bundle, OrchardDomain,
 };
 use rand_core::OsRng;
 use tracing::{debug, error};
+use zcash_note_encryption::try_output_recovery_with_ovk;
 use zcash_primitives::transaction::{
     components::{orchard as orchard_serialization, Amount},
     TxId,
@@ -281,9 +283,37 @@ pub extern "C" fn orchard_bundle_outputs_enabled(
 }
 
 #[no_mangle]
-pub extern "C" fn orchard_bundle_spends_enabled(
-    bundle: *const Bundle<Authorized, Amount>,
-) -> bool {
+pub extern "C" fn orchard_bundle_spends_enabled(bundle: *const Bundle<Authorized, Amount>) -> bool {
     let bundle = unsafe { bundle.as_ref() };
     bundle.map(|b| b.flags().spends_enabled()).unwrap_or(false)
+}
+
+/// Returns whether all actions contained in the Orchard bundle
+/// can be decrypted with the all-zeros OVK.
+///
+/// This should only be called on an Orchard bundle that is
+/// an element of a coinbase transaction.
+#[no_mangle]
+pub extern "C" fn orchard_bundle_has_valid_coinbase_outputs(
+    bundle: *const Bundle<Authorized, Amount>,
+) -> bool {
+    if let Some(bundle) = unsafe { bundle.as_ref() } {
+        for act in bundle.actions() {
+            if try_output_recovery_with_ovk(
+                &OrchardDomain::for_action(act),
+                &OutgoingViewingKey::from([0u8; 32]),
+                act,
+                act.cv_net(),
+                &act.encrypted_note().out_ciphertext,
+            )
+            .is_none()
+            {
+                return false;
+            }
+        }
+    }
+
+    // Either there are no Orchard actions, or all of the outputs
+    // are decryptable with the all-zeros OVK.
+    true
 }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -94,7 +94,7 @@ bool static IsCompressedOrUncompressedPubKey(const valtype &vchPubKey) {
  * Where R and S are not negative (their first byte has its highest bit not set), and not
  * excessively padded (do not start with a 0 byte, unless an otherwise negative number follows,
  * in which case a single 0 byte is necessary and even required).
- * 
+ *
  * See https://bitcointalk.org/index.php?topic=8392.msg127623#msg127623
  *
  * This function is consensus-critical since BIP66.
@@ -134,7 +134,7 @@ bool static IsValidSignatureEncoding(const std::vector<unsigned char> &sig) {
     // Verify that the length of the signature matches the sum of the length
     // of the elements.
     if ((size_t)(lenR + lenS + 7) != sig.size()) return false;
- 
+
     // Check whether the R element is an integer.
     if (sig[2] != 0x02) return false;
 
@@ -1288,7 +1288,7 @@ uint256 SignatureHash(
         ss << txTo.nExpiryHeight;
         if (sigversion == SIGVERSION_SAPLING) {
             // Sapling value balance
-            ss << txTo.valueBalance;
+            ss << txTo.valueBalanceSapling;
         }
         // Sighash type
         ss << nHashType;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1288,7 +1288,7 @@ uint256 SignatureHash(
         ss << txTo.nExpiryHeight;
         if (sigversion == SIGVERSION_SAPLING) {
             // Sapling value balance
-            ss << txTo.valueBalanceSapling;
+            ss << txTo.GetValueBalanceSapling();
         }
         // Sighash type
         ss << nHashType;

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -147,7 +147,7 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle, uint32_t co
         RandomScript(txout.scriptPubKey);
     }
     if (tx.nVersionGroupId == SAPLING_VERSION_GROUP_ID) {
-        tx.valueBalance = insecure_rand() % 100000000;
+        tx.valueBalanceSapling = insecure_rand() % 100000000;
         for (int spend = 0; spend < shielded_spends; spend++) {
             SpendDescription sdesc;
             zcash_test_harness_random_jubjub_point(sdesc.cv.begin());

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -477,7 +477,7 @@ void test_simple_joinsplit_invalidity(uint32_t consensusBranchId, CMutableTransa
         CValidationState state;
 
         newTx.vJoinSplit.push_back(JSDescription());
-        
+
         JSDescription *jsdesc = &newTx.vJoinSplit[0];
         jsdesc->vpub_old = -1;
 
@@ -921,7 +921,7 @@ BOOST_AUTO_TEST_CASE(TxV5)
             SignatureHash(
                 scriptCode, tx, nIn,
                 SIGHASH_ALL,
-                amount, tx.GetConsensusBranchId()
+                amount, *tx.GetConsensusBranchId()
             ).GetHex(),
             test[6].getValStr());
 
@@ -930,7 +930,7 @@ BOOST_AUTO_TEST_CASE(TxV5)
                 SignatureHash(
                     scriptCode, tx, nIn,
                     SIGHASH_NONE,
-                    amount, tx.GetConsensusBranchId()
+                    amount, *tx.GetConsensusBranchId()
                 ).GetHex(),
                 test[7].getValStr());
         }
@@ -940,7 +940,7 @@ BOOST_AUTO_TEST_CASE(TxV5)
                 SignatureHash(
                     scriptCode, tx, nIn,
                     SIGHASH_SINGLE,
-                    amount, tx.GetConsensusBranchId()
+                    amount, *tx.GetConsensusBranchId()
                 ).GetHex(),
                 test[8].getValStr());
         }
@@ -950,7 +950,7 @@ BOOST_AUTO_TEST_CASE(TxV5)
                 SignatureHash(
                     scriptCode, tx, nIn,
                     SIGHASH_ALL | SIGHASH_ANYONECANPAY,
-                    amount, tx.GetConsensusBranchId()
+                    amount, *tx.GetConsensusBranchId()
                 ).GetHex(),
                 test[9].getValStr());
         }
@@ -960,7 +960,7 @@ BOOST_AUTO_TEST_CASE(TxV5)
                 SignatureHash(
                     scriptCode, tx, nIn,
                     SIGHASH_NONE | SIGHASH_ANYONECANPAY,
-                    amount, tx.GetConsensusBranchId()
+                    amount, *tx.GetConsensusBranchId()
                 ).GetHex(),
                 test[10].getValStr());
         }
@@ -970,7 +970,7 @@ BOOST_AUTO_TEST_CASE(TxV5)
                 SignatureHash(
                     scriptCode, tx, nIn,
                     SIGHASH_SINGLE | SIGHASH_ANYONECANPAY,
-                    amount, tx.GetConsensusBranchId()
+                    amount, *tx.GetConsensusBranchId()
                 ).GetHex(),
                 test[11].getValStr());
         }

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -199,7 +199,7 @@ void TransactionBuilder::AddSaplingSpend(
     }
 
     spends.emplace_back(expsk, note, anchor, witness);
-    mtx.valueBalance += note.value();
+    mtx.valueBalanceSapling += note.value();
 }
 
 void TransactionBuilder::AddSaplingOutput(
@@ -221,7 +221,7 @@ void TransactionBuilder::AddSaplingOutput(
 
     auto note = libzcash::SaplingNote(to, value, zip_212_enabled);
     outputs.emplace_back(ovk, note, memo);
-    mtx.valueBalance -= value;
+    mtx.valueBalanceSapling -= value;
 }
 
 void TransactionBuilder::AddSproutInput(
@@ -307,7 +307,7 @@ TransactionBuilderResult TransactionBuilder::Build()
     //
 
     // Valid change
-    CAmount change = mtx.valueBalance - fee;
+    CAmount change = mtx.valueBalanceSapling - fee;
     for (auto jsInput : jsInputs) {
         change += jsInput.note.value();
     }
@@ -460,7 +460,7 @@ TransactionBuilderResult TransactionBuilder::Build()
     }
     librustzcash_sapling_binding_sig(
         ctx,
-        mtx.valueBalance,
+        mtx.valueBalanceSapling,
         dataToBeSigned.begin(),
         mtx.bindingSig.data());
 

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -1106,7 +1106,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
         EXPECT_EQ(tx2.vJoinSplit.size(), 0);
         EXPECT_EQ(tx2.vShieldedSpend.size(), 1);
         EXPECT_EQ(tx2.vShieldedOutput.size(), 2);
-        EXPECT_EQ(tx2.valueBalanceSapling, 10000);
+        EXPECT_EQ(tx2.GetValueBalanceSapling(), 10000);
 
         CWalletTx wtx2 {&wallet, tx2};
 
@@ -1973,7 +1973,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     EXPECT_EQ(tx1.vJoinSplit.size(), 0);
     EXPECT_EQ(tx1.vShieldedSpend.size(), 0);
     EXPECT_EQ(tx1.vShieldedOutput.size(), 1);
-    EXPECT_EQ(tx1.valueBalanceSapling, -40000);
+    EXPECT_EQ(tx1.GetValueBalanceSapling(), -40000);
 
     CWalletTx wtx {&wallet, tx1};
 
@@ -2027,7 +2027,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     EXPECT_EQ(tx2.vJoinSplit.size(), 0);
     EXPECT_EQ(tx2.vShieldedSpend.size(), 1);
     EXPECT_EQ(tx2.vShieldedOutput.size(), 2);
-    EXPECT_EQ(tx2.valueBalanceSapling, 10000);
+    EXPECT_EQ(tx2.GetValueBalanceSapling(), 10000);
 
     CWalletTx wtx2 {&wallet, tx2};
     auto hash2 = wtx2.GetHash();

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -1106,7 +1106,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
         EXPECT_EQ(tx2.vJoinSplit.size(), 0);
         EXPECT_EQ(tx2.vShieldedSpend.size(), 1);
         EXPECT_EQ(tx2.vShieldedOutput.size(), 2);
-        EXPECT_EQ(tx2.valueBalance, 10000);
+        EXPECT_EQ(tx2.valueBalanceSapling, 10000);
 
         CWalletTx wtx2 {&wallet, tx2};
 
@@ -1973,7 +1973,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     EXPECT_EQ(tx1.vJoinSplit.size(), 0);
     EXPECT_EQ(tx1.vShieldedSpend.size(), 0);
     EXPECT_EQ(tx1.vShieldedOutput.size(), 1);
-    EXPECT_EQ(tx1.valueBalance, -40000);
+    EXPECT_EQ(tx1.valueBalanceSapling, -40000);
 
     CWalletTx wtx {&wallet, tx1};
 
@@ -2027,7 +2027,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     EXPECT_EQ(tx2.vJoinSplit.size(), 0);
     EXPECT_EQ(tx2.vShieldedSpend.size(), 1);
     EXPECT_EQ(tx2.vShieldedOutput.size(), 2);
-    EXPECT_EQ(tx2.valueBalance, 10000);
+    EXPECT_EQ(tx2.valueBalanceSapling, 10000);
 
     CWalletTx wtx2 {&wallet, tx2};
     auto hash2 = wtx2.GetHash();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4423,10 +4423,10 @@ UniValue z_getmigrationstatus(const UniValue& params, bool fHelp) {
             //  A transaction is "finalized" iff it has at least 10 confirmations.
             // TODO: subject to change, if the recommended number of confirmations changes.
             if (tx.GetDepthInMainChain() >= 10) {
-                finalizedMigratedAmount -= tx.valueBalance;
+                finalizedMigratedAmount -= tx.valueBalanceSapling;
                 ++numFinalizedMigrationTxs;
             } else {
-                unfinalizedMigratedAmount -= tx.valueBalance;
+                unfinalizedMigratedAmount -= tx.valueBalanceSapling;
             }
             // If the transaction is in the mempool it will not be associated with a block yet
             if (tx.hashBlock.IsNull() || mapBlockIndex[tx.hashBlock] == nullptr) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4423,10 +4423,10 @@ UniValue z_getmigrationstatus(const UniValue& params, bool fHelp) {
             //  A transaction is "finalized" iff it has at least 10 confirmations.
             // TODO: subject to change, if the recommended number of confirmations changes.
             if (tx.GetDepthInMainChain() >= 10) {
-                finalizedMigratedAmount -= tx.valueBalanceSapling;
+                finalizedMigratedAmount -= tx.GetValueBalanceSapling();
                 ++numFinalizedMigrationTxs;
             } else {
-                unfinalizedMigratedAmount -= tx.valueBalanceSapling;
+                unfinalizedMigratedAmount -= tx.GetValueBalanceSapling();
             }
             // If the transaction is in the mempool it will not be associated with a block yet
             if (tx.hashBlock.IsNull() || mapBlockIndex[tx.hashBlock] == nullptr) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -158,7 +158,7 @@ SaplingPaymentAddress CWallet::GenerateNewSaplingZKey()
     return xsk.DefaultAddress();
 }
 
-// Add spending key to keystore 
+// Add spending key to keystore
 bool CWallet::AddSaplingZKey(const libzcash::SaplingExtendedSpendingKey &sk)
 {
     AssertLockHeld(cs_wallet); // mapSaplingZKeyMetadata
@@ -166,7 +166,7 @@ bool CWallet::AddSaplingZKey(const libzcash::SaplingExtendedSpendingKey &sk)
     if (!CCryptoKeyStore::AddSaplingSpendingKey(sk)) {
         return false;
     }
-    
+
     if (!fFileBacked) {
         return true;
     }
@@ -175,7 +175,7 @@ bool CWallet::AddSaplingZKey(const libzcash::SaplingExtendedSpendingKey &sk)
         auto ivk = sk.expsk.full_viewing_key().in_viewing_key();
         return CWalletDB(strWalletFile).WriteSaplingZKey(ivk, sk, mapSaplingZKeyMetadata[ivk]);
     }
-    
+
     return true;
 }
 
@@ -614,7 +614,7 @@ void CWallet::ChainTipAdded(const CBlockIndex *pindex,
     }
 }
 
-void CWallet::ChainTip(const CBlockIndex *pindex, 
+void CWallet::ChainTip(const CBlockIndex *pindex,
                        const CBlock *pblock,
                        std::optional<std::pair<SproutMerkleTree, SaplingMerkleTree>> added)
 {
@@ -1276,7 +1276,7 @@ void DecrementNoteWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t n
             if (nd->witnesses.size() > 0) {
                 nd->witnesses.pop_front();
             }
-            // indexHeight is the height of the block being removed, so 
+            // indexHeight is the height of the block being removed, so
             // the new witness cache height is one below it.
             nd->witnessHeight = indexHeight - 1;
         }
@@ -2602,14 +2602,14 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
         }
     }
 
-    // If we sent utxos from this transaction, create output for value taken from (negative valueBalance)
-    // or added (positive valueBalance) to the transparent value pool by Sapling shielding and unshielding.
+    // If we sent utxos from this transaction, create output for value taken from (negative valueBalanceSapling)
+    // or added (positive valueBalanceSapling) to the transparent value pool by Sapling shielding and unshielding.
     if (isFromMyTaddr) {
-        if (valueBalance < 0) {
-            COutputEntry output = {CNoDestination(), -valueBalance, (int) vout.size()};
+        if (valueBalanceSapling < 0) {
+            COutputEntry output = {CNoDestination(), -valueBalanceSapling, (int) vout.size()};
             listSent.push_back(output);
-        } else if (valueBalance > 0) {
-            COutputEntry output = {CNoDestination(), valueBalance, (int) vout.size()};
+        } else if (valueBalanceSapling > 0) {
+            COutputEntry output = {CNoDestination(), valueBalanceSapling, (int) vout.size()};
             listReceived.push_back(output);
         }
     }
@@ -5045,7 +5045,7 @@ void CWallet::GetFilteredNotes(
 }
 
 /**
- * Find notes in the wallet filtered by payment addresses, min depth, max depth, 
+ * Find notes in the wallet filtered by payment addresses, min depth, max depth,
  * if the note is spent, if a spending key is required, and if the notes are locked.
  * These notes are decrypted and added to the output parameter vector, outEntries.
  */
@@ -5366,7 +5366,7 @@ KeyAddResult AddSpendingKeyToWallet::operator()(const libzcash::SaplingExtendedS
                 m_wallet->mapSaplingZKeyMetadata[ivk].seedFp = seedFp;
             }
             return KeyAdded;
-        }    
+        }
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2605,11 +2605,11 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
     // If we sent utxos from this transaction, create output for value taken from (negative valueBalanceSapling)
     // or added (positive valueBalanceSapling) to the transparent value pool by Sapling shielding and unshielding.
     if (isFromMyTaddr) {
-        if (valueBalanceSapling < 0) {
-            COutputEntry output = {CNoDestination(), -valueBalanceSapling, (int) vout.size()};
+        if (GetValueBalanceSapling() < 0) {
+            COutputEntry output = {CNoDestination(), -GetValueBalanceSapling(), (int) vout.size()};
             listSent.push_back(output);
-        } else if (valueBalanceSapling > 0) {
-            COutputEntry output = {CNoDestination(), valueBalanceSapling, (int) vout.size()};
+        } else if (GetValueBalanceSapling() > 0) {
+            COutputEntry output = {CNoDestination(), GetValueBalanceSapling(), (int) vout.size()};
             listReceived.push_back(output);
         }
     }


### PR DESCRIPTION
This is built atop #5225 and should be rebased once that has merged.
