### PR TITLE
fix breakage on Arch by using Debian libtinfo5_6.0 to satisfy clang

### DIFF
--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -18,7 +18,9 @@ $(package)_download_file_aarch64_linux=clang+llvm-$($(package)_version)-aarch64-
 $(package)_file_name_aarch64_linux=clang-llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
 $(package)_sha256_hash_aarch64_linux=968d65d2593850ee9b37fcda074fb7641529bd45d2f976af6c8197de3c22612f
 
+ifneq (,$(wildcard /etc/arch-release))
 $(package)_dependencies=native_libtinfo
+endif
 
 # Ensure we have clang native to the builder, not the target host
 ifneq ($(canonical_host),$(build))

--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -18,6 +18,8 @@ $(package)_download_file_aarch64_linux=clang+llvm-$($(package)_version)-aarch64-
 $(package)_file_name_aarch64_linux=clang-llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
 $(package)_sha256_hash_aarch64_linux=968d65d2593850ee9b37fcda074fb7641529bd45d2f976af6c8197de3c22612f
 
+$(package)_dependencies=native_libtinfo
+
 # Ensure we have clang native to the builder, not the target host
 ifneq ($(canonical_host),$(build))
 $(package)_exact_download_path=$($(package)_download_path_$(build_os))

--- a/depends/packages/native_libtinfo.mk
+++ b/depends/packages/native_libtinfo.mk
@@ -1,51 +1,22 @@
 package=native_tinfo
-#$(package)_major_version=13
-#$(package)_version=13.0.0
-#$(package)_download_path=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
+$(package)_version=5.6.0
 $(package)_download_path_linux=http://ftp.debian.org/debian/pool/main/n/ncurses/
 $(package)_download_file_linux=libtinfo5_6.0+20161126-1+deb9u2_amd64.deb
 $(package)_file_name_linux=libtinfo5_6.0+20161126-1+deb9u2_amd64.deb
 $(package)_sha256_hash_linux=1d249a3193568b5ef785ad8993b9ba6d6fdca0eb359204c2355532b82d25e9f5
-#$(package)_download_path_darwin=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_major_version).0.0
-#$(package)_download_file_darwin=clang+llvm-$($(package)_major_version).0.0-x86_64-apple-darwin.tar.xz
-#$(package)_file_name_darwin=clang-llvm-$($(package)_major_version).0.0-x86_64-apple-darwin.tar.xz
-#$(package)_sha256_hash_darwin=d051234eca1db1f5e4bc08c64937c879c7098900f7a0370f3ceb7544816a8b09
-#$(package)_download_path_freebsd=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
-#$(package)_download_file_freebsd=clang+llvm-$($(package)_version)-amd64-unknown-freebsd12.tar.xz
-#$(package)_file_name_freebsd=clang-llvm-$($(package)_version)-amd64-unknown-freebsd12.tar.xz
-#$(package)_sha256_hash_freebsd=e579747a36ff78aa0a5533fe43bc1ed1f8ed449c9bfec43c358d953ffbbdcf76
-#$(package)_download_file_aarch64_linux=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
-#$(package)_file_name_aarch64_linux=clang-llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
-#$(package)_sha256_hash_aarch64_linux=968d65d2593850ee9b37fcda074fb7641529bd45d2f976af6c8197de3c22612f
 
-## Ensure we have clang native to the builder, not the target host
-#ifneq ($(canonical_host),$(build))
-#$(package)_exact_download_path=$($(package)_download_path_$(build_os))
-#$(package)_exact_download_file=$($(package)_download_file_$(build_os))
-#$(package)_exact_file_name=$($(package)_file_name_$(build_os))
-#$(package)_exact_sha256_hash=$($(package)_sha256_hash_$(build_os))
-#endif
+define $(package)_extract_cmds
+	mkdir -p $($(package)_extract_dir) && \
+	echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+	$(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+	mkdir -p libtinfo5 && \
+	ar x --output libtinfo5 $($(package)_source_dir)/$($(package)_file_name) && \
+	cd libtinfo5 && \
+	tar xf data.tar.xz
+endef
 
 define $(package)_stage_cmds
-	pwd
-	ls -l
-	ls -l
-	ls -l
+	pwd && \
+	mkdir -p $($(package)_staging_prefix_dir)/lib && \
+	cp libtinfo5/lib/x86_64-linux-gnu/libtinfo.so.5.9 $($(package)_staging_prefix_dir)/lib/libtinfo.so.5
 endef
-#mkdir -p $($(package)_staging_prefix_dir)/bin && \
-#cp bin/clang-$($(package)_major_version) $($(package)_staging_prefix_dir)/bin && \
-#cp bin/lld $($(package)_staging_prefix_dir)/bin && \
-#cp bin/llvm-ar $($(package)_staging_prefix_dir)/bin && \
-#cp bin/llvm-config $($(package)_staging_prefix_dir)/bin && \
-#cp bin/llvm-nm $($(package)_staging_prefix_dir)/bin && \
-#cp bin/llvm-objcopy $($(package)_staging_prefix_dir)/bin && \
-#cp -P bin/clang $($(package)_staging_prefix_dir)/bin && \
-#cp -P bin/clang++ $($(package)_staging_prefix_dir)/bin && \
-#cp -P bin/ld.lld $($(package)_staging_prefix_dir)/bin && \
-#cp -P bin/ld64.lld $($(package)_staging_prefix_dir)/bin && \
-#cp -P bin/lld-link $($(package)_staging_prefix_dir)/bin && \
-#cp -P bin/llvm-ranlib $($(package)_staging_prefix_dir)/bin && \
-#cp -P bin/llvm-strip $($(package)_staging_prefix_dir)/bin && \
-#mv include/ $($(package)_staging_prefix_dir) && \
-#mv lib/ $($(package)_staging_prefix_dir) && \
-#mv libexec/ $($(package)_staging_prefix_dir)

--- a/depends/packages/native_libtinfo.mk
+++ b/depends/packages/native_libtinfo.mk
@@ -1,0 +1,51 @@
+package=native_tinfo
+#$(package)_major_version=13
+#$(package)_version=13.0.0
+#$(package)_download_path=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
+$(package)_download_path_linux=http://ftp.debian.org/debian/pool/main/n/ncurses/
+$(package)_download_file_linux=libtinfo5_6.0+20161126-1+deb9u2_amd64.deb
+$(package)_file_name_linux=libtinfo5_6.0+20161126-1+deb9u2_amd64.deb
+$(package)_sha256_hash_linux=1d249a3193568b5ef785ad8993b9ba6d6fdca0eb359204c2355532b82d25e9f5
+#$(package)_download_path_darwin=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_major_version).0.0
+#$(package)_download_file_darwin=clang+llvm-$($(package)_major_version).0.0-x86_64-apple-darwin.tar.xz
+#$(package)_file_name_darwin=clang-llvm-$($(package)_major_version).0.0-x86_64-apple-darwin.tar.xz
+#$(package)_sha256_hash_darwin=d051234eca1db1f5e4bc08c64937c879c7098900f7a0370f3ceb7544816a8b09
+#$(package)_download_path_freebsd=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
+#$(package)_download_file_freebsd=clang+llvm-$($(package)_version)-amd64-unknown-freebsd12.tar.xz
+#$(package)_file_name_freebsd=clang-llvm-$($(package)_version)-amd64-unknown-freebsd12.tar.xz
+#$(package)_sha256_hash_freebsd=e579747a36ff78aa0a5533fe43bc1ed1f8ed449c9bfec43c358d953ffbbdcf76
+#$(package)_download_file_aarch64_linux=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
+#$(package)_file_name_aarch64_linux=clang-llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
+#$(package)_sha256_hash_aarch64_linux=968d65d2593850ee9b37fcda074fb7641529bd45d2f976af6c8197de3c22612f
+
+## Ensure we have clang native to the builder, not the target host
+#ifneq ($(canonical_host),$(build))
+#$(package)_exact_download_path=$($(package)_download_path_$(build_os))
+#$(package)_exact_download_file=$($(package)_download_file_$(build_os))
+#$(package)_exact_file_name=$($(package)_file_name_$(build_os))
+#$(package)_exact_sha256_hash=$($(package)_sha256_hash_$(build_os))
+#endif
+
+define $(package)_stage_cmds
+	pwd
+	ls -l
+	ls -l
+	ls -l
+endef
+#mkdir -p $($(package)_staging_prefix_dir)/bin && \
+#cp bin/clang-$($(package)_major_version) $($(package)_staging_prefix_dir)/bin && \
+#cp bin/lld $($(package)_staging_prefix_dir)/bin && \
+#cp bin/llvm-ar $($(package)_staging_prefix_dir)/bin && \
+#cp bin/llvm-config $($(package)_staging_prefix_dir)/bin && \
+#cp bin/llvm-nm $($(package)_staging_prefix_dir)/bin && \
+#cp bin/llvm-objcopy $($(package)_staging_prefix_dir)/bin && \
+#cp -P bin/clang $($(package)_staging_prefix_dir)/bin && \
+#cp -P bin/clang++ $($(package)_staging_prefix_dir)/bin && \
+#cp -P bin/ld.lld $($(package)_staging_prefix_dir)/bin && \
+#cp -P bin/ld64.lld $($(package)_staging_prefix_dir)/bin && \
+#cp -P bin/lld-link $($(package)_staging_prefix_dir)/bin && \
+#cp -P bin/llvm-ranlib $($(package)_staging_prefix_dir)/bin && \
+#cp -P bin/llvm-strip $($(package)_staging_prefix_dir)/bin && \
+#mv include/ $($(package)_staging_prefix_dir) && \
+#mv lib/ $($(package)_staging_prefix_dir) && \
+#mv libexec/ $($(package)_staging_prefix_dir)

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,6 +1,10 @@
 zcash_packages := libsodium utfcpp
 packages := boost libevent zeromq $(zcash_packages) googletest
-native_packages := native_clang native_libtinfo native_ccache native_rust
+native_packages := native_clang native_ccache native_rust 
+
+ifneq (,$(wildcard /etc/arch-release))
+native_packages += native_libtinfo
+endif
 
 wallet_packages=bdb
 

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,6 +1,6 @@
 zcash_packages := libsodium utfcpp
 packages := boost libevent zeromq $(zcash_packages) googletest
-native_packages := native_clang native_ccache native_rust
+native_packages := native_clang native_libtinfo native_ccache native_rust
 
 wallet_packages=bdb
 


### PR DESCRIPTION
This builds off of @defuse's https://github.com/zcash/zcash/pull/5553 and closes https://github.com/zcash/zcash/issues/5488.

i tested it on an arch machine and a debian machine, both seem to build fine and the `native_libtinfo` depend doesn't get used on the debian machine, as intended.

