### PR TITLE
Document Template '[WIP]'

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ License
 -------
 
 For license information see the file [COPYING](COPYING).
+tmp


### PR DESCRIPTION
That is, without having to launch with test_runner.py. There are several places where the BITCOIND environment variable determines the executable, but the default is "bitcoind"; change the default to "src/zcashd". This does require running the test from the top-level directory.

To run a test standalone with this PR, it's necessary to run it from the top-level directory, for example:

qa/rpc-tests/merkle_blocks.py

This is because the default executable (if $BITCOIND isn't set) is `src/zcashd`. Maybe this restriction can be eliminated? But it's pretty common to run these tests from there.