### PR TITLE
Make all CCoinsView methods pure-virtual.

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -378,7 +378,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& strInput)
     // starts as a clone of the raw tx:
     CMutableTransaction mergedTx(txVariants[0]);
     bool fComplete = true;
-    CCoinsView viewDummy;
+    CCoinsViewDummy viewDummy;
     CCoinsViewCache view(&viewDummy);
 
     if (!registers.count("privatekeys"))

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -45,32 +45,6 @@ bool CCoins::Spend(uint32_t nPos)
     Cleanup();
     return true;
 }
-bool CCoinsView::GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const { return false; }
-bool CCoinsView::GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const { return false; }
-bool CCoinsView::GetOrchardAnchorAt(const uint256 &rt, OrchardMerkleFrontier &tree) const { return false; }
-bool CCoinsView::GetNullifier(const uint256 &nullifier, ShieldedType type) const { return false; }
-bool CCoinsView::GetCoins(const uint256 &txid, CCoins &coins) const { return false; }
-bool CCoinsView::HaveCoins(const uint256 &txid) const { return false; }
-uint256 CCoinsView::GetBestBlock() const { return uint256(); }
-uint256 CCoinsView::GetBestAnchor(ShieldedType type) const { return uint256(); };
-HistoryIndex CCoinsView::GetHistoryLength(uint32_t epochId) const { return 0; }
-HistoryNode CCoinsView::GetHistoryAt(uint32_t epochId, HistoryIndex index) const { return HistoryNode(); }
-uint256 CCoinsView::GetHistoryRoot(uint32_t epochId) const { return uint256(); }
-
-bool CCoinsView::BatchWrite(CCoinsMap &mapCoins,
-                            const uint256 &hashBlock,
-                            const uint256 &hashSproutAnchor,
-                            const uint256 &hashSaplingAnchor,
-                            const uint256 &hashOrchardAnchor,
-                            CAnchorsSproutMap &mapSproutAnchors,
-                            CAnchorsSaplingMap &mapSaplingAnchors,
-                            CAnchorsOrchardMap &mapOrchardAnchors,
-                            CNullifiersMap &mapSproutNullifiers,
-                            CNullifiersMap &mapSaplingNullifiers,
-                            CNullifiersMap &mapOrchardNullifiers,
-                            CHistoryCacheMap &historyCacheMap) { return false; }
-bool CCoinsView::GetStats(CCoinsStats &stats) const { return false; }
-
 
 CCoinsViewBacked::CCoinsViewBacked(CCoinsView *viewIn) : base(viewIn) { }
 

--- a/src/gtest/test_coins.cpp
+++ b/src/gtest/test_coins.cpp
@@ -161,6 +161,14 @@ public:
 
     uint256 GetBestBlock() const { return hashBestBlock_; }
 
+    HistoryIndex GetHistoryLength(uint32_t epochId) const { return 0; }
+    HistoryNode GetHistoryAt(uint32_t epochId, HistoryIndex index) const {
+        throw std::runtime_error("`GetHistoryAt` unimplemented for mock CCoinsViewTest");
+    }
+    uint256 GetHistoryRoot(uint32_t epochId) const {
+        throw std::runtime_error("`GetHistoryRoot` unimplemented for mock CCoinsViewTest");
+    }
+
     void BatchWriteNullifiers(CNullifiersMap& mapNullifiers, std::map<uint256, bool>& cacheNullifiers)
     {
         for (CNullifiersMap::iterator it = mapNullifiers.begin(); it != mapNullifiers.end(); ) {
@@ -282,7 +290,7 @@ public:
         JSDescription jsd;
         jsd.nullifiers[0] = sproutNullifier;
         mutableTx.vJoinSplit.emplace_back(jsd);
-        
+
         saplingNullifier = GetRandHash();
         SpendDescription sd;
         sd.nullifier = saplingNullifier;
@@ -685,7 +693,7 @@ template<typename Tree> void anchorsFlushImpl(ShieldedType type)
         cache.PushAnchor(tree);
         cache.Flush();
     }
-    
+
     {
         CCoinsViewCacheTest cache(&base);
         Tree tree;
@@ -775,7 +783,7 @@ template<typename Tree> void anchorsTestImpl(ShieldedType type)
         {
             Tree test_tree2;
             GetAnchorAt(cache, newrt, test_tree2);
-            
+
             EXPECT_TRUE(test_tree2.root() == newrt);
         }
 

--- a/src/gtest/test_history.cpp
+++ b/src/gtest/test_history.cpp
@@ -4,78 +4,6 @@
 #include "util/test.h"
 #include "zcash/History.hpp"
 
-// Fake an empty view
-class FakeCoinsViewDB : public CCoinsView {
-public:
-    FakeCoinsViewDB() {}
-    ~FakeCoinsViewDB() {}
-
-    bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const {
-        return false;
-    }
-
-    bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const {
-        return false;
-    }
-
-    bool GetOrchardAnchorAt(const uint256 &rt, OrchardMerkleFrontier &tree) const {
-        return false;
-    }
-
-    bool GetNullifier(const uint256 &nf, ShieldedType type) const {
-        return false;
-    }
-
-    bool GetCoins(const uint256 &txid, CCoins &coins) const {
-        return false;
-    }
-
-    bool HaveCoins(const uint256 &txid) const {
-        return false;
-    }
-
-    uint256 GetBestBlock() const {
-        uint256 a;
-        return a;
-    }
-
-    uint256 GetBestAnchor(ShieldedType type) const {
-        uint256 a;
-        return a;
-    }
-
-    HistoryIndex GetHistoryLength(uint32_t branchId) const {
-        return 0;
-    }
-
-    HistoryNode GetHistoryAt(uint32_t branchId, HistoryIndex index) const {
-        return HistoryNode();
-    }
-
-    uint256 GetHistoryRoot(uint32_t epochId) const {
-        return uint256();
-    }
-
-    bool BatchWrite(CCoinsMap &mapCoins,
-                    const uint256 &hashBlock,
-                    const uint256 &hashSproutAnchor,
-                    const uint256 &hashSaplingAnchor,
-                    const uint256 &hashOrchardAnchor,
-                    CAnchorsSproutMap &mapSproutAnchors,
-                    CAnchorsSaplingMap &mapSaplingAnchors,
-                    CAnchorsOrchardMap &mapOrchardAnchors,
-                    CNullifiersMap &mapSproutNullifiers,
-                    CNullifiersMap &mapSaplingNullifiers,
-                    CNullifiersMap &mapOrchardNullifiers,
-                    CHistoryCacheMap &historyCacheMap) {
-        return false;
-    }
-
-    bool GetStats(CCoinsStats &stats) const {
-        return false;
-    }
-};
-
 HistoryNode getLeafN(uint64_t block_num) {
     HistoryNode node = libzcash::NewV1Leaf(
         uint256(),
@@ -91,7 +19,7 @@ HistoryNode getLeafN(uint64_t block_num) {
 
 TEST(History, Smoky) {
     // Fake an empty view
-    FakeCoinsViewDB fakeDB;
+    CCoinsViewDummy fakeDB;
     CCoinsViewCache view(&fakeDB);
 
     uint32_t epochId = 0;
@@ -129,7 +57,7 @@ TEST(History, Smoky) {
 
 TEST(History, EpochBoundaries) {
     // Fake an empty view
-    FakeCoinsViewDB fakeDB;
+    CCoinsViewDummy fakeDB;
     CCoinsViewCache view(&fakeDB);
 
     // Test with the Heartwood and Canopy epochs
@@ -196,7 +124,7 @@ TEST(History, EpochBoundaries) {
 TEST(History, GarbageMemoryHash) {
     const auto consensusBranchId = NetworkUpgradeInfo[Consensus::UPGRADE_HEARTWOOD].nBranchId;
 
-    FakeCoinsViewDB fakeDB;
+    CCoinsViewDummy fakeDB;
     CCoinsViewCache view(&fakeDB);
 
     // Hash two history nodes
@@ -209,7 +137,7 @@ TEST(History, GarbageMemoryHash) {
     uint256 historyRoot = view.GetHistoryRoot(consensusBranchId);
 
     // Change garbage memory and re-hash nodes
-    FakeCoinsViewDB fakeDBGarbage;
+    CCoinsViewDummy fakeDBGarbage;
     CCoinsViewCache viewGarbage(&fakeDBGarbage);
 
     HistoryNode node0Garbage = getLeafN(1);

--- a/src/gtest/test_history.cpp
+++ b/src/gtest/test_history.cpp
@@ -8,12 +8,17 @@
 class FakeCoinsViewDB : public CCoinsView {
 public:
     FakeCoinsViewDB() {}
+    ~FakeCoinsViewDB() {}
 
     bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const {
         return false;
     }
 
     bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const {
+        return false;
+    }
+
+    bool GetOrchardAnchorAt(const uint256 &rt, OrchardMerkleFrontier &tree) const {
         return false;
     }
 
@@ -39,27 +44,35 @@ public:
         return a;
     }
 
-    bool BatchWrite(CCoinsMap &mapCoins,
-                    const uint256 &hashBlock,
-                    const uint256 &hashSproutAnchor,
-                    const uint256 &hashSaplingAnchor,
-                    CAnchorsSproutMap &mapSproutAnchors,
-                    CAnchorsSaplingMap &mapSaplingAnchors,
-                    CNullifiersMap &mapSproutNullifiers,
-                    CNullifiersMap saplingNullifiersMap) {
-        return false;
-    }
-
-    bool GetStats(CCoinsStats &stats) const {
-        return false;
-    }
-
     HistoryIndex GetHistoryLength(uint32_t branchId) const {
         return 0;
     }
 
     HistoryNode GetHistoryAt(uint32_t branchId, HistoryIndex index) const {
         return HistoryNode();
+    }
+
+    uint256 GetHistoryRoot(uint32_t epochId) const {
+        return uint256();
+    }
+
+    bool BatchWrite(CCoinsMap &mapCoins,
+                    const uint256 &hashBlock,
+                    const uint256 &hashSproutAnchor,
+                    const uint256 &hashSaplingAnchor,
+                    const uint256 &hashOrchardAnchor,
+                    CAnchorsSproutMap &mapSproutAnchors,
+                    CAnchorsSaplingMap &mapSaplingAnchors,
+                    CAnchorsOrchardMap &mapOrchardAnchors,
+                    CNullifiersMap &mapSproutNullifiers,
+                    CNullifiersMap &mapSaplingNullifiers,
+                    CNullifiersMap &mapOrchardNullifiers,
+                    CHistoryCacheMap &historyCacheMap) {
+        return false;
+    }
+
+    bool GetStats(CCoinsStats &stats) const {
+        return false;
     }
 };
 

--- a/src/gtest/test_mempool.cpp
+++ b/src/gtest/test_mempool.cpp
@@ -18,12 +18,17 @@ extern CMutableTransaction GetValidTransaction(uint32_t consensusBranchId=SPROUT
 class FakeCoinsViewDB : public CCoinsView {
 public:
     FakeCoinsViewDB() {}
+    ~FakeCoinsViewDB() {}
 
     bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const {
         return false;
     }
 
     bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const {
+        return false;
+    }
+
+    bool GetOrchardAnchorAt(const uint256 &rt, OrchardMerkleFrontier &tree) const {
         return false;
     }
 
@@ -56,14 +61,30 @@ public:
         return a;
     }
 
+    HistoryIndex GetHistoryLength(uint32_t branchId) const {
+        return 0;
+    }
+
+    HistoryNode GetHistoryAt(uint32_t branchId, HistoryIndex index) const {
+        return HistoryNode();
+    }
+
+    uint256 GetHistoryRoot(uint32_t epochId) const {
+        return uint256();
+    }
+
     bool BatchWrite(CCoinsMap &mapCoins,
                     const uint256 &hashBlock,
                     const uint256 &hashSproutAnchor,
                     const uint256 &hashSaplingAnchor,
+                    const uint256 &hashOrchardAnchor,
                     CAnchorsSproutMap &mapSproutAnchors,
                     CAnchorsSaplingMap &mapSaplingAnchors,
+                    CAnchorsOrchardMap &mapOrchardAnchors,
                     CNullifiersMap &mapSproutNullifiers,
-                    CNullifiersMap &mapSaplingNullifiers) {
+                    CNullifiersMap &mapSaplingNullifiers,
+                    CNullifiersMap &mapOrchardNullifiers,
+                    CHistoryCacheMap &historyCacheMap) {
         return false;
     }
 

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -241,8 +241,7 @@ TEST(TransactionBuilder, TransparentToOrchard)
     libzcash::diversifier_index_t j(0);
     auto recipient = ivk.Address(j);
 
-    TransactionBuilderCoinsViewDB fakeDB;
-    auto orchardAnchor = fakeDB.GetBestAnchor(ShieldedType::ORCHARD);
+    auto orchardAnchor = uint256();
 
     // Create a shielding transaction from transparent to Orchard
     // 0.00005 t-ZEC in, 0.00004 z-ZEC out, default fee

--- a/src/gtest/test_transaction_builder.h
+++ b/src/gtest/test_transaction_builder.h
@@ -45,23 +45,33 @@ public:
     }
 
     uint256 GetBestBlock() const {
-        uint256 a;
-        return a;
+        throw std::runtime_error("`GetBestBlock` unimplemented for mock TransactionBuilderCoinsViewDB");
     }
 
     uint256 GetBestAnchor(ShieldedType type) const {
-        uint256 a;
-        return a;
+        throw std::runtime_error("`GetBestAnchor` unimplemented for mock TransactionBuilderCoinsViewDB");
+    }
+
+    HistoryIndex GetHistoryLength(uint32_t epochId) const { return 0; }
+    HistoryNode GetHistoryAt(uint32_t epochId, HistoryIndex index) const {
+        throw std::runtime_error("`GetHistoryAt` unimplemented for mock TransactionBuilderCoinsViewDB");
+    }
+    uint256 GetHistoryRoot(uint32_t epochId) const {
+        throw std::runtime_error("`GetHistoryRoot` unimplemented for mock TransactionBuilderCoinsViewDB");
     }
 
     bool BatchWrite(CCoinsMap &mapCoins,
                     const uint256 &hashBlock,
                     const uint256 &hashSproutAnchor,
                     const uint256 &hashSaplingAnchor,
+                    const uint256 &hashOrchardAnchor,
                     CAnchorsSproutMap &mapSproutAnchors,
                     CAnchorsSaplingMap &mapSaplingAnchors,
+                    CAnchorsOrchardMap &mapOrchardAnchors,
                     CNullifiersMap &mapSproutNullifiers,
-                    CNullifiersMap saplingNullifiersMap) {
+                    CNullifiersMap &mapSaplingNullifiers,
+                    CNullifiersMap &mapOrchardNullifiers,
+                    CHistoryCacheMap &historyCacheMap) {
         return false;
     }
 

--- a/src/gtest/test_validation.cpp
+++ b/src/gtest/test_validation.cpp
@@ -32,12 +32,17 @@ public:
     ValidationFakeCoinsViewDB() {}
     ValidationFakeCoinsViewDB(uint256 blockHash, uint256 txid, CTxOut txOut, int nHeight) :
         coin(std::make_pair(std::make_pair(blockHash, txid), std::make_pair(txOut, nHeight))) {}
+    ~ValidationFakeCoinsViewDB() {}
 
     bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const {
         return false;
     }
 
     bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const {
+        return false;
+    }
+
+    bool GetOrchardAnchorAt(const uint256 &rt, OrchardMerkleFrontier &tree) const {
         return false;
     }
 
@@ -80,14 +85,30 @@ public:
         return a;
     }
 
+    HistoryIndex GetHistoryLength(uint32_t branchId) const {
+        return 0;
+    }
+
+    HistoryNode GetHistoryAt(uint32_t branchId, HistoryIndex index) const {
+        return HistoryNode();
+    }
+
+    uint256 GetHistoryRoot(uint32_t epochId) const {
+        return uint256();
+    }
+
     bool BatchWrite(CCoinsMap &mapCoins,
                     const uint256 &hashBlock,
                     const uint256 &hashSproutAnchor,
                     const uint256 &hashSaplingAnchor,
+                    const uint256 &hashOrchardAnchor,
                     CAnchorsSproutMap &mapSproutAnchors,
                     CAnchorsSaplingMap &mapSaplingAnchors,
+                    CAnchorsOrchardMap &mapOrchardAnchors,
                     CNullifiersMap &mapSproutNullifiers,
-                    CNullifiersMap saplingNullifiersMap) {
+                    CNullifiersMap &mapSaplingNullifiers,
+                    CNullifiersMap &mapOrchardNullifiers,
+                    CHistoryCacheMap &historyCacheMap) {
         return false;
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -154,6 +154,8 @@ class CCoinsViewErrorCatcher : public CCoinsViewBacked
 {
 public:
     CCoinsViewErrorCatcher(CCoinsView* view) : CCoinsViewBacked(view) {}
+    ~CCoinsViewErrorCatcher() {}
+
     bool GetCoins(const uint256 &txid, CCoins &coins) const {
         try {
             return CCoinsViewBacked::GetCoins(txid, coins);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1843,7 +1843,7 @@ bool AcceptToMemoryPool(
     }
 
     {
-        CCoinsView dummy;
+        CCoinsViewDummy dummy;
         CCoinsViewCache view(&dummy);
 
         CAmount nValueIn = 0;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -511,7 +511,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
     {
         LOCK2(cs_main, mempool.cs);
 
-        CCoinsView viewDummy;
+        CCoinsViewDummy viewDummy;
         CCoinsViewCache view(&viewDummy);
 
         CCoinsViewCache& viewChain = *pcoinsTip;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1036,7 +1036,7 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
     CMutableTransaction mergedTx(txVariants[0]);
 
     // Fetch previous transactions (inputs):
-    CCoinsView viewDummy;
+    CCoinsViewDummy viewDummy;
     CCoinsViewCache view(&viewDummy);
     {
         LOCK(mempool.cs);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -45,6 +45,7 @@ public:
         hashBestSaplingAnchor_ = SaplingMerkleTree::empty_root();
         hashBestOrchardAnchor_ = OrchardMerkleFrontier::empty_root();
     }
+    ~CCoinsViewTest() {}
 
     bool GetSproutAnchorAt(const uint256& rt, SproutMerkleTree &tree) const {
         if (rt == SproutMerkleTree::empty_root()) {
@@ -192,6 +193,10 @@ public:
         }
     }
 
+    HistoryIndex GetHistoryLength(uint32_t epochId) const { return 0; }
+    HistoryNode GetHistoryAt(uint32_t epochId, HistoryIndex index) const { return HistoryNode(); }
+    uint256 GetHistoryRoot(uint32_t epochId) const { return uint256(); }
+
     bool BatchWrite(CCoinsMap& mapCoins,
                     const uint256& hashBlock,
                     const uint256& hashSproutAnchor,
@@ -243,6 +248,7 @@ class CCoinsViewCacheTest : public CCoinsViewCache
 {
 public:
     CCoinsViewCacheTest(CCoinsView* base) : CCoinsViewCache(base) {}
+    ~CCoinsViewCacheTest() {}
 
     void SelfTest() const
     {
@@ -279,7 +285,7 @@ public:
         JSDescription jsd;
         jsd.nullifiers[0] = sproutNullifier;
         mutableTx.vJoinSplit.emplace_back(jsd);
-        
+
         saplingNullifier = InsecureRand256();
         SpendDescription sd;
         sd.nullifier = saplingNullifier;

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -281,7 +281,7 @@ BOOST_DATA_TEST_CASE(AreInputsStandard, boost::unit_test::data::xrange(static_ca
 {
     LOCK(cs_main);
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
-    CCoinsView coinsDummy;
+    CCoinsViewDummy coinsDummy;
     CCoinsViewCache coins(&coinsDummy);
     CBasicKeyStore keystore;
     CKey key[6];

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -551,7 +551,7 @@ BOOST_DATA_TEST_CASE(test_Get, boost::unit_test::data::xrange(static_cast<int>(C
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 
     CBasicKeyStore keystore;
-    CCoinsView coinsDummy;
+    CCoinsViewDummy coinsDummy;
     CCoinsViewCache coins(&coinsDummy);
     std::vector<CMutableTransaction> dummyTransactions = SetupDummyInputs(keystore, coins);
 
@@ -675,7 +675,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     LOCK(cs_main);
     auto chainparams = Params();
     CBasicKeyStore keystore;
-    CCoinsView coinsDummy;
+    CCoinsViewDummy coinsDummy;
     CCoinsViewCache coins(&coinsDummy);
     std::vector<CMutableTransaction> dummyTransactions = SetupDummyInputs(keystore, coins);
 
@@ -769,7 +769,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandardV2)
     LOCK(cs_main);
     auto chainparams = Params();
     CBasicKeyStore keystore;
-    CCoinsView coinsDummy;
+    CCoinsViewDummy coinsDummy;
     CCoinsViewCache coins(&coinsDummy);
     std::vector<CMutableTransaction> dummyTransactions = SetupDummyInputs(keystore, coins);
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -81,6 +81,7 @@ protected:
     CCoinsViewDB(std::string dbName, size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 public:
     CCoinsViewDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    ~CCoinsViewDB() {}
 
     bool GetSproutAnchorAt(const uint256 &rt, SproutMerkleTree &tree) const;
     bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -662,6 +662,8 @@ protected:
 
 public:
     CCoinsViewMemPool(CCoinsView *baseIn, CTxMemPool &mempoolIn);
+    ~CCoinsViewMemPool() {}
+
     bool GetNullifier(const uint256 &txid, ShieldedType type) const;
     bool GetCoins(const uint256 &txid, CCoins &coins) const;
     bool HaveCoins(const uint256 &txid) const;

--- a/src/util/test.h
+++ b/src/util/test.h
@@ -33,6 +33,38 @@ public:
         // Always return false so we treat every nullifier as being unspent.
         return false;
     }
+
+    bool GetCoins(const uint256 &txid, CCoins &coins) const { return false; }
+    bool HaveCoins(const uint256 &txid) const { return false; }
+    uint256 GetBestBlock() const {
+        throw std::runtime_error("`GetBestBlock` unimplemented for mock AssumeShieldedInputsExistAndAreSpendable");
+    }
+    uint256 GetBestAnchor(ShieldedType type) const {
+        throw std::runtime_error("`GetBestAnchor` unimplemented for mock AssumeShieldedInputsExistAndAreSpendable");
+    }
+    HistoryIndex GetHistoryLength(uint32_t epochId) const { return 0; }
+    HistoryNode GetHistoryAt(uint32_t epochId, HistoryIndex index) const {
+        throw std::runtime_error("`GetHistoryAt` unimplemented for mock AssumeShieldedInputsExistAndAreSpendable");
+    }
+    uint256 GetHistoryRoot(uint32_t epochId) const {
+        throw std::runtime_error("`GetHistoryRoot` unimplemented for mock AssumeShieldedInputsExistAndAreSpendable");
+    }
+
+    bool BatchWrite(CCoinsMap &mapCoins,
+                    const uint256 &hashBlock,
+                    const uint256 &hashSproutAnchor,
+                    const uint256 &hashSaplingAnchor,
+                    const uint256 &hashOrchardAnchor,
+                    CAnchorsSproutMap &mapSproutAnchors,
+                    CAnchorsSaplingMap &mapSaplingAnchors,
+                    CAnchorsOrchardMap &mapOrchardAnchors,
+                    CNullifiersMap &mapSproutNullifiers,
+                    CNullifiersMap &mapSaplingNullifiers,
+                    CNullifiersMap &mapOrchardNullifiers,
+                    CHistoryCacheMap &historyCacheMap) {
+        return false;
+    }
+    bool GetStats(CCoinsStats &stats) const { return false; }
 };
 
 // Sprout

--- a/src/wallet/gtest/test_orchard_wallet.cpp
+++ b/src/wallet/gtest/test_orchard_wallet.cpp
@@ -9,8 +9,6 @@
 #include "wallet/orchard.h"
 #include "zcash/Address.hpp"
 
-#include "gtest/test_transaction_builder.h"
-
 #include <optional>
 
 using namespace libzcash;
@@ -30,9 +28,7 @@ CTransaction FakeOrchardTx(const OrchardSpendingKey& sk, libzcash::diversifier_i
     auto fvk = sk.ToFullViewingKey();
     auto ivk = fvk.ToIncomingViewingKey();
     auto recipient = ivk.Address(j);
-
-    TransactionBuilderCoinsViewDB fakeDB;
-    auto orchardAnchor = fakeDB.GetBestAnchor(ShieldedType::ORCHARD);
+    auto orchardAnchor = uint256();
 
     // Create a shielding transaction from transparent to Orchard
     // 0.0005 t-ZEC in, 0.0004 z-ZEC out, 0.0001 fee

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -458,6 +458,7 @@ public:
         OrchardMerkleFrontier emptyOrchardTree;
         orchardTrees.push_back(emptyOrchardTree);
     }
+    ~FakeCoinsViewDB() {}
 
     void SetSaplingTrees(std::vector<std::string> trees) {
         saplingTrees.clear();
@@ -545,6 +546,10 @@ public:
                 throw new std::runtime_error("Unknown shielded type");
         }
     }
+
+    HistoryIndex GetHistoryLength(uint32_t epochId) const { return 0; }
+    HistoryNode GetHistoryAt(uint32_t epochId, HistoryIndex index) const { return HistoryNode(); }
+    uint256 GetHistoryRoot(uint32_t epochId) const { return uint256(); }
 
     bool BatchWrite(CCoinsMap &mapCoins,
                     const uint256 &hashBlock,


### PR DESCRIPTION
This helped catch a number of places where the tests were relying upon default implementations of the CCoinsView superclass methods. It's a general code hygiene and safety improvement.