### PR TITLE
only load the proof parameters in gtests for tests that need them

### DIFF
--- a/src/gtest/main.cpp
+++ b/src/gtest/main.cpp
@@ -2,6 +2,7 @@
 #include "key.h"
 #include "pubkey.h"
 #include "util.h"
+#include "utiltest.h"
 
 #include "librustzcash.h"
 #include <sodium.h>

--- a/src/gtest/main.cpp
+++ b/src/gtest/main.cpp
@@ -19,26 +19,6 @@ int main(int argc, char **argv) {
   assert(sodium_init() != -1);
   ECC_Start();
 
-  fs::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
-  fs::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
-  fs::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
-
-    static_assert(
-        sizeof(fs::path::value_type) == sizeof(codeunit),
-        "librustzcash not configured correctly");
-    auto sapling_spend_str = sapling_spend.native();
-    auto sapling_output_str = sapling_output.native();
-    auto sprout_groth16_str = sprout_groth16.native();
-
-    librustzcash_init_zksnark_params(
-        reinterpret_cast<const codeunit*>(sapling_spend_str.c_str()),
-        sapling_spend_str.length(),
-        reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
-        sapling_output_str.length(),
-        reinterpret_cast<const codeunit*>(sprout_groth16_str.c_str()),
-        sprout_groth16_str.length()
-    );
-
   testing::InitGoogleMock(&argc, argv);
 
   // The "threadsafe" style is necessary for correct operation of death/exit

--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -1141,6 +1141,8 @@ TEST(ChecktransactionTests, InvalidShieldedCoinbase) {
 }
 
 TEST(ChecktransactionTests, HeartwoodAcceptsShieldedCoinbase) {
+    LoadProofParameters();
+
     RegtestActivateHeartwood(false, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto chainparams = Params();
 
@@ -1224,6 +1226,8 @@ TEST(ChecktransactionTests, HeartwoodAcceptsShieldedCoinbase) {
 // bindingSig from https://zips.z.cash/protocol/protocol.pdf#txnencoding are
 // applied to coinbase transactions.
 TEST(ChecktransactionTests, HeartwoodEnforcesSaplingRulesOnShieldedCoinbase) {
+    LoadProofParameters();
+
     RegtestActivateHeartwood(false, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto chainparams = Params();
 

--- a/src/gtest/test_dynamicusage.cpp
+++ b/src/gtest/test_dynamicusage.cpp
@@ -48,6 +48,8 @@ TEST(RecursiveDynamicUsageTests, TestTransactionJoinSplit)
 
 TEST(RecursiveDynamicUsageTests, TestTransactionSaplingToSapling)
 {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
     
     auto sk = libzcash::SaplingSpendingKey::random();
@@ -67,6 +69,8 @@ TEST(RecursiveDynamicUsageTests, TestTransactionSaplingToSapling)
 
 TEST(RecursiveDynamicUsageTests, TestTransactionTransparentToSapling)
 {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
     
     CBasicKeyStore keystore;
@@ -88,6 +92,8 @@ TEST(RecursiveDynamicUsageTests, TestTransactionTransparentToSapling)
 
 TEST(RecursiveDynamicUsageTests, TestTransactionSaplingToTransparent)
 {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
     
     CBasicKeyStore keystore;

--- a/src/gtest/test_joinsplit.cpp
+++ b/src/gtest/test_joinsplit.cpp
@@ -11,6 +11,7 @@
 #include "primitives/transaction.h"
 #include "proof_verifier.h"
 #include "transaction_builder.h"
+#include "utiltest.h"
 #include "zcash/JoinSplit.hpp"
 #include "zcash/Note.hpp"
 #include "zcash/NoteEncryption.hpp"
@@ -309,6 +310,8 @@ void increment_note_witnesses(
 
 TEST(Joinsplit, FullApiTest)
 {
+    LoadProofParameters();
+
     {
         std::vector<SproutWitness> witnesses;
         SproutMerkleTree tree;

--- a/src/gtest/test_mempoollimit.cpp
+++ b/src/gtest/test_mempoollimit.cpp
@@ -110,6 +110,8 @@ TEST(MempoolLimitTests, WeightedTxTreeCheckSizeAfterDropping)
 
 TEST(MempoolLimitTests, WeightedTxInfoFromTx)
 {
+    LoadProofParameters();
+
     // The transaction creation is based on the test:
     // test_transaction_builder.cpp/TEST(TransactionBuilder, SetFee)
     auto consensusParams = RegtestActivateSapling();

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -74,6 +74,8 @@ public:
 
 TEST(TransactionBuilder, TransparentToSapling)
 {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
 
     CBasicKeyStore keystore;
@@ -113,6 +115,8 @@ TEST(TransactionBuilder, TransparentToSapling)
 }
 
 TEST(TransactionBuilder, SaplingToSapling) {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
 
     auto sk = libzcash::SaplingSpendingKey::random();
@@ -150,6 +154,8 @@ TEST(TransactionBuilder, SaplingToSapling) {
 }
 
 TEST(TransactionBuilder, SaplingToSprout) {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
 
     auto sk = libzcash::SaplingSpendingKey::random();
@@ -188,6 +194,8 @@ TEST(TransactionBuilder, SaplingToSprout) {
 }
 
 TEST(TransactionBuilder, SproutToSproutAndSapling) {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
 
     auto sk = libzcash::SaplingSpendingKey::random();
@@ -270,6 +278,8 @@ TEST(TransactionBuilder, RejectsInvalidTransparentOutput)
 
 TEST(TransactionBuilder, FailsWithNegativeChange)
 {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
 
     // Generate dummy Sapling address
@@ -314,6 +324,8 @@ TEST(TransactionBuilder, FailsWithNegativeChange)
 
 TEST(TransactionBuilder, ChangeOutput)
 {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
 
     // Generate dummy Sapling address
@@ -393,6 +405,8 @@ TEST(TransactionBuilder, ChangeOutput)
 
 TEST(TransactionBuilder, SetFee)
 {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
 
     // Generate dummy Sapling address

--- a/src/rust/src/rustzcash.rs
+++ b/src/rust/src/rustzcash.rs
@@ -29,6 +29,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::slice;
+use std::sync::Once;
 use subtle::CtOption;
 use tracing::{error, info};
 
@@ -84,6 +85,7 @@ mod test_harness_ffi;
 #[cfg(test)]
 mod tests;
 
+static PROOF_PARAMETERS_LOADED: Once = Once::new();
 static mut SAPLING_SPEND_VK: Option<PreparedVerifyingKey<Bls12>> = None;
 static mut SAPLING_OUTPUT_VK: Option<PreparedVerifyingKey<Bls12>> = None;
 static mut SPROUT_GROTH16_VK: Option<PreparedVerifyingKey<Bls12>> = None;
@@ -127,64 +129,66 @@ pub extern "C" fn librustzcash_init_zksnark_params(
     #[cfg(target_os = "windows")] sprout_path: *const u16,
     sprout_path_len: usize,
 ) {
-    #[cfg(not(target_os = "windows"))]
-    let (spend_path, output_path, sprout_path) = {
-        (
-            OsStr::from_bytes(unsafe { slice::from_raw_parts(spend_path, spend_path_len) }),
-            OsStr::from_bytes(unsafe { slice::from_raw_parts(output_path, output_path_len) }),
-            if sprout_path.is_null() {
-                None
-            } else {
-                Some(OsStr::from_bytes(unsafe {
-                    slice::from_raw_parts(sprout_path, sprout_path_len)
-                }))
-            },
-        )
-    };
+    PROOF_PARAMETERS_LOADED.call_once(|| {
+        #[cfg(not(target_os = "windows"))]
+        let (spend_path, output_path, sprout_path) = {
+            (
+                OsStr::from_bytes(unsafe { slice::from_raw_parts(spend_path, spend_path_len) }),
+                OsStr::from_bytes(unsafe { slice::from_raw_parts(output_path, output_path_len) }),
+                if sprout_path.is_null() {
+                    None
+                } else {
+                    Some(OsStr::from_bytes(unsafe {
+                        slice::from_raw_parts(sprout_path, sprout_path_len)
+                    }))
+                },
+            )
+        };
 
-    #[cfg(target_os = "windows")]
-    let (spend_path, output_path, sprout_path) = {
-        (
-            OsString::from_wide(unsafe { slice::from_raw_parts(spend_path, spend_path_len) }),
-            OsString::from_wide(unsafe { slice::from_raw_parts(output_path, output_path_len) }),
-            if sprout_path.is_null() {
-                None
-            } else {
-                Some(OsString::from_wide(unsafe {
-                    slice::from_raw_parts(sprout_path, sprout_path_len)
-                }))
-            },
-        )
-    };
+        #[cfg(target_os = "windows")]
+        let (spend_path, output_path, sprout_path) = {
+            (
+                OsString::from_wide(unsafe { slice::from_raw_parts(spend_path, spend_path_len) }),
+                OsString::from_wide(unsafe { slice::from_raw_parts(output_path, output_path_len) }),
+                if sprout_path.is_null() {
+                    None
+                } else {
+                    Some(OsString::from_wide(unsafe {
+                        slice::from_raw_parts(sprout_path, sprout_path_len)
+                    }))
+                },
+            )
+        };
 
-    let (spend_path, output_path, sprout_path) = (
-        Path::new(&spend_path),
-        Path::new(&output_path),
-        sprout_path.as_ref().map(Path::new),
-    );
+        let (spend_path, output_path, sprout_path) = (
+            Path::new(&spend_path),
+            Path::new(&output_path),
+            sprout_path.as_ref().map(Path::new),
+        );
 
-    // Load params
-    let params = load_parameters(spend_path, output_path, sprout_path);
+        // Load params
+        let params = load_parameters(spend_path, output_path, sprout_path);
 
-    // Generate Orchard parameters.
-    info!(target: "main", "Loading Orchard parameters");
-    let orchard_pk = orchard::circuit::ProvingKey::build();
-    let orchard_vk = orchard::circuit::VerifyingKey::build();
+        // Generate Orchard parameters.
+        info!(target: "main", "Loading Orchard parameters");
+        let orchard_pk = orchard::circuit::ProvingKey::build();
+        let orchard_vk = orchard::circuit::VerifyingKey::build();
 
-    // Caller is responsible for calling this function once, so
-    // these global mutations are safe.
-    unsafe {
-        SAPLING_SPEND_PARAMS = Some(params.spend_params);
-        SAPLING_OUTPUT_PARAMS = Some(params.output_params);
-        SPROUT_GROTH16_PARAMS_PATH = sprout_path.map(|p| p.to_owned());
+        // Caller is responsible for calling this function once, so
+        // these global mutations are safe.
+        unsafe {
+            SAPLING_SPEND_PARAMS = Some(params.spend_params);
+            SAPLING_OUTPUT_PARAMS = Some(params.output_params);
+            SPROUT_GROTH16_PARAMS_PATH = sprout_path.map(|p| p.to_owned());
 
-        SAPLING_SPEND_VK = Some(params.spend_vk);
-        SAPLING_OUTPUT_VK = Some(params.output_vk);
-        SPROUT_GROTH16_VK = params.sprout_vk;
+            SAPLING_SPEND_VK = Some(params.spend_vk);
+            SAPLING_OUTPUT_VK = Some(params.output_vk);
+            SPROUT_GROTH16_VK = params.sprout_vk;
 
-        ORCHARD_PK = Some(orchard_pk);
-        ORCHARD_VK = Some(orchard_vk);
-    }
+            ORCHARD_PK = Some(orchard_pk);
+            ORCHARD_VK = Some(orchard_vk);
+        }
+    });
 }
 
 /// Writes the "uncommitted" note value for empty leaves of the Merkle tree.

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -357,3 +357,27 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
     CWalletTx wtx {NULL, tx};
     return wtx;
 }
+
+
+
+void LoadProofParameters() {
+    fs::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
+    fs::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
+    fs::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
+
+    static_assert(
+        sizeof(fs::path::value_type) == sizeof(codeunit),
+        "librustzcash not configured correctly");
+    auto sapling_spend_str = sapling_spend.native();
+    auto sapling_output_str = sapling_output.native();
+    auto sprout_groth16_str = sprout_groth16.native();
+
+    librustzcash_init_zksnark_params(
+        reinterpret_cast<const codeunit*>(sapling_spend_str.c_str()),
+        sapling_spend_str.length(),
+        reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
+        sapling_output_str.length(),
+        reinterpret_cast<const codeunit*>(sprout_groth16_str.c_str()),
+        sprout_groth16_str.length()
+    );
+}

--- a/src/utiltest.h
+++ b/src/utiltest.h
@@ -76,4 +76,6 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
                                  const libzcash::SaplingExtendedSpendingKey &sk,
                                  CAmount value);
 
+void LoadProofParameters();
+
 #endif // ZCASH_UTILTEST_H

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -375,6 +375,8 @@ TEST(WalletTests, SetSproutNoteAddrsInCWalletTx) {
 }
 
 TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
+    LoadProofParameters();
+
     std::vector<libzcash::Zip212Enabled> zip_212_enabled = {libzcash::Zip212Enabled::BeforeZip212, libzcash::Zip212Enabled::AfterZip212};
     const Consensus::Params& (*activations [])() = {RegtestActivateSapling, RegtestActivateCanopy};
     void (*deactivations [])() = {RegtestDeactivateSapling, RegtestDeactivateCanopy};
@@ -524,6 +526,8 @@ TEST(WalletTests, GetSproutNoteNullifier) {
 }
 
 TEST(WalletTests, FindMySaplingNotes) {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
     TestWallet wallet(Params());
     LOCK(wallet.cs_wallet);
@@ -653,6 +657,8 @@ TEST(WalletTests, GetConflictedSproutNotes) {
 
 // Generate note A and spend to create note B, from which we spend to create two conflicting transactions
 TEST(WalletTests, GetConflictedSaplingNotes) {
+    LoadProofParameters();
+
     std::vector<libzcash::Zip212Enabled> zip_212_enabled = {libzcash::Zip212Enabled::BeforeZip212, libzcash::Zip212Enabled::AfterZip212};
     const Consensus::Params& (*activations [])() = {RegtestActivateSapling, RegtestActivateCanopy};
     void (*deactivations [])() = {RegtestDeactivateSapling, RegtestDeactivateCanopy};
@@ -820,6 +826,8 @@ TEST(WalletTests, SproutNullifierIsSpent) {
 }
 
 TEST(WalletTests, SaplingNullifierIsSpent) {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
     TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
@@ -905,6 +913,8 @@ TEST(WalletTests, NavigateFromSproutNullifierToNote) {
 }
 
 TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
     TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
@@ -1028,6 +1038,8 @@ TEST(WalletTests, SpentSproutNoteIsFromMe) {
 
 // Create note A, spend A to create note B, spend and verify note B is from me.
 TEST(WalletTests, SpentSaplingNoteIsFromMe) {
+    LoadProofParameters();
+
     std::vector<libzcash::Zip212Enabled> zip_212_enabled = {libzcash::Zip212Enabled::BeforeZip212, libzcash::Zip212Enabled::AfterZip212};
     const Consensus::Params& (*activations [])() = {RegtestActivateSapling, RegtestActivateCanopy};
     void (*deactivations [])() = {RegtestDeactivateSapling, RegtestDeactivateCanopy};
@@ -1840,6 +1852,8 @@ TEST(WalletTests, UpdatedSproutNoteData) {
 }
 
 TEST(WalletTests, UpdatedSaplingNoteData) {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
     TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);
@@ -1983,6 +1997,8 @@ TEST(WalletTests, MarkAffectedSproutTransactionsDirty) {
 }
 
 TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
+    LoadProofParameters();
+
     auto consensusParams = RegtestActivateSapling();
     TestWallet wallet(Params());
     LOCK2(cs_main, wallet.cs_wallet);


### PR DESCRIPTION
Currently, the proof parameters are loaded in the `main` function of `zcash/src/gtest/main.cpp`. However, every time we execute a "death test", the gtest test framework forks a new process *which will load the proof parameters again*. 

No death test depends on the proofs. There are 13 death tests, and loading the proof params takes approximately 7 seconds (`time ./src/zcash-gtest --help`, yes, they're loaded even to print the help message!), so we can save approximately `7*13=91` seconds per test run. Also, if we're doing sharding and one of the shards doesn't have any proof-requiring test, this makes it run significantly faster.

i put the parameter loading (that used to be in `gtest/main.cpp`) into a function called `LoadProofParameters`  that lives in `utiltest.cpp`, and in each test that requires proofs, i inserted a call to `LoadProofParameters`.

`librustzcash_init_zksnark_params` has been changed to make calling it twice harmless.