### PR TITLE
Avoid a warning by explicitly calling drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_primitives",
  "zcash_proofs",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ zcash_note_encryption = "0.1"
 zcash_primitives = "0.5"
 zcash_proofs = "0.5"
 ed25519-zebra = "3"
+zeroize = "1.4.2"
 
 # Metrics
 hyper = { version = "=0.14.2", default-features = false, features = ["server", "tcp", "http1"] }

--- a/src/rust/src/zip339_ffi.rs
+++ b/src/rust/src/zip339_ffi.rs
@@ -63,7 +63,7 @@ pub extern "C" fn zip339_free_phrase(phrase: *const c_char) {
     if !phrase.is_null() {
         unsafe {
             // It is correct to cast away const here; the memory is not actually immutable.
-            CString::from_raw(phrase as *mut c_char);
+            drop(CString::from_raw(phrase as *mut c_char));
         }
     }
 }

--- a/src/rust/src/zip339_ffi.rs
+++ b/src/rust/src/zip339_ffi.rs
@@ -4,6 +4,7 @@ use std::{
     ffi::{CStr, CString},
     ptr, slice,
 };
+use zeroize::Zeroize;
 
 use zcash_primitives::zip339;
 
@@ -63,7 +64,9 @@ pub extern "C" fn zip339_free_phrase(phrase: *const c_char) {
     if !phrase.is_null() {
         unsafe {
             // It is correct to cast away const here; the memory is not actually immutable.
-            drop(CString::from_raw(phrase as *mut c_char));
+            CString::from_raw(phrase as *mut c_char)
+                .into_bytes()
+                .zeroize();
         }
     }
 }


### PR DESCRIPTION
This fixes the following spurious warning when compiling `zcashd`:
```
   Compiling librustzcash v0.2.0 (/home/daira/zecc/zcash)
warning: unused return value of `CString::from_raw` that must be used
  --> src/rust/src/zip339_ffi.rs:66:13
   |
66 |             CString::from_raw(phrase as *mut c_char);
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: call `drop(from_raw(ptr))` if you intend to drop the `CString`
```

Signed-off-by: Daira Hopwood <daira@jacaranda.org>
