### PR TITLE
Drop pyblake2 dependency

### DIFF
--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from pyblake2 import blake2b
+from hashlib import blake2b
 
 from .mininode import CBlock, CTransaction, CTxIn, CTxOut, COutPoint
 from .script import CScript, OP_0, OP_EQUAL, OP_HASH160, OP_TRUE, OP_CHECKSIG

--- a/qa/rpc-tests/test_framework/flyclient.py
+++ b/qa/rpc-tests/test_framework/flyclient.py
@@ -1,4 +1,4 @@
-from pyblake2 import blake2b
+from hashlib import blake2b
 import struct
 from typing import (List, Optional)
 

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -36,7 +36,7 @@ from threading import RLock
 from threading import Thread
 import logging
 import copy
-from pyblake2 import blake2b
+from hashlib import blake2b
 
 from .equihash import (
     gbp_basic,

--- a/qa/rpc-tests/test_framework/script.py
+++ b/qa/rpc-tests/test_framework/script.py
@@ -22,7 +22,7 @@ if sys.version > '3':
     bchr = lambda x: bytes([x])
     bord = lambda x: x
 
-from pyblake2 import blake2b
+from hashlib import blake2b
 
 from binascii import hexlify
 import struct

--- a/qa/rpc-tests/test_framework/zip244.py
+++ b/qa/rpc-tests/test_framework/zip244.py
@@ -13,7 +13,7 @@
 
 import struct
 
-from pyblake2 import blake2b
+from hashlib import blake2b
 
 from .mininode import ser_string, ser_uint256
 from .script import (

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -52,7 +52,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
  * transaction cannot be spent since it did not originally exist in the
  * database (and is in any case of zero value).
  *
- * >>> from pyblake2 import blake2s
+ * >>> from hashlib import blake2s
  * >>> 'Zcash' + blake2s(b'The Economist 2016-10-29 Known unknown: Another crypto-currency is born. BTC#436254 0000000000000000044f321997f336d2908cf8c8d6893e88dbf067e2d949487d ETH#2521903 483039a6b6bd8bd05f0584f9a078d075e454925eb71c1f13eaff59b405a721bb DJIA close on 27 Oct 2016: 18,169.68').hexdigest()
  *
  * CBlock(hash=00040fe8, ver=4, hashPrevBlock=00000000000000, hashMerkleRoot=c4eaa5, nTime=1477641360, nBits=1f07ffff, nNonce=4695, vtx=1)

--- a/src/gtest/test_joinsplit.cpp
+++ b/src/gtest/test_joinsplit.cpp
@@ -221,11 +221,11 @@ TEST(Joinsplit, HSig)
 /*
 // by Taylor Hornby
 
-import pyblake2
+import hashlib
 import binascii
 
 def hSig(randomSeed, nf1, nf2, joinSplitPubKey):
-    return pyblake2.blake2b(
+    return hashlib.blake2b(
         data=(randomSeed + nf1 + nf2 + joinSplitPubKey),
         digest_size=32,
         person=b"ZcashComputehSig"


### PR DESCRIPTION
Closes zcash/zcash#5457

NOTE:  there remain references to `pyblake2` in CI and release notes files:

```
grep --exclude-dir=target -r -I -i -n -e"pyblake2" ./*
./contrib/ci-builders/buildbot/bbworker-requirements.txt:2:pyblake2
./contrib/ci-builders/tekton/requirements.txt:2:pyblake2
./contrib/ci-workers/vars/default.yml:52:  - pyblake2
./doc/release-notes/release-notes-2.1.2-rc1.md:559:      update remaining encoding issues, add pyblake2
./doc/release-notes/release-notes-1.0.11.md:27:      Add pyblake2 to required Python modules
./doc/release-notes/release-notes-1.0.11-rc1.md:26:      Add pyblake2 to required Python modules
./doc/release-notes/release-notes-2.1.2.md:567:      update remaining encoding issues, add pyblake2
```