### PR TITLE
rust: Remove misleading log message

### DIFF
--- a/src/rust/src/address_ffi.rs
+++ b/src/rust/src/address_ffi.rs
@@ -139,8 +139,8 @@ pub extern "C" fn zcash_address_parse_unified(
 
     let ua: UnifiedAddressHelper = match addr.convert() {
         Ok(ua) => ua,
-        Err(e) => {
-            tracing::error!("{}", e);
+        Err(_) => {
+            // `KeyIO::DecodePaymentAddress` handles the rest of the address kinds.
             return false;
         }
     };


### PR DESCRIPTION
We use the `zcash_address` crate to parse Unified Addresses (which we
currently do nothing with). That crate returns an `UnsupportedAddress`
error for unhandled address kinds, which we were previously logging.
However, we _do_ support the other address kinds; we just parse them in
the C++ code.

Closes zcash/zcash#5321.