### PR TITLE
Add libtinfo5 to gitian packages list

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -18,6 +18,7 @@ packages:
 - "g++-multilib"
 - "git-core"
 - "libc6-dev"
+- "libtinfo5"
 - "libtool"
 - "libxml2"
 - "m4"


### PR DESCRIPTION
libtinfo5 is a build dependency of zcashd
https://zcash.readthedocs.io/en/latest/rtd_pages/Debian-Ubuntu-build.html
