### PR TITLE
Revert lint: Fix false positive

### DIFF
--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -21,7 +21,7 @@ DOWNLOAD_URL="https://download.z.cash/downloads"
 IPFS_HASH="/ipfs/QmXRHVGLQBiKwvNq7c2vPxAKz1zRVmMYbmt7G5TQss7tY7"
 
 SHA256CMD="$(command -v sha256sum || echo shasum)"
-SHA256ARGS="$(command -v sha256sum >/dev/null || echo \"-a 256\")"
+SHA256ARGS="$(command -v sha256sum >/dev/null || echo '-a 256')"
 
 WGETCMD="$(command -v wget || echo '')"
 IPFSCMD="$(command -v ipfs || echo '')"


### PR DESCRIPTION
This reverts commit fb38cf0d90d3b2b7b888040a601d884262d05ca0.

The lint fix caused a problem on macOS, where the escaped double quote
was interpreted as part of an argument, and not as defining an argument.
We will need to find another way to address the lint.

Closes zcash/zcash#5379.