### PR TITLE
Rename sapling-specific zip32 FFI methods.

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -7,14 +7,14 @@ Notable changes
 Mnemonic Recovery Phrases
 -------------------------
 
-The zcashd wallet has been modified to support ZIP 339 (to be compatible with BIP 39)
-which describes how to derive the wallet's HD seed from a mnemonic phrase.
-The mnemonic phrase will be generated on load of the wallet, or the first time
-the wallet is unlocked, and is available via the `z_exportwallet` RPC call. All
-new addresses produced by the wallet are now derived from this seed using the
-HD wallet functionality described in ZIP 32 and ZIP 316. For users upgrading an
-existing Zcashd wallet, it is recommended that the wallet be backed up prior to
-upgrading to the 4.5.2 Zcashd release.
+The zcashd wallet has been modified to support BIP 39, which describes how to
+derive the wallet's HD seed from a mnemonic phrase.  The mnemonic phrase will
+be generated on load of the wallet, or the first time the wallet is unlocked,
+and is available via the `z_exportwallet` RPC call. All new addresses produced
+by the wallet are now derived from this seed using the HD wallet functionality
+described in ZIP 32 and ZIP 316. For users upgrading an existing Zcashd wallet,
+it is recommended that the wallet be backed up prior to upgrading to the 4.5.2
+Zcashd release.
 
 Following the upgrade to 4.5.2, Zcashd will require that the user confirm that
 they have backed up their new emergency recovery phrase, which may be obtained

--- a/src/rust/include/librustzcash.h
+++ b/src/rust/include/librustzcash.h
@@ -286,27 +286,27 @@ extern "C" {
     );
 
     /// Derive the master ExtendedSpendingKey from a seed.
-    void librustzcash_zip32_xsk_master(
+    void librustzcash_zip32_sapling_xsk_master(
         const unsigned char *seed,
         size_t seedlen,
         unsigned char *xsk_master
     );
 
     /// Derive a child ExtendedSpendingKey from a parent.
-    void librustzcash_zip32_xsk_derive(
+    void librustzcash_zip32_sapling_xsk_derive(
         const unsigned char *xsk_parent,
         uint32_t i,
         unsigned char *xsk_i
     );
 
     /// Derive a internal ExtendedSpendingKey from an external key
-    void librustzcash_zip32_xsk_derive_internal(
+    void librustzcash_zip32_sapling_xsk_derive_internal(
         const unsigned char *xsk_external,
         unsigned char *xsk_internal
     );
 
     /// Derive a child ExtendedFullViewingKey from a parent.
-    bool librustzcash_zip32_xfvk_derive(
+    bool librustzcash_zip32_sapling_xfvk_derive(
         const unsigned char *xfvk_parent,
         uint32_t i,
         unsigned char *xfvk_i

--- a/src/rust/src/rustzcash.rs
+++ b/src/rust/src/rustzcash.rs
@@ -1039,7 +1039,7 @@ pub extern "C" fn librustzcash_sapling_proving_ctx_free(ctx: *mut SaplingProving
 
 /// Derive the master ExtendedSpendingKey from a seed.
 #[no_mangle]
-pub extern "C" fn librustzcash_zip32_xsk_master(
+pub extern "C" fn librustzcash_zip32_sapling_xsk_master(
     seed: *const c_uchar,
     seedlen: size_t,
     xsk_master: *mut [c_uchar; 169],
@@ -1054,7 +1054,7 @@ pub extern "C" fn librustzcash_zip32_xsk_master(
 
 /// Derive a child ExtendedSpendingKey from a parent.
 #[no_mangle]
-pub extern "C" fn librustzcash_zip32_xsk_derive(
+pub extern "C" fn librustzcash_zip32_sapling_xsk_derive(
     xsk_parent: *const [c_uchar; 169],
     i: u32,
     xsk_i: *mut [c_uchar; 169],
@@ -1072,7 +1072,7 @@ pub extern "C" fn librustzcash_zip32_xsk_derive(
 /// Derive the Sapling internal spending key from the external extended
 /// spending key
 #[no_mangle]
-pub extern "C" fn librustzcash_zip32_xsk_derive_internal(
+pub extern "C" fn librustzcash_zip32_sapling_xsk_derive_internal(
     xsk_external: *const [c_uchar; 169],
     xsk_internal_ret: *mut [c_uchar; 169],
 ) {
@@ -1088,7 +1088,7 @@ pub extern "C" fn librustzcash_zip32_xsk_derive_internal(
 
 /// Derive a child ExtendedFullViewingKey from a parent.
 #[no_mangle]
-pub extern "C" fn librustzcash_zip32_xfvk_derive(
+pub extern "C" fn librustzcash_zip32_sapling_xfvk_derive(
     xfvk_parent: *const [c_uchar; 169],
     i: u32,
     xfvk_i: *mut [c_uchar; 169],

--- a/src/zcash/Address.cpp
+++ b/src/zcash/Address.cpp
@@ -244,7 +244,7 @@ libzcash::UnifiedFullViewingKey libzcash::UnifiedFullViewingKey::FromZcashdUFVK(
 
 libzcash::UFVKId libzcash::UnifiedFullViewingKey::GetKeyID(const KeyConstants& keyConstants) const {
     // The ID of a ufvk is the blake2b hash of the serialized form of the
-    // ufvk with the receivers sorted in order of descending receiver type.
+    // ufvk with the receivers sorted in typecode order.
     CBLAKE2bWriter h(SER_GETHASH, 0, ZCASH_UFVK_ID_PERSONAL);
     h << Encode(keyConstants);
     return libzcash::UFVKId(h.GetHash());

--- a/src/zcash/address/zip32.cpp
+++ b/src/zcash/address/zip32.cpp
@@ -66,7 +66,7 @@ std::optional<SaplingExtendedFullViewingKey> SaplingExtendedFullViewingKey::Deri
     CSerializeData p_bytes(ss_p.begin(), ss_p.end());
 
     CSerializeData i_bytes(ZIP32_XFVK_SIZE);
-    if (librustzcash_zip32_xfvk_derive(
+    if (librustzcash_zip32_sapling_xfvk_derive(
         reinterpret_cast<unsigned char*>(p_bytes.data()),
         i,
         reinterpret_cast<unsigned char*>(i_bytes.data())
@@ -170,7 +170,7 @@ SaplingExtendedSpendingKey SaplingExtendedSpendingKey::Master(const HDSeed& seed
 {
     auto rawSeed = seed.RawSeed();
     CSerializeData m_bytes(ZIP32_XSK_SIZE);
-    librustzcash_zip32_xsk_master(
+    librustzcash_zip32_sapling_xsk_master(
         rawSeed.data(),
         rawSeed.size(),
         reinterpret_cast<unsigned char*>(m_bytes.data()));
@@ -188,7 +188,7 @@ SaplingExtendedSpendingKey SaplingExtendedSpendingKey::Derive(uint32_t i) const
     CSerializeData p_bytes(ss_p.begin(), ss_p.end());
 
     CSerializeData i_bytes(ZIP32_XSK_SIZE);
-    librustzcash_zip32_xsk_derive(
+    librustzcash_zip32_sapling_xsk_derive(
         reinterpret_cast<unsigned char*>(p_bytes.data()),
         i,
         reinterpret_cast<unsigned char*>(i_bytes.data()));
@@ -254,7 +254,7 @@ SaplingExtendedSpendingKey SaplingExtendedSpendingKey::DeriveInternalKey() const
     CSerializeData external_key_bytes(ss_p.begin(), ss_p.end());
 
     CSerializeData internal_key_bytes(ZIP32_XSK_SIZE);
-    librustzcash_zip32_xsk_derive_internal(
+    librustzcash_zip32_sapling_xsk_derive_internal(
         reinterpret_cast<unsigned char*>(external_key_bytes.data()),
         reinterpret_cast<unsigned char*>(internal_key_bytes.data()));
 


### PR DESCRIPTION
Also addresses a couple of other minor comments from code review.
