### PR TITLE
Update base image used by Dockerfile from debian 10 to debian 11

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10
+FROM debian:11
 
 RUN apt-get update \
   && apt-get install -y gnupg2 apt-transport-https curl


### PR DESCRIPTION
I built a docker image with this change and verified that it successfully started zcashd

I tried this after encountering an error with the debian 10 image: `docker build` terminated early on the third step when `apt-get update` returned a 100 exit status due to changed 'suite' values in the apt sources list.