### PR TITLE
Lock the wallet in SetBestChainINTERNAL

### DIFF
--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -189,6 +189,10 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
                 SyncWithWallets(tx, NULL, pindexLastTip->nHeight);
             }
             // Update cached incremental witnesses
+            // This will take the cs_main lock in order to obtain the CBlockLocator
+            // used by `SetBestChain`, but as that write only occurrs once every
+            // WRITE_WITNESS_INTERVAL * 1000000 microseconds this should not be
+            // exploitable as a timing channel.
             GetMainSignals().ChainTip(pindexLastTip, &block, std::nullopt);
 
             // On to the next block!
@@ -220,6 +224,10 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
                 SyncWithWallets(tx, &block, blockData.pindex->nHeight);
             }
             // Update cached incremental witnesses
+            // This will take the cs_main lock in order to obtain the CBlockLocator
+            // used by `SetBestChain`, but as that write only occurrs once every
+            // WRITE_WITNESS_INTERVAL * 1000000 microseconds this should not be
+            // exploitable as a timing channel.
             GetMainSignals().ChainTip(blockData.pindex, &block, blockData.oldTrees);
 
             // This block is done!

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -190,7 +190,7 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
             }
             // Update cached incremental witnesses
             // This will take the cs_main lock in order to obtain the CBlockLocator
-            // used by `SetBestChain`, but as that write only occurrs once every
+            // used by `SetBestChain`, but as that write only occurs once every
             // WRITE_WITNESS_INTERVAL * 1000000 microseconds this should not be
             // exploitable as a timing channel.
             GetMainSignals().ChainTip(pindexLastTip, &block, std::nullopt);
@@ -225,7 +225,7 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
             }
             // Update cached incremental witnesses
             // This will take the cs_main lock in order to obtain the CBlockLocator
-            // used by `SetBestChain`, but as that write only occurrs once every
+            // used by `SetBestChain`, but as that write only occurs once every
             // WRITE_WITNESS_INTERVAL * 1000000 microseconds this should not be
             // exploitable as a timing channel.
             GetMainSignals().ChainTip(blockData.pindex, &block, blockData.oldTrees);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -759,6 +759,7 @@ protected:
             return;
         }
         try {
+            LOCK(cs_wallet);
             for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
                 auto wtx = wtxItem.second;
                 // We skip transactions for which mapSproutNoteData and mapSaplingNoteData


### PR DESCRIPTION
This mitigates a potential race condition between mutation of
`mapWallet` and writes to the wallet database that can result
in the state of the databse becoming inconsistent with the in-memory
set of transactions.

Reported via https://github.com/zcash/zcash/issues/4970#issuecomment-904475385

Thanks to @miodragpop for the report.