### PR TITLE
Allow rpc python tests to be run standalone

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -22,3 +22,10 @@ Dependencies
 ------------
 
 - The `boost` and `native_b2` dependencies have been updated to version 1.79.0
+
+Tests
+-----
+
+- The environment variable that allows users of the rpc (Python) tests to
+  override the default path to the `zcashd` executable has been changed
+  from `BITCOIND` to `ZCASHD`.

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -273,8 +273,8 @@ def run_tests(test_list, src_dir, build_dir, exeext, jobs=1, enable_coverage=Fal
         BOLD = ('\033[0m', '\033[1m')
 
     #Set env vars
-    if "BITCOIND" not in os.environ:
-        os.environ["BITCOIND"] = build_dir + '/src/zcashd' + exeext
+    if "ZCASHD" not in os.environ:
+        os.environ["ZCASHD"] = build_dir + '/src/zcashd' + exeext
 
     tests_dir = src_dir + '/qa/rpc-tests/'
 

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -6,7 +6,7 @@
 from test_framework.mininode import NodeConn, NodeConnCB, NetworkThread, \
     EarlyDisconnectError, CInv, msg_inv, mininode_lock
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import start_nodes, p2p_port
+from test_framework.util import ZCASHD_BINARY, start_nodes, p2p_port
 
 import os
 import time
@@ -82,7 +82,7 @@ class TestManager(NodeConnCB):
 class MaxBlocksInFlightTest(BitcoinTestFramework):
     def add_options(self, parser):
         parser.add_option("--testbinary", dest="testbinary",
-                          default=os.getenv("BITCOIND", "bitcoind"),
+                          default=os.getenv("ZCASHD", ZCASHD_BINARY),
                           help="Binary to test max block requests behavior")
 
     def __init__(self):

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -12,7 +12,7 @@ from test_framework.mininode import ( \
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import ( \
-        assert_equal, initialize_chain_clean, \
+        ZCASHD_BINARY, assert_equal, initialize_chain_clean, \
         start_node, stop_node, \
         p2p_port, \
         )
@@ -112,10 +112,10 @@ class MaxUploadTest(BitcoinTestFramework):
             self.txouts = self.txouts + "fd0402"
             # add script_pubkey
             self.txouts = self.txouts + script_pubkey
- 
+
     def add_options(self, parser):
         parser.add_option("--testbinary", dest="testbinary",
-                          default=os.getenv("BITCOIND", "zcashd"),
+                          default=os.getenv("ZCASHD", ZCASHD_BINARY),
                           help="zcashd binary to test")
 
     def setup_chain(self):
@@ -142,7 +142,7 @@ class MaxUploadTest(BitcoinTestFramework):
             remchange = t["amount"] - Decimal("0.001000")
             outputs[address]=remchange
             # Create a basic transaction that will send change back to ourself after account for a fee
-            # and then insert the 128 generated transaction outs in the middle. rawtx[100] is where the 
+            # and then insert the 128 generated transaction outs in the middle. rawtx[100] is where the
             # number of txouts is stored and is the only thing we overwrite from the original transaction
             rawtx = node.createrawtransaction(inputs, outputs)
             newtx = rawtx[0:100]
@@ -222,7 +222,7 @@ class MaxUploadTest(BitcoinTestFramework):
             assert_equal(test_nodes[0].block_receive_map[big_old_block], i+1)
 
         assert_equal(len(self.nodes[0].getpeerinfo()), 3)
-        # At most a couple more tries should succeed (depending on how long 
+        # At most a couple more tries should succeed (depending on how long
         # the test has been running so far).
         for i in range(3):
             test_nodes[0].send_message(getdata_request)

--- a/qa/rpc-tests/p2p-acceptblock.py
+++ b/qa/rpc-tests/p2p-acceptblock.py
@@ -8,7 +8,7 @@ from test_framework.mininode import CBlockHeader, CInv, NodeConn, NodeConnCB, \
     mininode_lock
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, \
-    start_node, p2p_port
+    start_node, p2p_port, ZCASHD_BINARY
 from test_framework.blocktools import create_block, create_coinbase
 
 import os
@@ -114,8 +114,8 @@ class TestNode(NodeConnCB):
 class AcceptBlockTest(BitcoinTestFramework):
     def add_options(self, parser):
         parser.add_option("--testbinary", dest="testbinary",
-                          default=os.getenv("BITCOIND", "bitcoind"),
-                          help="bitcoind binary to test")
+                          default=os.getenv("ZCASHD", ZCASHD_BINARY),
+                          help="zcashd binary to test")
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -15,6 +15,7 @@ import traceback
 
 from .authproxy import JSONRPCException
 from .util import (
+    ZCASHD_BINARY,
     initialize_chain,
     start_nodes,
     connect_nodes_bi,
@@ -194,11 +195,11 @@ class ComparisonTestFramework(BitcoinTestFramework):
 
     def add_options(self, parser):
         parser.add_option("--testbinary", dest="testbinary",
-                          default=os.getenv("BITCOIND", "bitcoind"),
-                          help="bitcoind binary to test")
+                          default=os.getenv("ZCASHD", ZCASHD_BINARY),
+                          help="zcashd binary to test")
         parser.add_option("--refbinary", dest="refbinary",
-                          default=os.getenv("BITCOIND", "bitcoind"),
-                          help="bitcoind binary to use for reference nodes (if any)")
+                          default=os.getenv("ZCASHD", ZCASHD_BINARY),
+                          help="zcashd binary to use for reference nodes (if any)")
 
     def setup_network(self):
         self.nodes = start_nodes(

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -27,6 +27,8 @@ import errno
 from . import coverage
 from .authproxy import AuthServiceProxy, JSONRPCException
 
+ZCASHD_BINARY = os.path.join('src', 'zcashd')
+
 DEFAULT_FEE = Decimal('0.00001')
 DEFAULT_FEE_ZATS = 1000
 
@@ -261,7 +263,7 @@ def initialize_chain(test_dir, num_nodes, cachedir):
         # Create cache directories, run bitcoinds:
         for i in range(MAX_NODES):
             datadir=initialize_datadir(cachedir, i)
-            args = [ os.getenv("BITCOIND", "bitcoind"), "-keypool=1", "-datadir="+datadir, "-discover=0" ]
+            args = [ os.getenv("ZCASHD", ZCASHD_BINARY), "-keypool=1", "-datadir="+datadir, "-discover=0" ]
             args.extend([
                 '-nuparams=5ba81b19:1', # Overwinter
                 '-nuparams=76b809bb:1', # Sapling
@@ -353,7 +355,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     """
     datadir = os.path.join(dirname, "node"+str(i))
     if binary is None:
-        binary = os.getenv("BITCOIND", "bitcoind")
+        binary = os.getenv("ZCASHD", ZCASHD_BINARY)
     args = [ binary, "-datadir="+datadir, "-keypool=1", "-discover=0", "-rest" ]
     args.extend([
         '-nuparams=5ba81b19:1', # Overwinter
@@ -562,13 +564,13 @@ def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants):
 def assert_equal(expected, actual, message=""):
     if expected != actual:
         if message:
-            message = "; %s" % message 
+            message = "; %s" % message
         raise AssertionError("(left == right)%s\n  left: <%s>\n right: <%s>" % (message, str(expected), str(actual)))
 
 def assert_true(condition, message = ""):
     if not condition:
         raise AssertionError(message)
-        
+
 def assert_false(condition, message = ""):
     assert_true(not condition, message)
 


### PR DESCRIPTION
That is, without having to launch with test_runner.py. There are several places where the BITCOIND environment variable determines the executable, but the default is "bitcoind"; change the default to "src/zcashd". This does require running the test from the top-level directory.

To run a test standalone with this PR, it's necessary to run it from the top-level directory, for example:
```
$ qa/rpc-tests/merkle_blocks.py
```
This is because the default executable (if $BITCOIND isn't set) is `src/zcashd`. Maybe this restriction can be eliminated? But it's pretty common to run these tests from there.