### PR TITLE
Add unified addresses to the zcashd wallet.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -86,7 +86,7 @@ public:
     CMainParams() {
         keyConstants.strNetworkID = "main";
         strCurrencyUnits = "ZEC";
-        bip44CoinType = 133; // As registered in https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+        keyConstants.bip44CoinType = 133; // As registered in https://github.com/satoshilabs/slips/blob/master/slip-0044.md
         consensus.fCoinbaseMustBeShielded = true;
         consensus.nSubsidySlowStartInterval = 20000;
         consensus.nPreBlossomSubsidyHalvingInterval = Consensus::PRE_BLOSSOM_HALVING_INTERVAL;
@@ -370,7 +370,7 @@ public:
     CTestNetParams() {
         keyConstants.strNetworkID = "test";
         strCurrencyUnits = "TAZ";
-        bip44CoinType = 1;
+        keyConstants.bip44CoinType = 1;
         consensus.fCoinbaseMustBeShielded = true;
         consensus.nSubsidySlowStartInterval = 20000;
         consensus.nPreBlossomSubsidyHalvingInterval = Consensus::PRE_BLOSSOM_HALVING_INTERVAL;
@@ -621,7 +621,7 @@ public:
     CRegTestParams() {
         keyConstants.strNetworkID = "regtest";
         strCurrencyUnits = "REG";
-        bip44CoinType = 1;
+        keyConstants.bip44CoinType = 1;
         consensus.fCoinbaseMustBeShielded = false;
         consensus.nSubsidySlowStartInterval = 0;
         consensus.nPreBlossomSubsidyHalvingInterval = Consensus::PRE_BLOSSOM_REGTEST_HALVING_INTERVAL;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -32,17 +32,6 @@ struct CCheckpointData {
     double fTransactionsPerDay;
 };
 
-class CBaseKeyConstants : public KeyConstants {
-public:
-    std::string NetworkIDString() const { return strNetworkID; }
-    const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
-    const std::string& Bech32HRP(Bech32Type type) const { return bech32HRPs[type]; }
-
-    std::string strNetworkID;
-    std::vector<unsigned char> base58Prefixes[KeyConstants::MAX_BASE58_TYPES];
-    std::string bech32HRPs[KeyConstants::MAX_BECH32_TYPES];
-};
-
 /**
  * CChainParams defines various tweakable parameters of a given instance of the
  * Bitcoin system. There are three: the main network on which people trade goods
@@ -73,14 +62,19 @@ public:
     bool RequireStandard() const { return fRequireStandard; }
     int64_t PruneAfterHeight() const { return nPruneAfterHeight; }
     std::string CurrencyUnits() const { return strCurrencyUnits; }
-    uint32_t BIP44CoinType() const { return bip44CoinType; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */
     bool TestnetToBeDeprecatedFieldRPC() const { return fTestnetToBeDeprecatedFieldRPC; }
-    /** Return the BIP70 network string (main, test or regtest) */
-    std::string NetworkIDString() const { return keyConstants.NetworkIDString(); }
     const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
+    /** Return the BIP70 network string (main, test or regtest) */
+    std::string NetworkIDString() const {
+        return keyConstants.NetworkIDString();
+    }
+    /** Return the BIP44 coin type for addresses created by the zcashd embedded wallet. */
+    uint32_t BIP44CoinType() const {
+        return keyConstants.BIP44CoinType();
+    }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const {
         return keyConstants.Base58Prefix(type);
     }
@@ -107,7 +101,6 @@ protected:
     std::vector<CDNSSeedData> vSeeds;
     CBaseKeyConstants keyConstants;
     std::string strCurrencyUnits;
-    uint32_t bip44CoinType;
     CBlock genesis;
     std::vector<SeedSpec6> vFixedSeeds;
     bool fMiningRequiresPeers = false;

--- a/src/gtest/test_keystore.cpp
+++ b/src/gtest/test_keystore.cpp
@@ -560,7 +560,7 @@ TEST(KeystoreTests, AddUnifiedAddress) {
     auto addrPair = zufvk.FindAddress(diversifier_index_t(0), {ReceiverType::P2PKH, ReceiverType::Sapling});
     EXPECT_TRUE(addrPair.first.GetP2PKHReceiver().has_value());
 
-    keyStore.AddUnifiedAddress(ufvkid, addrPair);
+    keyStore.AddUnifiedAddress(ufvkid, addrPair.second, addrPair.first);
 
     auto ufvkmeta = keyStore.GetUFVKMetadataForReceiver(addrPair.first.GetP2PKHReceiver().value());
     EXPECT_TRUE(ufvkmeta.has_value());

--- a/src/gtest/test_keystore.cpp
+++ b/src/gtest/test_keystore.cpp
@@ -533,7 +533,7 @@ TEST(KeystoreTests, StoreAndRetrieveUFVK) {
     EXPECT_TRUE(keyStore.AddUnifiedFullViewingKey(zufvk));
     EXPECT_EQ(keyStore.GetUnifiedFullViewingKey(ufvkid).value(), zufvk);
 
-    auto addrPair = zufvk.FindAddress(diversifier_index_t(0), {ReceiverType::Sapling});
+    auto addrPair = zufvk.FindAddress(diversifier_index_t(0), {ReceiverType::Sapling}).value();
     EXPECT_TRUE(addrPair.first.GetSaplingReceiver().has_value());
     auto saplingReceiver = addrPair.first.GetSaplingReceiver().value();
 
@@ -557,7 +557,7 @@ TEST(KeystoreTests, AddUnifiedAddress) {
     auto ufvk = usk.value().ToFullViewingKey();
     auto zufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(Params(), ufvk);
     auto ufvkid = zufvk.GetKeyID();
-    auto addrPair = zufvk.FindAddress(diversifier_index_t(0), {ReceiverType::P2PKH, ReceiverType::Sapling});
+    auto addrPair = zufvk.FindAddress(diversifier_index_t(0), {ReceiverType::P2PKH, ReceiverType::Sapling}).value();
     EXPECT_TRUE(addrPair.first.GetP2PKHReceiver().has_value());
 
     keyStore.AddUnifiedAddress(ufvkid, addrPair.second, addrPair.first);

--- a/src/gtest/test_keystore.cpp
+++ b/src/gtest/test_keystore.cpp
@@ -525,12 +525,12 @@ TEST(KeystoreTests, StoreAndRetrieveUFVK) {
     auto usk = ZcashdUnifiedSpendingKey::ForAccount(seed, SLIP44_TESTNET_TYPE, 0);
     EXPECT_TRUE(usk.has_value());
 
-    auto zufvk = usk.value().ToFullViewingKey();
-    auto ufvk = UnifiedFullViewingKey::FromZcashdUFVK(zufvk);
-    auto ufvkid = ufvk.GetKeyID(Params());
+    auto ufvk = usk.value().ToFullViewingKey();
+    auto zufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(Params(), ufvk);
+    auto ufvkid = zufvk.GetKeyID();
     EXPECT_FALSE(keyStore.GetUnifiedFullViewingKey(ufvkid).has_value());
 
-    EXPECT_TRUE(keyStore.AddUnifiedFullViewingKey(ufvkid, zufvk));
+    EXPECT_TRUE(keyStore.AddUnifiedFullViewingKey(zufvk));
     EXPECT_EQ(keyStore.GetUnifiedFullViewingKey(ufvkid).value(), zufvk);
 
     auto addrPair = zufvk.FindAddress(diversifier_index_t(0), {ReceiverType::Sapling});
@@ -554,9 +554,9 @@ TEST(KeystoreTests, AddUnifiedAddress) {
     auto usk = ZcashdUnifiedSpendingKey::ForAccount(seed, SLIP44_TESTNET_TYPE, 0);
     EXPECT_TRUE(usk.has_value());
 
-    auto zufvk = usk.value().ToFullViewingKey();
-    auto ufvk = UnifiedFullViewingKey::FromZcashdUFVK(zufvk);
-    auto ufvkid = ufvk.GetKeyID(Params());
+    auto ufvk = usk.value().ToFullViewingKey();
+    auto zufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(Params(), ufvk);
+    auto ufvkid = zufvk.GetKeyID();
     auto addrPair = zufvk.FindAddress(diversifier_index_t(0), {ReceiverType::P2PKH, ReceiverType::Sapling});
     EXPECT_TRUE(addrPair.first.GetP2PKHReceiver().has_value());
 

--- a/src/gtest/test_keystore.cpp
+++ b/src/gtest/test_keystore.cpp
@@ -528,6 +528,7 @@ TEST(KeystoreTests, StoreAndRetrieveUFVK) {
     auto zufvk = usk.value().ToFullViewingKey();
     auto ufvk = UnifiedFullViewingKey::FromZcashdUFVK(zufvk);
     auto ufvkid = ufvk.GetKeyID(Params());
+    EXPECT_FALSE(keyStore.GetUnifiedFullViewingKey(ufvkid).has_value());
 
     EXPECT_TRUE(keyStore.AddUnifiedFullViewingKey(ufvkid, zufvk));
     EXPECT_EQ(keyStore.GetUnifiedFullViewingKey(ufvkid).value(), zufvk);

--- a/src/key_constants.h
+++ b/src/key_constants.h
@@ -6,6 +6,7 @@
 #define ZCASH_KEY_CONSTANTS_H
 
 #include <string>
+#include <vector>
 
 class KeyConstants
 {
@@ -35,8 +36,22 @@ public:
     };
 
     virtual std::string NetworkIDString() const =0;
+    virtual uint32_t BIP44CoinType() const =0;
     virtual const std::vector<unsigned char>& Base58Prefix(Base58Type type) const =0;
     virtual const std::string& Bech32HRP(Bech32Type type) const =0;
+};
+
+class CBaseKeyConstants : public KeyConstants {
+public:
+    std::string strNetworkID;
+    uint32_t bip44CoinType;
+    std::vector<unsigned char> base58Prefixes[KeyConstants::MAX_BASE58_TYPES];
+    std::string bech32HRPs[KeyConstants::MAX_BECH32_TYPES];
+
+    std::string NetworkIDString() const { return strNetworkID; }
+    uint32_t BIP44CoinType() const { return bip44CoinType; }
+    const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
+    const std::string& Bech32HRP(Bech32Type type) const { return bech32HRPs[type]; }
 };
 
 #endif // ZCASH_KEY_CONSTANTS_H

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -306,7 +306,7 @@ bool CBasicKeyStore::AddUnifiedFullViewingKey(
 
     // We can't reasonably add the transparent component here, because
     // of the way that transparent addresses are generated from the
-    // P2PHK part of the unified address. Instead, whenever a new
+    // P2PKH part of the unified address. Instead, whenever a new
     // unified address is generated, the keys associated with the
     // transparent part of the address must be added to the keystore.
 

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -293,7 +293,6 @@ bool CBasicKeyStore::GetSaplingExtendedSpendingKey(const libzcash::SaplingPaymen
 //
 
 bool CBasicKeyStore::AddUnifiedFullViewingKey(
-        const libzcash::UFVKId& keyId,
         const libzcash::ZcashdUnifiedFullViewingKey &ufvk)
 {
     LOCK(cs_KeyStore);
@@ -302,7 +301,7 @@ bool CBasicKeyStore::AddUnifiedFullViewingKey(
     auto saplingKey = ufvk.GetSaplingKey();
     if (saplingKey.has_value()) {
         auto ivk = saplingKey.value().fvk.in_viewing_key();
-        mapSaplingKeyUnified.insert(std::make_pair(ivk, keyId));
+        mapSaplingKeyUnified.insert(std::make_pair(ivk, ufvk.GetKeyID()));
     }
 
     // We can't reasonably add the transparent component here, because
@@ -312,7 +311,7 @@ bool CBasicKeyStore::AddUnifiedFullViewingKey(
     // transparent part of the address must be added to the keystore.
 
     // Add the UFVK by key identifier.
-    mapUnifiedFullViewingKeys.insert({keyId, ufvk});
+    mapUnifiedFullViewingKeys.insert({ufvk.GetKeyID(), ufvk});
 
     return true;
 }

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -298,12 +298,20 @@ bool CBasicKeyStore::AddUnifiedFullViewingKey(
 {
     LOCK(cs_KeyStore);
 
+    // Add the Sapling component of the UFVK to the wallet.
     auto saplingKey = ufvk.GetSaplingKey();
     if (saplingKey.has_value()) {
         auto ivk = saplingKey.value().fvk.in_viewing_key();
         mapSaplingKeyUnified.insert(std::make_pair(ivk, keyId));
     }
 
+    // We can't reasonably add the transparent component here, because
+    // of the way that transparent addresses are generated from the
+    // P2PHK part of the unified address. Instead, whenever a new
+    // unified address is generated, the keys associated with the
+    // transparent part of the address must be added to the keystore.
+
+    // Add the UFVK by key identifier.
     mapUnifiedFullViewingKeys.insert({keyId, ufvk});
 
     return true;

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -309,7 +309,7 @@ bool CBasicKeyStore::AddUnifiedFullViewingKey(
     return true;
 }
 
-bool CBasicKeyStore::AddUnifiedAddress(
+void CBasicKeyStore::AddUnifiedAddress(
         const libzcash::UFVKId& keyId,
         const libzcash::UnifiedAddress& ua)
 {
@@ -331,3 +331,13 @@ bool CBasicKeyStore::AddUnifiedAddress(
     }
 }
 
+std::optional<libzcash::ZcashdUnifiedFullViewingKey> CBasicKeyStore::GetUnifiedFullViewingKey(
+        const libzcash::UFVKId& keyId)
+{
+    auto mi = mapUnifiedFullViewingKeys.find(keyId);
+    if (mi != mapUnifiedFullViewingKeys.end()) {
+        return mi->second;
+    } else {
+        return std::nullopt;
+    }
+}

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -316,9 +316,10 @@ bool CBasicKeyStore::AddUnifiedFullViewingKey(
     return true;
 }
 
-void CBasicKeyStore::AddUnifiedAddress(
+bool CBasicKeyStore::AddUnifiedAddress(
         const libzcash::UFVKId& keyId,
-        const std::pair<libzcash::UnifiedAddress, libzcash::diversifier_index_t>& ua)
+        const libzcash::diversifier_index_t& diversifierIndex,
+        const libzcash::UnifiedAddress& ua)
 {
     LOCK(cs_KeyStore);
 
@@ -326,17 +327,19 @@ void CBasicKeyStore::AddUnifiedAddress(
     // the UA; all other lookups of the associated UFVK will be
     // made via the protocol-specific viewing key that is used
     // to trial-decrypt a transaction.
-    auto addrEntry = std::make_pair(keyId, ua.second);
+    auto addrEntry = std::make_pair(keyId, diversifierIndex);
 
-    auto p2pkhReceiver = ua.first.GetP2PKHReceiver();
+    auto p2pkhReceiver = ua.GetP2PKHReceiver();
     if (p2pkhReceiver.has_value()) {
         mapP2PKHUnified.insert(std::make_pair(p2pkhReceiver.value(), addrEntry));
     }
 
-    auto p2shReceiver = ua.first.GetP2SHReceiver();
+    auto p2shReceiver = ua.GetP2SHReceiver();
     if (p2shReceiver.has_value()) {
         mapP2SHUnified.insert(std::make_pair(p2shReceiver.value(), addrEntry));
     }
+
+    return true;
 }
 
 std::optional<libzcash::ZcashdUnifiedFullViewingKey> CBasicKeyStore::GetUnifiedFullViewingKey(

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -316,7 +316,7 @@ bool CBasicKeyStore::AddUnifiedFullViewingKey(
     return true;
 }
 
-bool CBasicKeyStore::AddUnifiedAddress(
+bool CBasicKeyStore::AddTransparentReceiverForUnifiedAddress(
         const libzcash::UFVKId& keyId,
         const libzcash::diversifier_index_t& diversifierIndex,
         const libzcash::UnifiedAddress& ua)
@@ -361,10 +361,11 @@ CBasicKeyStore::GetUFVKMetadataForReceiver(const libzcash::Receiver& receiver) c
 
 std::optional<std::pair<libzcash::UFVKId, std::optional<libzcash::diversifier_index_t>>>
 FindUFVKId::operator()(const libzcash::SaplingPaymentAddress& saplingAddr) const {
-    if (keystore.mapSaplingIncomingViewingKeys.count(saplingAddr) > 0) {
-        const auto& saplingIvk = keystore.mapSaplingIncomingViewingKeys.at(saplingAddr);
-        if (keystore.mapSaplingKeyUnified.count(saplingIvk) > 0) {
-            return std::make_pair(keystore.mapSaplingKeyUnified.at(saplingIvk), std::nullopt);
+    const auto saplingIvk = keystore.mapSaplingIncomingViewingKeys.find(saplingAddr);
+    if (saplingIvk != keystore.mapSaplingIncomingViewingKeys.end()) {
+        const auto ufvkId = keystore.mapSaplingKeyUnified.find(saplingIvk->second);
+        if (ufvkId != keystore.mapSaplingKeyUnified.end()) {
+            return std::make_pair(ufvkId->second, std::nullopt);
         } else {
             return std::nullopt;
         }
@@ -374,16 +375,18 @@ FindUFVKId::operator()(const libzcash::SaplingPaymentAddress& saplingAddr) const
 }
 std::optional<std::pair<libzcash::UFVKId, std::optional<libzcash::diversifier_index_t>>>
 FindUFVKId::operator()(const CScriptID& scriptId) const {
-    if (keystore.mapP2SHUnified.count(scriptId) > 0) {
-        return keystore.mapP2SHUnified.at(scriptId);
+    const auto metadata = keystore.mapP2SHUnified.find(scriptId);
+    if (metadata != keystore.mapP2SHUnified.end()) {
+        return metadata->second;
     } else {
         return std::nullopt;
     }
 }
 std::optional<std::pair<libzcash::UFVKId, std::optional<libzcash::diversifier_index_t>>>
 FindUFVKId::operator()(const CKeyID& keyId) const {
-    if (keystore.mapP2PKHUnified.count(keyId) > 0) {
-        return keystore.mapP2PKHUnified.at(keyId);
+    const auto metadata = keystore.mapP2PKHUnified.find(keyId);
+    if (metadata != keystore.mapP2PKHUnified.end()) {
+        return metadata->second;
     } else {
         return std::nullopt;
     }

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -287,3 +287,31 @@ bool CBasicKeyStore::GetSaplingExtendedSpendingKey(const libzcash::SaplingPaymen
             GetSaplingFullViewingKey(ivk, extfvk) &&
             GetSaplingSpendingKey(extfvk, extskOut);
 }
+
+//
+// Unified Keys
+//
+
+bool CBasicKeyStore::AddUnifiedFullViewingKey(
+        const libzcash::UFVKId& keyId,
+        const libzcash::ZcashdUnifiedFullViewingKey &ufvk)
+{
+    LOCK(cs_KeyStore);
+
+    auto tKey = ufvk.GetTransparentKey();
+    if (tKey.has_value()) {
+        // FIXME: this is probably not the right thing; we need to actually track
+        // addresses, not the id at the FVK level?
+        mapTKeyUnified.insert(std::make_pair(tKey.value().GetPubKey().GetID(), keyId));
+    }
+
+    auto saplingKey = ufvk.GetSaplingKey();
+    if (saplingKey.has_value()) {
+        auto ivk = saplingKey.value().fvk.in_viewing_key();
+        mapSaplingKeyUnified.insert(std::make_pair(ivk, keyId));
+    }
+
+    mapUnifiedFullViewingKeys.insert({keyId, ufvk});
+
+    return true;
+}

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -108,10 +108,13 @@ public:
             const libzcash::ZcashdUnifiedFullViewingKey &ufvk
             ) = 0;
 
-    virtual bool AddUnifiedAddress(
+    virtual void AddUnifiedAddress(
             const libzcash::UFVKId& keyId,
             const libzcash::UnifiedAddress &ua
             ) = 0;
+
+    virtual std::optional<libzcash::ZcashdUnifiedFullViewingKey> GetUnifiedFullViewingKey(
+            const libzcash::UFVKId& keyId) = 0;
 };
 
 typedef std::map<CKeyID, CKey> KeyMap;
@@ -346,9 +349,12 @@ public:
      * Add the transparent component of the unified address, if any,
      * to the keystore to make it possible to identify the
      */
-    virtual bool AddUnifiedAddress(
+    virtual void AddUnifiedAddress(
             const libzcash::UFVKId& keyId,
             const libzcash::UnifiedAddress &ua);
+
+    virtual std::optional<libzcash::ZcashdUnifiedFullViewingKey> GetUnifiedFullViewingKey(
+            const libzcash::UFVKId& keyId);
 };
 
 typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -117,7 +117,7 @@ public:
      * viewing key upon discovery of the address as having received
      * funds.
      */
-    virtual bool AddUnifiedAddress(
+    virtual bool AddTransparentReceiverForUnifiedAddress(
         const libzcash::UFVKId& keyId,
         const libzcash::diversifier_index_t& diversifierIndex,
         const libzcash::UnifiedAddress& ua) = 0;
@@ -357,7 +357,7 @@ public:
     virtual bool AddUnifiedFullViewingKey(
             const libzcash::ZcashdUnifiedFullViewingKey &ufvk);
 
-    virtual bool AddUnifiedAddress(
+    virtual bool AddTransparentReceiverForUnifiedAddress(
         const libzcash::UFVKId& keyId,
         const libzcash::diversifier_index_t& diversifierIndex,
         const libzcash::UnifiedAddress& ua);

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -107,6 +107,11 @@ public:
             const libzcash::UFVKId& keyId,
             const libzcash::ZcashdUnifiedFullViewingKey &ufvk
             ) = 0;
+
+    virtual bool AddUnifiedAddress(
+            const libzcash::UFVKId& keyId,
+            const libzcash::UnifiedAddress &ua
+            ) = 0;
 };
 
 typedef std::map<CKeyID, CKey> KeyMap;
@@ -127,6 +132,12 @@ typedef std::map<
     libzcash::SaplingExtendedFullViewingKey> SaplingFullViewingKeyMap;
 // Only maps from default addresses to ivk, may need to be reworked when adding diversified addresses.
 typedef std::map<libzcash::SaplingPaymentAddress, libzcash::SaplingIncomingViewingKey> SaplingIncomingViewingKeyMap;
+
+struct UnifiedAddressMetadata {
+    libzcash::UFVKId keyId;
+    libzcash::diversifier_index_t j;
+    std::vector<libzcash::ReceiverType> receiverTypes;
+};
 
 /** Basic key store, that keeps keys in an address->secret map */
 class CBasicKeyStore : public CKeyStore
@@ -150,7 +161,8 @@ protected:
     SaplingIncomingViewingKeyMap mapSaplingIncomingViewingKeys;
 
     // Unified key support
-    std::map<CKeyID, libzcash::UFVKId> mapTKeyUnified;
+    std::map<CKeyID, libzcash::UFVKId> mapP2PKHUnified;
+    std::map<CScriptID, libzcash::UFVKId> mapP2SHUnified;
     std::map<libzcash::SaplingIncomingViewingKey, libzcash::UFVKId> mapSaplingKeyUnified;
     std::map<libzcash::UFVKId, libzcash::ZcashdUnifiedFullViewingKey> mapUnifiedFullViewingKeys;
 public:
@@ -329,6 +341,14 @@ public:
     virtual bool AddUnifiedFullViewingKey(
             const libzcash::UFVKId& keyId,
             const libzcash::ZcashdUnifiedFullViewingKey &ufvk);
+
+    /**
+     * Add the transparent component of the unified address, if any,
+     * to the keystore to make it possible to identify the
+     */
+    virtual bool AddUnifiedAddress(
+            const libzcash::UFVKId& keyId,
+            const libzcash::UnifiedAddress &ua);
 };
 
 typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -107,6 +107,16 @@ public:
             const libzcash::ZcashdUnifiedFullViewingKey &ufvk
             ) = 0;
 
+    /**
+     * Add the transparent component of the unified address, if any,
+     * to the keystore to make it possible to identify the unified
+     * full viewing key from which a transparent address was derived.
+     * It is not necessary for implementations to add shielded address
+     * components to the keystore because those will be automatically
+     * reconstructed when scanning the chain with a shielded incoming
+     * viewing key upon discovery of the address as having received
+     * funds.
+     */
     virtual void AddUnifiedAddress(
             const libzcash::UFVKId& keyId,
             const std::pair<libzcash::UnifiedAddress, libzcash::diversifier_index_t>& ua
@@ -347,10 +357,6 @@ public:
     virtual bool AddUnifiedFullViewingKey(
             const libzcash::ZcashdUnifiedFullViewingKey &ufvk);
 
-    /**
-     * Add the transparent component of the unified address, if any,
-     * to the keystore to make it possible to identify the
-     */
     virtual void AddUnifiedAddress(
             const libzcash::UFVKId& keyId,
             const std::pair<libzcash::UnifiedAddress, libzcash::diversifier_index_t>& ua);

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -104,7 +104,6 @@ public:
 
     //! Unified addresses and keys
     virtual bool AddUnifiedFullViewingKey(
-            const libzcash::UFVKId& keyId,
             const libzcash::ZcashdUnifiedFullViewingKey &ufvk
             ) = 0;
 
@@ -346,7 +345,6 @@ public:
         libzcash::SproutViewingKey& vkOut) const;
 
     virtual bool AddUnifiedFullViewingKey(
-            const libzcash::UFVKId& keyId,
             const libzcash::ZcashdUnifiedFullViewingKey &ufvk);
 
     /**

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -12,6 +12,7 @@
 #include "script/standard.h"
 #include "sync.h"
 #include "zcash/address/mnemonic.h"
+#include "zcash/address/unified.h"
 #include "zcash/Address.hpp"
 #include "zcash/NoteEncryption.hpp"
 
@@ -100,6 +101,12 @@ public:
     virtual bool GetSproutViewingKey(
         const libzcash::SproutPaymentAddress &address,
         libzcash::SproutViewingKey& vkOut) const =0;
+
+    //! Unified addresses and keys
+    virtual bool AddUnifiedFullViewingKey(
+            const libzcash::UFVKId& keyId,
+            const libzcash::ZcashdUnifiedFullViewingKey &ufvk
+            ) = 0;
 };
 
 typedef std::map<CKeyID, CKey> KeyMap;
@@ -142,6 +149,10 @@ protected:
     SaplingFullViewingKeyMap mapSaplingFullViewingKeys;
     SaplingIncomingViewingKeyMap mapSaplingIncomingViewingKeys;
 
+    // Unified key support
+    std::map<CKeyID, libzcash::UFVKId> mapTKeyUnified;
+    std::map<libzcash::SaplingIncomingViewingKey, libzcash::UFVKId> mapSaplingKeyUnified;
+    std::map<libzcash::UFVKId, libzcash::ZcashdUnifiedFullViewingKey> mapUnifiedFullViewingKeys;
 public:
     bool SetMnemonicSeed(const MnemonicSeed& seed);
     bool HaveMnemonicSeed() const;
@@ -314,6 +325,10 @@ public:
     virtual bool GetSproutViewingKey(
         const libzcash::SproutPaymentAddress &address,
         libzcash::SproutViewingKey& vkOut) const;
+
+    virtual bool AddUnifiedFullViewingKey(
+            const libzcash::UFVKId& keyId,
+            const libzcash::ZcashdUnifiedFullViewingKey &ufvk);
 };
 
 typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -117,10 +117,10 @@ public:
      * viewing key upon discovery of the address as having received
      * funds.
      */
-    virtual void AddUnifiedAddress(
-            const libzcash::UFVKId& keyId,
-            const std::pair<libzcash::UnifiedAddress, libzcash::diversifier_index_t>& ua
-            ) = 0;
+    virtual bool AddUnifiedAddress(
+        const libzcash::UFVKId& keyId,
+        const libzcash::diversifier_index_t& diversifierIndex,
+        const libzcash::UnifiedAddress& ua) = 0;
 
     virtual std::optional<libzcash::ZcashdUnifiedFullViewingKey> GetUnifiedFullViewingKey(
             const libzcash::UFVKId& keyId
@@ -357,9 +357,10 @@ public:
     virtual bool AddUnifiedFullViewingKey(
             const libzcash::ZcashdUnifiedFullViewingKey &ufvk);
 
-    virtual void AddUnifiedAddress(
-            const libzcash::UFVKId& keyId,
-            const std::pair<libzcash::UnifiedAddress, libzcash::diversifier_index_t>& ua);
+    virtual bool AddUnifiedAddress(
+        const libzcash::UFVKId& keyId,
+        const libzcash::diversifier_index_t& diversifierIndex,
+        const libzcash::UnifiedAddress& ua);
 
     virtual std::optional<libzcash::ZcashdUnifiedFullViewingKey> GetUnifiedFullViewingKey(
             const libzcash::UFVKId& keyId) const;

--- a/src/rust/include/librustzcash.h
+++ b/src/rust/include/librustzcash.h
@@ -364,7 +364,7 @@ extern "C" {
      * Arguments:
      * - dk: [c_uchar; 32] the byte representation of a Sapling diversifier key
      * - addr: [c_uchar; 11] the bytes of the diversifier
-     * - j_ret: [c_uchar; 11] array that will store the retulgin diversifier index
+     * - j_ret: [c_uchar; 11] array that will store the resulting diversifier index
      */
     bool librustzcash_sapling_diversifier_index(
         const unsigned char *dk,

--- a/src/rust/include/librustzcash.h
+++ b/src/rust/include/librustzcash.h
@@ -355,7 +355,7 @@ extern "C" {
 
     /**
      * Decrypts a Sapling diversifier using the specified diversifier key
-     * to obtain the diversifier index `j` at which the diversivier was
+     * to obtain the diversifier index `j` at which the diversifier was
      * derived.
      *
      * Arguments:

--- a/src/rust/include/librustzcash.h
+++ b/src/rust/include/librustzcash.h
@@ -353,6 +353,25 @@ extern "C" {
         unsigned char *addr_ret
     );
 
+    /**
+     * Decrypts a Sapling diversifier using the specified diversifier key
+     * to obtain the diversifier index `j` at which the diversivier was
+     * derived.
+     *
+     * Returns `true` if the diversifier decrypted successfully to an index,
+     * `false` otherwise.
+     *
+     * Arguments:
+     * - dk: [c_uchar; 32] the byte representation of a Sapling diversifier key
+     * - addr: [c_uchar; 11] the bytes of the diversifier
+     * - j_ret: [c_uchar; 11] array that will store the retulgin diversifier index
+     */
+    bool librustzcash_sapling_diversifier_index(
+        const unsigned char *dk,
+        const unsigned char *d,
+        unsigned char *j_ret
+    );
+
     /// Fills the provided buffer with random bytes. This is intended to
     /// be a cryptographically secure RNG; it uses Rust's `OsRng`, which
     /// is implemented in terms of the `getrandom` crate. The first call

--- a/src/rust/include/librustzcash.h
+++ b/src/rust/include/librustzcash.h
@@ -358,15 +358,12 @@ extern "C" {
      * to obtain the diversifier index `j` at which the diversivier was
      * derived.
      *
-     * Returns `true` if the diversifier decrypted successfully to an index,
-     * `false` otherwise.
-     *
      * Arguments:
      * - dk: [c_uchar; 32] the byte representation of a Sapling diversifier key
      * - addr: [c_uchar; 11] the bytes of the diversifier
      * - j_ret: [c_uchar; 11] array that will store the resulting diversifier index
      */
-    bool librustzcash_sapling_diversifier_index(
+    void librustzcash_sapling_diversifier_index(
         const unsigned char *dk,
         const unsigned char *d,
         unsigned char *j_ret

--- a/src/rust/src/rustzcash.rs
+++ b/src/rust/src/rustzcash.rs
@@ -47,6 +47,7 @@ use zcash_primitives::{
     constants::{CRH_IVK_PERSONALIZATION, PROOF_GENERATION_KEY_GENERATOR, SPENDING_KEY_GENERATOR},
     merkle_tree::MerklePath,
     sapling::{
+        self,
         keys::FullViewingKey,
         note_encryption::sapling_ka_agree,
         redjubjub::{self, Signature},
@@ -1128,6 +1129,21 @@ pub extern "C" fn librustzcash_zip32_find_sapling_address(
         }
         None => false,
     }
+}
+
+#[no_mangle]
+pub extern "C" fn librustzcash_sapling_diversifier_index(
+    dk: *const [c_uchar; 32],
+    d: *const [c_uchar; 11],
+    j_ret: *mut [c_uchar; 11],
+) -> bool {
+    let dk = zip32::DiversifierKey(unsafe { *dk });
+    let diversifier = sapling::Diversifier(unsafe { *d });
+    let j_ret = unsafe { &mut *j_ret };
+
+    let j = dk.diversifier_index(&diversifier);
+    j_ret.copy_from_slice(&j.0);
+    true
 }
 
 #[no_mangle]

--- a/src/rust/src/rustzcash.rs
+++ b/src/rust/src/rustzcash.rs
@@ -1136,14 +1136,13 @@ pub extern "C" fn librustzcash_sapling_diversifier_index(
     dk: *const [c_uchar; 32],
     d: *const [c_uchar; 11],
     j_ret: *mut [c_uchar; 11],
-) -> bool {
+) {
     let dk = zip32::DiversifierKey(unsafe { *dk });
     let diversifier = sapling::Diversifier(unsafe { *d });
     let j_ret = unsafe { &mut *j_ret };
 
     let j = dk.diversifier_index(&diversifier);
     j_ret.copy_from_slice(&j.0);
-    true
 }
 
 #[no_mangle]

--- a/src/util/match.h
+++ b/src/util/match.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#ifndef ZCASH_UTIL_MATCH_H
+#define ZCASH_UTIL_MATCH_H
+
+// Helper for using `std::visit` with Rust-style match syntax.
+//
+// This can be used in place of defining an explicit visitor. `std::visit` requires an
+// exhaustive match; to emulate Rust's catch-all binding, use an `(auto arg)` template
+// operator().
+//
+// Care must be taken that implicit conversions are handled correctly. For instance, a
+// `(double arg)` operator() *will also* bind to `int` and `long`, if there isn't an
+// earlier satisfying match.
+//
+// This corresponds to visitor example #4 in the `std::visit` documentation:
+// https://en.cppreference.com/w/cpp/utility/variant/visit
+template<class... Ts> struct match : Ts... { using Ts::operator()...; };
+// explicit deduction guide (not needed as of C++20)
+template<class... Ts> match(Ts...) -> match<Ts...>;
+
+#endif // ZCASH_UTIL_MATCH_H

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -182,7 +182,6 @@ TEST(WalletTests, SproutNoteDataSerialisation) {
     EXPECT_EQ(noteData[jsoutpt].witnesses, noteData2[jsoutpt].witnesses);
 }
 
-
 TEST(WalletTests, FindUnspentSproutNotes) {
     SelectParams(CBaseChainParams::TESTNET);
 
@@ -356,9 +355,6 @@ TEST(WalletTests, FindUnspentSproutNotes) {
     mapBlockIndex.erase(blockHash);
     mapBlockIndex.erase(blockHash2);
     mapBlockIndex.erase(blockHash3);
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 
@@ -2232,4 +2228,7 @@ TEST(WalletTests, GenerateUnifiedAddress) {
         expected = AddressGenerationError::DiversifierSpaceExhausted;
         EXPECT_EQ(uaResult, expected);
     }
+
+    // Revert to default
+    RegtestDeactivateSapling();
 }

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -20,6 +20,7 @@
 #include <optional>
 
 using ::testing::Return;
+using namespace libzcash;
 
 ACTION(ThrowLogicError) {
     throw std::logic_error("Boom");
@@ -187,6 +188,7 @@ TEST(WalletTests, FindUnspentSproutNotes) {
 
     CWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
+
     auto sk = libzcash::SproutSpendingKey::random();
     wallet.AddSproutSpendingKey(sk);
 
@@ -468,6 +470,7 @@ TEST(WalletTests, SetInvalidSaplingNoteDataInCWalletTx) {
 }
 
 TEST(WalletTests, CheckSproutNoteCommitmentAgainstNotePlaintext) {
+    SelectParams(CBaseChainParams::REGTEST);
     CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
@@ -492,6 +495,7 @@ TEST(WalletTests, CheckSproutNoteCommitmentAgainstNotePlaintext) {
 }
 
 TEST(WalletTests, GetSproutNoteNullifier) {
+    SelectParams(CBaseChainParams::REGTEST);
     CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
@@ -527,7 +531,6 @@ TEST(WalletTests, GetSproutNoteNullifier) {
 
 TEST(WalletTests, FindMySaplingNotes) {
     auto consensusParams = RegtestActivateSapling();
-
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
@@ -562,6 +565,7 @@ TEST(WalletTests, FindMySaplingNotes) {
 }
 
 TEST(WalletTests, FindMySproutNotes) {
+    SelectParams(CBaseChainParams::REGTEST);
     CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
@@ -588,8 +592,10 @@ TEST(WalletTests, FindMySproutNotes) {
 }
 
 TEST(WalletTests, FindMySproutNotesInEncryptedWallet) {
+    SelectParams(CBaseChainParams::REGTEST);
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
+
     uint256 r {GetRandHash()};
     CKeyingMaterial vMasterKey (r.begin(), r.end());
 
@@ -619,6 +625,7 @@ TEST(WalletTests, FindMySproutNotesInEncryptedWallet) {
 }
 
 TEST(WalletTests, GetConflictedSproutNotes) {
+    SelectParams(CBaseChainParams::REGTEST);
     CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
@@ -779,6 +786,7 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
 }
 
 TEST(WalletTests, SproutNullifierIsSpent) {
+    SelectParams(CBaseChainParams::REGTEST);
     CWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
 
@@ -821,7 +829,6 @@ TEST(WalletTests, SproutNullifierIsSpent) {
 
 TEST(WalletTests, SaplingNullifierIsSpent) {
     auto consensusParams = RegtestActivateSapling();
-
     TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
 
@@ -878,6 +885,7 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
 }
 
 TEST(WalletTests, NavigateFromSproutNullifierToNote) {
+    SelectParams(CBaseChainParams::REGTEST);
     CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
@@ -906,7 +914,6 @@ TEST(WalletTests, NavigateFromSproutNullifierToNote) {
 
 TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     auto consensusParams = RegtestActivateSapling();
-
     TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
 
@@ -998,6 +1005,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
 }
 
 TEST(WalletTests, SpentSproutNoteIsFromMe) {
+    SelectParams(CBaseChainParams::REGTEST);
     CWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
@@ -1238,8 +1246,10 @@ TEST(WalletTests, CachedWitnessesEmptyChain) {
 }
 
 TEST(WalletTests, CachedWitnessesChainTip) {
+    SelectParams(CBaseChainParams::REGTEST);
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
+
     std::pair<uint256, uint256> anchors1;
     CBlock block1;
     SproutMerkleTree sproutTree;
@@ -1341,8 +1351,10 @@ TEST(WalletTests, CachedWitnessesChainTip) {
 }
 
 TEST(WalletTests, CachedWitnessesDecrementFirst) {
+    SelectParams(CBaseChainParams::REGTEST);
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
+
     SproutMerkleTree sproutTree;
     SaplingMerkleTree saplingTree;
 
@@ -1422,8 +1434,10 @@ TEST(WalletTests, CachedWitnessesDecrementFirst) {
 }
 
 TEST(WalletTests, CachedWitnessesCleanIndex) {
+    SelectParams(CBaseChainParams::REGTEST);
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
+
     std::vector<CBlock> blocks;
     std::vector<CBlockIndex> indices;
     std::vector<JSOutPoint> sproutNotes;
@@ -1510,6 +1524,7 @@ TEST(WalletTests, CachedWitnessesCleanIndex) {
 }
 
 TEST(WalletTests, ClearNoteWitnessCache) {
+    SelectParams(CBaseChainParams::REGTEST);
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
@@ -1577,8 +1592,10 @@ TEST(WalletTests, ClearNoteWitnessCache) {
 }
 
 TEST(WalletTests, WriteWitnessCache) {
+    SelectParams(CBaseChainParams::REGTEST);
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
+
     MockWalletDB walletdb;
     CBlockLocator loc;
 
@@ -1664,9 +1681,9 @@ TEST(WalletTests, WriteWitnessCache) {
 
 TEST(WalletTests, SetBestChainIgnoresTxsWithoutShieldedData) {
     SelectParams(CBaseChainParams::REGTEST);
-
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
+
     MockWalletDB walletdb;
     CBlockLocator loc;
 
@@ -1746,8 +1763,10 @@ TEST(WalletTests, SetBestChainIgnoresTxsWithoutShieldedData) {
 }
 
 TEST(WalletTests, UpdateSproutNullifierNoteMap) {
+    SelectParams(CBaseChainParams::REGTEST);
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
+
     uint256 r {GetRandHash()};
     CKeyingMaterial vMasterKey (r.begin(), r.end());
 
@@ -1782,6 +1801,7 @@ TEST(WalletTests, UpdateSproutNullifierNoteMap) {
 }
 
 TEST(WalletTests, UpdatedSproutNoteData) {
+    SelectParams(CBaseChainParams::REGTEST);
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
@@ -1831,7 +1851,6 @@ TEST(WalletTests, UpdatedSproutNoteData) {
 
 TEST(WalletTests, UpdatedSaplingNoteData) {
     auto consensusParams = RegtestActivateSapling();
-
     TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
 
@@ -1941,6 +1960,7 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
 }
 
 TEST(WalletTests, MarkAffectedSproutTransactionsDirty) {
+    SelectParams(CBaseChainParams::REGTEST);
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
@@ -1974,7 +1994,6 @@ TEST(WalletTests, MarkAffectedSproutTransactionsDirty) {
 
 TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     auto consensusParams = RegtestActivateSapling();
-
     TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
 
@@ -2084,6 +2103,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
 }
 
 TEST(WalletTests, SproutNoteLocking) {
+    SelectParams(CBaseChainParams::REGTEST);
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
 
@@ -2118,8 +2138,10 @@ TEST(WalletTests, SproutNoteLocking) {
 }
 
 TEST(WalletTests, SaplingNoteLocking) {
+    SelectParams(CBaseChainParams::REGTEST);
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
+
     SaplingOutPoint sop1 {uint256(), 1};
     SaplingOutPoint sop2 {uint256(), 2};
 
@@ -2148,4 +2170,43 @@ TEST(WalletTests, SaplingNoteLocking) {
     wallet.UnlockAllSaplingNotes();
     EXPECT_FALSE(wallet.IsLockedNote(sop1));
     EXPECT_FALSE(wallet.IsLockedNote(sop2));
+}
+
+TEST(WalletTests, GenerateUnifiedAddress) {
+    SelectParams(CBaseChainParams::TESTNET);
+    TestWallet wallet(Params());
+
+    UAGenerationResult uaResult = wallet.GenerateUnifiedAddress(0, diversifier_index_t(0), {ReceiverType::P2PKH, ReceiverType::Sapling});
+
+    // If the wallet does not have a mnemonic seed available, it is
+    // treated as if the wallet is encrypted.
+    UAGenerationResult expected = AddressGenerationError::WalletEncrypted;
+    EXPECT_EQ(uaResult, expected);
+
+    wallet.GenerateNewSeed();
+    EXPECT_FALSE(wallet.IsCrypted());
+    EXPECT_TRUE(wallet.GetMnemonicSeed().has_value());
+
+    // If the user has not generated a unified spending key,
+    // we cannot create an address for the account corresponding
+    // to that spending key.
+    uaResult = wallet.GenerateUnifiedAddress(0, diversifier_index_t(0), {ReceiverType::P2PKH, ReceiverType::Sapling});
+    expected = AddressGenerationError::NoSuchAccount;
+    EXPECT_EQ(uaResult, expected);
+
+    // Create an account, then generate an address for that account.
+    auto skpair = wallet.GenerateNewUnifiedSpendingKey();
+    uaResult = wallet.GenerateUnifiedAddress(
+            skpair.second.GetAccountId(),
+            diversifier_index_t(0),
+            {ReceiverType::P2PKH, ReceiverType::Sapling});
+    bool success = std::holds_alternative<std::pair<UnifiedAddress, ZcashdUnifiedAddressMetadata>>(uaResult);
+    EXPECT_TRUE(success);
+
+    auto zufvk = skpair.first.ToFullViewingKey();
+    auto addrpair = std::get<std::pair<UnifiedAddress, ZcashdUnifiedAddressMetadata>>(uaResult);
+    EXPECT_TRUE(addrpair.first.GetSaplingReceiver().has_value());
+
+    auto u4r = wallet.GetUnifiedForReceiver(addrpair.first.GetSaplingReceiver().value());
+    EXPECT_EQ(u4r, addrpair.first);
 }

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -2180,6 +2180,8 @@ TEST(WalletTests, GenerateUnifiedAddress) {
 
     // If the wallet does not have a mnemonic seed available, it is
     // treated as if the wallet is encrypted.
+    EXPECT_FALSE(wallet.IsCrypted());
+    EXPECT_FALSE(wallet.GetMnemonicSeed().has_value());
     UAGenerationResult expected = AddressGenerationError::WalletEncrypted;
     EXPECT_EQ(uaResult, expected);
 

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -184,7 +184,7 @@ TEST(WalletTests, SproutNoteDataSerialisation) {
 
 
 TEST(WalletTests, FindUnspentSproutNotes) {
-    auto consensusParams = RegtestActivateSapling();
+    SelectParams(CBaseChainParams::TESTNET);
 
     CWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
@@ -379,8 +379,6 @@ TEST(WalletTests, SetSproutNoteAddrsInCWalletTx) {
 }
 
 TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
-    SelectParams(CBaseChainParams::REGTEST);
-
     std::vector<libzcash::Zip212Enabled> zip_212_enabled = {libzcash::Zip212Enabled::BeforeZip212, libzcash::Zip212Enabled::AfterZip212};
     const Consensus::Params& (*activations [])() = {RegtestActivateSapling, RegtestActivateCanopy};
     void (*deactivations [])() = {RegtestDeactivateSapling, RegtestDeactivateCanopy};
@@ -659,8 +657,6 @@ TEST(WalletTests, GetConflictedSproutNotes) {
 
 // Generate note A and spend to create note B, from which we spend to create two conflicting transactions
 TEST(WalletTests, GetConflictedSaplingNotes) {
-    SelectParams(CBaseChainParams::REGTEST);
-
     std::vector<libzcash::Zip212Enabled> zip_212_enabled = {libzcash::Zip212Enabled::BeforeZip212, libzcash::Zip212Enabled::AfterZip212};
     const Consensus::Params& (*activations [])() = {RegtestActivateSapling, RegtestActivateCanopy};
     void (*deactivations [])() = {RegtestDeactivateSapling, RegtestDeactivateCanopy};
@@ -1036,8 +1032,6 @@ TEST(WalletTests, SpentSproutNoteIsFromMe) {
 
 // Create note A, spend A to create note B, spend and verify note B is from me.
 TEST(WalletTests, SpentSaplingNoteIsFromMe) {
-    SelectParams(CBaseChainParams::REGTEST);
-
     std::vector<libzcash::Zip212Enabled> zip_212_enabled = {libzcash::Zip212Enabled::BeforeZip212, libzcash::Zip212Enabled::AfterZip212};
     const Consensus::Params& (*activations [])() = {RegtestActivateSapling, RegtestActivateCanopy};
     void (*deactivations [])() = {RegtestDeactivateSapling, RegtestDeactivateCanopy};
@@ -2173,7 +2167,7 @@ TEST(WalletTests, SaplingNoteLocking) {
 }
 
 TEST(WalletTests, GenerateUnifiedAddress) {
-    SelectParams(CBaseChainParams::TESTNET);
+    (void) RegtestActivateSapling();
     TestWallet wallet(Params());
 
     UAGenerationResult uaResult = wallet.GenerateUnifiedAddress(0, diversifier_index_t(0), {ReceiverType::P2PKH, ReceiverType::Sapling});

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -2205,9 +2205,12 @@ TEST(WalletTests, GenerateUnifiedAddress) {
     bool success = std::holds_alternative<std::pair<UnifiedAddress, ZcashdUnifiedAddressMetadata>>(uaResult);
     EXPECT_TRUE(success);
 
-    auto zufvk = skpair.first.ToFullViewingKey();
+    auto ufvk = skpair.first.ToFullViewingKey();
     auto addrpair = std::get<std::pair<UnifiedAddress, ZcashdUnifiedAddressMetadata>>(uaResult);
     EXPECT_TRUE(addrpair.first.GetSaplingReceiver().has_value());
+    EXPECT_EQ(
+            addrpair.first.GetSaplingReceiver(),
+            ufvk.GetSaplingKey().value().Address(addrpair.second.GetDiversifierIndex()));
 
     auto u4r = wallet.GetUnifiedForReceiver(addrpair.first.GetSaplingReceiver().value());
     EXPECT_EQ(u4r, addrpair.first);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -870,7 +870,7 @@ UniValue z_importviewingkey(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid viewing key");
     }
 
-    auto addrInfo = std::visit(libzcash::AddressInfoFromViewingKey{}, viewingkey);
+    auto addrInfo = std::visit(libzcash::AddressInfoFromViewingKey(Params()), viewingkey);
     UniValue result(UniValue::VOBJ);
     const string strAddress = keyIO.EncodePaymentAddress(addrInfo.second);
     result.pushKV("type", addrInfo.first);

--- a/src/wallet/test/rpc_wallet_tests.cpp
+++ b/src/wallet/test/rpc_wallet_tests.cpp
@@ -79,6 +79,7 @@ static SaplingPaymentAddress DefaultSaplingAddress(CWallet* pwallet) {
     auto usk = pwallet->GenerateUnifiedSpendingKeyForAccount(0);
 
     return usk.value()
+        .first
         .ToFullViewingKey()
         .GetSaplingKey().value()
         .FindAddress(libzcash::diversifier_index_t(0)).first;

--- a/src/wallet/test/rpc_wallet_tests.cpp
+++ b/src/wallet/test/rpc_wallet_tests.cpp
@@ -79,7 +79,6 @@ static SaplingPaymentAddress DefaultSaplingAddress(CWallet* pwallet) {
     auto usk = pwallet->GenerateUnifiedSpendingKeyForAccount(0);
 
     return usk.value()
-        .first
         .ToFullViewingKey()
         .GetSaplingKey().value()
         .FindAddress(libzcash::diversifier_index_t(0)).first;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -679,6 +679,11 @@ UAGenerationResult CWallet::GenerateUnifiedAddress(
 //     once the UFVK has been loaded.
 //   - if we have already loaded the unified full viewing key from disk,
 //     regenerate the address from its metadata and add it to the keystore
+//
+// While this is somewhat complicated, it has the benefit of making each
+// piece of unified full viewing key and address metadata write-once in
+// the wallet database; we never need to update ufvk or address metadata
+// once written.
 bool CWallet::LoadUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &key)
 {
     auto zufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(Params(), key);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5845,7 +5845,6 @@ std::optional<libzcash::UnifiedAddress> LookupUnifiedAddress::operator()(const C
         } else {
             return std::nullopt;
         }
-
     } else {
         return std::nullopt;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -423,7 +423,7 @@ bool CWallet::AddCryptedSaplingSpendingKey(const libzcash::SaplingExtendedFullVi
     return false;
 }
 
-std::pair<ZcashdUnifiedSpendingKey, ZcashdUnifiedSpendingKeyMetadata> CWallet::GenerateNewUnifiedSpendingKey() {
+std::pair<ZcashdUnifiedSpendingKey, ZcashdUnifiedAccount> CWallet::GenerateNewUnifiedSpendingKey() {
     AssertLockHeld(cs_wallet);
 
     if (!mnemonicHDChain.has_value()) {
@@ -448,7 +448,7 @@ std::pair<ZcashdUnifiedSpendingKey, ZcashdUnifiedSpendingKeyMetadata> CWallet::G
     }
 }
 
-std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedSpendingKeyMetadata>>
+std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedAccount>>
         CWallet::GenerateUnifiedSpendingKeyForAccount(libzcash::AccountId accountId) {
     AssertLockHeld(cs_wallet); // mapUnifiedSpendingKeyMeta
 
@@ -463,7 +463,7 @@ std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedSpendin
         auto ufvk = sk.ToFullViewingKey();
         auto ufvkid = ufvk.GetKeyID(Params());
 
-        ZcashdUnifiedSpendingKeyMetadata skmeta(seed.value().Fingerprint(), BIP44CoinType(), accountId, ufvkid);
+        ZcashdUnifiedAccount skmeta(seed.value().Fingerprint(), BIP44CoinType(), accountId, ufvkid);
 
         // We don't store the spending key directly; instead, we store each of
         // the spending key's components, in order to not violate invariants
@@ -503,7 +503,7 @@ std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedSpendin
         if (fFileBacked) {
             auto walletdb = CWalletDB(strWalletFile);
             if (!( walletdb.WriteUnifiedFullViewingKey(ufvk) &&
-                   walletdb.WriteUnifiedSpendingKeyMetadata(skmeta)
+                   walletdb.WriteUnifiedAccount(skmeta)
                  )) {
                 throw std::runtime_error("CWalletDB::GenerateUnifiedSpendingKeyForAccount(): walletdb write failed.");
             }
@@ -645,7 +645,7 @@ bool CWallet::LoadUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &k
     return CCryptoKeyStore::AddUnifiedFullViewingKey(zufvk);
 }
 
-bool CWallet::LoadUnifiedKeyMetadata(const ZcashdUnifiedSpendingKeyMetadata &skmeta)
+bool CWallet::LoadUnifiedAccount(const ZcashdUnifiedAccount &skmeta)
 {
     AssertLockHeld(cs_wallet); // mapUnifiedSpendingKeyMeta
     auto metaKey = std::make_pair(skmeta.GetSeedFingerprint(), skmeta.GetAccountId());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -604,11 +604,11 @@ UAGenerationResult CWallet::GenerateUnifiedAddress(
         }
 
         // Find a working diversifier and construct the associated address.
-        auto found = ufvk.FindAddress(j, receiverTypes);
-        auto diversifierIndex = found.second;
+        auto foundAddress = ufvk.FindAddress(j, receiverTypes);
+        auto diversifierIndex = foundAddress.second;
 
         // Persist the newly created address to the keystore
-        AddUnifiedAddress(ufvkid, found.first);
+        AddUnifiedAddress(ufvkid, foundAddress);
 
         if (hasTransparent) {
             // Regenerate the secret key for the transparent address and add it to
@@ -621,12 +621,12 @@ UAGenerationResult CWallet::GenerateUnifiedAddress(
 
         // Save the metadata for the generated address so that we can re-derive
         // it in the future.
-        ZcashdUnifiedAddressMetadata addrmeta(ufvkid, found.second, receiverTypes);
+        ZcashdUnifiedAddressMetadata addrmeta(ufvkid, foundAddress.second, receiverTypes);
         mapUnifiedAddressMetadata[ufvkid].insert({diversifierIndex, receiverTypes});
         if (fFileBacked) {
             CWalletDB(strWalletFile).WriteUnifiedAddressMetadata(addrmeta);
         }
-        return std::make_pair(found.first, addrmeta);
+        return std::make_pair(foundAddress.first, addrmeta);
     } else {
         return AddressGenerationError::NoSuchAccount;
     }
@@ -641,7 +641,7 @@ bool CWallet::LoadUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &k
         // keystore
         for (const auto &[j, receiverTypes] : mapUnifiedAddressMetadata[ufvkid]) {
             auto addr = zufvk.Address(j, receiverTypes).value();
-            AddUnifiedAddress(ufvkid, addr);
+            AddUnifiedAddress(ufvkid, std::make_pair(addr, j));
         }
     }
     return CCryptoKeyStore::AddUnifiedFullViewingKey(ufvkid, zufvk);
@@ -660,9 +660,10 @@ bool CWallet::LoadUnifiedAddressMetadata(const ZcashdUnifiedAddressMetadata &add
     auto ufvk = GetUnifiedFullViewingKey(addrmeta.GetKeyID());
     if (ufvk.has_value()) {
         // restore unified addresses that have been previously generated
-        auto addr = ufvk.value().Address(addrmeta.GetDiversifierIndex(), addrmeta.GetReceiverTypes());
+        auto j = addrmeta.GetDiversifierIndex();
+        auto addr = ufvk.value().Address(j, addrmeta.GetReceiverTypes());
         if (addr.has_value()) {
-            AddUnifiedAddress(addrmeta.GetKeyID(), addr.value());
+            AddUnifiedAddress(addrmeta.GetKeyID(), std::make_pair(addr.value(), j));
         } else {
             // an error has occurred; the ufvk is loaded but cannot reproduce the
             // address identified by the address metadata.
@@ -5524,6 +5525,10 @@ void CWallet::GetFilteredNotes(
 }
 
 
+std::optional<UnifiedAddress> CWallet::GetUnifiedForReceiver(const Receiver& receiver) {
+    return std::visit(LookupUnifiedAddress(*this), receiver);
+}
+
 //
 // Shielded key and address generalizations
 //
@@ -5793,4 +5798,58 @@ KeyAddResult AddSpendingKeyToWallet::operator()(const libzcash::SaplingExtendedS
 
 KeyAddResult AddSpendingKeyToWallet::operator()(const libzcash::InvalidEncoding& no) const {
     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid spending key");
+}
+
+std::optional<libzcash::UnifiedAddress> LookupUnifiedAddress::operator()(const libzcash::SaplingPaymentAddress& saplingAddr) const {
+    auto ufvkPair = wallet.GetUFVKMetadataForReceiver(saplingAddr);
+    if (ufvkPair.has_value()) {
+        auto ufvkid = ufvkPair.value().first;
+        auto ufvk = wallet.GetUnifiedFullViewingKey(ufvkid);
+        if (!(ufvk.has_value() && ufvk.value().GetSaplingKey().has_value())) {
+            throw std::runtime_error("CWallet::LookupUnifiedAddress(): UFVK has no Sapling key part.");
+        }
+
+        diversifier_index_t j;
+        if (wallet.mapUnifiedAddressMetadata.count(ufvkid) > 0 &&
+            librustzcash_sapling_diversifier_index(
+                    ufvk.value().GetSaplingKey().value().dk.begin(),
+                    saplingAddr.d.begin(),
+                    j.begin()) &&
+            wallet.mapUnifiedAddressMetadata.at(ufvkid).count(j) > 0) {
+
+            return ufvk.value().Address(j, wallet.mapUnifiedAddressMetadata.at(ufvkid).at(j));
+        } else {
+            return std::nullopt;
+        }
+    } else {
+        return std::nullopt;
+    }
+}
+std::optional<libzcash::UnifiedAddress> LookupUnifiedAddress::operator()(const CScriptID& scriptId) const {
+    return std::nullopt;
+}
+std::optional<libzcash::UnifiedAddress> LookupUnifiedAddress::operator()(const CKeyID& keyId) const {
+    auto ufvkPair = wallet.GetUFVKMetadataForReceiver(keyId);
+    if (ufvkPair.has_value()) {
+        auto ufvkid = ufvkPair.value().first;
+        // transparent address UFVK metadata is always accompanied by the child
+        // index at which the address was produced
+        diversifier_index_t j = ufvkPair.value().second.value();
+        auto ufvk = wallet.GetUnifiedFullViewingKey(ufvkid);
+        if (!(ufvk.has_value() && ufvk.value().GetTransparentKey().has_value())) {
+            throw std::runtime_error("CWallet::LookupUnifiedAddress(): UFVK has no P2PKH key part.");
+        }
+
+        if (wallet.mapUnifiedAddressMetadata.count(ufvkid) > 0) {
+            return ufvk.value().Address(j, wallet.mapUnifiedAddressMetadata.at(ufvkid).at(j));
+        } else {
+            return std::nullopt;
+        }
+
+    } else {
+        return std::nullopt;
+    }
+}
+std::optional<libzcash::UnifiedAddress> LookupUnifiedAddress::operator()(const libzcash::UnknownReceiver& receiver) const {
+    return std::nullopt;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -282,7 +282,7 @@ CPubKey CWallet::GenerateNewKey()
             BIP44CoinType(),
             ZCASH_LEGACY_ACCOUNT).value();
 
-    std::optional<std::pair<CExtKey, HDKeyPath>> extKey = std::nullopt;
+    std::optional<std::pair<CKey, HDKeyPath>> extKey = std::nullopt;
     do {
         extKey = accountChains.DeriveExternal(hdChain.GetLegacyTKeyCounter());
         hdChain.IncrementLegacyTKeyCounter();
@@ -301,10 +301,10 @@ CPubKey CWallet::GenerateNewKey()
 
 CPubKey CWallet::AddTransparentSecretKey(
         const uint256& seedFingerprint,
-        const std::pair<CExtKey, HDKeyPath>& extSecret,
+        const std::pair<CKey, HDKeyPath>& extSecret,
         const std::optional<libzcash::UFVKId>& ufvkId)
 {
-    CKey secret = extSecret.first.key;
+    CKey secret = extSecret.first;
     CPubKey pubkey = secret.GetPubKey();
     assert(secret.VerifyPubKey(pubkey));
 
@@ -479,8 +479,10 @@ std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedSpendin
         // Add Transparent component to the wallet
         if (sk.GetTransparentKey().has_value()) {
             auto keypath = libzcash::Bip44TransparentAccountKeyPath(BIP44CoinType(), accountId);
-            AddTransparentSecretKey(skmeta.GetSeedFingerprint(),
-                   std::make_pair(sk.GetTransparentKey().value(), keypath));
+            AddTransparentSecretKey(
+                    skmeta.GetSeedFingerprint(),
+                    std::make_pair(sk.GetTransparentKey().value().key, keypath)
+                    );
         }
 
         // Add Sapling component to the wallet
@@ -591,6 +593,9 @@ UAGenerationResult CWallet::GenerateUnifiedAddress(
 
         // Persist the newly created address to the keystore
         AddUnifiedAddress(ufvkid, found.first);
+
+        // If we have the associated spending key, add this to the keystore as one
+        // of our own addresses with AddTransparentSecretKey,
 
         // Save the metadata for the generated address so that we can re-derive
         // it in the future.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -474,7 +474,7 @@ std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedSpendin
         // the fingerprint of the associated full viewing key.
 
         auto metaKey = std::make_pair(skmeta.GetSeedFingerprint(), skmeta.GetAccountId());
-        mapUnifiedKeyMetadata.insert({ufvkid, skmeta});
+        mapUnifiedKeyMetadata.insert({metaKey, skmeta});
 
         // Add Transparent component to the wallet
         if (sk.GetTransparentKey().has_value()) {
@@ -532,17 +532,117 @@ bool CWallet::AddUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &uf
     return CWalletDB(strWalletFile).WriteUnifiedFullViewingKey(ufvk);
 }
 
-bool CWallet::LoadUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &key)
-{
-    auto keyId = key.GetKeyID(Params());
-    auto zufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(key);
-    return CCryptoKeyStore::AddUnifiedFullViewingKey(keyId, zufvk);
+std::optional<std::pair<UFVKId, ZcashdUnifiedFullViewingKey>> CWallet::GetUnifiedFullViewingKeyByAccount(libzcash::AccountId accountId) {
+    if (!mnemonicHDChain.has_value()) {
+        throw std::runtime_error(
+                "CWallet::GenerateNewUnifiedSpendingKey(): Wallet is missing mnemonic seed metadata.");
+    }
+
+    auto seedfp = mnemonicHDChain.value().GetSeedFingerprint();
+    auto i = mapUnifiedKeyMetadata.find(std::make_pair(seedfp, accountId));
+    if (i != mapUnifiedKeyMetadata.end()) {
+        auto keyId = i->second.GetKeyID();
+        auto key = CCryptoKeyStore::GetUnifiedFullViewingKey(keyId);
+        if (key.has_value()) {
+            return std::make_pair(keyId, key.value());
+        } else {
+            return std::nullopt;
+        }
+    } else {
+        return std::nullopt;
+    }
 }
 
-void CWallet::LoadUnifiedKeyMetadata(const ZcashdUnifiedSpendingKeyMetadata &meta)
+UAGenerationResult CWallet::GenerateUnifiedAddress(
+    const libzcash::AccountId& accountId,
+    const libzcash::diversifier_index_t& j,
+    const std::set<libzcash::ReceiverType>& receiverTypes)
+{
+    if (!libzcash::HasShielded(receiverTypes)) {
+        return AddressGenerationError::InvalidReceiverTypes;
+    }
+
+    auto identifiedKey = GetUnifiedFullViewingKeyByAccount(accountId);
+    if (identifiedKey.has_value()) {
+        auto ufvkid = identifiedKey.value().first;
+        auto ufvk = identifiedKey.value().second;
+
+        // Check whether an address has already been generated for this
+        // diversifier index. If so, ensure that the set of receiver types
+        // being requested is the same as the set of receiver types that was
+        // previously generated; if so, return the previously generated address,
+        // otherwise return an error.
+        if (mapUnifiedAddressMetadata.count(ufvkid) > 0) {
+            const auto& accountKeys = mapUnifiedAddressMetadata.at(ufvkid);
+            if (accountKeys.count(j) > 0) {
+                if (accountKeys.at(j) == receiverTypes) {
+                    ZcashdUnifiedAddressMetadata addrmeta(ufvkid, j, receiverTypes);
+                    auto addr = ufvk.Address(j, receiverTypes);
+                    return std::make_pair(addr.value(), addrmeta);
+                } else {
+                    return AddressGenerationError::ExistingAddressMismatch;
+                }
+            }
+        }
+
+        // Find a working diversifier and construct the associated address.
+        auto found = ufvk.FindAddress(j, receiverTypes);
+        auto diversifierIndex = found.second;
+
+        // Persist the newly created address to the keystore
+        AddUnifiedAddress(ufvkid, found.first);
+
+        // Save the metadata for the generated address so that we can re-derive
+        // it in the future.
+        ZcashdUnifiedAddressMetadata addrmeta(ufvkid, found.second, receiverTypes);
+        mapUnifiedAddressMetadata[ufvkid].insert({diversifierIndex, receiverTypes});
+        if (fFileBacked) {
+            CWalletDB(strWalletFile).WriteUnifiedAddressMetadata(addrmeta);
+        }
+        return std::make_pair(found.first, addrmeta);
+    } else {
+        return AddressGenerationError::NoSuchAccount;
+    }
+}
+
+bool CWallet::LoadUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &key)
+{
+    auto ufvkid = key.GetKeyID(Params());
+    auto zufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(key);
+    if (mapUnifiedAddressMetadata.count(ufvkid) > 0) {
+        // restore unified addresses that have been previously generated to the
+        // keystore
+        for (const auto &[j, receiverTypes] : mapUnifiedAddressMetadata[ufvkid]) {
+            auto addr = zufvk.Address(j, receiverTypes).value();
+            AddUnifiedAddress(ufvkid, addr);
+        }
+    }
+    return CCryptoKeyStore::AddUnifiedFullViewingKey(ufvkid, zufvk);
+}
+
+void CWallet::LoadUnifiedKeyMetadata(const ZcashdUnifiedSpendingKeyMetadata &skmeta)
 {
     AssertLockHeld(cs_wallet); // mapUnifiedKeyMetadata
-    mapUnifiedKeyMetadata.insert({meta.GetKeyID(), meta});
+    auto metaKey = std::make_pair(skmeta.GetSeedFingerprint(), skmeta.GetAccountId());
+    mapUnifiedKeyMetadata.insert({metaKey, skmeta});
+}
+
+bool CWallet::LoadUnifiedAddressMetadata(const ZcashdUnifiedAddressMetadata &addrmeta)
+{
+    AssertLockHeld(cs_wallet); // mapUnifiedKeyMetadata
+    auto ufvk = GetUnifiedFullViewingKey(addrmeta.GetKeyID());
+    if (ufvk.has_value()) {
+        // restore unified addresses that have been previously generated
+        auto addr = ufvk.value().Address(addrmeta.GetDiversifierIndex(), addrmeta.GetReceiverTypes());
+        if (addr.has_value()) {
+            AddUnifiedAddress(addrmeta.GetKeyID(), addr.value());
+        } else {
+            // an error has occurred; the ufvk is loaded but cannot reproduce the
+            // address identified by the address metadata.
+            return false;
+        }
+    }
+    return true;
 }
 
 void CWallet::LoadKeyMetadata(const CPubKey &pubkey, const CKeyMetadata &meta)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -301,8 +301,7 @@ CPubKey CWallet::GenerateNewKey()
 
 CPubKey CWallet::AddTransparentSecretKey(
         const uint256& seedFingerprint,
-        const std::pair<CKey, HDKeyPath>& extSecret,
-        const std::optional<libzcash::UFVKId>& ufvkId)
+        const std::pair<CKey, HDKeyPath>& extSecret)
 {
     CKey secret = extSecret.first;
     CPubKey pubkey = secret.GetPubKey();
@@ -316,7 +315,7 @@ CPubKey CWallet::AddTransparentSecretKey(
     if (nTimeFirstKey == 0 || keyMeta.nCreateTime < nTimeFirstKey)
         nTimeFirstKey = keyMeta.nCreateTime;
 
-    if (!AddKeyPubKey(secret, pubkey, ufvkId))
+    if (!AddKeyPubKey(secret, pubkey))
         throw std::runtime_error("CWallet::GenerateNewKey(): AddKeyPubKey failed");
 
     return pubkey;
@@ -324,8 +323,7 @@ CPubKey CWallet::AddTransparentSecretKey(
 
 bool CWallet::AddKeyPubKey(
         const CKey& secret,
-        const CPubKey &pubkey,
-        const std::optional<libzcash::UFVKId>& ufvkId)
+        const CPubKey &pubkey)
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
     if (!CCryptoKeyStore::AddKeyPubKey(secret, pubkey))
@@ -611,7 +609,7 @@ UAGenerationResult CWallet::GenerateUnifiedAddress(
             auto seed = GetMnemonicSeed().value();
             auto b44 = libzcash::Bip44AccountChains::ForAccount(seed, BIP44CoinType(), accountId).value();
             auto key = b44.DeriveExternal(diversifierIndex.ToTransparentChildIndex().value()).value();
-            AddTransparentSecretKey(seed.Fingerprint(), key, ufvkid);
+            AddTransparentSecretKey(seed.Fingerprint(), key);
         }
 
         // Save the metadata for the generated address so that we can re-derive

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -195,7 +195,9 @@ bool CWallet::AddSaplingZKey(const libzcash::SaplingExtendedSpendingKey &sk)
     return true;
 }
 
-bool CWallet::AddSaplingFullViewingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk)
+bool CWallet::AddSaplingFullViewingKey(
+        const libzcash::SaplingExtendedFullViewingKey &extfvk,
+        const std::optional<libzcash::UFVKId>& ufvkId)
 {
     AssertLockHeld(cs_wallet);
 
@@ -287,7 +289,7 @@ CPubKey CWallet::GenerateNewKey()
         // if we did not successfully generate a key, try again.
     } while (!extKey.has_value());
 
-    auto pubkey = AddKey(seed.Fingerprint(), extKey.value());
+    auto pubkey = AddTransparentSecretKey(seed.Fingerprint(), extKey.value());
 
     // Update the persisted chain information
     if (fFileBacked && !CWalletDB(strWalletFile).WriteMnemonicHDChain(hdChain)) {
@@ -297,7 +299,10 @@ CPubKey CWallet::GenerateNewKey()
     return pubkey;
 }
 
-CPubKey CWallet::AddKey(const uint256& seedFingerprint, const std::pair<CExtKey, HDKeyPath>& extSecret)
+CPubKey CWallet::AddTransparentSecretKey(
+        const uint256& seedFingerprint,
+        const std::pair<CExtKey, HDKeyPath>& extSecret,
+        const std::optional<libzcash::UFVKId>& ufvkId)
 {
     CKey secret = extSecret.first.key;
     CPubKey pubkey = secret.GetPubKey();
@@ -311,13 +316,16 @@ CPubKey CWallet::AddKey(const uint256& seedFingerprint, const std::pair<CExtKey,
     if (nTimeFirstKey == 0 || keyMeta.nCreateTime < nTimeFirstKey)
         nTimeFirstKey = keyMeta.nCreateTime;
 
-    if (!AddKeyPubKey(secret, pubkey))
-        throw std::runtime_error("CWallet::GenerateNewKey(): AddKey failed");
+    if (!AddKeyPubKey(secret, pubkey, ufvkId))
+        throw std::runtime_error("CWallet::GenerateNewKey(): AddKeyPubKey failed");
 
     return pubkey;
 }
 
-bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)
+bool CWallet::AddKeyPubKey(
+        const CKey& secret,
+        const CPubKey &pubkey,
+        const std::optional<libzcash::UFVKId>& ufvkId)
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
     if (!CCryptoKeyStore::AddKeyPubKey(secret, pubkey))
@@ -334,11 +342,13 @@ bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)
 
     if (!fFileBacked)
         return true;
+
     if (!IsCrypted()) {
         return CWalletDB(strWalletFile).WriteKey(pubkey,
                                                  secret.GetPrivKey(),
                                                  mapKeyMetadata[pubkey.GetID()]);
     }
+
     return true;
 }
 
@@ -456,29 +466,42 @@ std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, libzcash::ZcashdUnif
     }
 }
 
-// Add spending key to keystore
 bool CWallet::AddUnifiedSpendingKey(
         const libzcash::ZcashdUnifiedSpendingKey& sk,
         const libzcash::ZcashdUnifiedKeyMetadata& metadata) {
-    AssertLockHeld(cs_wallet); // mapSaplingZKeyMetadata
+    AssertLockHeld(cs_wallet); // mapUnifiedKeyMetadata
 
-    auto ufvk = sk.ToFullViewingKey();
+    // We don't store the spending key directly; instead, we store each of the spending key's
+    // components, in order to not violate invariants with respect to the encryption of the
+    // wallet. Instead, we store each component in the appropriate wallet subsystem, and
+    // store the metadata that can be used to re-derive the key associated with the fingerprint
+    // of the associated full viewing key.
+
+    auto zufvk = sk.ToFullViewingKey();
     auto metaKey = std::make_pair(metadata.GetSeedFingerprint(), metadata.GetAccountId());
     mapUnifiedKeyMetadata.insert({metaKey, metadata});
 
     // Add Transparent component to the wallet
     if (sk.GetTransparentKey().has_value()) {
-        AddKey(metadata.GetSeedFingerprint(),
+        AddTransparentSecretKey(metadata.GetSeedFingerprint(),
                std::make_pair(sk.GetTransparentKey().value(), metadata.TransparentKeyPath().value()));
     }
 
     // Add Sapling component to the wallet
-    auto addSpendingKey = AddSpendingKeyToWallet(
+    if (sk.GetSaplingExtendedSpendingKey().has_value()) {
+        auto esk = sk.GetSaplingExtendedSpendingKey().value();
+        auto addSpendingKey = AddSpendingKeyToWallet(
             this, Params().GetConsensus(), GetTime(),
             metadata.SaplingKeyPath(), metadata.GetSeedFingerprint().GetHex(), true);
-    if (sk.GetSaplingExtendedSpendingKey().has_value() &&
-        addSpendingKey(sk.GetSaplingExtendedSpendingKey().value()) == KeyNotAdded) {
-        // If adding the Sapling key to the wallet failed, abort the process.
+        if (addSpendingKey(esk) == KeyNotAdded) {
+            // If adding the Sapling key to the wallet failed, abort the process.
+            return false;
+        }
+    }
+
+    auto ufvk = UnifiedFullViewingKey::FromZcashdUFVK(zufvk);
+    auto ufvkid = ufvk.GetKeyID(Params());
+    if (!CCryptoKeyStore::AddUnifiedFullViewingKey(ufvkid, zufvk)) {
         return false;
     }
 
@@ -486,11 +509,32 @@ bool CWallet::AddUnifiedSpendingKey(
         return true;
     }
 
-    if (!IsCrypted()) {
-        //return CWalletDB(strWalletFile).WriteUnifiedFullViewingKey(ufvk, metadata);
+    return CWalletDB(strWalletFile).WriteUnifiedFullViewingKey(ufvkid, ufvk);
+}
+
+bool CWallet::AddUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &ufvk)
+{
+    AssertLockHeld(cs_wallet);
+
+    auto zufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(ufvk);
+    auto keyId = ufvk.GetKeyID(Params());
+    if (!CCryptoKeyStore::AddUnifiedFullViewingKey(keyId, zufvk)) {
+        return false;
     }
 
-    return true;
+    if (!fFileBacked) {
+        return true;
+    }
+
+    return CWalletDB(strWalletFile).WriteUnifiedFullViewingKey(keyId, ufvk);
+}
+
+bool CWallet::LoadUnifiedFullViewingKey(
+    const libzcash::UFVKId& keyId,
+    const libzcash::UnifiedFullViewingKey &key)
+{
+    auto zufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(key);
+    return CCryptoKeyStore::AddUnifiedFullViewingKey(keyId, zufvk);
 }
 
 void CWallet::LoadUnifiedKeyMetadata(const libzcash::ZcashdUnifiedKeyMetadata &meta)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -564,6 +564,22 @@ UAGenerationResult CWallet::GenerateUnifiedAddress(
         return AddressGenerationError::InvalidReceiverTypes;
     }
 
+    // The wallet must be unlocked in order to generate new transparent UA
+    // receivers, because we need to be able to add the secret key for the
+    // external child address at the diversifier index to the wallet's
+    // transparent backend in order to be able to detect transactions as
+    // ours rather than considering them as watch-only.
+    bool hasTransparent = receiverTypes.find(ReceiverType::P2PKH) != receiverTypes.end();
+    if (hasTransparent) {
+        if (!j.ToTransparentChildIndex().has_value()) {
+            return AddressGenerationError::InvalidTransparentChildIndex;
+        }
+
+        if (IsCrypted() || !GetMnemonicSeed().has_value()) {
+            return AddressGenerationError::WalletEncrypted;
+        }
+    }
+
     auto identifiedKey = GetUnifiedFullViewingKeyByAccount(accountId);
     if (identifiedKey.has_value()) {
         auto ufvkid = identifiedKey.value().first;
@@ -594,8 +610,14 @@ UAGenerationResult CWallet::GenerateUnifiedAddress(
         // Persist the newly created address to the keystore
         AddUnifiedAddress(ufvkid, found.first);
 
-        // If we have the associated spending key, add this to the keystore as one
-        // of our own addresses with AddTransparentSecretKey,
+        if (hasTransparent) {
+            // Regenerate the secret key for the transparent address and add it to
+            // the wallet.
+            auto seed = GetMnemonicSeed().value();
+            auto b44 = libzcash::Bip44AccountChains::ForAccount(seed, BIP44CoinType(), accountId).value();
+            auto key = b44.DeriveExternal(j.ToTransparentChildIndex().value()).value();
+            AddTransparentSecretKey(seed.Fingerprint(), key, ufvkid);
+        }
 
         // Save the metadata for the generated address so that we can re-derive
         // it in the future.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1177,7 +1177,7 @@ public:
         GenerateUnifiedSpendingKeyForAccount(libzcash::AccountId accountId);
 
     //! Retrieves the UFVK derived from the wallet's mnemonic seed for the specified account.
-    std::optional<std::pair<libzcash::UFVKId, libzcash::ZcashdUnifiedFullViewingKey>>
+    std::optional<libzcash::ZcashdUnifiedFullViewingKey>
         GetUnifiedFullViewingKeyByAccount(libzcash::AccountId account);
 
     //! Generate a new unified address for the specified account, diversifier, and

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -696,8 +696,9 @@ public:
 
     std::optional<std::set<libzcash::ReceiverType>> GetReceivers(
             const libzcash::diversifier_index_t& j) const {
-        if (addressReceivers.count(j) > 0) {
-            return addressReceivers.at(j);
+        auto receivers = addressReceivers.find(j);
+        if (receivers != addressReceivers.end()) {
+            return receivers->second;
         } else {
             return std::nullopt;
         }
@@ -706,12 +707,7 @@ public:
     bool SetReceivers(
             const libzcash::diversifier_index_t& j,
             const std::set<libzcash::ReceiverType>& receivers) {
-        if (addressReceivers.count(j) > 0) {
-            return false;
-        } else {
-            addressReceivers[j] = receivers;
-            return true;
-        }
+        return addressReceivers.insert(std::make_pair(j, receivers)).second;
     }
 
     bool SetAccountId(libzcash::AccountId accountIdIn) {
@@ -753,7 +749,7 @@ private:
     bool fBroadcastTransactions;
 
     /**
-     * A map from protocol-specifiec transaction output identifier to
+     * A map from a protocol-specific transaction output identifier to
      * a txid.
      */
     template <class T>
@@ -859,7 +855,7 @@ private:
     void SyncMetaData(std::pair<typename TxSpendMap<T>::iterator, typename TxSpendMap<T>::iterator>);
     void ChainTipAdded(const CBlockIndex *pindex, const CBlock *pblock, SproutMerkleTree sproutTree, SaplingMerkleTree saplingTree);
 
-    /* Add an extended secret key to the wallet. Internal use only. */
+    /* Add a transparent secret key to the wallet. Internal use only. */
     CPubKey AddTransparentSecretKey(
             const uint256& seedFingerprint,
             const std::pair<CKey, HDKeyPath>& extSecret,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -406,7 +406,9 @@ enum class AddressGenerationError {
     NoSuchAccount,
     InvalidReceiverTypes,
     ExistingAddressMismatch,
-    NoSaplingAddressForDiversifier
+    NoSaplingAddressForDiversifier,
+    WalletEncrypted,
+    InvalidTransparentChildIndex
 };
 
 typedef std::variant<

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -823,7 +823,7 @@ private:
     /* Add an extended secret key to the wallet. Internal use only. */
     CPubKey AddTransparentSecretKey(
             const uint256& seedFingerprint,
-            const std::pair<CExtKey, HDKeyPath>& extSecret,
+            const std::pair<CKey, HDKeyPath>& extSecret,
             const std::optional<libzcash::UFVKId>& ufvkId = std::nullopt);
 
 protected:

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -843,8 +843,7 @@ public:
 
     std::map<libzcash::SproutPaymentAddress, CKeyMetadata> mapSproutZKeyMetadata;
     std::map<libzcash::SaplingIncomingViewingKey, CKeyMetadata> mapSaplingZKeyMetadata;
-
-    std::map<std::pair<libzcash::SeedFingerprint, libzcash::AccountId>, libzcash::ZcashdUnifiedKeyMetadata> mapUnifiedKeyMetadata;
+    std::map<libzcash::UFVKId, ZcashdUnifiedSpendingKeyMetadata> mapUnifiedKeyMetadata;
 
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
     MasterKeyMap mapMasterKeys;
@@ -1122,18 +1121,18 @@ public:
 
     //! Generate the unified spending key from the wallet's mnemonic seed
     //! for the next unused account identifier.
-    std::pair<libzcash::ZcashdUnifiedSpendingKey, libzcash::ZcashdUnifiedKeyMetadata>
+    std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedSpendingKeyMetadata>
         GenerateNewUnifiedSpendingKey();
 
     //! Generate the next available unified spending key from the wallet's
     //! mnemonic seed.
-    std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, libzcash::ZcashdUnifiedKeyMetadata>>
+    std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedSpendingKeyMetadata>>
         GenerateUnifiedSpendingKeyForAccount(libzcash::AccountId accountId);
 
     bool AddUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &ufvk);
     bool LoadUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &key);
 
-    void LoadUnifiedKeyMetadata(const libzcash::ZcashdUnifiedKeyMetadata &meta);
+    void LoadUnifiedKeyMetadata(const ZcashdUnifiedSpendingKeyMetadata &meta);
 
     /**
      * Increment the next transaction order id

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1154,6 +1154,8 @@ public:
         const libzcash::diversifier_index_t& j,
         const std::set<libzcash::ReceiverType>& receivers);
 
+    std::optional<libzcash::UnifiedAddress> GetUnifiedForReceiver(const libzcash::Receiver& receiver);
+
     bool AddUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &ufvk);
     bool LoadUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &ufvk);
 
@@ -1568,6 +1570,19 @@ public:
     KeyAddResult operator()(const libzcash::SproutSpendingKey &sk) const;
     KeyAddResult operator()(const libzcash::SaplingExtendedSpendingKey &sk) const;
     KeyAddResult operator()(const libzcash::InvalidEncoding& no) const;
+};
+
+class LookupUnifiedAddress {
+private:
+    const CWallet& wallet;
+
+public:
+    LookupUnifiedAddress(const CWallet& wallet): wallet(wallet) {}
+
+    std::optional<libzcash::UnifiedAddress> operator()(const libzcash::SaplingPaymentAddress& saplingAddr) const;
+    std::optional<libzcash::UnifiedAddress> operator()(const CScriptID& scriptId) const;
+    std::optional<libzcash::UnifiedAddress> operator()(const CKeyID& keyId) const;
+    std::optional<libzcash::UnifiedAddress> operator()(const libzcash::UnknownReceiver& receiver) const;
 };
 
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -889,7 +889,7 @@ public:
 
     std::map<libzcash::SproutPaymentAddress, CKeyMetadata> mapSproutZKeyMetadata;
     std::map<libzcash::SaplingIncomingViewingKey, CKeyMetadata> mapSaplingZKeyMetadata;
-    std::map<std::pair<libzcash::SeedFingerprint, libzcash::AccountId>, ZcashdUnifiedSpendingKeyMetadata> mapUnifiedSpendingKeyMeta;
+    std::map<std::pair<libzcash::SeedFingerprint, libzcash::AccountId>, ZcashdUnifiedAccount> mapUnifiedSpendingKeyMeta;
     std::map<libzcash::UFVKId, ZcashdUnifiedFullViewingKeyMetadata> mapUnifiedFullViewingKeyMeta;
 
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
@@ -1168,12 +1168,12 @@ public:
 
     //! Generate the unified spending key from the wallet's mnemonic seed
     //! for the next unused account identifier.
-    std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedSpendingKeyMetadata>
+    std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedAccount>
         GenerateNewUnifiedSpendingKey();
 
     //! Generate the next available unified spending key from the wallet's
     //! mnemonic seed.
-    std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedSpendingKeyMetadata>>
+    std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, ZcashdUnifiedAccount>>
         GenerateUnifiedSpendingKeyForAccount(libzcash::AccountId accountId);
 
     //! Retrieves the UFVK derived from the wallet's mnemonic seed for the specified account.
@@ -1192,7 +1192,7 @@ public:
     bool AddUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &ufvk);
     bool LoadUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &ufvk);
 
-    bool LoadUnifiedKeyMetadata(const ZcashdUnifiedSpendingKeyMetadata &skmeta);
+    bool LoadUnifiedAccount(const ZcashdUnifiedAccount &skmeta);
     bool LoadUnifiedAddressMetadata(const ZcashdUnifiedAddressMetadata &addrmeta);
 
     /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1130,16 +1130,8 @@ public:
     std::optional<std::pair<libzcash::ZcashdUnifiedSpendingKey, libzcash::ZcashdUnifiedKeyMetadata>>
         GenerateUnifiedSpendingKeyForAccount(libzcash::AccountId accountId);
 
-    //! Add the specified unified spending key to the wallet with the provided key
-    //! metadata. -- TODO, this should probably not be part of the public API?
-    bool AddUnifiedSpendingKey(
-            const libzcash::ZcashdUnifiedSpendingKey& sk,
-            const libzcash::ZcashdUnifiedKeyMetadata& metadata);
-
     bool AddUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &ufvk);
-    bool LoadUnifiedFullViewingKey(
-        const libzcash::UFVKId& keyId,
-        const libzcash::UnifiedFullViewingKey &key);
+    bool LoadUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &key);
 
     void LoadUnifiedKeyMetadata(const libzcash::ZcashdUnifiedKeyMetadata &meta);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -858,8 +858,7 @@ private:
     /* Add a transparent secret key to the wallet. Internal use only. */
     CPubKey AddTransparentSecretKey(
             const uint256& seedFingerprint,
-            const std::pair<CKey, HDKeyPath>& extSecret,
-            const std::optional<libzcash::UFVKId>& ufvkId = std::nullopt);
+            const std::pair<CKey, HDKeyPath>& extSecret);
 
 protected:
     bool UpdatedNoteData(const CWalletTx& wtxIn, CWalletTx& wtx);
@@ -1056,10 +1055,7 @@ public:
      */
     CPubKey GenerateNewKey();
     //! Adds a key to the store, and saves it to disk.
-    bool AddKeyPubKey(
-            const CKey& key,
-            const CPubKey &pubkey,
-            const std::optional<libzcash::UFVKId>& ufvkId = std::nullopt);
+    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key, const CPubKey &pubkey) { return CCryptoKeyStore::AddKeyPubKey(key, pubkey); }
     //! Load metadata (used by LoadWallet)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -649,6 +649,30 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         {
             ssValue >> pwallet->vchDefaultKey;
         }
+        else if (strType == "unifiedfvk")
+        {
+            libzcash::UFVKId fp;
+            ssKey >> fp;
+
+            std::string ufvkenc;
+            ssValue >> ufvkenc;
+
+            auto ufvkopt = libzcash::UnifiedFullViewingKey::Decode(ufvkenc, Params());
+            if (ufvkopt.has_value()) {
+                auto ufvk = ufvkopt.value();
+                if (fp != ufvk.GetKeyID(Params())) {
+                    strErr = "Error reading wallet database: key fingerprint did not match decoded key";
+                    return false;
+                }
+                if (!pwallet->LoadUnifiedFullViewingKey(ufvk)) {
+                    strErr = "Error reading wallet database: LoadUnifiedFullViewingKey failed.";
+                    return false;
+                }
+            } else {
+                strErr = "Error reading wallet database: failed to decode unified full viewing key.";
+                return false;
+            }
+        }
         else if (strType == "pool")
         {
             int64_t nIndex;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -169,6 +169,7 @@ bool CWalletDB::WriteZKey(const libzcash::SproutPaymentAddress& addr, const libz
     // pair is: tuple_key("zkey", paymentaddress) --> secretkey
     return Write(std::make_pair(std::string("zkey"), addr), key, false);
 }
+
 bool CWalletDB::WriteSaplingZKey(const libzcash::SaplingIncomingViewingKey &ivk,
                 const libzcash::SaplingExtendedSpendingKey &key,
                 const CKeyMetadata &keyMeta)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -689,12 +689,18 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         else if (strType == "unifiedskmeta")
         {
             auto keymeta = ZcashdUnifiedSpendingKeyMetadata::Read(ssValue);
-            pwallet->LoadUnifiedKeyMetadata(keymeta);
+            if (!pwallet->LoadUnifiedKeyMetadata(keymeta)) {
+                strErr = "Error reading wallet database: account ID mismatch for unified spending key.";
+                return false;
+            };
         }
         else if (strType == "unifiedaddrmeta")
         {
             auto keymeta = ZcashdUnifiedAddressMetadata::Read(ssValue);
-            pwallet->LoadUnifiedAddressMetadata(keymeta);
+            if (!pwallet->LoadUnifiedAddressMetadata(keymeta)) {
+                strErr = "Error reading wallet database: cannot reproduce previously generated unified address.";
+                return false;
+            }
         }
         else if (strType == "pool")
         {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -217,6 +217,22 @@ bool CWalletDB::EraseSaplingExtendedFullViewingKey(
     return Erase(std::make_pair(std::string("sapextfvk"), extfvk));
 }
 
+//
+// Unified address & key storage
+//
+
+bool CWalletDB::WriteUnifiedFullViewingKey(
+    const libzcash::UFVKId& ufvkId,
+    const libzcash::UnifiedFullViewingKey& ufvk)
+{
+    nWalletDBUpdateCounter++;
+    return Write(std::make_pair(std::string("unifiedfvk"), ufvkId), ufvk.Encode(Params()));
+}
+
+//
+//
+//
+
 bool CWalletDB::WriteCScript(const uint160& hash, const CScript& redeemScript)
 {
     nWalletDBUpdateCounter++;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -235,6 +235,13 @@ bool CWalletDB::WriteUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey
     return Write(std::make_pair(std::string("unifiedfvk"), ufvkId), ufvk.Encode(Params()));
 }
 
+bool CWalletDB::WriteUnifiedAddressMetadata(const ZcashdUnifiedAddressMetadata& addrmeta)
+{
+    nWalletDBUpdateCounter++;
+    auto ufvkId = addrmeta.GetKeyID();
+    return Write(std::make_pair(std::string("unifiedaddrmeta"), ufvkId), addrmeta);
+}
+
 //
 //
 //
@@ -683,6 +690,11 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         {
             auto keymeta = ZcashdUnifiedSpendingKeyMetadata::Read(ssValue);
             pwallet->LoadUnifiedKeyMetadata(keymeta);
+        }
+        else if (strType == "unifiedaddrmeta")
+        {
+            auto keymeta = ZcashdUnifiedAddressMetadata::Read(ssValue);
+            pwallet->LoadUnifiedAddressMetadata(keymeta);
         }
         else if (strType == "pool")
         {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -172,16 +172,16 @@ public:
     }
 };
 
-class ZcashdUnifiedSpendingKeyMetadata {
+class ZcashdUnifiedAccount {
 private:
     libzcash::SeedFingerprint seedFp;
     uint32_t bip44CoinType;
     libzcash::AccountId accountId;
     libzcash::UFVKId ufvkId;
 
-    ZcashdUnifiedSpendingKeyMetadata() {}
+    ZcashdUnifiedAccount() {}
 public:
-    ZcashdUnifiedSpendingKeyMetadata(
+    ZcashdUnifiedAccount(
             libzcash::SeedFingerprint seedFp,
             uint32_t bip44CoinType,
             libzcash::AccountId accountId,
@@ -216,8 +216,8 @@ public:
     }
 
     template <typename Stream>
-    static ZcashdUnifiedSpendingKeyMetadata Read(Stream& stream) {
-        ZcashdUnifiedSpendingKeyMetadata meta;
+    static ZcashdUnifiedAccount Read(Stream& stream) {
+        ZcashdUnifiedAccount meta;
         stream >> meta;
         return meta;
     }
@@ -386,7 +386,7 @@ public:
 
     /// Unified key support.
 
-    bool WriteUnifiedSpendingKeyMetadata(const ZcashdUnifiedSpendingKeyMetadata& keymeta);
+    bool WriteUnifiedAccount(const ZcashdUnifiedAccount& keymeta);
     bool WriteUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey& ufvk);
     bool WriteUnifiedAddressMetadata(const ZcashdUnifiedAddressMetadata& addrmeta);
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -251,14 +251,14 @@ class ZcashdUnifiedAddressMetadata {
 private:
     libzcash::UFVKId ufvkId;
     libzcash::diversifier_index_t diversifierIndex;
-    std::vector<libzcash::ReceiverType> receiverTypes;
+    std::set<libzcash::ReceiverType> receiverTypes;
 
     ZcashdUnifiedAddressMetadata() {}
 public:
     ZcashdUnifiedAddressMetadata(
             libzcash::UFVKId ufvkId,
             libzcash::diversifier_index_t diversifierIndex,
-            std::vector<libzcash::ReceiverType> receiverTypes):
+            std::set<libzcash::ReceiverType> receiverTypes):
             ufvkId(ufvkId), diversifierIndex(diversifierIndex), receiverTypes(receiverTypes) {}
 
     libzcash::UFVKId GetKeyID() const {
@@ -267,7 +267,7 @@ public:
     libzcash::diversifier_index_t GetDiversifierIndex() const {
         return diversifierIndex;
     }
-    const std::vector<libzcash::ReceiverType>& GetReceiverTypes() const {
+    const std::set<libzcash::ReceiverType>& GetReceiverTypes() const {
         return receiverTypes;
     }
 
@@ -282,7 +282,7 @@ public:
             READWRITE(serReceiverTypes);
             receiverTypes.clear();
             for (ReceiverTypeSer r : serReceiverTypes)
-                receiverTypes.push_back(r.t);
+                receiverTypes.insert(r.t);
         } else {
             std::vector<ReceiverTypeSer> serReceiverTypes;
             for (libzcash::ReceiverType r : receiverTypes)
@@ -381,6 +381,7 @@ public:
 
     bool WriteUnifiedSpendingKeyMetadata(const ZcashdUnifiedSpendingKeyMetadata& keymeta);
     bool WriteUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey& ufvk);
+    bool WriteUnifiedAddressMetadata(const ZcashdUnifiedAddressMetadata& addrmeta);
 
     static void IncrementUpdateCounter();
     static unsigned int GetUpdateCounter();

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -297,6 +297,13 @@ public:
         stream >> meta;
         return meta;
     }
+
+    friend inline bool operator==(const ZcashdUnifiedAddressMetadata& a, const ZcashdUnifiedAddressMetadata& b) {
+        return
+            a.ufvkId == b.ufvkId &&
+            a.diversifierIndex == b.diversifierIndex &&
+            a.receiverTypes == b.receiverTypes;
+    }
 };
 
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -172,16 +172,16 @@ public:
     }
 };
 
-class ZcashdUnifiedAccount {
+class ZcashdUnifiedAccountMetadata {
 private:
     libzcash::SeedFingerprint seedFp;
     uint32_t bip44CoinType;
     libzcash::AccountId accountId;
     libzcash::UFVKId ufvkId;
 
-    ZcashdUnifiedAccount() {}
+    ZcashdUnifiedAccountMetadata() {}
 public:
-    ZcashdUnifiedAccount(
+    ZcashdUnifiedAccountMetadata(
             libzcash::SeedFingerprint seedFp,
             uint32_t bip44CoinType,
             libzcash::AccountId accountId,
@@ -216,8 +216,8 @@ public:
     }
 
     template <typename Stream>
-    static ZcashdUnifiedAccount Read(Stream& stream) {
-        ZcashdUnifiedAccount meta;
+    static ZcashdUnifiedAccountMetadata Read(Stream& stream) {
+        ZcashdUnifiedAccountMetadata meta;
         stream >> meta;
         return meta;
     }
@@ -386,7 +386,7 @@ public:
 
     /// Unified key support.
 
-    bool WriteUnifiedAccount(const ZcashdUnifiedAccount& keymeta);
+    bool WriteUnifiedAccountMetadata(const ZcashdUnifiedAccountMetadata& keymeta);
     bool WriteUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey& ufvk);
     bool WriteUnifiedAddressMetadata(const ZcashdUnifiedAddressMetadata& addrmeta);
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -249,6 +249,12 @@ public:
     bool WriteSaplingExtendedFullViewingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk);
     bool EraseSaplingExtendedFullViewingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk);
 
+    /// Unified key support.
+
+    bool WriteUnifiedFullViewingKey(
+            const libzcash::UFVKId& ufvkId,
+            const libzcash::UnifiedFullViewingKey& ufvk);
+
     static void IncrementUpdateCounter();
     static unsigned int GetUpdateCounter();
 private:

--- a/src/zcash/Address.cpp
+++ b/src/zcash/Address.cpp
@@ -43,6 +43,37 @@ bool UnifiedAddress::AddReceiver(Receiver receiver) {
     return true;
 }
 
+std::optional<CKeyID> UnifiedAddress::GetP2PKHReceiver() const {
+    for (const auto& r : receivers) {
+        if (std::holds_alternative<CKeyID>(r)) {
+            return std::get<CKeyID>(r);
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<CScriptID> UnifiedAddress::GetP2SHReceiver() const {
+    for (const auto& r : receivers) {
+        if (std::holds_alternative<CScriptID>(r)) {
+            return std::get<CScriptID>(r);
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<SaplingPaymentAddress> UnifiedAddress::GetSaplingReceiver() const {
+    for (const auto& r : receivers) {
+        if (std::holds_alternative<SaplingPaymentAddress>(r)) {
+            return std::get<SaplingPaymentAddress>(r);
+        }
+    }
+
+    return std::nullopt;
+}
+
+
 std::pair<std::string, PaymentAddress> AddressInfoFromSpendingKey::operator()(const SproutSpendingKey &sk) const {
     return std::make_pair("sprout", sk.address());
 }

--- a/src/zcash/Address.cpp
+++ b/src/zcash/Address.cpp
@@ -93,7 +93,7 @@ std::pair<std::string, PaymentAddress> AddressInfoFromViewingKey::operator()(con
 std::pair<std::string, PaymentAddress> AddressInfoFromViewingKey::operator()(const UnifiedFullViewingKey &ufvk) const {
     return std::make_pair(
             "unified",
-            ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(ufvk)
+            ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(keyConstants, ufvk)
                 .FindAddress(diversifier_index_t(0))
                 .first
             );

--- a/src/zcash/Address.cpp
+++ b/src/zcash/Address.cpp
@@ -95,6 +95,7 @@ std::pair<std::string, PaymentAddress> AddressInfoFromViewingKey::operator()(con
             "unified",
             ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(keyConstants, ufvk)
                 .FindAddress(diversifier_index_t(0))
+                .value() //safe because we're searching from 0
                 .first
             );
 }

--- a/src/zcash/Address.cpp
+++ b/src/zcash/Address.cpp
@@ -12,6 +12,10 @@ const uint8_t ZCASH_UA_TYPECODE_SAPLING = 0x02;
 
 namespace libzcash {
 
+//
+// Unified Addresses
+//
+
 std::vector<const Receiver*> UnifiedAddress::GetSorted() const {
     std::vector<const libzcash::Receiver*> sorted;
     for (const auto& receiver : receivers) {
@@ -189,6 +193,10 @@ std::set<libzcash::RawAddress> GetRawAddresses::operator()(
     return ret;
 }
 
+//
+// Unified full viewing keys
+//
+
 std::optional<libzcash::UnifiedFullViewingKey> libzcash::UnifiedFullViewingKey::Decode(
         const std::string& str,
         const KeyConstants& keyConstants) {
@@ -279,4 +287,12 @@ libzcash::UnifiedFullViewingKey libzcash::UnifiedFullViewingKey::FromZcashdUFVK(
         throw std::invalid_argument("Cannot convert from invalid viewing key.");
     }
     return result.value();
+}
+
+libzcash::UFVKId libzcash::UnifiedFullViewingKey::GetKeyID(const KeyConstants& keyConstants) const {
+    // The ID of a ufvk is the blake2b hash of the serialized form of the
+    // ufvk with the receivers sorted in order of descending receiver type.
+    CBLAKE2bWriter h(SER_GETHASH, 0, ZCASH_UFVK_ID_PERSONAL);
+    h << Encode(keyConstants);
+    return libzcash::UFVKId(h.GetHash());
 }

--- a/src/zcash/Address.hpp
+++ b/src/zcash/Address.hpp
@@ -123,6 +123,12 @@ public:
         return receivers.size();
     }
 
+    std::optional<CKeyID> GetP2PKHReceiver() const;
+
+    std::optional<CScriptID> GetP2SHReceiver() const;
+
+    std::optional<SaplingPaymentAddress> GetSaplingReceiver() const;
+
     friend inline bool operator==(const UnifiedAddress& a, const UnifiedAddress& b) {
         return a.receivers == b.receivers;
     }

--- a/src/zcash/Address.hpp
+++ b/src/zcash/Address.hpp
@@ -3,6 +3,7 @@
 
 #include "key_constants.h"
 #include "pubkey.h"
+#include "key_constants.h"
 #include "script/script.h"
 #include "uint256.h"
 #include "zcash/address/orchard.hpp"
@@ -132,6 +133,12 @@ public:
 
 class UnifiedFullViewingKeyBuilder;
 
+class UFVKId: public uint256 {
+public:
+    UFVKId() : uint256() {}
+    UFVKId(const uint256& in) : uint256(in) {}
+};
+
 /**
  * Wrapper for a zcash_address::unified::Ufvk.
  */
@@ -147,9 +154,10 @@ private:
 
     friend class UnifiedFullViewingKeyBuilder;
 public:
-    static std::optional<UnifiedFullViewingKey> Decode(
-            const std::string& str,
-            const KeyConstants& keyConstants);
+    UnifiedFullViewingKey(UnifiedFullViewingKey&& key) : inner(std::move(key.inner)) {}
+
+    UnifiedFullViewingKey(const UnifiedFullViewingKey& key) :
+        inner(unified_full_viewing_key_clone(key.inner.get()), unified_full_viewing_key_free) {}
 
     /**
      * This method should only be used for serialization of unified full
@@ -161,16 +169,17 @@ public:
      */
     static UnifiedFullViewingKey FromZcashdUFVK(const ZcashdUnifiedFullViewingKey&);
 
+    static std::optional<UnifiedFullViewingKey> Decode(
+            const std::string& str,
+            const KeyConstants& keyConstants);
+
     std::string Encode(const KeyConstants& keyConstants) const;
 
     std::optional<SaplingDiversifiableFullViewingKey> GetSaplingKey() const;
 
     std::optional<CChainablePubKey> GetTransparentKey() const;
 
-    UnifiedFullViewingKey(UnifiedFullViewingKey&& key) : inner(std::move(key.inner)) {}
-
-    UnifiedFullViewingKey(const UnifiedFullViewingKey& key) :
-        inner(unified_full_viewing_key_clone(key.inner.get()), unified_full_viewing_key_free) {}
+    UFVKId GetKeyID(const KeyConstants& keyConstants) const;
 
     UnifiedFullViewingKey& operator=(UnifiedFullViewingKey&& key)
     {

--- a/src/zcash/Address.hpp
+++ b/src/zcash/Address.hpp
@@ -15,6 +15,9 @@
 #include <variant>
 #include <rust/unified_keys.h>
 
+const unsigned char ZCASH_UFVK_ID_PERSONAL[BLAKE2bPersonalBytes] =
+    {'Z', 'c', 'a', 's', 'h', '_', 'U', 'F', 'V', 'K', '_', 'I', 'd', '_', 'F', 'P'};
+
 namespace libzcash {
 
 /** Protocol addresses that can receive funds in a transaction. */

--- a/src/zcash/Address.hpp
+++ b/src/zcash/Address.hpp
@@ -135,6 +135,9 @@ public:
     friend inline bool operator==(const UnifiedAddress& a, const UnifiedAddress& b) {
         return a.receivers == b.receivers;
     }
+    friend inline bool operator!=(const UnifiedAddress& a, const UnifiedAddress& b) {
+        return a.receivers != b.receivers;
+    }
     friend inline bool operator<(const UnifiedAddress& a, const UnifiedAddress& b) {
         return a.receivers < b.receivers;
     }

--- a/src/zcash/Address.hpp
+++ b/src/zcash/Address.hpp
@@ -145,12 +145,6 @@ public:
 
 class UnifiedFullViewingKeyBuilder;
 
-class UFVKId: public uint256 {
-public:
-    UFVKId() : uint256() {}
-    UFVKId(const uint256& in) : uint256(in) {}
-};
-
 /**
  * Wrapper for a zcash_address::unified::Ufvk.
  */
@@ -249,7 +243,11 @@ public:
 };
 
 class AddressInfoFromViewingKey {
+private:
+    const KeyConstants& keyConstants;
+
 public:
+    AddressInfoFromViewingKey(const KeyConstants& keyConstants): keyConstants(keyConstants) {}
     std::pair<std::string, PaymentAddress> operator()(const SproutViewingKey&) const;
     std::pair<std::string, PaymentAddress> operator()(const struct SaplingExtendedFullViewingKey&) const;
     std::pair<std::string, PaymentAddress> operator()(const UnifiedFullViewingKey&) const;

--- a/src/zcash/address/bip44.cpp
+++ b/src/zcash/address/bip44.cpp
@@ -4,6 +4,10 @@
 
 #include "bip44.h"
 
+HDKeyPath libzcash::Bip44TransparentAccountKeyPath(uint32_t bip44CoinType, libzcash::AccountId accountId) {
+    return "m/44'/" + std::to_string(bip44CoinType) + "'/" + std::to_string(accountId) + "'";
+}
+
 std::optional<std::pair<CExtKey, HDKeyPath>> libzcash::DeriveBip44TransparentAccountKey(const HDSeed& seed, uint32_t bip44CoinType, libzcash::AccountId accountId) {
     auto rawSeed = seed.RawSeed();
     auto m = CExtKey::Master(rawSeed.data(), rawSeed.size());
@@ -21,7 +25,7 @@ std::optional<std::pair<CExtKey, HDKeyPath>> libzcash::DeriveBip44TransparentAcc
     auto result = m_44h_cth.value().Derive(accountId | HARDENED_KEY_LIMIT);
     if (!result.has_value()) return std::nullopt;
 
-    auto hdKeypath = "m/44'/" + std::to_string(bip44CoinType) + "'/" + std::to_string(accountId) + "'";
+    auto hdKeypath = libzcash::Bip44TransparentAccountKeyPath(bip44CoinType, accountId);
 
     return std::make_pair(result.value(), hdKeypath);
 }

--- a/src/zcash/address/bip44.cpp
+++ b/src/zcash/address/bip44.cpp
@@ -46,7 +46,7 @@ std::optional<libzcash::Bip44AccountChains> libzcash::Bip44AccountChains::ForAcc
     return Bip44AccountChains(seed.Fingerprint(), bip44CoinType, accountId, external.value(), internal.value());
 }
 
-std::optional<std::pair<CExtKey, HDKeyPath>> libzcash::Bip44AccountChains::DeriveExternal(uint32_t addrIndex) {
+std::optional<std::pair<CKey, HDKeyPath>> libzcash::Bip44AccountChains::DeriveExternal(uint32_t addrIndex) {
     auto childKey = external.Derive(addrIndex);
     if (!childKey.has_value()) return std::nullopt;
 
@@ -56,10 +56,10 @@ std::optional<std::pair<CExtKey, HDKeyPath>> libzcash::Bip44AccountChains::Deriv
         + "0/"
         + std::to_string(addrIndex);
 
-    return std::make_pair(childKey.value(), hdKeypath);
+    return std::make_pair(childKey.value().key, hdKeypath);
 }
 
-std::optional<std::pair<CExtKey, HDKeyPath>> libzcash::Bip44AccountChains::DeriveInternal(uint32_t addrIndex) {
+std::optional<std::pair<CKey, HDKeyPath>> libzcash::Bip44AccountChains::DeriveInternal(uint32_t addrIndex) {
     auto childKey = internal.Derive(addrIndex);
     if (!childKey.has_value()) return std::nullopt;
 
@@ -69,6 +69,6 @@ std::optional<std::pair<CExtKey, HDKeyPath>> libzcash::Bip44AccountChains::Deriv
         + "1/"
         + std::to_string(addrIndex);
 
-    return std::make_pair(childKey.value(), hdKeypath);
+    return std::make_pair(childKey.value().key, hdKeypath);
 }
 

--- a/src/zcash/address/bip44.cpp
+++ b/src/zcash/address/bip44.cpp
@@ -50,11 +50,7 @@ std::optional<std::pair<CKey, HDKeyPath>> libzcash::Bip44AccountChains::DeriveEx
     auto childKey = external.Derive(addrIndex);
     if (!childKey.has_value()) return std::nullopt;
 
-    auto hdKeypath = "m/44'/"
-        + std::to_string(bip44CoinType) + "'/"
-        + std::to_string(accountId) + "'/"
-        + "0/"
-        + std::to_string(addrIndex);
+    auto hdKeypath = Bip44TransparentAccountKeyPath(bip44CoinType, accountId) + "/0/" + std::to_string(addrIndex);
 
     return std::make_pair(childKey.value().key, hdKeypath);
 }
@@ -63,11 +59,7 @@ std::optional<std::pair<CKey, HDKeyPath>> libzcash::Bip44AccountChains::DeriveIn
     auto childKey = internal.Derive(addrIndex);
     if (!childKey.has_value()) return std::nullopt;
 
-    auto hdKeypath = "m/44'/"
-        + std::to_string(bip44CoinType) + "'/"
-        + std::to_string(accountId) + "'/"
-        + "1/"
-        + std::to_string(addrIndex);
+    auto hdKeypath = Bip44TransparentAccountKeyPath(bip44CoinType, accountId) + "/1/" + std::to_string(addrIndex);
 
     return std::make_pair(childKey.value().key, hdKeypath);
 }

--- a/src/zcash/address/bip44.h
+++ b/src/zcash/address/bip44.h
@@ -29,8 +29,19 @@ public:
             uint32_t bip44CoinType,
             libzcash::AccountId accountId);
 
+    /**
+     * Generate the key corresponding to the specified index at the "external child"
+     * level of the BIP44 path for the account.
+     */
     std::optional<std::pair<CKey, HDKeyPath>> DeriveExternal(uint32_t addrIndex);
-    std::optional<std::pair<CKey, HDKeyPath>> DeriveInternal(uint32_t addrIndex);
+
+    /**
+     * Generate the key corresponding to the specified index at the "internal child"
+     * level of the BIP44 path for the account. This should probably only usually be
+     * used at address index 0, but ordinarily it won't need to be used at all since
+     * all change should be shielded by default.
+     */
+    std::optional<std::pair<CKey, HDKeyPath>> DeriveInternal(uint32_t addrIndex = 0);
 };
 
 } //namespace libzcash

--- a/src/zcash/address/bip44.h
+++ b/src/zcash/address/bip44.h
@@ -11,6 +11,10 @@ namespace libzcash {
 
 HDKeyPath Bip44TransparentAccountKeyPath(uint32_t bip44CoinType, libzcash::AccountId accountId);
 
+/**
+ * Derive a transparent extended key in compressed format for the specified
+ * seed, bip44 coin type, and account ID.
+ */
 std::optional<std::pair<CExtKey, HDKeyPath>> DeriveBip44TransparentAccountKey(const HDSeed& seed, uint32_t bip44CoinType, libzcash::AccountId accountId);
 
 class Bip44AccountChains {

--- a/src/zcash/address/bip44.h
+++ b/src/zcash/address/bip44.h
@@ -29,8 +29,8 @@ public:
             uint32_t bip44CoinType,
             libzcash::AccountId accountId);
 
-    std::optional<std::pair<CExtKey, HDKeyPath>> DeriveExternal(uint32_t addrIndex);
-    std::optional<std::pair<CExtKey, HDKeyPath>> DeriveInternal(uint32_t addrIndex);
+    std::optional<std::pair<CKey, HDKeyPath>> DeriveExternal(uint32_t addrIndex);
+    std::optional<std::pair<CKey, HDKeyPath>> DeriveInternal(uint32_t addrIndex);
 };
 
 } //namespace libzcash

--- a/src/zcash/address/bip44.h
+++ b/src/zcash/address/bip44.h
@@ -9,6 +9,8 @@
 
 namespace libzcash {
 
+HDKeyPath Bip44TransparentAccountKeyPath(uint32_t bip44CoinType, libzcash::AccountId accountId);
+
 std::optional<std::pair<CExtKey, HDKeyPath>> DeriveBip44TransparentAccountKey(const HDSeed& seed, uint32_t bip44CoinType, libzcash::AccountId accountId);
 
 class Bip44AccountChains {

--- a/src/zcash/address/unified.cpp
+++ b/src/zcash/address/unified.cpp
@@ -12,9 +12,11 @@ using namespace libzcash;
 // Unified Keys
 //
 
-std::optional<std::pair<ZcashdUnifiedSpendingKey, HDKeyPath>> ZcashdUnifiedSpendingKey::ForAccount(const HDSeed& seed, uint32_t bip44CoinType, AccountId accountId) {
+std::optional<std::pair<ZcashdUnifiedSpendingKey, HDKeyPath>> ZcashdUnifiedSpendingKey::ForAccount(
+        const HDSeed& seed,
+        const uint32_t bip44CoinType,
+        AccountId accountId) {
     ZcashdUnifiedSpendingKey usk;
-    usk.accountId = accountId;
 
     auto transparentKey = DeriveBip44TransparentAccountKey(seed, bip44CoinType, accountId);
     if (!transparentKey.has_value()) return std::nullopt;
@@ -105,4 +107,3 @@ std::pair<UnifiedAddress, diversifier_index_t> ZcashdUnifiedFullViewingKey::Find
     }
     return std::make_pair(addr.value(), j);
 }
-

--- a/src/zcash/address/unified.cpp
+++ b/src/zcash/address/unified.cpp
@@ -12,23 +12,7 @@ using namespace libzcash;
 // Unified Keys
 //
 
-std::optional<HDKeyPath> ZcashdUnifiedKeyMetadata::TransparentKeyPath() const {
-    if(std::find(receiverTypes.begin(), receiverTypes.end(), ReceiverType::P2PKH) != receiverTypes.end()) {
-        return libzcash::Bip44TransparentAccountKeyPath(bip44CoinType, accountId);
-    } else {
-        return std::nullopt;
-    }
-}
-
-std::optional<HDKeyPath> ZcashdUnifiedKeyMetadata::SaplingKeyPath() const {
-    if(std::find(receiverTypes.begin(), receiverTypes.end(), ReceiverType::Sapling) != receiverTypes.end()) {
-        return libzcash::Bip44TransparentAccountKeyPath(bip44CoinType, accountId);
-    } else {
-        return std::nullopt;
-    }
-}
-
-std::optional<std::pair<ZcashdUnifiedSpendingKey, ZcashdUnifiedKeyMetadata>> ZcashdUnifiedSpendingKey::ForAccount(
+std::optional<ZcashdUnifiedSpendingKey> ZcashdUnifiedSpendingKey::ForAccount(
         const HDSeed& seed,
         uint32_t bip44CoinType,
         AccountId accountId) {
@@ -41,12 +25,7 @@ std::optional<std::pair<ZcashdUnifiedSpendingKey, ZcashdUnifiedKeyMetadata>> Zca
     auto saplingKey = SaplingExtendedSpendingKey::ForAccount(seed, bip44CoinType, accountId);
     usk.saplingKey = saplingKey.first;
 
-    ZcashdUnifiedKeyMetadata keyMetadata(
-            seed.Fingerprint(),
-            bip44CoinType, accountId,
-            { ReceiverType::P2PKH, ReceiverType::Sapling });
-
-    return std::make_pair(usk, keyMetadata);
+    return usk;
 }
 
 ZcashdUnifiedFullViewingKey ZcashdUnifiedSpendingKey::ToFullViewingKey() const {

--- a/src/zcash/address/unified.cpp
+++ b/src/zcash/address/unified.cpp
@@ -80,8 +80,7 @@ std::optional<UnifiedAddress> ZcashdUnifiedFullViewingKey::Address(
     }
 
     UnifiedAddress ua;
-    if (saplingKey.has_value() &&
-            std::find(receiverTypes.begin(), receiverTypes.end(), ReceiverType::Sapling) != receiverTypes.end()) {
+    if (saplingKey.has_value() && receiverTypes.count(ReceiverType::Sapling) > 0) {
         auto saplingAddress = saplingKey.value().Address(j);
         if (saplingAddress.has_value()) {
             ua.AddReceiver(saplingAddress.value());
@@ -90,8 +89,7 @@ std::optional<UnifiedAddress> ZcashdUnifiedFullViewingKey::Address(
         }
     }
 
-    if (transparentKey.has_value() &&
-            std::find(receiverTypes.begin(), receiverTypes.end(), ReceiverType::P2PKH) != receiverTypes.end()) {
+    if (transparentKey.has_value() && receiverTypes.count(ReceiverType::P2PKH) > 0) {
         const auto& tkey = transparentKey.value();
         auto childIndex = j.ToTransparentChildIndex();
         if (!childIndex.has_value()) return std::nullopt;

--- a/src/zcash/address/unified.cpp
+++ b/src/zcash/address/unified.cpp
@@ -21,11 +21,11 @@ bool libzcash::HasShielded(const std::set<ReceiverType>& receiverTypes) {
 }
 
 bool libzcash::HasTransparent(const std::set<ReceiverType>& receiverTypes) {
-    auto has_shielded = [](ReceiverType r) {
+    auto has_transparent = [](ReceiverType r) {
         // TODO: update this as support for new transparent protocols is added.
         return r == ReceiverType::P2PKH || r == ReceiverType::P2SH;
     };
-    return std::find_if(receiverTypes.begin(), receiverTypes.end(), has_shielded) != receiverTypes.end();
+    return std::find_if(receiverTypes.begin(), receiverTypes.end(), has_transparent) != receiverTypes.end();
 }
 
 std::optional<ZcashdUnifiedSpendingKey> ZcashdUnifiedSpendingKey::ForAccount(
@@ -132,5 +132,5 @@ std::optional<std::pair<UnifiedAddress, diversifier_index_t>> ZcashdUnifiedFullV
 
 std::optional<std::pair<UnifiedAddress, diversifier_index_t>> ZcashdUnifiedFullViewingKey::FindAddress(
         const diversifier_index_t& j) const {
-    return FindAddress(j, {ReceiverType::P2PKH, ReceiverType::Sapling, ReceiverType::Orchard});
+    return FindAddress(j, {ReceiverType::P2PKH, ReceiverType::Sapling});
 }

--- a/src/zcash/address/unified.h
+++ b/src/zcash/address/unified.h
@@ -17,6 +17,12 @@ enum class ReceiverType: uint32_t {
     Orchard = 0x03
 };
 
+/**
+ * Test whether the specified list of receiver types contains a
+ * shielded receiver type
+ */
+bool HasShielded(const std::set<ReceiverType>& receiverTypes);
+
 class ZcashdUnifiedSpendingKey;
 
 // prototypes for the classes handling ZIP-316 encoding (in Address.hpp)
@@ -51,9 +57,33 @@ public:
         return saplingKey;
     }
 
-    std::optional<UnifiedAddress> Address(diversifier_index_t j) const;
+    /**
+     * Creates a new unified address having the specified receiver types, at the specified
+     * diversifier index, unless the diversifer index would generate an invalid receiver.
+     * Returns `std::nullopt` if the diversifier index does not produce a valid receiver
+     * for one or more of the specified receiver types; under this circumstance, the caller
+     * should usually try successive diversifier indices until the operation returns a
+     * non-null value.
+     *
+     * This method will throw if `receiverTypes` does not include a shielded receiver type.
+     */
+    std::optional<UnifiedAddress> Address(
+            const diversifier_index_t& j,
+            const std::set<ReceiverType>& receiverTypes) const;
 
-    std::pair<UnifiedAddress, diversifier_index_t> FindAddress(diversifier_index_t j) const;
+    /**
+     * Find the smallest diversifier index >= `j` such that it generates a valid
+     * unified address according to the conditions specified in the documentation
+     * for the `Address` method above, and returns the newly created address along
+     * with the diversifier index used to produce it.
+     *
+     * This method will throw if `receiverTypes` does not include a shielded receiver type.
+     */
+    std::pair<UnifiedAddress, diversifier_index_t> FindAddress(
+            const diversifier_index_t& j,
+            const std::set<ReceiverType>& receiverTypes) const;
+
+    std::pair<UnifiedAddress, diversifier_index_t> FindAddress(const diversifier_index_t& j) const;
 };
 
 /**

--- a/src/zcash/address/unified.h
+++ b/src/zcash/address/unified.h
@@ -15,7 +15,7 @@ enum class ReceiverType: uint32_t {
     P2PKH = 0x00,
     P2SH = 0x01,
     Sapling = 0x02,
-    Orchard = 0x03
+    //Orchard = 0x03
 };
 
 /**

--- a/src/zcash/address/unified.h
+++ b/src/zcash/address/unified.h
@@ -84,6 +84,11 @@ public:
             const std::set<ReceiverType>& receiverTypes) const;
 
     std::pair<UnifiedAddress, diversifier_index_t> FindAddress(const diversifier_index_t& j) const;
+
+    friend bool operator==(const ZcashdUnifiedFullViewingKey& a, const ZcashdUnifiedFullViewingKey& b)
+    {
+        return a.transparentKey == b.transparentKey && a.saplingKey == b.saplingKey;
+    }
 };
 
 /**

--- a/src/zcash/address/unified.h
+++ b/src/zcash/address/unified.h
@@ -24,6 +24,12 @@ enum class ReceiverType: uint32_t {
  */
 bool HasShielded(const std::set<ReceiverType>& receiverTypes);
 
+/**
+ * Test whether the specified list of receiver types contains a
+ * shielded receiver type
+ */
+bool HasTransparent(const std::set<ReceiverType>& receiverTypes);
+
 class ZcashdUnifiedSpendingKey;
 
 // prototypes for the classes handling ZIP-316 encoding (in Address.hpp)
@@ -94,15 +100,21 @@ public:
      * Find the smallest diversifier index >= `j` such that it generates a valid
      * unified address according to the conditions specified in the documentation
      * for the `Address` method above, and returns the newly created address along
-     * with the diversifier index used to produce it.
+     * with the diversifier index used to produce it. Returns `std::nullopt` if the
+     * diversifier space is exhausted, or if the set of receiver types contains a
+     * transparent receiver and the diversifier exceeds the maximum transparent
+     * child index.
      *
      * This method will throw if `receiverTypes` does not include a shielded receiver type.
      */
-    std::pair<UnifiedAddress, diversifier_index_t> FindAddress(
+    std::optional<std::pair<UnifiedAddress, diversifier_index_t>> FindAddress(
             const diversifier_index_t& j,
             const std::set<ReceiverType>& receiverTypes) const;
 
-    std::pair<UnifiedAddress, diversifier_index_t> FindAddress(const diversifier_index_t& j) const;
+    /**
+     * Find the next available address that contains all supported receiver types.
+     */
+    std::optional<std::pair<UnifiedAddress, diversifier_index_t>> FindAddress(const diversifier_index_t& j) const;
 
     friend bool operator==(const ZcashdUnifiedFullViewingKey& a, const ZcashdUnifiedFullViewingKey& b)
     {

--- a/src/zcash/address/unified.h
+++ b/src/zcash/address/unified.h
@@ -13,12 +13,41 @@ const unsigned char ZCASH_UFVK_ID_PERSONAL[BLAKE2bPersonalBytes] =
 
 namespace libzcash {
 
+enum class ReceiverType: uint32_t {
+    P2PKH = 0x00,
+    P2SH = 0x01,
+    Sapling = 0x02,
+    Orchard = 0x03
+};
+
 class ZcashdUnifiedSpendingKey;
 class ZcashdUnifiedFullViewingKey;
+
 
 // prototypes for the classes handling ZIP-316 encoding (in Address.hpp)
 class UnifiedAddress;
 class UnifiedFullViewingKey;
+
+class ZcashdUnifiedKeyMetadata {
+private:
+    uint256 seedFp;
+    uint32_t bip44CoinType;
+    libzcash::AccountId accountId;
+    std::vector<ReceiverType> receiverTypes;
+public:
+    ZcashdUnifiedKeyMetadata(
+            uint256 seedFp, uint32_t bip44CoinType, libzcash::AccountId accountId, std::vector<ReceiverType> receiverTypes):
+            seedFp(seedFp), bip44CoinType(bip44CoinType), accountId(accountId), receiverTypes(receiverTypes) {}
+
+    const uint256& GetSeedFingerprint() const {
+        return seedFp;
+    }
+    const std::vector<ReceiverType>& GetReceiverTypes() const {
+        return receiverTypes;
+    }
+    std::optional<HDKeyPath> TransparentKeyPath() const;
+    std::optional<HDKeyPath> SaplingKeyPath() const;
+};
 
 /**
  * An internal-only type for unified full viewing keys that represents only the
@@ -63,7 +92,7 @@ private:
 
     ZcashdUnifiedSpendingKey() {}
 public:
-    static std::optional<std::pair<ZcashdUnifiedSpendingKey, HDKeyPath>> ForAccount(
+    static std::optional<std::pair<ZcashdUnifiedSpendingKey, ZcashdUnifiedKeyMetadata>> ForAccount(
             const HDSeed& seed,
             uint32_t bip44CoinType,
             libzcash::AccountId accountId);

--- a/src/zcash/address/unified.h
+++ b/src/zcash/address/unified.h
@@ -8,6 +8,9 @@
 #include "zip32.h"
 #include "bip44.h"
 
+const unsigned char ZCASH_UFVK_ID_PERSONAL[BLAKE2bPersonalBytes] =
+    {'Z', 'c', 'a', 's', 'h', '_', 'U', 'F', 'V', 'K', '_', 'I', 'd', '_', 'F', 'P'};
+
 namespace libzcash {
 
 class ZcashdUnifiedSpendingKey;
@@ -55,7 +58,6 @@ public:
  */
 class ZcashdUnifiedSpendingKey {
 private:
-    libzcash::AccountId accountId;
     std::optional<CExtKey> transparentKey;
     std::optional<SaplingExtendedSpendingKey> saplingKey;
 

--- a/src/zcash/address/zip32.cpp
+++ b/src/zcash/address/zip32.cpp
@@ -48,12 +48,12 @@ uint256 ovkForShieldingFromTaddr(HDSeed& seed) {
 
 namespace libzcash {
 
-std::optional<unsigned int> diversifier_index_t::ToTransparentChildIndex() const {
+std::optional<uint32_t> diversifier_index_t::ToTransparentChildIndex() const {
     // ensure that the diversifier index is small enough for a t-addr
     if (MAX_TRANSPARENT_CHILD_IDX < *this) {
         return std::nullopt;
     } else {
-        return (unsigned int) GetUint64(0);
+        return (uint32_t) GetUint64(0);
     }
 }
 

--- a/src/zcash/address/zip32.cpp
+++ b/src/zcash/address/zip32.cpp
@@ -19,8 +19,6 @@ const unsigned char ZCASH_HD_SEED_FP_PERSONAL[BLAKE2bPersonalBytes] =
 const unsigned char ZCASH_TADDR_OVK_PERSONAL[BLAKE2bPersonalBytes] =
     {'Z', 'c', 'T', 'a', 'd', 'd', 'r', 'T', 'o', 'S', 'a', 'p', 'l', 'i', 'n', 'g'};
 
-const libzcash::diversifier_index_t MAX_TRANSPARENT_CHILD_IDX(0x7FFFFFFF);
-
 uint256 HDSeed::Fingerprint() const
 {
     CBLAKE2bWriter h(SER_GETHASH, 0, ZCASH_HD_SEED_FP_PERSONAL);

--- a/src/zcash/address/zip32.cpp
+++ b/src/zcash/address/zip32.cpp
@@ -173,10 +173,7 @@ std::pair<SaplingExtendedSpendingKey, HDKeyPath> SaplingExtendedSpendingKey::For
     // Derive account key at the given account index
     auto xsk = m_32h_cth.Derive(accountId | HARDENED_KEY_LIMIT);
 
-    // Create new metadata
-    auto hdKeypath = "m/32'/" + std::to_string(bip44CoinType) + "'/" + std::to_string(accountId) + "'";
-
-    return std::make_pair(xsk, hdKeypath);
+    return std::make_pair(xsk, libzcash::Zip32AccountKeyPath(bip44CoinType, accountId));
 }
 
 std::pair<SaplingExtendedSpendingKey, HDKeyPath> SaplingExtendedSpendingKey::Legacy(const HDSeed& seed, uint32_t bip44CoinType, uint32_t addressIndex) {
@@ -198,13 +195,7 @@ std::pair<SaplingExtendedSpendingKey, HDKeyPath> SaplingExtendedSpendingKey::Leg
     // Derive key at the specified address index
     auto xsk = m_32h_cth_l.Derive(addressIndex | HARDENED_KEY_LIMIT);
 
-    // Create new metadata
-    auto hdKeypath = "m/32'/"
-        + std::to_string(bip44CoinType) + "'/"
-        + std::to_string(ZCASH_LEGACY_ACCOUNT) + "'/"
-        + std::to_string(addressIndex) + "'";
-
-    return std::make_pair(xsk, hdKeypath);
+    return std::make_pair(xsk, libzcash::Zip32AccountKeyPath(bip44CoinType, ZCASH_LEGACY_ACCOUNT, addressIndex));
 }
 
 SaplingExtendedFullViewingKey SaplingExtendedSpendingKey::ToXFVK() const
@@ -217,6 +208,17 @@ SaplingExtendedFullViewingKey SaplingExtendedSpendingKey::ToXFVK() const
     ret.fvk = expsk.full_viewing_key();
     ret.dk = dk;
     return ret;
+}
+
+HDKeyPath Zip32AccountKeyPath(
+        uint32_t bip44CoinType,
+        libzcash::AccountId accountId,
+        std::optional<uint32_t> legacyAddressIndex) {
+    HDKeyPath addrSuffix = "";
+    if (legacyAddressIndex.has_value()) {
+        addrSuffix = "/" + std::to_string(legacyAddressIndex.value()) + "'";
+    }
+    return "m/32'/" + std::to_string(bip44CoinType) + "'/" + std::to_string(accountId) + "'" + addrSuffix;
 }
 
 std::optional<unsigned long> ParseHDKeypathAccount(uint32_t purpose, uint32_t coinType, const std::string& keyPath) {

--- a/src/zcash/address/zip32.h
+++ b/src/zcash/address/zip32.h
@@ -62,6 +62,7 @@ uint256 ovkForShieldingFromTaddr(HDSeed& seed);
 
 namespace libzcash {
 
+typedef uint256 SeedFingerprint;
 typedef uint32_t AccountId;
 
 /**

--- a/src/zcash/address/zip32.h
+++ b/src/zcash/address/zip32.h
@@ -240,7 +240,15 @@ struct SaplingExtendedSpendingKey {
     }
 };
 
-std::optional<unsigned long> ParseHDKeypathAccount(uint32_t purpose, uint32_t coinType, const std::string& keyPath);
+HDKeyPath Zip32AccountKeyPath(
+        uint32_t bip44CoinType,
+        libzcash::AccountId accountId,
+        std::optional<uint32_t> legacyAddressIndex = std::nullopt);
+
+std::optional<unsigned long> ParseHDKeypathAccount(
+        uint32_t purpose,
+        uint32_t coinType,
+        const std::string& keyPath);
 
 } //namespace libzcash
 

--- a/src/zcash/address/zip32.h
+++ b/src/zcash/address/zip32.h
@@ -103,7 +103,7 @@ public:
         return false; //overflow
     }
 
-    std::optional<unsigned int> ToTransparentChildIndex() const;
+    std::optional<uint32_t> ToTransparentChildIndex() const;
 
     friend bool operator<(const diversifier_index_t& a, const diversifier_index_t& b) {
         for (int i = 10; i >= 0; i--) {

--- a/src/zcash/address/zip32.h
+++ b/src/zcash/address/zip32.h
@@ -103,6 +103,15 @@ public:
         return false; //overflow
     }
 
+    std::optional<diversifier_index_t> succ() const {
+        diversifier_index_t next(*this);
+        if (next.increment()) {
+            return next;
+        } else {
+            return std::nullopt;
+        }
+    }
+
     std::optional<uint32_t> ToTransparentChildIndex() const;
 
     friend bool operator<(const diversifier_index_t& a, const diversifier_index_t& b) {
@@ -117,6 +126,9 @@ public:
         return false;
     }
 };
+
+// The maximum allowed transparent child index according to BIP-44
+const libzcash::diversifier_index_t MAX_TRANSPARENT_CHILD_IDX(0x7FFFFFFF);
 
 class SaplingDiversifiableFullViewingKey {
 public:


### PR DESCRIPTION
Fixes #5179

- [x] Add method for new account generation; i.e. generate a new Unified Spending Key for the next available account #
- [x] Persist the metadata & UFVK corresponding to the generated USK to the walletdb
- [x] When a new UFVK is generated, or when a UFVK is read from the walletdb, add its Sapling components to the keystore so that note detection can find the correct UFVK.
- [x] Add Unified Address generation for a particular account & set of receivers.
- [x] When a new UA is generated, add an association between its diversifier and the source account and set of receivers to the walletdb and keystore so that we can look up/regenerate the original UA.
- [x] Make it possible to look up the source UA from a receiver on which a payment was received.