### PR TITLE
Only use legacy transparent keypool for internal keys

### DIFF
--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -40,13 +40,13 @@ class KeyPoolTest(BitcoinTestFramework):
         bitcoind_processes[0].wait()
         # Restart node 0
         nodes[0] = start_node(0, self.options.tmpdir)
-        # Keep creating keys
-        addr = nodes[0].getnewaddress()
+        # We can't create any external addresses, which don't use the keypool.
+        # We should get an error that we need to unlock the wallet.
         try:
             addr = nodes[0].getnewaddress()
-            raise AssertionError('Keypool should be exhausted after one address')
+            raise AssertionError('Wallet should be locked.')
         except JSONRPCException as e:
-            assert(e.error['code']==-12)
+            assert_equal(e.error['code'], -13)
 
         # put three new keys in the keypool
         nodes[0].walletpassphrase('test', 12000)

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -96,10 +96,10 @@ class WalletBackupTest(BitcoinTestFramework):
         self.sync_all()
 
     # As above, this mirrors the original bash test.
-    def start_three(self):
-        self.nodes[0] = start_node(0, self.options.tmpdir)
-        self.nodes[1] = start_node(1, self.options.tmpdir)
-        self.nodes[2] = start_node(2, self.options.tmpdir)
+    def start_three(self, extra_args=None):
+        self.nodes[0] = start_node(0, self.options.tmpdir, extra_args)
+        self.nodes[1] = start_node(1, self.options.tmpdir, extra_args)
+        self.nodes[2] = start_node(2, self.options.tmpdir, extra_args)
         connect_nodes(self.nodes[0], 3)
         connect_nodes(self.nodes[1], 3)
         connect_nodes(self.nodes[2], 3)
@@ -191,6 +191,30 @@ class WalletBackupTest(BitcoinTestFramework):
         self.start_three()
         sync_blocks(self.nodes)
 
+        # We made extra transactions that involved addresses generated after the
+        # backups were taken, and external addresses do not use the keypool, so
+        # the balances shouldn't line up.
+        balance0backup = self.nodes[0].getbalance()
+        balance1backup = self.nodes[1].getbalance()
+        balance2backup = self.nodes[2].getbalance()
+        assert(balance0backup != balance0)
+        assert(balance1backup != balance1)
+        assert(balance2backup != balance2)
+
+        # However, because addresses are derived deterministically, we can
+        # recover the balances by generating the extra addresses and then
+        # rescanning.
+        for i in range(5):
+            self.nodes[0].getnewaddress()
+            self.nodes[1].getnewaddress()
+            self.nodes[2].getnewaddress()
+
+        logging.info("Re-starting nodes with -rescan")
+        self.stop_three()
+        self.start_three(['-rescan'])
+        sync_blocks(self.nodes)
+
+        # TODO: Alter keypool to not use external addresses, so this passes.
         assert_equal(self.nodes[0].getbalance(), balance0)
         assert_equal(self.nodes[1].getbalance(), balance1)
         assert_equal(self.nodes[2].getbalance(), balance2)
@@ -215,9 +239,9 @@ class WalletBackupTest(BitcoinTestFramework):
 
         sync_blocks(self.nodes)
 
-        assert_equal(self.nodes[0].getbalance(), balance0)
-        assert_equal(self.nodes[1].getbalance(), balance1)
-        assert_equal(self.nodes[2].getbalance(), balance2)
+        assert_equal(self.nodes[0].getbalance(), balance0backup)
+        assert_equal(self.nodes[1].getbalance(), balance1backup)
+        assert_equal(self.nodes[2].getbalance(), balance2backup)
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -214,7 +214,6 @@ class WalletBackupTest(BitcoinTestFramework):
         self.start_three(['-rescan'])
         sync_blocks(self.nodes)
 
-        # TODO: Alter keypool to not use external addresses, so this passes.
         assert_equal(self.nodes[0].getbalance(), balance0)
         assert_equal(self.nodes[1].getbalance(), balance1)
         assert_equal(self.nodes[2].getbalance(), balance2)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -182,14 +182,11 @@ UniValue getnewaddress(const UniValue& params, bool fHelp)
     const CChainParams& chainparams = Params();
     EnsureWalletIsBackedUp(chainparams);
 
-    if (!pwalletMain->IsLocked())
-        pwalletMain->TopUpKeyPool();
+    EnsureWalletIsUnlocked();
 
     // Generate a new key that is added to wallet
-    std::optional<CPubKey> newKey = pwalletMain->GetKeyFromPool();
-    if (!newKey.has_value())
-        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
-    CKeyID keyID = newKey.value().GetID();
+    CPubKey newKey = pwalletMain->GenerateNewKey(true);
+    CKeyID keyID = newKey.GetID();
 
     std::string dummy_account;
     pwalletMain->SetAddressBook(keyID, dummy_account, "receive");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -271,12 +271,12 @@ CPubKey CWallet::GenerateNewKey(bool external)
     transparent::AccountKey accountKey = this->GetLegacyAccountKey();
     std::optional<CPubKey> pubkey = std::nullopt;
     do {
-        auto index = hdChain.GetLegacyTKeyCounter();
+        auto index = hdChain.GetLegacyTKeyCounter(external);
         auto key = external ?
             accountKey.DeriveExternalSpendingKey(index) :
             accountKey.DeriveInternalSpendingKey(index);
 
-        hdChain.IncrementLegacyTKeyCounter();
+        hdChain.IncrementLegacyTKeyCounter(external);
         if (key.has_value()) {
             pubkey = AddTransparentSecretKey(
                 hdChain.GetSeedFingerprint(),

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1531,7 +1531,9 @@ public:
      */
     static CAmount GetRequiredFee(unsigned int nTxBytes);
 
+private:
     bool NewKeyPool();
+public:
     bool TopUpKeyPool(unsigned int kpSize = 0);
     void ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool);
     void KeepKey(int64_t nIndex);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1536,7 +1536,6 @@ public:
     void ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool);
     void KeepKey(int64_t nIndex);
     void ReturnKey(int64_t nIndex);
-    std::optional<CPubKey> GetKeyFromPool();
     int64_t GetOldestKeyPoolTime();
     void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -49,7 +49,8 @@ private:
     uint256 seedFp;
     int64_t nCreateTime; // 0 means unknown
     uint32_t accountCounter;
-    uint32_t legacyTKeyCounter;
+    uint32_t legacyTKeyExternalCounter;
+    uint32_t legacyTKeyInternalCounter;
     uint32_t legacySaplingKeyCounter;
     bool mnemonicSeedBackupConfirmed;
 
@@ -61,7 +62,8 @@ private:
         seedFp.SetNull();
         nCreateTime = 0;
         accountCounter = 0;
-        legacyTKeyCounter = 0;
+        legacyTKeyExternalCounter = 0;
+        legacyTKeyInternalCounter = 0;
         legacySaplingKeyCounter = 0;
         mnemonicSeedBackupConfirmed = false;
     }
@@ -69,7 +71,7 @@ public:
     static const int VERSION_HD_BASE = 1;
     static const int CURRENT_VERSION = VERSION_HD_BASE;
 
-    CHDChain(uint256 seedFpIn, int64_t nCreateTimeIn): nVersion(CHDChain::CURRENT_VERSION), seedFp(seedFpIn), nCreateTime(nCreateTimeIn), accountCounter(0), legacyTKeyCounter(0), legacySaplingKeyCounter(0), mnemonicSeedBackupConfirmed(false) {}
+    CHDChain(uint256 seedFpIn, int64_t nCreateTimeIn): nVersion(CHDChain::CURRENT_VERSION), seedFp(seedFpIn), nCreateTime(nCreateTimeIn), accountCounter(0), legacyTKeyExternalCounter(0), legacyTKeyInternalCounter(0), legacySaplingKeyCounter(0), mnemonicSeedBackupConfirmed(false) {}
 
     ADD_SERIALIZE_METHODS;
 
@@ -80,7 +82,8 @@ public:
         READWRITE(seedFp);
         READWRITE(nCreateTime);
         READWRITE(accountCounter);
-        READWRITE(legacyTKeyCounter);
+        READWRITE(legacyTKeyExternalCounter);
+        READWRITE(legacyTKeyInternalCounter);
         READWRITE(legacySaplingKeyCounter);
         READWRITE(mnemonicSeedBackupConfirmed);
     }
@@ -105,12 +108,16 @@ public:
         accountCounter += 1;
     }
 
-    uint32_t GetLegacyTKeyCounter() {
-        return legacyTKeyCounter;
+    uint32_t GetLegacyTKeyCounter(bool external) {
+        return external ? legacyTKeyExternalCounter : legacyTKeyInternalCounter;
     }
 
-    void IncrementLegacyTKeyCounter() {
-        legacyTKeyCounter += 1;
+    void IncrementLegacyTKeyCounter(bool external) {
+        if (external) {
+            legacyTKeyExternalCounter += 1;
+        } else {
+            legacyTKeyInternalCounter += 1;
+        }
     }
 
     uint32_t GetLegacySaplingKeyCounter() const {


### PR DESCRIPTION
This includes a breaking change to the `wallet.dat` format, relative to #5419. If you've been testing #5419, you will see the following error on wallet load:
```
Error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.
```

To fix, delete the `wallet.dat` (after using a prior version of `zcashd` to send any testnet funds you want to keep to a new wallet generated using this branch).

Closes #5528.
Closes #5529.