### PR TITLE
Add `zcash_script` APIs for handling v5 transactions

### DIFF
--- a/src/script/zcash_script.cpp
+++ b/src/script/zcash_script.cpp
@@ -127,6 +127,39 @@ void* zcash_script_new_precomputed_tx(
     }
 }
 
+void* zcash_script_new_precomputed_tx_v5(
+    const unsigned char* txTo,
+    unsigned int txToLen,
+    const unsigned char* allPrevOutputs,
+    unsigned int allPrevOutputsLen,
+    zcash_script_error* err)
+{
+    try {
+        TxInputStream stream(SER_NETWORK, PROTOCOL_VERSION, txTo, txToLen);
+        CTransaction tx;
+        stream >> tx;
+        if (GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) != txToLen) {
+            set_error(err, zcash_script_ERR_TX_SIZE_MISMATCH);
+            return nullptr;
+        }
+
+        try {
+            auto preTx = new PrecomputedTransaction(tx, allPrevOutputs, allPrevOutputsLen);
+            // Deserializing the tx did not error.
+            set_error(err, zcash_script_ERR_OK);
+            return preTx;
+        } catch (const std::exception&) {
+            // We had some error when parsing allPrevOutputs inside the
+            // PrecomputedTransactionData constructor.
+            set_error(err, zcash_script_ERR_ALL_PREV_OUTPUTS_DESERIALIZE);
+            return nullptr;
+        }
+    } catch (const std::exception&) {
+        set_error(err, zcash_script_ERR_TX_DESERIALIZE); // Error deserializing
+        return nullptr;
+    }
+}
+
 void zcash_script_free_precomputed_tx(void* pre_preTx)
 {
     PrecomputedTransaction* preTx = static_cast<PrecomputedTransaction*>(pre_preTx);
@@ -189,6 +222,53 @@ int zcash_script_verify(
             CScript(scriptPubKey, scriptPubKey + scriptPubKeyLen),
             flags,
             TransactionSignatureChecker(&tx, txdata, nIn, amount),
+            consensusBranchId,
+            NULL);
+    } catch (const std::exception&) {
+        return set_error(err, zcash_script_ERR_TX_DESERIALIZE); // Error deserializing
+    }
+}
+
+int zcash_script_verify_v5(
+    const unsigned char* txTo,
+    unsigned int txToLen,
+    const unsigned char* allPrevOutputs,
+    unsigned int allPrevOutputsLen,
+    unsigned int nIn,
+    unsigned int flags,
+    uint32_t consensusBranchId,
+    zcash_script_error* err)
+{
+    try {
+        TxInputStream stream(SER_NETWORK, PROTOCOL_VERSION, txTo, txToLen);
+        CTransaction tx;
+        stream >> tx;
+        if (nIn >= tx.vin.size())
+            return set_error(err, zcash_script_ERR_TX_INDEX);
+        if (GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) != txToLen)
+            return set_error(err, zcash_script_ERR_TX_SIZE_MISMATCH);
+
+        // TODO: we can swap this second deserialization for an FFI call by
+        // fetching this through PrecomputedTransactionData. Simplicity for now.
+        CDataStream sAllPrevOutputs(
+            reinterpret_cast<const char*>(allPrevOutputs),
+            reinterpret_cast<const char*>(allPrevOutputs + allPrevOutputsLen),
+            SER_NETWORK,
+            PROTOCOL_VERSION);
+        std::vector<CTxOut> prevOutputs;
+        sAllPrevOutputs >> prevOutputs;
+        if (!(tx.IsCoinBase() ? prevOutputs.empty() : tx.vin.size() == prevOutputs.size())) {
+            return set_error(err, zcash_script_ERR_ALL_PREV_OUTPUTS_SIZE_MISMATCH);
+        }
+
+        // Regardless of the verification result, the tx did not error.
+        set_error(err, zcash_script_ERR_OK);
+        PrecomputedTransactionData txdata(tx, allPrevOutputs, allPrevOutputsLen);
+        return VerifyScript(
+            tx.vin[nIn].scriptSig,
+            prevOutputs[nIn].scriptPubKey,
+            flags,
+            TransactionSignatureChecker(&tx, txdata, nIn, prevOutputs[nIn].nValue),
             consensusBranchId,
             NULL);
     } catch (const std::exception&) {

--- a/src/script/zcash_script.h
+++ b/src/script/zcash_script.h
@@ -45,6 +45,7 @@ typedef enum zcash_script_error_t
     zcash_script_ERR_TX_VERSION,
     zcash_script_ERR_ALL_PREV_OUTPUTS_SIZE_MISMATCH,
     zcash_script_ERR_ALL_PREV_OUTPUTS_DESERIALIZE,
+    zcash_script_ERR_VERIFY_SCRIPT,
 } zcash_script_error;
 
 /** Script verification flags */


### PR DESCRIPTION
https://github.com/zcash/zips/issues/574 requires changing the `zcash_script` API in order to receive the previous outputs `(amounts, pk_scripts)`. This PR adds the new API, which would be the easiest to call from Zebra.