### PR TITLE
Log calls to getblocktemplate

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -431,8 +431,7 @@ void JSONRequest::parse(const UniValue& valRequest)
     if (!valMethod.isStr())
         throw JSONRPCError(RPC_INVALID_REQUEST, "Method must be a string");
     strMethod = valMethod.get_str();
-    if (strMethod != "getblocktemplate")
-        LogPrint("rpc", "ThreadRPCServer method=%s\n", SanitizeString(strMethod));
+    LogPrint("rpc", "ThreadRPCServer method=%s\n", SanitizeString(strMethod));
 
     // Parse params
     UniValue valParams = find_value(request, "params");


### PR DESCRIPTION
(cherry picked from commit bitcoin/bitcoin@1352092dbd5c59cb6460ed0cc5890271acf6efef)

Nick at [Luxor](https://mining.luxor.tech/) enabled RPC logging (`-debug=rpc`), and was surprised to not see any `getblocktemplate` calls. This cherry-pick reenables it.