### PR TITLE
test: assert that the return value of submitblock is None

### DIFF
--- a/qa/rpc-tests/getblocktemplate.py
+++ b/qa/rpc-tests/getblocktemplate.py
@@ -98,7 +98,8 @@ class GetBlockTemplateTest(BitcoinTestFramework):
         block = codecs.encode(block, 'hex_codec')
 
         print("Submitting block")
-        node.submitblock(block)
+        submitblock_reply = node.submitblock(block)
+        assert_equal(None, submitblock_reply)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Follow-on to #5431, the python RPC test needs to check the `submitblock` return value is `None` (success); it doesn't throw an exception as I previously thought. I did some manual mutation testing to ensure that if `getblocktemplate` returns incorrect hash roots or prevhash, the `submitblock` fails and the test catches the failure.