### PR TITLE
Orchard: invalidate mempool transactions that use orphaned anchors.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3782,6 +3782,7 @@ bool static DisconnectTip(CValidationState &state, const CChainParams& chainpara
     // Apply the block atomically to the chain state.
     uint256 sproutAnchorBeforeDisconnect = pcoinsTip->GetBestAnchor(SPROUT);
     uint256 saplingAnchorBeforeDisconnect = pcoinsTip->GetBestAnchor(SAPLING);
+    uint256 orchardAnchorBeforeDisconnect = pcoinsTip->GetBestAnchor(ORCHARD);
     int64_t nStart = GetTimeMicros();
     {
         CCoinsViewCache view(pcoinsTip);
@@ -3793,6 +3794,7 @@ bool static DisconnectTip(CValidationState &state, const CChainParams& chainpara
     LogPrint("bench", "- Disconnect block: %.2fms\n", (GetTimeMicros() - nStart) * 0.001);
     uint256 sproutAnchorAfterDisconnect = pcoinsTip->GetBestAnchor(SPROUT);
     uint256 saplingAnchorAfterDisconnect = pcoinsTip->GetBestAnchor(SAPLING);
+    uint256 orchardAnchorAfterDisconnect = pcoinsTip->GetBestAnchor(ORCHARD);
     // Write the chain state to disk, if necessary.
     if (!FlushStateToDisk(chainparams, state, FLUSH_STATE_IF_NEEDED))
         return false;
@@ -3815,6 +3817,11 @@ bool static DisconnectTip(CValidationState &state, const CChainParams& chainpara
             // The anchor may not change between block disconnects,
             // in which case we don't want to evict from the mempool yet!
             mempool.removeWithAnchor(saplingAnchorBeforeDisconnect, SAPLING);
+        }
+        if (orchardAnchorBeforeDisconnect != orchardAnchorAfterDisconnect) {
+            // The anchor may not change between block disconnects,
+            // in which case we don't want to evict from the mempool yet!
+            mempool.removeWithAnchor(orchardAnchorBeforeDisconnect, ORCHARD);
         }
     }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -387,6 +387,14 @@ void CTxMemPool::removeWithAnchor(const uint256 &invalidRoot, ShieldedType type)
                     }
                 }
             break;
+            case ORCHARD:
+            {
+                auto anchor = tx.GetOrchardBundle().GetAnchor();
+                if (anchor == invalidRoot) {
+                    transactionsToRemove.push_back(tx);
+                }
+                break;
+            }
             default:
                 throw runtime_error("Unknown shielded type");
             break;


### PR DESCRIPTION
Closes #5619.