### PR TITLE
Dont log ERROR: spent index not enabled

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,3 +4,9 @@ release-notes at release time)
 Notable changes
 ===============
 
+RPC changes
+-----------
+
+- Fixed an issue where `ERROR: spent index not enabled` would be logged
+  unnecessarily on nodes that have either insightexplorer or lightwalletd
+  configuration options enabled.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2019,27 +2019,31 @@ bool AcceptToMemoryPool(
 bool GetTimestampIndex(unsigned int high, unsigned int low, bool fActiveOnly,
     std::vector<std::pair<uint256, unsigned int> > &hashes)
 {
-    if (!fTimestampIndex)
-        return error("Timestamp index not enabled");
-
-    if (!pblocktree->ReadTimestampIndex(high, low, fActiveOnly, hashes))
-        return error("Unable to get hashes for timestamps");
-
+    if (!fTimestampIndex) {
+        LogPrint("rpc", "Timestamp index not enabled");
+        return false;
+    }
+    if (!pblocktree->ReadTimestampIndex(high, low, fActiveOnly, hashes)) {
+        LogPrint("rpc", "Unable to get hashes for timestamps");
+        return false;
+    }
     return true;
 }
 
 bool GetSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value)
 {
     AssertLockHeld(cs_main);
-    if (!fSpentIndex)
-        return error("Spent index not enabled");
-
+    if (!fSpentIndex) {
+        LogPrint("rpc", "Spent index not enabled");
+        return false;
+    }
     if (mempool.getSpentIndex(key, value))
         return true;
 
-    if (!pblocktree->ReadSpentIndex(key, value))
-        return error("Unable to get spent index information");
-
+    if (!pblocktree->ReadSpentIndex(key, value)) {
+        LogPrint("rpc", "Unable to get spent index information");
+        return false;
+    }
     return true;
 }
 
@@ -2047,24 +2051,28 @@ bool GetAddressIndex(const uint160& addressHash, int type,
                      std::vector<CAddressIndexDbEntry>& addressIndex,
                      int start, int end)
 {
-    if (!fAddressIndex)
-        return error("address index not enabled");
-
-    if (!pblocktree->ReadAddressIndex(addressHash, type, addressIndex, start, end))
-        return error("unable to get txids for address");
-
+    if (!fAddressIndex) {
+        LogPrint("rpc", "address index not enabled");
+        return false;
+    }
+    if (!pblocktree->ReadAddressIndex(addressHash, type, addressIndex, start, end)) {
+        LogPrint("rpc", "unable to get txids for address");
+        return false;
+    }
     return true;
 }
 
 bool GetAddressUnspent(const uint160& addressHash, int type,
                        std::vector<CAddressUnspentDbEntry>& unspentOutputs)
 {
-    if (!fAddressIndex)
-        return error("address index not enabled");
-
-    if (!pblocktree->ReadAddressUnspentIndex(addressHash, type, unspentOutputs))
-        return error("unable to get txids for address");
-
+    if (!fAddressIndex) {
+        LogPrint("rpc", "address index not enabled");
+        return false;
+    }
+    if (!pblocktree->ReadAddressUnspentIndex(addressHash, type, unspentOutputs)) {
+        LogPrint("rpc", "unable to get txids for address");
+        return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
Closes #5420. This PR is an extension of #4114, which fixed this excessive logging
problem for nodes that were not insight explorer or lightwalletd enabled. This PR
extends the fix to nodes that are enabled to support either of those services.

This and related messages can be useful, so they are retained, but are restricted
to only log when `-debug=rpc` logging is enabled.