### PR TITLE
add zcash_script_transparent_output_address() to get address from output

### DIFF
--- a/src/script/zcash_script.h
+++ b/src/script/zcash_script.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-#define ZCASH_SCRIPT_API_VER 2
+#define ZCASH_SCRIPT_API_VER 3
 
 typedef enum zcash_script_error_t
 {
@@ -43,6 +43,7 @@ typedef enum zcash_script_error_t
     zcash_script_ERR_TX_DESERIALIZE,
     // Defined since API version 3.
     zcash_script_ERR_TX_VERSION,
+    zcash_script_ERR_TX_INVALID_SCRIPT,
 } zcash_script_error;
 
 /** Script verification flags */
@@ -52,6 +53,19 @@ enum
     zcash_script_SCRIPT_FLAGS_VERIFY_P2SH                = (1U << 0), // evaluate P2SH (BIP16) subscripts
     zcash_script_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9), // enable CHECKLOCKTIMEVERIFY (BIP65)
 };
+
+/** Address type enumeration */
+typedef enum zcash_script_type_t
+{
+    zcash_script_TYPE_P2PKH = 1,
+    zcash_script_TYPE_P2SH  = 2,
+} zcash_script_type;
+
+/// A Zcash transparent address encoded as 20 bytes.
+typedef struct zcash_script_uint160_t
+{
+    unsigned char value[20];
+} zcash_script_uint160;
 
 /// Deserializes the given transaction and precomputes values to improve
 /// script verification performance.
@@ -127,6 +141,26 @@ EXPORT_SYMBOL unsigned int zcash_script_legacy_sigop_count_precomputed(
 EXPORT_SYMBOL unsigned int zcash_script_legacy_sigop_count(
     const unsigned char *txTo,
     unsigned int txToLen,
+    zcash_script_error* err);
+
+/// Return the destination address for transparent output nOut of the precomputed transaction
+/// pointed to by preTx.
+/// If not NULL, type will contain the address type.
+/// If not NULL, err will contain an error/success code for the operation.
+EXPORT_SYMBOL zcash_script_uint160 zcash_script_transparent_output_address_precomputed(
+    const void* pre_preTx,
+    unsigned int nOut,
+    zcash_script_type* type,
+    zcash_script_error* err);
+
+/// Return the destination address for transparent output nOut of the transaction txTo.
+/// If not NULL, type will contain the address type.
+/// If not NULL, err will contain an error/success code for the operation.
+EXPORT_SYMBOL zcash_script_uint160 zcash_script_transparent_output_address(
+    const unsigned char *txTo,
+    unsigned int txToLen,
+    unsigned int nOut,
+    zcash_script_type* type,
     zcash_script_error* err);
 
 /// Returns the current version of the zcash_script library.


### PR DESCRIPTION
This not related to NU5, but something that ZF needs for the lightwalletd support, and you may be interested in including it in the next API version bump. (We can keep pointing it to a fork, so this PR merging is not totally required for us, but it would make things easier)

We need to get the destination address from an output, so we added a `zcash_script_transparent_output_address` function that returns the address hash and the address type, so that the address can be recomputed. The address hash is returned in a struct so that it can be returned directly by the function and make the Rust wrapping a bit easier (and safer, since we don't need to pass a buffer with the correct size to be filled)

---


Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.
* [ ] Relevant documentation for this PR has to be completed and reviewed by @mdr0id before the PR can be merged
* [ ] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release

As a note, all buildbot tests need to be passing and all appropriate code reviews need to be done before this PR can be merged
