### PR TITLE
Update test logging

### DIFF
--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -25,7 +25,7 @@ class TestManager(NodeConnCB):
     # set up NodeConnCB callbacks, overriding base class
     def on_getdata(self, conn, message):
         delimiter = '\nINFO:'+self.log.name+': '
-        formatted = delimiter.join([str(x) for x in message.inv])
+        formatted = delimiter.join([str(x.hash) for x in message.inv])
         self.log.info("got getdata:\n%s" % formatted)
         # Log the requests
         for inv in message.inv:

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -24,7 +24,9 @@ MAX_REQUESTS = 128
 class TestManager(NodeConnCB):
     # set up NodeConnCB callbacks, overriding base class
     def on_getdata(self, conn, message):
-        self.log.debug("got getdata %s" % repr(message))
+        delimiter = '\nINFO:'+self.log.name+': '
+        formatted = delimiter.join([str(x) for x in message.inv])
+        self.log.info("got getdata:\n%s" % formatted)
         # Log the requests
         for inv in message.inv:
             if inv.hash not in self.blockReqCounts:

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -56,9 +56,6 @@ class TestManager(NodeConnCB):
                 current_invs = []
                 for i in range(numBlocksToGenerate[count]):
                     current_invs.append(CInv(2, random.randrange(0, 1<<256)))
-                    if len(current_invs) >= 50000:
-                        self.connection.send_message(msg_inv(current_invs))
-                        current_invs = []
                 if len(current_invs) > 0:
                     self.connection.send_message(msg_inv(current_invs))
 

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1963,15 +1963,12 @@ class NodeConn(asyncore.dispatcher):
             self.handle_close()
         self.rpc = rpc
 
-    def show_debug_msg(self, msg):
-        self.log.debug(msg)
-
     def handle_connect(self):
-        self.show_debug_msg("MiniNode: Connected & Listening: \n")
+        self.log.debug("MiniNode: Connected & Listening: \n")
         self.state = b"connected"
 
     def handle_close(self):
-        self.show_debug_msg("MiniNode: Closing Connection to %s:%d... "
+        self.log.debug("MiniNode: Closing Connection to %s:%d... "
                             % (self.dstaddr, self.dstport))
         self.state = b"closed"
         self.recvbuf = b""
@@ -2045,7 +2042,7 @@ class NodeConn(asyncore.dispatcher):
                     t.deserialize(f)
                     self.got_message(t)
                 else:
-                    self.show_debug_msg("Unknown command: '" + command + "' " +
+                    self.log.debug("Unknown command: '" + command + "' " +
                                         repr(msg))
         except Exception as e:
             print('got_data:', repr(e))
@@ -2055,7 +2052,7 @@ class NodeConn(asyncore.dispatcher):
     def send_message(self, message, pushbuf=False):
         if self.state != b"connected" and not pushbuf:
             return
-        self.show_debug_msg("Send %s" % repr(message))
+        self.log.debug("Send %s" % repr(message))
         command = message.command
         data = message.serialize()
         tmsg = self.MAGIC_BYTES[self.network]
@@ -2077,7 +2074,7 @@ class NodeConn(asyncore.dispatcher):
                 self.messagemap[b'ping'] = msg_ping_prebip31
         if self.last_sent + 30 * 60 < time.time():
             self.send_message(self.messagemap[b'ping']())
-        self.show_debug_msg("Recv %s" % repr(message))
+        self.log.debug("Recv %s" % repr(message))
         self.cb.deliver(self, message)
 
     def disconnect_node(self):

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -40,11 +40,11 @@ class BitcoinTestFramework(object):
     def run_test(self):
         raise NotImplementedError
 
-    def setup_logging(self):
+    def setup_logging(self, sensitivity=logging.DEBUG):
         stem = os.path.basename(inspect.getfile(self.__class__).rstrip(".py")) 
         filename = stem + "_test.log"
         log_file = os.path.join(self.options.tmpdir, filename)
-        logging.basicConfig(filename=log_file, level=logging.INFO)
+        logging.basicConfig(filename=log_file, level=sensitivity)
     
     def add_options(self, parser):
         pass

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -41,9 +41,10 @@ class BitcoinTestFramework(object):
         raise NotImplementedError
 
     def setup_logging(self):
-        filename = os.path.basename(inspect.getfile(self.__class__).rstrip(".py")) + "_test.log"
+        stem = os.path.basename(inspect.getfile(self.__class__).rstrip(".py")) 
+        filename = stem + "_test.log"
         log_file = os.path.join(self.options.tmpdir, filename)
-        print(log_file)
+        logging.basicConfig(filename=log_file, level=logging.INFO)
     
     def add_options(self, parser):
         pass

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -41,10 +41,11 @@ class BitcoinTestFramework(object):
         raise NotImplementedError
 
     def setup_logging(self, sensitivity=logging.DEBUG):
+        # This means that the log file name is a pointer to the producing test's filename.
         stem = os.path.basename(inspect.getfile(self.__class__).rstrip(".py")) 
         filename = stem + "_test.log"
         log_file = os.path.join(self.options.tmpdir, filename)
-        logging.basicConfig(filename=log_file, level=sensitivity)
+        logging.basicConfig(filename=log_file, filemode='w', level=sensitivity)
     
     def add_options(self, parser):
         pass

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -5,6 +5,7 @@
 
 # Base class for RPC testing
 
+import inspect
 import logging
 import optparse
 import os
@@ -39,9 +40,14 @@ class BitcoinTestFramework(object):
     def run_test(self):
         raise NotImplementedError
 
+    def setup_logging(self):
+        filename = os.path.basename(inspect.getfile(self.__class__).rstrip(".py")) + "_test.log"
+        log_file = os.path.join(self.options.tmpdir, filename)
+        print(log_file)
+    
     def add_options(self, parser):
         pass
-
+    
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
         if self.setup_clean_chain:
@@ -138,6 +144,7 @@ class BitcoinTestFramework(object):
         success = False
         try:
             os.makedirs(self.options.tmpdir, exist_ok=False)
+            self.setup_logging()
             self.setup_chain()
             self.setup_network()
             self.run_test()


### PR DESCRIPTION
Use standard Python `logging` to automatically log in-test diagnostics to a test-named log file with the test's `tmpdir`.