### PR TITLE
Recover orchard keys and mappings during wallet load

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -902,7 +902,12 @@ bool CWallet::LoadUnifiedCaches()
                             // an orchard receiver present in this address.
                             auto orchardFvk = ufvk.value().GetOrchardKey();
                             auto orchardReceiver = addr.first.GetOrchardReceiver();
-                            assert (orchardFvk.has_value() == orchardReceiver.has_value());
+
+                            if (orchardFvk.has_value() != orchardReceiver.has_value()) {
+                                // Inconsistency between full viewing key and address
+                                // metadata.
+                                return false;
+                            }
 
                             if (orchardFvk.has_value()) {
                                 if (!AddOrchardRawAddress(orchardFvk.value().ToIncomingViewingKey(), orchardReceiver.value())) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1534,6 +1534,14 @@ public:
     bool LoadUnifiedAccountMetadata(const ZcashdUnifiedAccountMetadata &skmeta);
     bool LoadUnifiedAddressMetadata(const ZcashdUnifiedAddressMetadata &addrmeta);
 
+    //! Reconstructs (in memory) caches and mappings for unified accounts,
+    //! addresses and keying material. This should be called once, after the
+    //! remainder of the on-disk wallet data has been loaded.
+    //!
+    //! Returns true if and only if there were no detected inconsistencies or
+    //! failures in reconstructing the cache.
+    bool LoadUnifiedCaches();
+
     std::optional<libzcash::UFVKId> FindUnifiedFullViewingKey(const libzcash::UnifiedAddress& addr) const;
     std::optional<libzcash::AccountId> GetUnifiedAccountId(const libzcash::UFVKId& ufvkId) const;
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -963,6 +963,14 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
         }
         pcursor->close();
 
+        // Load unified address/account/key caches based on what was loaded
+        if (!pwallet->LoadUnifiedCaches()) {
+            // We can be more permissive of certain kinds of failures during
+            // loading; for now we'll interpret failure to reconstruct the
+            // caches to be "as bad" as losing keys.
+            result = DB_CORRUPT;
+        }
+
         // Run the Orchard batch validator; if it fails, treat it like a bad transaction record.
         if (!wss.orchardAuth.Validate()) {
             fNoncriticalErrors = true;
@@ -1282,6 +1290,13 @@ bool CWalletDB::Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKe
     }
     ptxn->commit(0);
     pdbCopy->close(0);
+
+    // Try to load the unified caches, uncovering inconsistencies in wallet
+    // records like missing viewing key records despite existing account
+    // records.
+    if (!dummyWallet.LoadUnifiedCaches()) {
+        LogPrintf("WARNING: unified caches could not be reconstructed; salvaged wallet file may have omissions");
+    }
 
     return fSuccess;
 }


### PR DESCRIPTION
Closes #5567

Everything is already persisted, we just need to reconstruct the in-memory maps. The IVK -> FVK maps are already reloaded during wallet loading inside of `AddUnifiedFullViewingKey` (that map exists inside of the keystore itself rather than the wallet). This PR just reloads the Orchard spending keys and the addr -> IVK maps (inside the wallet) for Orchard addresses (both internal and per-address).

First commit just consolidates cache reconstruction for unified addresses into a single function.