### PR TITLE
Add comment to zcash_script_new_precomputed_tx about references to input buffers

### DIFF
--- a/src/script/zcash_script.h
+++ b/src/script/zcash_script.h
@@ -56,6 +56,9 @@ enum
 ///
 /// Returns a pointer to the precomputed transaction. Free this with
 /// zcash_script_free_precomputed_tx once you are done.
+/// The precomputed transaction is guaranteed to not keep a reference to any
+/// part of the input buffers, so they can be safely overwritten or deallocated
+/// after this function returns.
 ///
 /// If not NULL, err will contain an error/success code for the operation.
 void* zcash_script_new_precomputed_tx(


### PR DESCRIPTION
This came up [in a Zebra discussion](https://github.com/ZcashFoundation/zebra/pull/3415/files#r795038933). If `zcash_script_new_precomputed_tx` guarantees the precomputed object won't keep a reference to input buffers, then we have some assurance that the caller Rust `unsafe` code is correct, since we most likely will just drop these input buffers after the preprecomputation.

(I used "input buffers" in the plural because https://github.com/zcash/zcash/pull/5493 adds a new input buffer)

…

Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.
* [ ] Relevant documentation for this PR has to be completed and reviewed by @mdr0id before the PR can be merged
* [ ] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release

As a note, all buildbot tests need to be passing and all appropriate code reviews need to be done before this PR can be merged
