### PR TITLE
fix ordering issues with gtests: WalletZkeysTest, ContextualCheckBlockTest, CheckBlock, Metrics.GetLocalSolPS 

### DIFF
--- a/src/gtest/test_checkblock.cpp
+++ b/src/gtest/test_checkblock.cpp
@@ -37,6 +37,9 @@ TEST(CheckBlock, VersionTooLow) {
     block.nVersion = 1;
 
     MockCValidationState state;
+
+    SelectParams(CBaseChainParams::MAIN);
+
     EXPECT_CALL(state, DoS(100, false, REJECT_INVALID, "version-too-low", false, "")).Times(1);
     EXPECT_FALSE(CheckBlock(block, state, Params(), verifier, orchardAuth, false, false, true));
 }

--- a/src/gtest/test_checkblock.cpp
+++ b/src/gtest/test_checkblock.cpp
@@ -93,7 +93,7 @@ protected:
 
     void TearDown() override {
         // Revert to test default. No-op on mainnet params.
-        RegtestDeactivateSapling();
+        RegtestDeactivateBlossom();
     }
 
     // Returns a valid but empty mutable transaction at block height 1.

--- a/src/gtest/test_metrics.cpp
+++ b/src/gtest/test_metrics.cpp
@@ -92,6 +92,12 @@ TEST(Metrics, GetLocalSolPS) {
     // Increment time
     SetMockTime(104);
     EXPECT_EQ(1, GetLocalSolPS());
+
+    miningTimer.stop();
+    miningTimer.zeroize();
+    solutionTargetChecks.decrement();
+    solutionTargetChecks.decrement();
+    solutionTargetChecks.decrement();
 }
 
 TEST(Metrics, EstimateNetHeight) {

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -50,6 +50,17 @@ void AtomicTimer::stop()
     }
 }
 
+
+void AtomicTimer::zeroize()
+{
+    std::unique_lock<std::mutex> lock(mtx);
+    // only zeroize it if there's no more threads (same semantics as start())
+    if (threads < 1) {
+        start_time = 0;
+        total_time = 0;
+    }
+}
+
 bool AtomicTimer::running()
 {
     std::unique_lock<std::mutex> lock(mtx);

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -52,6 +52,8 @@ public:
      */
     void stop();
 
+    void zeroize();
+
     bool running();
 
     uint64_t threadCount();

--- a/src/wallet/gtest/test_wallet_zkeys.cpp
+++ b/src/wallet/gtest/test_wallet_zkeys.cpp
@@ -228,7 +228,7 @@ TEST(WalletZkeysTest, WriteZkeyDirectToDb) {
     mapArgs["-datadir"] = pathTemp.string();
 
     bool fFirstRun;
-    CWallet wallet(Params(), "wallet.dat");
+    CWallet wallet(Params(), "wallet_direct_zkey_test.dat");
     LOCK(wallet.cs_wallet);
     ASSERT_EQ(DB_LOAD_OK, wallet.LoadWallet(fFirstRun));
 
@@ -252,7 +252,7 @@ TEST(WalletZkeysTest, WriteZkeyDirectToDb) {
     auto addr = sk.address();
     int64_t now = GetTime();
     CKeyMetadata meta(now);
-    CWalletDB db("wallet.dat");
+    CWalletDB db("wallet_direct_zkey_test.dat");
     db.WriteZKey(addr, sk, meta);
 
     // wallet should not be aware of key

--- a/src/wallet/gtest/test_wallet_zkeys.cpp
+++ b/src/wallet/gtest/test_wallet_zkeys.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "fs.h"
+#include "db.h"
 #include "zcash/Address.hpp"
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
@@ -227,7 +228,10 @@ TEST(WalletZkeysTest, WriteZkeyDirectToDb) {
     fs::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 
-    bool fFirstRun;
+    bool fFirstRun, fFirstRunDummy;
+    CWallet dummyWallet(Params(), "wallet_direct_zkey_test.dat");
+    dummyWallet.LoadWallet(fFirstRunDummy);
+    bitdb.RemoveDb("wallet_direct_zkey_test.dat");
     CWallet wallet(Params(), "wallet_direct_zkey_test.dat");
     LOCK(wallet.cs_wallet);
     ASSERT_EQ(DB_LOAD_OK, wallet.LoadWallet(fFirstRun));
@@ -300,7 +304,10 @@ TEST(WalletZkeysTest, WriteViewingKeyDirectToDB) {
     fs::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 
-    bool fFirstRun;
+    bool fFirstRun, fFirstRunDummy;
+    CWallet dummyWallet(Params(), "wallet-vkey.dat");
+    dummyWallet.LoadWallet(fFirstRunDummy);
+    bitdb.RemoveDb("wallet-vkey.dat");
     CWallet wallet(Params(), "wallet-vkey.dat");
     LOCK(wallet.cs_wallet);
     ASSERT_EQ(DB_LOAD_OK, wallet.LoadWallet(fFirstRun));
@@ -347,7 +354,10 @@ TEST(WalletZkeysTest, WriteCryptedzkeyDirectToDb) {
     fs::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 
-    bool fFirstRun;
+    bool fFirstRun, fFirstRunDummy;
+    CWallet dummyWallet(Params(), "wallet_crypted.dat");
+    dummyWallet.LoadWallet(fFirstRunDummy);
+    bitdb.RemoveDb("wallet_crypted.dat");
     CWallet wallet(Params(), "wallet_crypted.dat");
     LOCK(wallet.cs_wallet);
     ASSERT_EQ(DB_LOAD_OK, wallet.LoadWallet(fFirstRun));
@@ -422,7 +432,10 @@ TEST(WalletZkeysTest, WriteCryptedSaplingZkeyDirectToDb) {
     fs::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 
-    bool fFirstRun;
+    bool fFirstRun, fFirstRunDummy;
+    CWallet dummyWallet(Params(), "wallet_crypted_sapling.dat");
+    dummyWallet.LoadWallet(fFirstRunDummy);
+    bitdb.RemoveDb("wallet_crypted_sapling.dat");
     CWallet wallet(Params(), "wallet_crypted_sapling.dat");
     LOCK(wallet.cs_wallet);
     ASSERT_EQ(DB_LOAD_OK, wallet.LoadWallet(fFirstRun));


### PR DESCRIPTION
renaming the string `wallet.dat` in `WriteZkeyDirectToDb`: `CWallet wallet(Params(), "wallet.dat");` [here](https://github.com/zcash/zcash/blob/e568a190f3d56440820dab6b7c434b8d9800adee/src/wallet/gtest/test_wallet_zkeys.cpp#L231Z) and  `CWalletDB db("wallet.dat");` [here](https://github.com/zcash/zcash/blob/e568a190f3d56440820dab6b7c434b8d9800adee/src/wallet/gtest/test_wallet_zkeys.cpp#L255)

to something like:

`CWallet wallet(Params(), "wallet_direct_zkey_test.dat");`
and
`CWalletDB db("wallet_direct_zkey_test.dat");`

fixes this error which can be provoked by the gtests running in a different order (or if they're sharded):

```
[ RUN      ] WalletZkeysTest.WriteZkeyDirectToDb                                                      
wallet/gtest/test_wallet_zkeys.cpp:236: Failure                                                       
Value of: fFirstRun                                                                                   
  Actual: false                                                                                       
Expected: true                                                                                        
[  FAILED  ] WalletZkeysTest.WriteZkeyDirectToDb (4 ms) 
```

To demonstrate this error with the unpatched version and show the error goes away with my patch do `./zcash-gtest --gtest_shuffle --gtest_random_seed=34191`


Also, the `[TearDown]` [function](https://github.com/zcash/zcash/blob/cf9a0799b425e8ecf2ca3e332afabc8f8031fc03/src/gtest/test_checkblock.cpp#L94-L97) in `ContextualCheckBlockTest` doesn't deactivate Blossom, causing mysterious failures with other tests, as exhibited by any of:

```
./src/zcash-gtest --gtest_shuffle --gtest_random_seed=36449
./src/zcash-gtest --gtest_shuffle --gtest_random_seed=60053
./src/zcash-gtest --gtest_shuffle --gtest_random_seed=34485
```

(see my comments in #1539)

Replacing `RegtestDeactivateSapling()` with `RegtestDeactivateBlossom();` causes all the activated NUs to be deactivated, and prevents the mysterious failures in other tests.
