### PR TITLE
Fix csBestBlock/cvBlockChange waiting in rpc/mining

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -305,7 +305,7 @@ bool static Bind(const CService &addr, unsigned int flags) {
 
 void OnRPCStopped()
 {
-    cvBlockChange.notify_all();
+    g_best_block_cv.notify_all();
     LogPrint("rpc", "RPC stopped.\n");
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,10 +66,10 @@ BlockMap mapBlockIndex;
 CChain chainActive;
 CBlockIndex *pindexBestHeader = NULL;
 static std::atomic<int64_t> nTimeBestReceived(0); // Used only to inform the wallet of when we last received a block
-CWaitableCriticalSection csBestBlock;
-CConditionVariable cvBlockChange;
-uint256 hashBestBlock;
-int heightBestBlock;
+CWaitableCriticalSection g_best_block_mutex;
+CConditionVariable g_best_block_cv;
+uint256 g_best_block;
+int g_best_block_height;
 int nScriptCheckThreads = 0;
 std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
@@ -3760,10 +3760,10 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
     RenderPoolMetrics("transparent", transparentPool);
 
     {
-        boost::unique_lock<boost::mutex> lock(csBestBlock);
-        hashBestBlock = pindexNew->GetBlockHash();
-        heightBestBlock = pindexNew->nHeight;
-        cvBlockChange.notify_all();
+        boost::unique_lock<boost::mutex> lock(g_best_block_mutex);
+        g_best_block = pindexNew->GetBlockHash();
+        g_best_block_height = pindexNew->nHeight;
+        g_best_block_cv.notify_all();
     }
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -160,8 +160,13 @@ extern BlockMap mapBlockIndex;
 extern std::optional<uint64_t> last_block_num_txs;
 extern std::optional<uint64_t> last_block_size;
 extern const std::string strMessageMagic;
+
+// These prevent lock-ordering problems in getblocktemplate() RPC
 extern CWaitableCriticalSection csBestBlock;
 extern CConditionVariable cvBlockChange;
+extern uint256 hashBestBlock;
+extern int heightBestBlock;
+
 extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;
 extern int nScriptCheckThreads;

--- a/src/main.h
+++ b/src/main.h
@@ -161,11 +161,17 @@ extern std::optional<uint64_t> last_block_num_txs;
 extern std::optional<uint64_t> last_block_size;
 extern const std::string strMessageMagic;
 
-// These prevent lock-ordering problems in getblocktemplate() RPC
+//! These four variables are used to notify getblocktemplate RPC of new tips.
+//! When UpdateTip() establishes a new tip (best block), it must awaken a
+//! waiting getblocktemplate RPC (if there is one) immediately. But upon waking
+//! up, getblocktemplate cannot call chainActive->Tip() because it does not
+//! (and cannot) hold cs_main. So the g_best_block_height and g_best_block variables
+//! (protected by g_best_block_mutex) provide the needed height and block
+//! hash respectively to getblocktemplate without it requiring cs_main.
 extern CWaitableCriticalSection g_best_block_mutex;
 extern CConditionVariable g_best_block_cv;
-extern uint256 g_best_block;
 extern int g_best_block_height;
+extern uint256 g_best_block;
 
 extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;

--- a/src/main.h
+++ b/src/main.h
@@ -162,10 +162,10 @@ extern std::optional<uint64_t> last_block_size;
 extern const std::string strMessageMagic;
 
 // These prevent lock-ordering problems in getblocktemplate() RPC
-extern CWaitableCriticalSection csBestBlock;
-extern CConditionVariable cvBlockChange;
-extern uint256 hashBestBlock;
-extern int heightBestBlock;
+extern CWaitableCriticalSection g_best_block_mutex;
+extern CConditionVariable g_best_block_cv;
+extern uint256 g_best_block;
+extern int g_best_block_height;
 
 extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;


### PR DESCRIPTION
Cherry-pick https://github.com/bitcoin/bitcoin/pull/12743
This is an alternative to #5591, which isn't correct because it calls `chainActive->Tip()` without holding `cs_main`. The upstream fix is correct.