### PR TITLE
Add Orchard to default UA receiver types

### DIFF
--- a/qa/rpc-tests/wallet_accounts.py
+++ b/qa/rpc-tests/wallet_accounts.py
@@ -55,7 +55,7 @@ class WalletAccountsTest(BitcoinTestFramework):
         # Generate the first address for account 0.
         addr0 = self.nodes[0].z_getaddressforaccount(0)
         assert_equal(addr0['account'], 0)
-        assert_equal(set(addr0['pools']), set(['transparent', 'sapling']))
+        assert_equal(set(addr0['pools']), set(['transparent', 'sapling', 'orchard']))
         ua0 = addr0['unifiedaddress']
 
         # We pick mnemonic phrases to ensure that we can always generate the default
@@ -70,16 +70,38 @@ class WalletAccountsTest(BitcoinTestFramework):
                 'no address at diversifier index 0',
                 self.nodes[0].z_getaddressforaccount, 0, [], 0)
 
+        # The second address for account 0 is different to the first address.
+        addr0_2 = self.nodes[0].z_getaddressforaccount(0)
+        assert_equal(addr0_2['account'], 0)
+        assert_equal(set(addr0_2['pools']), set(['transparent', 'sapling', 'orchard']))
+        ua0_2 = addr0_2['unifiedaddress']
+        assert(ua0 != ua0_2)
+
+        # We can generate a fully-shielded address.
+        addr0_3 = self.nodes[0].z_getaddressforaccount(0, ['sapling', 'orchard'])
+        assert_equal(addr0_3['account'], 0)
+        assert_equal(set(addr0_3['pools']), set(['sapling', 'orchard']))
+        ua0_3 = addr0_3['unifiedaddress']
+
+        # We can generate an address without a Sapling receiver.
+        addr0_4 = self.nodes[0].z_getaddressforaccount(0, ['transparent', 'orchard'])
+        assert_equal(addr0_4['account'], 0)
+        assert_equal(set(addr0_4['pools']), set(['transparent', 'orchard']))
+        ua0_4 = addr0_4['unifiedaddress']
+
         # The first address for account 1 is different to account 0.
         addr1 = self.nodes[0].z_getaddressforaccount(1)
         assert_equal(addr1['account'], 1)
-        assert_equal(set(addr1['pools']), set(['transparent', 'sapling']))
+        assert_equal(set(addr1['pools']), set(['transparent', 'sapling', 'orchard']))
         ua1 = addr1['unifiedaddress']
         assert(ua0 != ua1)
 
         # The UA contains the expected receiver kinds.
-        self.check_receiver_types(ua0, ['transparent', 'sapling'])
-        self.check_receiver_types(ua1, ['transparent', 'sapling'])
+        self.check_receiver_types(ua0,   ['transparent', 'sapling', 'orchard'])
+        self.check_receiver_types(ua0_2, ['transparent', 'sapling', 'orchard'])
+        self.check_receiver_types(ua0_3, [               'sapling', 'orchard'])
+        self.check_receiver_types(ua0_4, ['transparent',            'orchard'])
+        self.check_receiver_types(ua1,   ['transparent', 'sapling', 'orchard'])
 
         # The balances of the accounts are all zero.
         self.check_balance(0, 0, ua0, {})

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -381,9 +381,10 @@ class ListReceivedTest (BitcoinTestFramework):
         r = node.z_getaddressforaccount(account)
         unified_addr = r['unifiedaddress']
         receivers = node.z_listunifiedreceivers(unified_addr)
-        assert_equal(len(receivers), 2)
+        assert_equal(len(receivers), 3)
         assert 'transparent' in receivers
         assert 'sapling' in receivers
+        assert 'orchard' in receivers
         # Wallet contains no notes
         r = node.z_listreceivedbyaddress(unified_addr, 0)
         assert_equal(len(r), 0, "unified_addr should have received zero notes")

--- a/src/rust/src/wallet.rs
+++ b/src/rust/src/wallet.rs
@@ -73,8 +73,12 @@ impl KeyStore {
     }
 
     pub fn add_full_viewing_key(&mut self, fvk: FullViewingKey) {
-        let ivk = IncomingViewingKey::from(&fvk);
-        self.viewing_keys.insert(ivk, fvk);
+        // When we add a full viewing key, we need to add both the internal and external
+        // incoming viewing keys.
+        let external_ivk = IncomingViewingKey::from(&fvk);
+        let internal_ivk = IncomingViewingKey::from(&fvk.derive_internal());
+        self.viewing_keys.insert(external_ivk, fvk.clone());
+        self.viewing_keys.insert(internal_ivk, fvk);
     }
 
     pub fn add_spending_key(&mut self, sk: SpendingKey) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -605,7 +605,7 @@ std::optional<libzcash::ZcashdUnifiedSpendingKey>
         // when the user calls z_getaddressforaccount.
         auto orchardInternalFvk = orchardSk.ToFullViewingKey().ToInternalIncomingViewingKey();
         if (!AddOrchardRawAddress(orchardInternalFvk, orchardInternalFvk.Address(0))) {
-            throw std::runtime_error("CWallet::GenerateUnifiedSpendingKeyForAccount(): Failed to add Sapling change address to the wallet.");
+            throw std::runtime_error("CWallet::GenerateUnifiedSpendingKeyForAccount(): Failed to add Orchard change address to the wallet.");
         };
 
         auto zufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(Params(), ufvk);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1463,7 +1463,15 @@ public:
     bool AddOrchardZKey(const libzcash::OrchardSpendingKey &sk);
     bool AddOrchardFullViewingKey(const libzcash::OrchardFullViewingKey &fvk);
     /**
-     * Adds an address/ivk mapping to the in-memory wallet. Returns `true`
+     * Adds an address/ivk mapping to the in-memory wallet. Returns `false` if
+     * the mapping could not be persisted, or the IVK does not correspond to an
+     * FVK known by the wallet.
+     */
+    bool AddOrchardRawAddress(
+        const libzcash::OrchardIncomingViewingKey &ivk,
+        const libzcash::OrchardRawAddress &addr);
+    /**
+     * Loads an address/ivk mapping to the in-memory wallet. Returns `true`
      * if the provided IVK corresponds to an FVK known by the wallet.
      */
     bool LoadOrchardRawAddress(

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -794,6 +794,7 @@ public:
     std::vector<COutput> utxos;
     std::vector<SproutNoteEntry> sproutNoteEntries;
     std::vector<SaplingNoteEntry> saplingNoteEntries;
+    std::vector<OrchardNoteMetadata> orchardNoteMetadata;
 
     /**
      * Selectively discard notes that are not required to obtain the desired
@@ -815,6 +816,9 @@ public:
         }
         for (const auto& t : saplingNoteEntries) {
             result += t.note.value();
+        }
+        for (const auto& t : orchardNoteMetadata) {
+            result += t.GetNoteValue();
         }
         return result;
     }

--- a/src/zcash/address/orchard.cpp
+++ b/src/zcash/address/orchard.cpp
@@ -24,7 +24,7 @@ OrchardIncomingViewingKey OrchardFullViewingKey::ToIncomingViewingKey() const {
 }
 
 OrchardIncomingViewingKey OrchardFullViewingKey::ToInternalIncomingViewingKey() const {
-    return OrchardIncomingViewingKey(orchard_full_viewing_key_to_incoming_viewing_key(inner.get()));
+    return OrchardIncomingViewingKey(orchard_full_viewing_key_to_internal_incoming_viewing_key(inner.get()));
 }
 
 OrchardSpendingKey OrchardSpendingKey::ForAccount(

--- a/src/zcash/address/unified.cpp
+++ b/src/zcash/address/unified.cpp
@@ -150,7 +150,7 @@ UnifiedAddressGenerationResult ZcashdUnifiedFullViewingKey::FindAddress(
 
 UnifiedAddressGenerationResult ZcashdUnifiedFullViewingKey::FindAddress(
         const diversifier_index_t& j) const {
-    return FindAddress(j, {ReceiverType::P2PKH, ReceiverType::Sapling});
+    return FindAddress(j, {ReceiverType::P2PKH, ReceiverType::Sapling, ReceiverType::Orchard});
 }
 
 std::optional<RecipientAddress> ZcashdUnifiedFullViewingKey::GetChangeAddress(const ChangeRequest& req) const {


### PR DESCRIPTION
This enables UAs returned by `z_getaddressforaccount` to contain Orchard receivers.

Closes zcash/zcash#5499.