### PR TITLE
Add network information to persisted wallet state.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1077,7 +1077,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
 #ifdef ENABLE_WALLET
-    if (!CWallet::ParameterInteraction())
+    if (!CWallet::ParameterInteraction(chainparams))
         return false;
 #endif // ENABLE_WALLET
 
@@ -1633,7 +1633,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         pwalletMain = NULL;
         LogPrintf("Wallet disabled!\n");
     } else {
-        CWallet::InitLoadWallet(clearWitnessCaches);
+        CWallet::InitLoadWallet(chainparams, clearWitnessCaches);
         if (!pwalletMain)
             return false;
     }

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -41,7 +41,7 @@ template void CWallet::SetBestChainINTERNAL<MockWalletDB>(
 
 class TestWallet : public CWallet {
 public:
-    TestWallet() : CWallet() { }
+    TestWallet(const CChainParams& params) : CWallet(params) { }
 
     bool EncryptKeys(CKeyingMaterial& vMasterKeyIn) {
         return CCryptoKeyStore::EncryptKeys(vMasterKeyIn);
@@ -154,7 +154,7 @@ TEST(WalletTests, SproutNoteDataSerialisation) {
 TEST(WalletTests, FindUnspentSproutNotes) {
     auto consensusParams = RegtestActivateSapling();
 
-    CWallet wallet;
+    CWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
     auto sk = libzcash::SproutSpendingKey::random();
     wallet.AddSproutSpendingKey(sk);
@@ -355,7 +355,7 @@ TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
     for (int ver = 0; ver < zip_212_enabled.size(); ver++) {
         auto consensusParams = (*activations[ver])();
 
-        TestWallet wallet;
+        TestWallet wallet(Params());
         LOCK(wallet.cs_wallet);
 
         auto sk = GetTestMasterSaplingSpendingKey();
@@ -437,7 +437,7 @@ TEST(WalletTests, SetInvalidSaplingNoteDataInCWalletTx) {
 }
 
 TEST(WalletTests, CheckSproutNoteCommitmentAgainstNotePlaintext) {
-    CWallet wallet;
+    CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -461,7 +461,7 @@ TEST(WalletTests, CheckSproutNoteCommitmentAgainstNotePlaintext) {
 }
 
 TEST(WalletTests, GetSproutNoteNullifier) {
-    CWallet wallet;
+    CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -497,7 +497,7 @@ TEST(WalletTests, GetSproutNoteNullifier) {
 TEST(WalletTests, FindMySaplingNotes) {
     auto consensusParams = RegtestActivateSapling();
 
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     // Generate dummy Sapling address
@@ -531,7 +531,7 @@ TEST(WalletTests, FindMySaplingNotes) {
 }
 
 TEST(WalletTests, FindMySproutNotes) {
-    CWallet wallet;
+    CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -557,7 +557,7 @@ TEST(WalletTests, FindMySproutNotes) {
 }
 
 TEST(WalletTests, FindMySproutNotesInEncryptedWallet) {
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
     uint256 r {GetRandHash()};
     CKeyingMaterial vMasterKey (r.begin(), r.end());
@@ -588,7 +588,7 @@ TEST(WalletTests, FindMySproutNotesInEncryptedWallet) {
 }
 
 TEST(WalletTests, GetConflictedSproutNotes) {
-    CWallet wallet;
+    CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -630,7 +630,7 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
     for (int ver = 0; ver < zip_212_enabled.size(); ver++) {
         auto consensusParams = (*activations[ver])();
 
-        TestWallet wallet;
+        TestWallet wallet(Params());
         LOCK2(cs_main, wallet.cs_wallet);
 
         // Generate Sapling address
@@ -748,7 +748,7 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
 }
 
 TEST(WalletTests, SproutNullifierIsSpent) {
-    CWallet wallet;
+    CWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -791,7 +791,7 @@ TEST(WalletTests, SproutNullifierIsSpent) {
 TEST(WalletTests, SaplingNullifierIsSpent) {
     auto consensusParams = RegtestActivateSapling();
 
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
 
     // Generate dummy Sapling address
@@ -847,7 +847,7 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
 }
 
 TEST(WalletTests, NavigateFromSproutNullifierToNote) {
-    CWallet wallet;
+    CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -876,7 +876,7 @@ TEST(WalletTests, NavigateFromSproutNullifierToNote) {
 TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     auto consensusParams = RegtestActivateSapling();
 
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
 
     // Generate dummy Sapling address
@@ -967,7 +967,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
 }
 
 TEST(WalletTests, SpentSproutNoteIsFromMe) {
-    CWallet wallet;
+    CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -1006,7 +1006,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     for (int ver = 0; ver < zip_212_enabled.size(); ver++) {
         auto consensusParams = (*activations[ver])();
 
-        TestWallet wallet;
+        TestWallet wallet(Params());
         LOCK2(cs_main, wallet.cs_wallet);
 
         // Generate Sapling address
@@ -1147,7 +1147,8 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
 }
 
 TEST(WalletTests, CachedWitnessesEmptyChain) {
-    TestWallet wallet;
+    SelectParams(CBaseChainParams::REGTEST);
+    TestWallet wallet(Params());
 
     auto sk = libzcash::SproutSpendingKey::random();
     wallet.AddSproutSpendingKey(sk);
@@ -1206,7 +1207,7 @@ TEST(WalletTests, CachedWitnessesEmptyChain) {
 }
 
 TEST(WalletTests, CachedWitnessesChainTip) {
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
     std::pair<uint256, uint256> anchors1;
     CBlock block1;
@@ -1309,7 +1310,7 @@ TEST(WalletTests, CachedWitnessesChainTip) {
 }
 
 TEST(WalletTests, CachedWitnessesDecrementFirst) {
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
     SproutMerkleTree sproutTree;
     SaplingMerkleTree saplingTree;
@@ -1390,7 +1391,7 @@ TEST(WalletTests, CachedWitnessesDecrementFirst) {
 }
 
 TEST(WalletTests, CachedWitnessesCleanIndex) {
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
     std::vector<CBlock> blocks;
     std::vector<CBlockIndex> indices;
@@ -1478,7 +1479,7 @@ TEST(WalletTests, CachedWitnessesCleanIndex) {
 }
 
 TEST(WalletTests, ClearNoteWitnessCache) {
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -1545,7 +1546,7 @@ TEST(WalletTests, ClearNoteWitnessCache) {
 }
 
 TEST(WalletTests, WriteWitnessCache) {
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
     MockWalletDB walletdb;
     CBlockLocator loc;
@@ -1633,7 +1634,7 @@ TEST(WalletTests, WriteWitnessCache) {
 TEST(WalletTests, SetBestChainIgnoresTxsWithoutShieldedData) {
     SelectParams(CBaseChainParams::REGTEST);
 
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
     MockWalletDB walletdb;
     CBlockLocator loc;
@@ -1714,7 +1715,7 @@ TEST(WalletTests, SetBestChainIgnoresTxsWithoutShieldedData) {
 }
 
 TEST(WalletTests, UpdateSproutNullifierNoteMap) {
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
     uint256 r {GetRandHash()};
     CKeyingMaterial vMasterKey (r.begin(), r.end());
@@ -1750,7 +1751,7 @@ TEST(WalletTests, UpdateSproutNullifierNoteMap) {
 }
 
 TEST(WalletTests, UpdatedSproutNoteData) {
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -1800,7 +1801,7 @@ TEST(WalletTests, UpdatedSproutNoteData) {
 TEST(WalletTests, UpdatedSaplingNoteData) {
     auto consensusParams = RegtestActivateSapling();
 
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
 
     auto m = GetTestMasterSaplingSpendingKey();
@@ -1909,7 +1910,7 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
 }
 
 TEST(WalletTests, MarkAffectedSproutTransactionsDirty) {
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -1943,7 +1944,7 @@ TEST(WalletTests, MarkAffectedSproutTransactionsDirty) {
 TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     auto consensusParams = RegtestActivateSapling();
 
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
 
     // Generate Sapling address
@@ -2052,7 +2053,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
 }
 
 TEST(WalletTests, SproutNoteLocking) {
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     auto sk = libzcash::SproutSpendingKey::random();
@@ -2086,7 +2087,7 @@ TEST(WalletTests, SproutNoteLocking) {
 }
 
 TEST(WalletTests, SaplingNoteLocking) {
-    TestWallet wallet;
+    TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
     SaplingOutPoint sop1 {uint256(), 1};
     SaplingOutPoint sop2 {uint256(), 2};

--- a/src/wallet/gtest/test_wallet_zkeys.cpp
+++ b/src/wallet/gtest/test_wallet_zkeys.cpp
@@ -20,7 +20,7 @@ TEST(WalletZkeysTest, StoreAndLoadSaplingZkeys) {
 
     SelectParams(CBaseChainParams::MAIN);
 
-    CWallet wallet;
+    CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     // wallet should be empty
@@ -42,10 +42,10 @@ TEST(WalletZkeysTest, StoreAndLoadSaplingZkeys) {
     // wallet should have one key
     wallet.GetSaplingPaymentAddresses(addrs);
     ASSERT_EQ(1, addrs.size());
-    
+
     // verify wallet has incoming viewing key for the address
     ASSERT_TRUE(wallet.HaveSaplingIncomingViewingKey(address));
-    
+
     // manually add new spending key to wallet
     auto m = libzcash::SaplingExtendedSpendingKey::Master(seed);
     auto sk = m.Derive(0);
@@ -115,7 +115,7 @@ TEST(WalletZkeysTest, StoreAndLoadSaplingZkeys) {
 TEST(WalletZkeysTest, StoreAndLoadZkeys) {
     SelectParams(CBaseChainParams::MAIN);
 
-    CWallet wallet;
+    CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     // wallet should be empty
@@ -173,7 +173,7 @@ TEST(WalletZkeysTest, StoreAndLoadZkeys) {
 TEST(WalletZkeysTest, StoreAndLoadViewingKeys) {
     SelectParams(CBaseChainParams::MAIN);
 
-    CWallet wallet;
+    CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
     // wallet should be empty
@@ -226,7 +226,7 @@ TEST(WalletZkeysTest, WriteZkeyDirectToDb) {
     mapArgs["-datadir"] = pathTemp.string();
 
     bool fFirstRun;
-    CWallet wallet("wallet.dat");
+    CWallet wallet(Params(), "wallet.dat");
     LOCK(wallet.cs_wallet);
     ASSERT_EQ(DB_LOAD_OK, wallet.LoadWallet(fFirstRun));
 
@@ -299,7 +299,7 @@ TEST(WalletZkeysTest, WriteViewingKeyDirectToDB) {
     mapArgs["-datadir"] = pathTemp.string();
 
     bool fFirstRun;
-    CWallet wallet("wallet-vkey.dat");
+    CWallet wallet(Params(), "wallet-vkey.dat");
     LOCK(wallet.cs_wallet);
     ASSERT_EQ(DB_LOAD_OK, wallet.LoadWallet(fFirstRun));
 
@@ -346,7 +346,7 @@ TEST(WalletZkeysTest, WriteCryptedzkeyDirectToDb) {
     mapArgs["-datadir"] = pathTemp.string();
 
     bool fFirstRun;
-    CWallet wallet("wallet_crypted.dat");
+    CWallet wallet(Params(), "wallet_crypted.dat");
     LOCK(wallet.cs_wallet);
     ASSERT_EQ(DB_LOAD_OK, wallet.LoadWallet(fFirstRun));
 
@@ -370,25 +370,25 @@ TEST(WalletZkeysTest, WriteCryptedzkeyDirectToDb) {
     strWalletPass.reserve(100);
     strWalletPass = "hello";
     ASSERT_TRUE(wallet.EncryptWallet(strWalletPass));
-    
+
     // adding a new key will fail as the wallet is locked
     EXPECT_ANY_THROW(wallet.GenerateNewSproutZKey());
-    
+
     // unlock wallet and then add
     wallet.Unlock(strWalletPass);
     auto paymentAddress2 = wallet.GenerateNewSproutZKey();
 
     // Create a new wallet from the existing wallet path
-    CWallet wallet2("wallet_crypted.dat");
+    CWallet wallet2(Params(), "wallet_crypted.dat");
     ASSERT_EQ(DB_LOAD_OK, wallet2.LoadWallet(fFirstRun));
 
     // Confirm it's not the same as the other wallet
     ASSERT_TRUE(&wallet != &wallet2);
-    
+
     // wallet should have two keys
     wallet2.GetSproutPaymentAddresses(addrs);
     ASSERT_EQ(2, addrs.size());
-    
+
     // check we have entries for our payment addresses
     ASSERT_TRUE(addrs.count(paymentAddress));
     ASSERT_TRUE(addrs.count(paymentAddress2));
@@ -397,13 +397,13 @@ TEST(WalletZkeysTest, WriteCryptedzkeyDirectToDb) {
     libzcash::SproutSpendingKey keyOut;
     wallet2.GetSproutSpendingKey(paymentAddress, keyOut);
     ASSERT_FALSE(paymentAddress == keyOut.address());
-    
+
     // unlock wallet to get spending keys and verify payment addresses
     wallet2.Unlock(strWalletPass);
 
     wallet2.GetSproutSpendingKey(paymentAddress, keyOut);
     ASSERT_EQ(paymentAddress, keyOut.address());
-    
+
     wallet2.GetSproutSpendingKey(paymentAddress2, keyOut);
     ASSERT_EQ(paymentAddress2, keyOut.address());
 }
@@ -421,7 +421,7 @@ TEST(wallet_zkeys_tests, WriteCryptedSaplingZkeyDirectToDb) {
     mapArgs["-datadir"] = pathTemp.string();
 
     bool fFirstRun;
-    CWallet wallet("wallet_crypted_sapling.dat");
+    CWallet wallet(Params(), "wallet_crypted_sapling.dat");
     LOCK(wallet.cs_wallet);
     ASSERT_EQ(DB_LOAD_OK, wallet.LoadWallet(fFirstRun));
 
@@ -472,7 +472,7 @@ TEST(wallet_zkeys_tests, WriteCryptedSaplingZkeyDirectToDb) {
     wallet.Flush();
 
     // Create a new wallet from the existing wallet path
-    CWallet wallet2("wallet_crypted_sapling.dat");
+    CWallet wallet2(Params(), "wallet_crypted_sapling.dat");
     ASSERT_EQ(DB_LOAD_OK, wallet2.LoadWallet(fFirstRun));
 
     // Confirm it's not the same as the other wallet

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -9,7 +9,7 @@ WalletTestingSetup::WalletTestingSetup(): TestingSetup()
     bitdb.MakeMock();
 
     bool fFirstRun;
-    pwalletMain = new CWallet("wallet_test.dat");
+    pwalletMain = new CWallet(Params(), "wallet_test.dat");
     pwalletMain->LoadWallet(fFirstRun);
     RegisterValidationInterface(pwalletMain);
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -26,7 +26,6 @@ typedef set<pair<const CWalletTx*,unsigned int> > CoinSet;
 
 BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
 
-static CWallet wallet;
 static vector<COutput> vCoins;
 
 static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0)
@@ -41,7 +40,7 @@ static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = fa
         // so stop vin being empty, and cache a non-zero Debit to fake out IsFromMe()
         tx.vin.resize(1);
     }
-    CWalletTx* wtx = new CWalletTx(&wallet, tx);
+    CWalletTx* wtx = new CWalletTx(pwalletMain, tx);
     if (fIsFromMe)
     {
         wtx->fDebitCached = true;
@@ -69,32 +68,30 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
     CoinSet setCoinsRet, setCoinsRet2;
     CAmount nValueRet;
 
-    LOCK(wallet.cs_wallet);
-
     // test multiple times to allow for differences in the shuffle order
     for (int i = 0; i < RUN_TESTS; i++)
     {
         empty_wallet();
 
         // with an empty wallet we can't even pay one cent
-        BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(!CWallet::SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
 
         add_coin(1*CENT, 4);        // add a new 1 cent coin
 
         // with a new 1 cent coin, we still can't find a mature 1 cent
-        BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(!CWallet::SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
 
         // but we can find a new 1 cent
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf( 1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);
 
         add_coin(2*CENT);           // add a mature 2 cent coin
 
         // we can't make 3 cents of mature coins
-        BOOST_CHECK(!wallet.SelectCoinsMinConf( 3 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(!CWallet::SelectCoinsMinConf( 3 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
 
         // we can make 3 cents of new  coins
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 3 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf( 3 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 3 * CENT);
 
         add_coin(5*CENT);           // add a mature 5 cent coin,
@@ -104,33 +101,33 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         // now we have new: 1+10=11 (of which 10 was self-sent), and mature: 2+5+20=27.  total = 38
 
         // we can't make 38 cents only if we disallow new coins:
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(!CWallet::SelectCoinsMinConf(38 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
         // we can't even make 37 cents if we don't allow new coins even if they're from us
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * CENT, 6, 6, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(!CWallet::SelectCoinsMinConf(38 * CENT, 6, 6, vCoins, setCoinsRet, nValueRet));
         // but we can make 37 cents if we accept new coins from ourself
-        BOOST_CHECK( wallet.SelectCoinsMinConf(37 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(37 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 37 * CENT);
         // and we can make 38 cents if we accept all new coins
-        BOOST_CHECK( wallet.SelectCoinsMinConf(38 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(38 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 38 * CENT);
 
         // try making 34 cents from 1,2,5,10,20 - we can't do it exactly
-        BOOST_CHECK( wallet.SelectCoinsMinConf(34 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(34 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 35 * CENT);       // but 35 cents is closest
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);     // the best should be 20+10+5.  it's incredibly unlikely the 1 or 2 got included (but possible)
 
         // when we try making 7 cents, the smaller coins (1,2,5) are enough.  We should see just 2+5
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 7 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf( 7 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 7 * CENT);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
 
         // when we try making 8 cents, the smaller coins (1,2,5) are exactly enough.
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 8 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf( 8 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK(nValueRet == 8 * CENT);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
 
         // when we try making 9 cents, no subset of smaller coins is enough, and we get the next bigger coin (10)
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 9 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf( 9 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 10 * CENT);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
@@ -144,30 +141,30 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         add_coin(30*CENT); // now we have 6+7+8+20+30 = 71 cents total
 
         // check that we have 71 and not 72
-        BOOST_CHECK( wallet.SelectCoinsMinConf(71 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(72 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(71 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(!CWallet::SelectCoinsMinConf(72 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
 
         // now try making 16 cents.  the best smaller coins can do is 6+7+8 = 21; not as good at the next biggest coin, 20
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 20 * CENT); // we should get 20 in one coin
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
         add_coin( 5*CENT); // now we have 5+6+7+8+20+30 = 75 cents total
 
         // now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, better than the next biggest coin, 20
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 18 * CENT); // we should get 18 in 3 coins
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
 
         add_coin( 18*CENT); // now we have 5+6+7+8+18+20+30
 
         // and now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, the same as the next biggest coin, 18
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 18 * CENT);  // we should get 18 in 1 coin
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U); // because in the event of a tie, the biggest coin wins
 
         // now try making 11 cents.  we should get 5+6
-        BOOST_CHECK( wallet.SelectCoinsMinConf(11 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(11 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 11 * CENT);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
 
@@ -176,11 +173,11 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         add_coin( 2*COIN);
         add_coin( 3*COIN);
         add_coin( 4*COIN); // now we have 5+6+7+8+18+20+30+100+200+300+400 = 1094 cents
-        BOOST_CHECK( wallet.SelectCoinsMinConf(95 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(95 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * COIN);  // we should get 1 BTC in 1 coin
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
-        BOOST_CHECK( wallet.SelectCoinsMinConf(195 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(195 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 2 * COIN);  // we should get 2 BTC in 1 coin
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
@@ -195,14 +192,14 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
 
         // try making 1 * MIN_CHANGE from the 1.5 * MIN_CHANGE
         // we'll get change smaller than MIN_CHANGE whatever happens, so can expect MIN_CHANGE exactly
-        BOOST_CHECK( wallet.SelectCoinsMinConf(MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, MIN_CHANGE);
 
         // but if we add a bigger coin, small change is avoided
         add_coin(1111*MIN_CHANGE);
 
         // try making 1 from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 1111 = 1112.5
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(1 * MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * MIN_CHANGE); // we should get the exact amount
 
         // if we add more small coins:
@@ -210,7 +207,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         add_coin(0.7*MIN_CHANGE);
 
         // and try again to make 1.0 * MIN_CHANGE
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(1 * MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * MIN_CHANGE); // we should get the exact amount
 
         // run the 'mtgox' test (see https://blockchair.com/bitcoin/transaction/29a3efd3ef04f9153d47a990bd7b048a4b2d213daaa5fb8ed670fb85f13bdbcf)
@@ -219,7 +216,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         for (int i = 0; i < 20; i++)
             add_coin(50000 * COIN);
 
-        BOOST_CHECK( wallet.SelectCoinsMinConf(500000 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(500000 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 500000 * COIN); // we should get the exact amount
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 10U); // in ten coins
 
@@ -232,7 +229,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         add_coin(0.6 * MIN_CHANGE);
         add_coin(0.7 * MIN_CHANGE);
         add_coin(1111 * MIN_CHANGE);
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(1 * MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1111 * MIN_CHANGE); // we get the bigger coin
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
@@ -242,7 +239,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         add_coin(0.6 * MIN_CHANGE);
         add_coin(0.8 * MIN_CHANGE);
         add_coin(1111 * MIN_CHANGE);
-        BOOST_CHECK( wallet.SelectCoinsMinConf(MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, MIN_CHANGE);   // we should get the exact amount
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U); // in two coins 0.4+0.6
 
@@ -253,12 +250,12 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         add_coin(100  * MIN_CHANGE);
 
         // trying to make 100.01 from these three coins
-        BOOST_CHECK( wallet.SelectCoinsMinConf(100.01 * MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(100.01 * MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 101.05 * MIN_CHANGE);   // we should get all coins
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
 
         // but if we try to make 99.9, we should take the bigger of the two small coins to avoid small change
-        BOOST_CHECK( wallet.SelectCoinsMinConf(99.9 * MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( CWallet::SelectCoinsMinConf(99.9 * MIN_CHANGE, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 101 * MIN_CHANGE);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
 
@@ -268,7 +265,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
              // Create 676 inputs (= MAX_STANDARD_TX_SIZE / 148 bytes per input)
              for (uint16_t j = 0; j < 676; j++)
                  add_coin(amt);
-             BOOST_CHECK(wallet.SelectCoinsMinConf(2000, 1, 1, vCoins, setCoinsRet, nValueRet));
+             BOOST_CHECK(CWallet::SelectCoinsMinConf(2000, 1, 1, vCoins, setCoinsRet, nValueRet));
              if (amt - 2000 < MIN_CHANGE) {
                  // needs more than one input:
                  uint16_t returnSize = std::ceil((2000.0 + MIN_CHANGE)/amt);
@@ -290,8 +287,8 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
 
             // picking 50 from 100 coins doesn't depend on the shuffle,
             // but does depend on randomness in the stochastic approximation code
-            BOOST_CHECK(wallet.SelectCoinsMinConf(50 * COIN, 1, 6, vCoins, setCoinsRet , nValueRet));
-            BOOST_CHECK(wallet.SelectCoinsMinConf(50 * COIN, 1, 6, vCoins, setCoinsRet2, nValueRet));
+            BOOST_CHECK(CWallet::SelectCoinsMinConf(50 * COIN, 1, 6, vCoins, setCoinsRet , nValueRet));
+            BOOST_CHECK(CWallet::SelectCoinsMinConf(50 * COIN, 1, 6, vCoins, setCoinsRet2, nValueRet));
             BOOST_CHECK(!equal_sets(setCoinsRet, setCoinsRet2));
 
             int fails = 0;
@@ -299,8 +296,8 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
             {
                 // selecting 1 from 100 identical coins depends on the shuffle; this test will fail 1% of the time
                 // run the test RANDOM_REPEATS times and only complain if all of them fail
-                BOOST_CHECK(wallet.SelectCoinsMinConf(COIN, 1, 6, vCoins, setCoinsRet , nValueRet));
-                BOOST_CHECK(wallet.SelectCoinsMinConf(COIN, 1, 6, vCoins, setCoinsRet2, nValueRet));
+                BOOST_CHECK(CWallet::SelectCoinsMinConf(COIN, 1, 6, vCoins, setCoinsRet , nValueRet));
+                BOOST_CHECK(CWallet::SelectCoinsMinConf(COIN, 1, 6, vCoins, setCoinsRet2, nValueRet));
                 if (equal_sets(setCoinsRet, setCoinsRet2))
                     fails++;
             }
@@ -316,8 +313,8 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
             {
                 // selecting 1 from 100 identical coins depends on the shuffle; this test will fail 1% of the time
                 // run the test RANDOM_REPEATS times and only complain if all of them fail
-                BOOST_CHECK(wallet.SelectCoinsMinConf(90*CENT, 1, 6, vCoins, setCoinsRet , nValueRet));
-                BOOST_CHECK(wallet.SelectCoinsMinConf(90*CENT, 1, 6, vCoins, setCoinsRet2, nValueRet));
+                BOOST_CHECK(CWallet::SelectCoinsMinConf(90*CENT, 1, 6, vCoins, setCoinsRet , nValueRet));
+                BOOST_CHECK(CWallet::SelectCoinsMinConf(90*CENT, 1, 6, vCoins, setCoinsRet2, nValueRet));
                 if (equal_sets(setCoinsRet, setCoinsRet2))
                     fails++;
             }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -806,6 +806,7 @@ protected:
 
     /* the hd chain data model (chain counters) */
     CHDChain hdChain;
+    uint32_t bip44CoinType;
 
 public:
     /*
@@ -829,14 +830,14 @@ public:
     MasterKeyMap mapMasterKeys;
     unsigned int nMasterKeyMaxID;
 
-    CWallet()
+    CWallet(const CChainParams& params)
     {
-        SetNull();
+        SetNull(params);
     }
 
-    CWallet(const std::string& strWalletFileIn)
+    CWallet(const CChainParams& params, const std::string& strWalletFileIn)
     {
-        SetNull();
+        SetNull(params);
 
         strWalletFile = strWalletFileIn;
         fFileBacked = true;
@@ -848,7 +849,7 @@ public:
         pwalletdbEncryption = NULL;
     }
 
-    void SetNull()
+    void SetNull(const CChainParams& params)
     {
         nWalletVersion = FEATURE_BASE;
         nWalletMaxVersion = FEATURE_BASE;
@@ -863,6 +864,7 @@ public:
         nTimeFirstKey = 0;
         fBroadcastTransactions = false;
         nWitnessCacheSize = 0;
+        bip44CoinType = params.BIP44CoinType();
     }
 
     /**
@@ -958,7 +960,7 @@ public:
      * completion the coin set and corresponding actual target value is
      * assembled
      */
-    bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
+    static bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet);
 
     bool IsSpent(const uint256& hash, unsigned int n) const;
     bool IsSproutSpent(const uint256& nullifier) const;
@@ -1296,6 +1298,8 @@ public:
     void SetHDChain(const CHDChain& chain, bool memonly);
     const CHDChain& GetHDChain() const { return hdChain; }
 
+    void CheckBIP44CoinType(uint32_t coinType);
+
     /* Set the current HD seed, without saving it to disk (used by LoadWallet) */
     bool LoadHDSeed(const HDSeed& key);
     /* Set the current encrypted HD seed, without saving it to disk (used by LoadWallet) */
@@ -1324,10 +1328,10 @@ public:
     static std::string GetWalletHelpString(bool showDebug);
 
     /* Initializes the wallet, returns a new CWallet instance or a null pointer in case of an error */
-    static bool InitLoadWallet(bool clearWitnessCaches);
+    static bool InitLoadWallet(const CChainParams& params, bool clearWitnessCaches);
 
     /* Wallets parameter interaction */
-    static bool ParameterInteraction();
+    static bool ParameterInteraction(const CChainParams& params);
 };
 
 /** A key allocated from the key pool. */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -806,7 +806,7 @@ protected:
 
     /* the hd chain data model (chain counters) */
     CHDChain hdChain;
-    uint32_t bip44CoinType;
+    std::string networkIdString;
 
 public:
     /*
@@ -864,7 +864,7 @@ public:
         nTimeFirstKey = 0;
         fBroadcastTransactions = false;
         nWitnessCacheSize = 0;
-        bip44CoinType = params.BIP44CoinType();
+        networkIdString = params.NetworkIDString();
     }
 
     /**
@@ -1298,7 +1298,8 @@ public:
     void SetHDChain(const CHDChain& chain, bool memonly);
     const CHDChain& GetHDChain() const { return hdChain; }
 
-    void CheckBIP44CoinType(uint32_t coinType);
+    void CheckNetworkInfo(std::pair<std::string, std::string> networkInfo);
+    uint32_t BIP44CoinType();
 
     /* Set the current HD seed, without saving it to disk (used by LoadWallet) */
     bool LoadHDSeed(const HDSeed& key);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -724,6 +724,12 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssValue >> chain;
             pwallet->SetHDChain(chain, true);
         }
+        else if (strType == "bip44cointype")
+        {
+            uint32_t bip44CoinType;
+            ssValue >> bip44CoinType;
+            pwallet->CheckBIP44CoinType(bip44CoinType);
+        }
     } catch (...)
     {
         return false;
@@ -1087,7 +1093,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKe
         LogPrintf("Cannot create database file %s\n", filename);
         return false;
     }
-    CWallet dummyWallet;
+    CWallet dummyWallet(Params());
     CWalletScanState wss;
 
     DbTxn* ptxn = dbenv.TxnBegin();
@@ -1142,6 +1148,11 @@ bool CWalletDB::EraseDestData(const std::string &address, const std::string &key
     return Erase(std::make_pair(std::string("destdata"), std::make_pair(address, key)));
 }
 
+bool CWalletDB::WriteBIP44CoinType(uint32_t bip44CoinType)
+{
+    nWalletDBUpdateCounter++;
+    return Write(std::string("bip44cointype"), bip44CoinType);
+}
 
 bool CWalletDB::WriteHDSeed(const HDSeed& seed)
 {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -724,11 +724,11 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssValue >> chain;
             pwallet->SetHDChain(chain, true);
         }
-        else if (strType == "bip44cointype")
+        else if (strType == "networkinfo")
         {
-            uint32_t bip44CoinType;
-            ssValue >> bip44CoinType;
-            pwallet->CheckBIP44CoinType(bip44CoinType);
+            std::pair<std::string, std::string> networkInfo;
+            ssValue >> networkInfo;
+            pwallet->CheckNetworkInfo(networkInfo);
         }
     } catch (...)
     {
@@ -1148,10 +1148,11 @@ bool CWalletDB::EraseDestData(const std::string &address, const std::string &key
     return Erase(std::make_pair(std::string("destdata"), std::make_pair(address, key)));
 }
 
-bool CWalletDB::WriteBIP44CoinType(uint32_t bip44CoinType)
+bool CWalletDB::WriteNetworkInfo(const std::string& networkId)
 {
     nWalletDBUpdateCounter++;
-    return Write(std::string("bip44cointype"), bip44CoinType);
+    std::pair<std::string, std::string> networkInfo(PACKAGE_NAME, networkId);
+    return Write(std::string("networkinfo"), networkInfo);
 }
 
 bool CWalletDB::WriteHDSeed(const HDSeed& seed)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -168,6 +168,7 @@ public:
     static bool Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, const std::string& filename);
 
+    bool WriteBIP44CoinType(uint32_t bip44CoinType);
     bool WriteHDSeed(const HDSeed& seed);
     bool WriteCryptedHDSeed(const uint256& seedFp, const std::vector<unsigned char>& vchCryptedSecret);
     //! write the hdchain model (external chain child index counter)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -168,7 +168,7 @@ public:
     static bool Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, const std::string& filename);
 
-    bool WriteBIP44CoinType(uint32_t bip44CoinType);
+    bool WriteNetworkInfo(const std::string& networkId);
     bool WriteHDSeed(const HDSeed& seed);
     bool WriteCryptedHDSeed(const uint256& seedFp, const std::vector<unsigned char>& vchCryptedSecret);
     //! write the hdchain model (external chain child index counter)

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -271,7 +271,7 @@ double benchmark_large_tx(size_t nInputs)
 // wallet. We call assert(...) to ensure that this is true.
 double benchmark_try_decrypt_sprout_notes(size_t nKeys)
 {
-    CWallet wallet;
+    CWallet wallet(Params());
     for (int i = 0; i < nKeys; i++) {
         auto sk = libzcash::SproutSpendingKey::random();
         wallet.AddSproutSpendingKey(sk);
@@ -295,7 +295,7 @@ double benchmark_try_decrypt_sapling_notes(size_t nKeys)
 
     auto masterKey = GetTestMasterSaplingSpendingKey();
 
-    CWallet wallet;
+    CWallet wallet(Params());
 
     for (int i = 0; i < nKeys; i++) {
         auto sk = masterKey.Derive(i);
@@ -332,7 +332,7 @@ double benchmark_increment_sprout_note_witnesses(size_t nTxs)
 {
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
-    CWallet wallet;
+    CWallet wallet(Params());
     SproutMerkleTree sproutTree;
     SaplingMerkleTree saplingTree;
 
@@ -394,7 +394,7 @@ double benchmark_increment_sapling_note_witnesses(size_t nTxs)
 {
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
-    CWallet wallet;
+    CWallet wallet(Params());
     SproutMerkleTree sproutTree;
     SaplingMerkleTree saplingTree;
 
@@ -587,7 +587,7 @@ double benchmark_loadwallet()
     struct timeval tv_start;
     bool fFirstRunRet=true;
     timer_start(tv_start);
-    pwalletMain = new CWallet("wallet.dat");
+    pwalletMain = new CWallet(Params(), "wallet.dat");
     DBErrors nLoadWalletRet = pwalletMain->LoadWallet(fFirstRunRet);
     auto res = timer_stop(tv_start);
     post_wallet_load();


### PR DESCRIPTION
This enables the node to check on startup that the `wallet.dat` being loaded is for the network that the node is configured for.