### PR TITLE
Update comparison test framework

### DIFF
--- a/qa/rpc-tests/bip65-cltv-p2p.py
+++ b/qa/rpc-tests/bip65-cltv-p2p.py
@@ -23,10 +23,6 @@ TODO: factor out common code from {bipdersig-p2p,bip65-cltv-p2p}.py.
 
 class BIP65Test(ComparisonTestFramework):
 
-    def __init__(self):
-        super().__init__()
-        self.num_nodes = 1
-
     def setup_network(self):
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
                                  extra_args=[['-debug', '-whitelist=127.0.0.1']],

--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -23,10 +23,6 @@ TODO: factor out common code from {bipdersig-p2p,bip65-cltv-p2p}.py.
 '''
 class BIP66Test(ComparisonTestFramework):
 
-    def __init__(self):
-        super().__init__()
-        self.num_nodes = 1
-
     def setup_network(self):
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
                                  extra_args=[['-debug', '-whitelist=127.0.0.1']],

--- a/qa/rpc-tests/invalidblockrequest.py
+++ b/qa/rpc-tests/invalidblockrequest.py
@@ -26,10 +26,6 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
 
     ''' Can either run this test as 1 node with expected answers, or two and compare them.
         Change the "outcome" variable from each TestInstance object to only do the comparison. '''
-    def __init__(self):
-        super().__init__()
-        self.num_nodes = 1
-
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)
         test.add_all_connections(self.nodes)

--- a/qa/rpc-tests/invalidtxrequest.py
+++ b/qa/rpc-tests/invalidtxrequest.py
@@ -20,10 +20,6 @@ class InvalidTxRequestTest(ComparisonTestFramework):
 
     ''' Can either run this test as 1 node with expected answers, or two and compare them. 
         Change the "outcome" variable from each TestInstance object to only do the comparison. '''
-    def __init__(self):
-        super().__init__()
-        self.num_nodes = 1
-
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)
         test.add_all_connections(self.nodes)

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -39,7 +39,6 @@ class FullBlockTest(ComparisonTestFramework):
         Change the "outcome" variable from each TestInstance object to only do the comparison. '''
     def __init__(self):
         super().__init__()
-        self.num_nodes = 1
         self.block_heights = {}
         self.coinbase_key = CECKey()
         self.coinbase_key.set_secretbytes(b"horsebattery")

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -30,6 +30,8 @@ using a script provided.
 To use, create a class that implements get_tests(), and pass it in
 as the test generator to TestManager.  get_tests() should be a python
 generator that returns TestInstance objects.  See below for definition.
+
+In practice get_tests is always implemented on a subclass of ComparisonTestFramework.
 '''
 
 # TestNode behaves as follows:

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -186,7 +186,7 @@ class ComparisonTestFramework(BitcoinTestFramework):
 
     def __init__(self):
         super().__init__()
-        self.num_nodes = 2
+        self.num_nodes = 1
         self.setup_clean_chain = True
 
     def add_options(self, parser):

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -203,3 +203,6 @@ class ComparisonTestFramework(BitcoinTestFramework):
             extra_args=[['-debug', '-whitelist=127.0.0.1']] * self.num_nodes,
             binary=[self.options.testbinary] +
             [self.options.refbinary]*(self.num_nodes-1))
+
+    def get_tests(self):
+        raise NotImplementedError


### PR DESCRIPTION
This test-only refactor is a net reduction in lines that leverages the `get_tests` interface in the `ComparisonTestFramework` in (what seems to me to be) the obvious way.
