### PR TITLE
[image-upgrade] vuln upgrade for docker base image

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10
+FROM debian:bullseye-20210902
 
 RUN apt-get update \
   && apt-get install -y gnupg2 apt-transport-https curl


### PR DESCRIPTION
Requesting the project considers changing the image in docker for building the image from a less vuln base image which inherently would reduce the overall un patchable vuln exposure of using this suggested image of "debian:bullseye-20210902".  Vulns like - debian@10 › glibc/libc6@2.28-10 can cause a "infinite loop" for this package in the image. This can cause a self inflicted ddos on the app itself. Theoretical examples but something to consider for improved security if the update to new images is low to medium effort level.  https://cwe.mitre.org/data/definitions/835.html - Debian 11 bullseye includes numerous updated software packages (over 72% of all packages in the previous release)

Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.
* [ ] Relevant documentation for this PR has to be completed and reviewed by @mdr0id before the PR can be merged
* [ ] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release

As a note, all buildbot tests need to be passing and all appropriate code reviews need to be done before this PR can be merged
