### PR TITLE
Use -j option in underlying python script for RPCs call

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -177,6 +177,8 @@ def main():
     parser.add_argument('--force', '-f', action='store_true', help='run tests even on platforms where they are disabled by default (e.g. windows).')
     parser.add_argument('--help', '-h', '-?', action='store_true', help='print help text and exit')
     parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
+    parser.add_argument('--machines', '-m', type=int, default=4, help='how many machines run in parallel. Default=4.')
+    parser.add_argument('--numtests', '-t', type=int, default=4, help='how many test on each machine to run in parallel. Default=4.')
     parser.add_argument('--nozmq', action='store_true', help='do not run the zmq tests')
     args, unknown_args = parser.parse_known_args()
 
@@ -253,7 +255,7 @@ def main():
         subprocess.check_call((config["environment"]["SRCDIR"] + '/qa/rpc-tests/' + test_list[0]).split() + ['-h'])
         sys.exit(0)
 
-    run_tests(test_list, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)
+    run_tests(test_list[args.machines::args.numtests], config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)
 
 def run_tests(test_list, src_dir, build_dir, exeext, jobs=1, enable_coverage=False, args=[]):
     BOLD = ("","")

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -182,7 +182,7 @@ STAGE_COMMANDS = {
     'util-test': util_test,
     'secp256k1': ['make', '-C', repofile('src/secp256k1'), 'check'],
     'univalue': ['make', '-C', repofile('src/univalue'), 'check'],
-    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j12'],
+    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16'],
 }
 
 

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -182,7 +182,7 @@ STAGE_COMMANDS = {
     'util-test': util_test,
     'secp256k1': ['make', '-C', repofile('src/secp256k1'), 'check'],
     'univalue': ['make', '-C', repofile('src/univalue'), 'check'],
-    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16'],
+    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m4', '-t4'],
 }
 
 

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -182,7 +182,7 @@ STAGE_COMMANDS = {
     'util-test': util_test,
     'secp256k1': ['make', '-C', repofile('src/secp256k1'), 'check'],
     'univalue': ['make', '-C', repofile('src/univalue'), 'check'],
-    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '-j8'],
+    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '-j16', '-nozmq'],
 }
 
 

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -171,6 +171,10 @@ STAGES = [
     'secp256k1',
     'univalue',
     'rpc',
+    'rpc0',
+    'rpc1',
+    'rpc2',
+    'rpc3',   
 ]
 
 STAGE_COMMANDS = {

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -182,7 +182,7 @@ STAGE_COMMANDS = {
     'util-test': util_test,
     'secp256k1': ['make', '-C', repofile('src/secp256k1'), 'check'],
     'univalue': ['make', '-C', repofile('src/univalue'), 'check'],
-    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '-j16', '-nozmq'],
+    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16'],
 }
 
 

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -174,7 +174,11 @@ STAGES = [
     'rpc0',
     'rpc1',
     'rpc2',
-    'rpc3',   
+    'rpc3',
+    'rpc4',
+    'rpc5',
+    'rpc6',
+    'rpc7', 
 ]
 
 STAGE_COMMANDS = {
@@ -191,6 +195,10 @@ STAGE_COMMANDS = {
     'rpc1': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m1', '-t4'],
     'rpc2': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m2', '-t4'],
     'rpc3': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m3', '-t4'],
+    'rpc4': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m0', '-t4'],
+    'rpc5': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m1', '-t4'],
+    'rpc6': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m2', '-t4'],
+    'rpc7': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m3', '-t4'],
 }
 
 

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -182,7 +182,7 @@ STAGE_COMMANDS = {
     'util-test': util_test,
     'secp256k1': ['make', '-C', repofile('src/secp256k1'), 'check'],
     'univalue': ['make', '-C', repofile('src/univalue'), 'check'],
-    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16'],
+    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j32'],
 }
 
 

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -182,7 +182,7 @@ STAGE_COMMANDS = {
     'util-test': util_test,
     'secp256k1': ['make', '-C', repofile('src/secp256k1'), 'check'],
     'univalue': ['make', '-C', repofile('src/univalue'), 'check'],
-    'rpc': [repofile('qa/pull-tester/rpc-tests.py')],
+    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '-j8'],
 }
 
 

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -182,7 +182,7 @@ STAGE_COMMANDS = {
     'util-test': util_test,
     'secp256k1': ['make', '-C', repofile('src/secp256k1'), 'check'],
     'univalue': ['make', '-C', repofile('src/univalue'), 'check'],
-    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16'],
+    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j12'],
 }
 
 

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -182,7 +182,11 @@ STAGE_COMMANDS = {
     'util-test': util_test,
     'secp256k1': ['make', '-C', repofile('src/secp256k1'), 'check'],
     'univalue': ['make', '-C', repofile('src/univalue'), 'check'],
-    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m4', '-t4'],
+    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m0', '-t1'],
+    'rpc0': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m0', '-t4'],
+    'rpc1': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m1', '-t4'],
+    'rpc2': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m2', '-t4'],
+    'rpc3': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16', '-m3', '-t4'],
 }
 
 

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -182,7 +182,7 @@ STAGE_COMMANDS = {
     'util-test': util_test,
     'secp256k1': ['make', '-C', repofile('src/secp256k1'), 'check'],
     'univalue': ['make', '-C', repofile('src/univalue'), 'check'],
-    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j32'],
+    'rpc': [repofile('qa/pull-tester/rpc-tests.py'), '--nozmq', '-j16'],
 }
 
 


### PR DESCRIPTION
Make use of the jobs option on machines that have more than the default 4 threads.
