### PR TITLE
wallet: Check spent shielded notes in CWalletTx::IsFromMe

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,3 +4,19 @@ release-notes at release time)
 Notable changes
 ===============
 
+Fixed regression in `getbalance` RPC method
+-------------------------------------------
+
+`zcashd v4.5.0` removed the account API from the wallet, following its
+deprecation and removal in upstream Bitcoin Core. As part of the upstream
+changes, the `getbalance` RPC method was altered from using two custom balance
+computation methods, to instead relying on `CWallet::GetBalance`. This method
+internally relies on `CWalletTx::IsFromMe` as part of identifying "trusted"
+zero-confirmation transactions to include in the balance calculation.
+
+There is an equivalent and closely-named `CWallet::IsFromMe` method, which is
+used throughout the wallet, and had been updated before Zcash launched to be
+aware of spent shielded notes. The change to `getbalance` exposed a bug:
+`CWalletTx::IsFromMe` had not been similarly updated, which caused `getbalance`
+to ignore wallet-internal (sent between two addresses in the node's wallet)
+unshielding transactions with zero confirmations. This release fixes the bug.

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -69,6 +69,7 @@ BASE_SCRIPTS= [
     'wallet_anchorfork.py',
     'wallet_changeindicator.py',
     'wallet_import_export.py',
+    'wallet_isfromme.py',
     'wallet_nullifiers.py',
     'wallet_sapling.py',
     'wallet_sendmany_any_taddr.py',

--- a/qa/rpc-tests/wallet_isfromme.py
+++ b/qa/rpc-tests/wallet_isfromme.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    BLOSSOM_BRANCH_ID,
+    CANOPY_BRANCH_ID,
+    HEARTWOOD_BRANCH_ID,
+    OVERWINTER_BRANCH_ID,
+    SAPLING_BRANCH_ID,
+    assert_equal,
+    get_coinbase_address,
+    initialize_chain_clean,
+    nuparams,
+    start_nodes,
+    wait_and_assert_operationid_status,
+)
+
+from decimal import Decimal
+
+class WalletIsFromMe(BitcoinTestFramework):
+    def setup_chain(self):
+        initialize_chain_clean(self.options.tmpdir, 1)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(1, self.options.tmpdir, extra_args=[[
+            nuparams(OVERWINTER_BRANCH_ID, 1),
+            nuparams(SAPLING_BRANCH_ID, 1),
+            nuparams(BLOSSOM_BRANCH_ID, 1),
+            nuparams(HEARTWOOD_BRANCH_ID, 1),
+            nuparams(CANOPY_BRANCH_ID, 1),
+        ]])
+        self.is_network_split=False
+
+    def run_test (self):
+        node = self.nodes[0]
+
+        node.generate(101)
+        assert_equal(node.getbalance('', 0), Decimal('6.25'))
+
+        coinbase_addr = get_coinbase_address(node)
+
+        # Send all available funds to a z-address.
+        zaddr = node.z_getnewaddress()
+        wait_and_assert_operationid_status(
+            node,
+            node.z_sendmany(
+                coinbase_addr,
+                [
+                    {'address': zaddr, 'amount': Decimal('6.25')},
+                ],
+                0,
+                0,
+            ),
+        )
+        self.sync_all()
+        assert_equal(node.getbalance('', 0), 0)
+
+        # Mine the transaction; we get another coinbase output.
+        self.nodes[0].generate(1)
+        self.sync_all()
+        assert_equal(node.getbalance('', 0), Decimal('6.25'))
+
+        # Now send the funds back to a new t-address.
+        taddr = node.getnewaddress()
+        wait_and_assert_operationid_status(
+            node,
+            node.z_sendmany(
+                zaddr,
+                [
+                    {'address': taddr, 'amount': Decimal('6.25')},
+                ],
+                1,
+                0,
+            ),
+        )
+        self.sync_all()
+
+        # At this point we have created the conditions for the bug in
+        # https://github.com/zcash/zcash/issues/5325.
+
+        # listunspent should show the coinbase output, and optionally the
+        # newly-received unshielding output.
+        assert_equal(len(node.listunspent()), 1)
+        assert_equal(len(node.listunspent(0)), 2)
+
+        # "getbalance '' 0" should count both outputs. The bug failed here.
+        assert_equal(node.getbalance('', 0), Decimal('12.5'))
+
+if __name__ == '__main__':
+    WalletIsFromMe().main ()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3016,6 +3016,26 @@ CAmount CWalletTx::GetChange() const
     return nChangeCached;
 }
 
+bool CWalletTx::IsFromMe(const isminefilter& filter) const
+{
+    if (GetDebit(filter) > 0) {
+        return true;
+    }
+    for (const JSDescription& jsdesc : vJoinSplit) {
+        for (const uint256& nullifier : jsdesc.nullifiers) {
+            if (pwallet->IsSproutNullifierFromMe(nullifier)) {
+                return true;
+            }
+        }
+    }
+    for (const SpendDescription &spend : vShieldedSpend) {
+        if (pwallet->IsSaplingNullifierFromMe(spend.nullifier)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool CWalletTx::IsTrusted() const
 {
     // Quick answer in most cases

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -610,10 +610,7 @@ public:
     void GetAmounts(std::list<COutputEntry>& listReceived,
                     std::list<COutputEntry>& listSent, CAmount& nFee, const isminefilter& filter) const;
 
-    bool IsFromMe(const isminefilter& filter) const
-    {
-        return (GetDebit(filter) > 0);
-    }
+    bool IsFromMe(const isminefilter& filter) const;
 
     bool IsTrusted() const;
 


### PR DESCRIPTION
The "IsFromMe" logic was implemented in several places in the Bitcoin
Core wallet. We had correctly updated CWallet::IsFromMe(CTransaction)
(which was used in most places in the wallet) to check for shielded
notes being spent, but did not notice that CWalletTx::IsFromMe also
needed this check.

This bug has existed since before Zcash launched. It went unnoticed
because CWalletTx::IsFromMe was previously only called from code
used to either create purely-transparent transactions, or provide
informational output on non-critical RPC methods.

This commit fixes the bug (at the expense of some duplicated logic
which can be cleaned up later).

Closes zcash/zcash#5325.