### PR TITLE
contrib/devtools/rust-deps-graph.sh: allow overriding the arguments to cargo deps

### DIFF
--- a/contrib/devtools/rust-deps-graph.sh
+++ b/contrib/devtools/rust-deps-graph.sh
@@ -2,7 +2,11 @@
 
 export LC_ALL=C
 
-cargo deps --no-transitive-deps | dot \
+# default arguments are --no-transitive-deps
+ARGS="${*:---no-transitive-deps}"
+echo "Using args: $ARGS"
+
+cargo deps $ARGS | dot \
     -Earrowhead=vee \
     -Gratio=0.45 \
     -Gsize=50 \


### PR DESCRIPTION
My use case for this is to create simpler graphs that illustrate particular properties of the overall graph. See https://crates.io/crates/cargo-deps for argument documentation.