### PR TITLE
Final dependecy updates for 4.5.0

### DIFF
--- a/.cargo/config.offline
+++ b/.cargo/config.offline
@@ -13,7 +13,7 @@ replace-with = "vendored-sources"
 
 [source."https://github.com/zcash/halo2.git"]
 git = "https://github.com/zcash/halo2.git"
-rev = "26047eaf323929935fd1e6aa3ae100b1113706e0"
+rev = "a7cd600eb60b1528159b92af5e426adcc615de1a"
 replace-with = "vendored-sources"
 
 [source."https://github.com/zcash/incrementalmerkletree"]
@@ -23,12 +23,12 @@ replace-with = "vendored-sources"
 
 [source."https://github.com/zcash/librustzcash.git"]
 git = "https://github.com/zcash/librustzcash.git"
-rev = "ba3f13bbedd95908419f104f67b9fcd3b3e13111"
+rev = "bfd083b339e0a21e9663d8c269f79fcc57eb742d"
 replace-with = "vendored-sources"
 
 [source."https://github.com/zcash/orchard.git"]
 git = "https://github.com/zcash/orchard.git"
-rev = "f8280c98a3d0e41b8ff5b7f615802bd197f781e1"
+rev = "8779ce8f1a638ebbc9b229d4eff3a29ef4de7ac0"
 replace-with = "vendored-sources"
 
 [source.vendored-sources]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64ct"
-version = "1.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a96587c05c810ddbb79e2674d519cff1379517e7b91d166dff7a7cc0e9af6e"
+checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "bech32"
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "bip0039"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4d1925000f9183da41ed95477ea815512b5bb7e06e6c6964986ca077e2b75c"
+checksum = "d0830ae4cc96b0617cc912970c2b17e89456fecbf55e8eed53a956f37ab50c41"
 dependencies = [
  "hmac",
  "pbkdf2",
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "3.0.2"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69600ff1703123957937708eb27f7a564e48885c537782722ed0ba3189ce1d7"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
 dependencies = [
  "dirs-sys",
 ]
@@ -534,10 +534,18 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ba3f13bbedd95908419f104f67b9fcd3b3e13111#ba3f13bbedd95908419f104f67b9fcd3b3e13111"
+source = "git+https://github.com/zcash/librustzcash.git?rev=bfd083b339e0a21e9663d8c269f79fcc57eb742d#bfd083b339e0a21e9663d8c269f79fcc57eb742d"
 dependencies = [
  "blake2b_simd",
  "byteorder",
+]
+
+[[package]]
+name = "f4jumble"
+version = "0.0.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=bfd083b339e0a21e9663d8c269f79fcc57eb742d#bfd083b339e0a21e9663d8c269f79fcc57eb742d"
+dependencies = [
+ "blake2b_simd",
 ]
 
 [[package]]
@@ -658,7 +666,7 @@ dependencies = [
 [[package]]
 name = "halo2"
 version = "0.0.1"
-source = "git+https://github.com/zcash/halo2.git?rev=26047eaf323929935fd1e6aa3ae100b1113706e0#26047eaf323929935fd1e6aa3ae100b1113706e0"
+source = "git+https://github.com/zcash/halo2.git?rev=a7cd600eb60b1528159b92af5e426adcc615de1a#a7cd600eb60b1528159b92af5e426adcc615de1a"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -1115,7 +1123,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.0.0"
-source = "git+https://github.com/zcash/orchard.git?rev=f8280c98a3d0e41b8ff5b7f615802bd197f781e1#f8280c98a3d0e41b8ff5b7f615802bd197f781e1"
+source = "git+https://github.com/zcash/orchard.git?rev=8779ce8f1a638ebbc9b229d4eff3a29ef4de7ac0#8779ce8f1a638ebbc9b229d4eff3a29ef4de7ac0"
 dependencies = [
  "aes",
  "arrayvec 0.7.1",
@@ -1183,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.2.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e0b28ace46c5a396546bcf443bf422b57049617433d8854227352a4a9b24e7"
+checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
 dependencies = [
  "base64ct",
  "rand_core 0.6.3",
@@ -1209,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
+checksum = "f05894bce6a1ba4be299d0c5f29563e08af2bc18bb7d48313113bed71e904739"
 dependencies = [
  "crypto-mac",
  "password-hash",
@@ -1887,18 +1895,19 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ba3f13bbedd95908419f104f67b9fcd3b3e13111#ba3f13bbedd95908419f104f67b9fcd3b3e13111"
+source = "git+https://github.com/zcash/librustzcash.git?rev=bfd083b339e0a21e9663d8c269f79fcc57eb742d#bfd083b339e0a21e9663d8c269f79fcc57eb742d"
 dependencies = [
  "bech32",
  "blake2b_simd",
  "bs58",
+ "f4jumble",
  "zcash_encoding",
 ]
 
 [[package]]
 name = "zcash_encoding"
 version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ba3f13bbedd95908419f104f67b9fcd3b3e13111#ba3f13bbedd95908419f104f67b9fcd3b3e13111"
+source = "git+https://github.com/zcash/librustzcash.git?rev=bfd083b339e0a21e9663d8c269f79fcc57eb742d#bfd083b339e0a21e9663d8c269f79fcc57eb742d"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -1907,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ba3f13bbedd95908419f104f67b9fcd3b3e13111#ba3f13bbedd95908419f104f67b9fcd3b3e13111"
+source = "git+https://github.com/zcash/librustzcash.git?rev=bfd083b339e0a21e9663d8c269f79fcc57eb742d#bfd083b339e0a21e9663d8c269f79fcc57eb742d"
 dependencies = [
  "bigint",
  "blake2b_simd",
@@ -1917,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ba3f13bbedd95908419f104f67b9fcd3b3e13111#ba3f13bbedd95908419f104f67b9fcd3b3e13111"
+source = "git+https://github.com/zcash/librustzcash.git?rev=bfd083b339e0a21e9663d8c269f79fcc57eb742d#bfd083b339e0a21e9663d8c269f79fcc57eb742d"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1932,7 +1941,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ba3f13bbedd95908419f104f67b9fcd3b3e13111#ba3f13bbedd95908419f104f67b9fcd3b3e13111"
+source = "git+https://github.com/zcash/librustzcash.git?rev=bfd083b339e0a21e9663d8c269f79fcc57eb742d#bfd083b339e0a21e9663d8c269f79fcc57eb742d"
 dependencies = [
  "aes",
  "bip0039",
@@ -1966,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ba3f13bbedd95908419f104f67b9fcd3b3e13111#ba3f13bbedd95908419f104f67b9fcd3b3e13111"
+source = "git+https://github.com/zcash/librustzcash.git?rev=bfd083b339e0a21e9663d8c269f79fcc57eb742d#bfd083b339e0a21e9663d8c269f79fcc57eb742d"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
 
 [[package]]
 name = "byteorder"
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1194,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "pasta_curves"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e9f954e56b84a250978f89358bc9f5a68f6c68f1082d41db1ddc9664316ee5"
+checksum = "d647d91972bad78120fd61e06b225fcda117805c9bbf17676b51bd03a251278b"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -1635,9 +1635,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg",
  "libc",
@@ -1666,9 +1666,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba9ab62b7d6497a8638dfda5e5c4fb3b2d5a7fca4118f2b96151c8ef1a437e"
+checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -1709,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c42e73a9d277d4d2b6a88389a137ccf3c58599660b17e8f5fc39305e490669"
+checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -1983,18 +1983,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,11 +69,11 @@ codegen-units = 1
 
 [patch.crates-io]
 ed25519-zebra = { git = "https://github.com/ZcashFoundation/ed25519-zebra.git", rev = "d3512400227a362d08367088ffaa9bd4142a69c7" }
-halo2 = { git = "https://github.com/zcash/halo2.git", rev = "26047eaf323929935fd1e6aa3ae100b1113706e0" }
+halo2 = { git = "https://github.com/zcash/halo2.git", rev = "a7cd600eb60b1528159b92af5e426adcc615de1a" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "b7bd6246122a6e9ace8edb51553fbf5228906cbb" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "f8280c98a3d0e41b8ff5b7f615802bd197f781e1" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "ba3f13bbedd95908419f104f67b9fcd3b3e13111" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "ba3f13bbedd95908419f104f67b9fcd3b3e13111" }
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "ba3f13bbedd95908419f104f67b9fcd3b3e13111" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "ba3f13bbedd95908419f104f67b9fcd3b3e13111" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "ba3f13bbedd95908419f104f67b9fcd3b3e13111" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "8779ce8f1a638ebbc9b229d4eff3a29ef4de7ac0" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "bfd083b339e0a21e9663d8c269f79fcc57eb742d" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "bfd083b339e0a21e9663d8c269f79fcc57eb742d" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "bfd083b339e0a21e9663d8c269f79fcc57eb742d" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "bfd083b339e0a21e9663d8c269f79fcc57eb742d" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "bfd083b339e0a21e9663d8c269f79fcc57eb742d" }

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -122,8 +122,8 @@ License: Boost-Software-License-1.0
 
 Files: depends/*/vendored-sources/halo2/*
  depends/*/vendored-sources/orchard/*
-Copyright: 2020 The Electric Coin Company
-License: Bootstrap-Open-Source-Licence-1.0
+Copyright: 2020-2021 The Electric Coin Company
+License: BOSL-1.0-or-later-with-Zcash-exception
 
 Files: src/crypto/ctaes/*
 Copyright: Copyright (c) 2016 Pieter Wuille
@@ -1156,6 +1156,41 @@ License: Expat-with-advertising-clause
  their institutions shall not be used in advertising or otherwise to
  promote the sale, use or other dealings in this Software without
  prior written authorization from the authors.
+
+License: BOSL-1.0-or-later-with-Zcash-exception
+ This package ("Original Work") is licensed under the terms of the Bootstrap Open
+ Source License, version 1.0, or at your option, any later version ("BOSL"). See
+ the file ./LICENSE-BOSL for the terms of the Bootstrap Open Source Licence,
+ version 1.0.
+ .
+ Only if this Original Work is included as part of the distribution of one of the
+ following projects ("the Project"):
+ .
+ - The Zcash projects published by the Electric Coin Company,
+ - The Zebra project published by the Zcash Foundation,
+ .
+ then License is granted to use this package under the BOSL as modified by the
+ following clarification and special exception. This exception applies only to
+ the Original Work when linked or combined with the Project and not to the
+ Original Work when linked, combined, or included in or with any other software
+ or project or on a standalone basis.
+ .
+     Under the terms of the BOSL, linking or combining this Original Work with
+     the Project creates a Derivative Work based upon the Original Work and the
+     terms of the BOSL thus apply to both the Original Work and that Derivative
+     Work. As a special exception to the BOSL, and to allow this Original Work to
+     be linked and combined with the Project without having to apply the BOSL to
+     the other portions of the Project, you are granted permission to link or
+     combine this Original Work with the Project and to copy and distribute the
+     resulting work ("Resulting Work") under the open source license applicable
+     to the Project ("Project License"), provided that any portions of this
+     Original Work included in the Resulting Work remain subject to the BOSL. For
+     clarity, you may continue to treat all other portions of the Project under
+     the Project License, provided that you comply with the BOSL with respect to
+     the Original Work. If you modify this Original Work, your version of the
+     Original Work must remain under the BOSL. You may also extend this exception
+     to your version, but you are not obligated to do so. If you do not wish to
+     do so, delete this exception statement from your version.
 
 License: Bootstrap-Open-Source-Licence-1.0
  =======================================================

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -122,7 +122,6 @@ License: Boost-Software-License-1.0
 
 Files: depends/*/vendored-sources/halo2/*
  depends/*/vendored-sources/orchard/*
- depends/*/vendored-sources/pasta_curves/*
 Copyright: 2020 The Electric Coin Company
 License: Bootstrap-Open-Source-Licence-1.0
 


### PR DESCRIPTION
This migrates us to BOSL-licensed dependencies with the Zcash exception, enabling `zcashd` to continue being licensed as MIT.