### PR TITLE
better wallet network info error handling

### DIFF
--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -138,8 +138,14 @@ TEST(WalletTests, WalletNetworkSerialization) {
     // create a new testnet wallet and generate a seed
     CWallet wallet(Params(), "wallet.dat");
     wallet.InitLoadWallet(Params(), true);
-    wallet.GenerateNewSeed();
     wallet.Flush();
+
+    // Stay on TESTNET, make sure wallet can be successfully loaded.
+    {
+        CWallet restored(Params(), "wallet.dat");
+        bool fFirstRunRet;
+        EXPECT_EQ(restored.LoadWallet(fFirstRunRet), DB_LOAD_OK);
+    }
 
     // now, switch to mainnet and attempt to restore the wallet
     // using the same wallet.dat
@@ -148,7 +154,7 @@ TEST(WalletTests, WalletNetworkSerialization) {
 
     // load should fail due to being associated with the wrong network
     bool fFirstRunRet;
-    EXPECT_NE(restored.LoadWallet(fFirstRunRet), DB_LOAD_OK);
+    EXPECT_EQ(restored.LoadWallet(fFirstRunRet), DB_WRONG_NETWORK);
 }
 
 TEST(WalletTests, SproutNoteDataSerialisation) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2295,17 +2295,11 @@ void CWallet::SetHDChain(const CHDChain& chain, bool memonly)
     hdChain = chain;
 }
 
-void CWallet::CheckNetworkInfo(std::pair<std::string, std::string> readNetworkInfo)
+bool CWallet::CheckNetworkInfo(std::pair<std::string, std::string> readNetworkInfo)
 {
     LOCK(cs_wallet);
     std::pair<string, string> networkInfo(PACKAGE_NAME, networkIdString);
-    if (readNetworkInfo != networkInfo)
-        throw std::runtime_error(
-                strprintf("%s: this wallet is for a different network (%s, %s) than the node is configured for (%s, %s)",
-                          std::string(__func__),
-                          readNetworkInfo.first, readNetworkInfo.second,
-                          networkInfo.first, networkInfo.second)
-        );
+    return readNetworkInfo == networkInfo;
 }
 
 uint32_t CWallet::BIP44CoinType() {
@@ -4772,6 +4766,10 @@ bool CWallet::InitLoadWallet(const CChainParams& params, bool clearWitnessCaches
         else if (nLoadWalletRet == DB_NEED_REWRITE)
         {
             return UIError(strprintf(_("Wallet needed to be rewritten: restart %s to complete"), _(PACKAGE_NAME)));
+        }
+        else if (nLoadWalletRet == DB_WRONG_NETWORK)
+        {
+            return UIError(strprintf(_("Wallet %s is not for %s %s network"), walletFile, _(PACKAGE_NAME), params.NetworkIDString()));
         }
         else
             return UIError(strprintf(_("Error loading %s"), walletFile));

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1298,7 +1298,7 @@ public:
     void SetHDChain(const CHDChain& chain, bool memonly);
     const CHDChain& GetHDChain() const { return hdChain; }
 
-    void CheckNetworkInfo(std::pair<std::string, std::string> networkInfo);
+    bool CheckNetworkInfo(std::pair<std::string, std::string> networkInfo);
     uint32_t BIP44CoinType();
 
     /* Set the current HD seed, without saving it to disk (used by LoadWallet) */

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -37,7 +37,8 @@ enum DBErrors
     DB_NONCRITICAL_ERROR,
     DB_TOO_NEW,
     DB_LOAD_FAIL,
-    DB_NEED_REWRITE
+    DB_NEED_REWRITE,
+    DB_WRONG_NETWORK,
 };
 
 /* simple hd chain data model */


### PR DESCRIPTION
This is a follow-up to #5309. Summary of changes:
- better internal error propagation beginning with `CWallet::CheckNetworkInfo()`
- user sees a better error message when this occurs (using a `wallet.dat` from a different network)
- fixed unit test (wasn't testing what was intended)