### PR TITLE
GenerateNewKey must be guarded by a cs_wallet lock

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5719,6 +5719,8 @@ bool CWallet::InitLoadWallet(const CChainParams& params, bool clearWitnessCaches
     {
         // Create new keyUser and set as default key
         if (!walletInstance->IsCrypted()) {
+            LOCK(walletInstance->cs_wallet);
+
             CPubKey newDefaultKey = walletInstance->GenerateNewKey(true);
             walletInstance->SetDefaultKey(newDefaultKey);
             if (!walletInstance->SetAddressBook(walletInstance->vchDefaultKey.GetID(), "", "receive"))


### PR DESCRIPTION
This was missed in the update to InitLoadWallet.