### PR TITLE
Fix for chain forks on NU5 testnet

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -683,6 +683,14 @@ void CCoinsViewCache::PopAnchor(const uint256 &newrt, ShieldedType type) {
                 hashSaplingAnchor
             );
             break;
+        case ORCHARD:
+            AbstractPopAnchor<OrchardMerkleFrontier, CAnchorsOrchardMap, CAnchorsOrchardCacheEntry>(
+                newrt,
+                ORCHARD,
+                cacheOrchardAnchors,
+                hashOrchardAnchor
+            );
+            break;
         default:
             throw std::runtime_error("Unknown shielded type");
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2909,6 +2909,17 @@ static DisconnectResult DisconnectBlock(const CBlock& block, CValidationState& s
         view.PopAnchor(SaplingMerkleTree::empty_root(), SAPLING);
     }
 
+    // Set the old best Orchard anchor back. We can get this from the
+    // `hashFinalOrchardRoot` of the last block. However, if the last
+    // block was not on or after the Orchard activation height, this
+    // will be set to `null`. For logical consistency, in this case we
+    // set the last anchor to the empty root.
+    if (chainparams.GetConsensus().NetworkUpgradeActive(pindex->pprev->nHeight, Consensus::UPGRADE_NU5)) {
+        view.PopAnchor(pindex->pprev->hashFinalOrchardRoot, ORCHARD);
+    } else {
+        view.PopAnchor(OrchardMerkleFrontier::empty_root(), ORCHARD);
+    }
+
     // This is guaranteed to be filled by LoadBlockIndex.
     assert(pindex->nCachedBranchId);
     auto consensusBranchId = pindex->nCachedBranchId.value();


### PR DESCRIPTION
A missing `view.PopAnchor()` led to chain forks on testnet shortly after the first Orchard note was created, due to the node becoming confused about the current Orchard commitment tree root.

Testnet nodes will need to restart with `-reindex` to fix their local view and rejoin the expected chain. Alternatively, when 4.7.0 is released we will be rolling back testnet to before NU5 activated, which will similarly fix the problem for testnet nodes.