### PR TITLE
Update Orchard commitment tree hashes to use total MerkleCRH^Orchard.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.0.0"
-source = "git+https://github.com/zcash/orchard.git?rev=21b77d6ec56fc7e37aab9da68e88bc5dd754fe10#21b77d6ec56fc7e37aab9da68e88bc5dd754fe10"
+source = "git+https://github.com/zcash/orchard.git?rev=74df35ce890726478983fb892ff38a5e44ceb08a#74df35ce890726478983fb892ff38a5e44ceb08a"
 dependencies = [
  "aes",
  "arrayvec 0.7.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ codegen-units = 1
 ed25519-zebra = { git = "https://github.com/ZcashFoundation/ed25519-zebra.git", rev = "d3512400227a362d08367088ffaa9bd4142a69c7" }
 halo2 = { git = "https://github.com/zcash/halo2.git", rev = "d04b532368d05b505e622f8cac4c0693574fbd93" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "8b59049f1746827ffa3763efa8af948f680491d0" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "21b77d6ec56fc7e37aab9da68e88bc5dd754fe10" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "74df35ce890726478983fb892ff38a5e44ceb08a" }
 zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "3cab105c9c3bf4ba31f779095d939ad0c7057539" }
 zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "3cab105c9c3bf4ba31f779095d939ad0c7057539" }
 zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "3cab105c9c3bf4ba31f779095d939ad0c7057539" }

--- a/src/rust/include/rust/orchard/incremental_sinsemilla_tree.h
+++ b/src/rust/include/rust/orchard/incremental_sinsemilla_tree.h
@@ -61,13 +61,8 @@ bool orchard_merkle_frontier_append_bundle(
         OrchardMerkleFrontierPtr* tree_ptr,
         const OrchardBundlePtr* bundle);
 
-// Compute the root of the provided orchard Merkle frontier
-//
-// If the bottom value is not derived by the Sinsemilla hash, `digest_ret` will
-// point to the resulting digest and this procedure returns `true`.
-// If the Sinsemilla hash returns the bottom value, `digest_ret` will be
-// unaltered and this procedure returns `false`.
-bool orchard_merkle_frontier_root(
+// Computes the root of the provided orchard Merkle frontier
+void orchard_merkle_frontier_root(
         const OrchardMerkleFrontierPtr* tree_ptr,
         unsigned char* digest_ret);
 
@@ -138,18 +133,13 @@ void incremental_sinsemilla_tree_checkpoint(
 bool incremental_sinsemilla_tree_rewind(
         IncrementalSinsemillaTreePtr* tree_ptr);
 
-// Compute the root of the provided incremental Sinsemilla tree.
-//
-// If the bottom value is not derived by the Sinsemilla hash, `digest_ret` will
-// point to the resulting digest and this procedure returns `true`.
-// If the Sinsemilla hash returns the bottom value, `digest_ret` will be
-// unaltered and this procedure returns `false`.
-bool incremental_sinsemilla_tree_root(
+// Computes the root of the provided incremental Sinsemilla tree.
+void incremental_sinsemilla_tree_root(
         const IncrementalSinsemillaTreePtr* tree_ptr,
         unsigned char* digest_ret);
 
-// Return the empty leaf value for the incremental Sinsemilla tree.
-bool incremental_sinsemilla_tree_empty_root(
+// Computes the empty leaf value for the incremental Sinsemilla tree.
+void incremental_sinsemilla_tree_empty_root(
         unsigned char* digest_ret);
 
 #ifdef __cplusplus

--- a/src/rust/src/orchard_ffi/incremental_sinsemilla_tree_ffi.rs
+++ b/src/rust/src/orchard_ffi/incremental_sinsemilla_tree_ffi.rs
@@ -6,7 +6,7 @@ use incrementalmerkletree::{
 use std::mem::size_of_val;
 use std::ptr;
 
-use orchard::{bundle::Authorized, tree::OrchardIncrementalTreeDigest};
+use orchard::{bundle::Authorized, tree::MerkleCrhOrchardOutput};
 
 use zcash_primitives::transaction::components::Amount;
 
@@ -21,15 +21,15 @@ pub const MAX_CHECKPOINTS: usize = 100;
 
 #[no_mangle]
 pub extern "C" fn orchard_merkle_frontier_empty(
-) -> *mut bridgetree::Frontier<OrchardIncrementalTreeDigest, MERKLE_DEPTH> {
-    let empty_tree = bridgetree::Frontier::<OrchardIncrementalTreeDigest, MERKLE_DEPTH>::new();
+) -> *mut bridgetree::Frontier<MerkleCrhOrchardOutput, MERKLE_DEPTH> {
+    let empty_tree = bridgetree::Frontier::<MerkleCrhOrchardOutput, MERKLE_DEPTH>::new();
     Box::into_raw(Box::new(empty_tree))
 }
 
 #[no_mangle]
 pub extern "C" fn orchard_merkle_frontier_clone(
-    tree: *const bridgetree::Frontier<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
-) -> *mut bridgetree::Frontier<OrchardIncrementalTreeDigest, MERKLE_DEPTH> {
+    tree: *const bridgetree::Frontier<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
+) -> *mut bridgetree::Frontier<MerkleCrhOrchardOutput, MERKLE_DEPTH> {
     unsafe { tree.as_ref() }
         .map(|tree| Box::into_raw(Box::new(tree.clone())))
         .unwrap_or(std::ptr::null_mut())
@@ -37,7 +37,7 @@ pub extern "C" fn orchard_merkle_frontier_clone(
 
 #[no_mangle]
 pub extern "C" fn orchard_merkle_frontier_free(
-    tree: *mut bridgetree::Frontier<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *mut bridgetree::Frontier<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
 ) {
     if !tree.is_null() {
         drop(unsafe { Box::from_raw(tree) });
@@ -48,7 +48,7 @@ pub extern "C" fn orchard_merkle_frontier_free(
 pub extern "C" fn orchard_merkle_frontier_parse(
     stream: Option<StreamObj>,
     read_cb: Option<ReadCb>,
-) -> *mut bridgetree::Frontier<OrchardIncrementalTreeDigest, MERKLE_DEPTH> {
+) -> *mut bridgetree::Frontier<MerkleCrhOrchardOutput, MERKLE_DEPTH> {
     let reader = CppStreamReader::from_raw_parts(stream, read_cb.unwrap());
 
     match bincode::deserialize_from(reader) {
@@ -62,7 +62,7 @@ pub extern "C" fn orchard_merkle_frontier_parse(
 
 #[no_mangle]
 pub extern "C" fn orchard_merkle_frontier_serialize(
-    tree: *const bridgetree::Frontier<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *const bridgetree::Frontier<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
     stream: Option<StreamObj>,
     write_cb: Option<WriteCb>,
 ) -> bool {
@@ -83,7 +83,7 @@ pub extern "C" fn orchard_merkle_frontier_serialize(
 
 #[no_mangle]
 pub extern "C" fn orchard_merkle_frontier_append_bundle(
-    tree: *mut bridgetree::Frontier<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *mut bridgetree::Frontier<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
     bundle: *const orchard::Bundle<Authorized, Amount>,
 ) -> bool {
     let tree = unsafe {
@@ -92,7 +92,7 @@ pub extern "C" fn orchard_merkle_frontier_append_bundle(
     };
     if let Some(bundle) = unsafe { bundle.as_ref() } {
         for action in bundle.actions().iter() {
-            if !tree.append(&OrchardIncrementalTreeDigest::from_cmx(action.cmx())) {
+            if !tree.append(&MerkleCrhOrchardOutput::from_cmx(action.cmx())) {
                 error!("Orchard note commitment tree is full.");
                 return false;
             }
@@ -104,9 +104,9 @@ pub extern "C" fn orchard_merkle_frontier_append_bundle(
 
 #[no_mangle]
 pub extern "C" fn orchard_merkle_frontier_root(
-    tree: *const bridgetree::Frontier<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *const bridgetree::Frontier<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
     root_ret: *mut [u8; 32],
-) -> bool {
+) {
     let tree = unsafe {
         tree.as_ref()
             .expect("Orchard note commitment tree pointer may not be null.")
@@ -118,17 +118,12 @@ pub extern "C" fn orchard_merkle_frontier_root(
             .expect("Cannot return to the null pointer.")
     };
 
-    if let Some(root) = tree.root().to_bytes() {
-        root_ret.copy_from_slice(&root);
-        true
-    } else {
-        false
-    }
+    root_ret.copy_from_slice(&tree.root().to_bytes());
 }
 
 #[no_mangle]
 pub extern "C" fn orchard_merkle_frontier_num_leaves(
-    tree: *const bridgetree::Frontier<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *const bridgetree::Frontier<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
 ) -> usize {
     let tree = unsafe {
         tree.as_ref()
@@ -140,7 +135,7 @@ pub extern "C" fn orchard_merkle_frontier_num_leaves(
 
 #[no_mangle]
 pub extern "C" fn orchard_merkle_frontier_dynamic_mem_usage(
-    tree: *const bridgetree::Frontier<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *const bridgetree::Frontier<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
 ) -> usize {
     let tree = unsafe {
         tree.as_ref()
@@ -157,15 +152,15 @@ pub extern "C" fn orchard_merkle_frontier_dynamic_mem_usage(
 
 #[no_mangle]
 pub extern "C" fn incremental_sinsemilla_tree_empty(
-) -> *mut BridgeTree<OrchardIncrementalTreeDigest, MERKLE_DEPTH> {
-    let empty_tree = BridgeTree::<OrchardIncrementalTreeDigest, MERKLE_DEPTH>::new(MAX_CHECKPOINTS);
+) -> *mut BridgeTree<MerkleCrhOrchardOutput, MERKLE_DEPTH> {
+    let empty_tree = BridgeTree::<MerkleCrhOrchardOutput, MERKLE_DEPTH>::new(MAX_CHECKPOINTS);
     Box::into_raw(Box::new(empty_tree))
 }
 
 #[no_mangle]
 pub extern "C" fn incremental_sinsemilla_tree_clone(
-    tree: *const BridgeTree<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
-) -> *mut BridgeTree<OrchardIncrementalTreeDigest, MERKLE_DEPTH> {
+    tree: *const BridgeTree<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
+) -> *mut BridgeTree<MerkleCrhOrchardOutput, MERKLE_DEPTH> {
     unsafe { tree.as_ref() }
         .map(|tree| Box::into_raw(Box::new(tree.clone())))
         .unwrap_or(std::ptr::null_mut())
@@ -173,7 +168,7 @@ pub extern "C" fn incremental_sinsemilla_tree_clone(
 
 #[no_mangle]
 pub extern "C" fn incremental_sinsemilla_tree_free(
-    tree: *mut BridgeTree<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *mut BridgeTree<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
 ) {
     if !tree.is_null() {
         drop(unsafe { Box::from_raw(tree) });
@@ -184,7 +179,7 @@ pub extern "C" fn incremental_sinsemilla_tree_free(
 pub extern "C" fn incremental_sinsemilla_tree_parse(
     stream: Option<StreamObj>,
     read_cb: Option<ReadCb>,
-) -> *mut BridgeTree<OrchardIncrementalTreeDigest, MERKLE_DEPTH> {
+) -> *mut BridgeTree<MerkleCrhOrchardOutput, MERKLE_DEPTH> {
     let reader = CppStreamReader::from_raw_parts(stream, read_cb.unwrap());
 
     match bincode::deserialize_from(reader) {
@@ -198,7 +193,7 @@ pub extern "C" fn incremental_sinsemilla_tree_parse(
 
 #[no_mangle]
 pub extern "C" fn incremental_sinsemilla_tree_serialize(
-    tree: *const BridgeTree<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *const BridgeTree<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
     stream: Option<StreamObj>,
     write_cb: Option<WriteCb>,
 ) -> bool {
@@ -219,7 +214,7 @@ pub extern "C" fn incremental_sinsemilla_tree_serialize(
 
 #[no_mangle]
 pub extern "C" fn incremental_sinsemilla_tree_append_bundle(
-    tree: *mut BridgeTree<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *mut BridgeTree<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
     bundle: *const orchard::Bundle<Authorized, Amount>,
 ) -> bool {
     let tree = unsafe {
@@ -228,7 +223,7 @@ pub extern "C" fn incremental_sinsemilla_tree_append_bundle(
     };
     if let Some(bundle) = unsafe { bundle.as_ref() } {
         for action in bundle.actions().iter() {
-            if !tree.append(&OrchardIncrementalTreeDigest::from_cmx(action.cmx())) {
+            if !tree.append(&MerkleCrhOrchardOutput::from_cmx(action.cmx())) {
                 error!("Orchard note commitment tree is full.");
                 return false;
             }
@@ -240,7 +235,7 @@ pub extern "C" fn incremental_sinsemilla_tree_append_bundle(
 
 #[no_mangle]
 pub extern "C" fn incremental_sinsemilla_tree_checkpoint(
-    tree: *mut BridgeTree<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *mut BridgeTree<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
 ) {
     let tree = unsafe {
         tree.as_mut()
@@ -252,7 +247,7 @@ pub extern "C" fn incremental_sinsemilla_tree_checkpoint(
 
 #[no_mangle]
 pub extern "C" fn incremental_sinsemilla_tree_rewind(
-    tree: *mut BridgeTree<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *mut BridgeTree<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
 ) -> bool {
     let tree = unsafe {
         tree.as_mut()
@@ -264,9 +259,9 @@ pub extern "C" fn incremental_sinsemilla_tree_rewind(
 
 #[no_mangle]
 pub extern "C" fn incremental_sinsemilla_tree_root(
-    tree: *const BridgeTree<OrchardIncrementalTreeDigest, MERKLE_DEPTH>,
+    tree: *const BridgeTree<MerkleCrhOrchardOutput, MERKLE_DEPTH>,
     root_ret: *mut [u8; 32],
-) -> bool {
+) {
     let tree = unsafe {
         tree.as_ref()
             .expect("Orchard note commitment tree pointer may not be null.")
@@ -278,12 +273,7 @@ pub extern "C" fn incremental_sinsemilla_tree_root(
             .expect("Cannot return to the null pointer.")
     };
 
-    if let Some(root) = tree.root().to_bytes() {
-        root_ret.copy_from_slice(&root);
-        true
-    } else {
-        false
-    }
+    root_ret.copy_from_slice(&tree.root().to_bytes());
 }
 
 #[no_mangle]
@@ -296,9 +286,7 @@ pub extern "C" fn incremental_sinsemilla_tree_empty_root(root_ret: *mut [u8; 32]
 
     let altitude = Altitude::from(MERKLE_DEPTH);
 
-    let digest = OrchardIncrementalTreeDigest::empty_root(altitude)
-        .to_bytes()
-        .unwrap();
+    let digest = MerkleCrhOrchardOutput::empty_root(altitude).to_bytes();
 
     root_ret.copy_from_slice(&digest);
 }

--- a/src/rust/src/orchard_ffi/incremental_sinsemilla_tree_ffi.rs
+++ b/src/rust/src/orchard_ffi/incremental_sinsemilla_tree_ffi.rs
@@ -118,7 +118,7 @@ pub extern "C" fn orchard_merkle_frontier_root(
             .expect("Cannot return to the null pointer.")
     };
 
-    root_ret.copy_from_slice(&tree.root().to_bytes());
+    *root_ret = tree.root().to_bytes();
 }
 
 #[no_mangle]
@@ -273,7 +273,7 @@ pub extern "C" fn incremental_sinsemilla_tree_root(
             .expect("Cannot return to the null pointer.")
     };
 
-    root_ret.copy_from_slice(&tree.root().to_bytes());
+    *root_ret = tree.root().to_bytes();
 }
 
 #[no_mangle]
@@ -288,5 +288,5 @@ pub extern "C" fn incremental_sinsemilla_tree_empty_root(root_ret: *mut [u8; 32]
 
     let digest = MerkleCrhOrchardOutput::empty_root(altitude).to_bytes();
 
-    root_ret.copy_from_slice(&digest);
+    *root_ret = digest;
 }


### PR DESCRIPTION
See zcash/zips#530