### PR TITLE
Make check-symbols.py compatible with Python 3

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -60,13 +60,13 @@ import os
 ALLOW_DYNAMIC_LIBSTDCXX = False
 
 MAX_VERSIONS = {
-    'GCC':   (4,5,0),
-    'GLIBC': (2,23),
+    b'GCC':   (4,5,0),
+    b'GLIBC': (2,23),
 }
 if ALLOW_DYNAMIC_LIBSTDCXX:
     MAX_VERSIONS.update({
-        'GLIBCXX': (3,4,14),
-        'CXXABI':  (1,3,4),
+        b'GLIBCXX': (3,4,14),
+        b'CXXABI':  (1,3,4),
     })
 
 # See here for a description of _IO_stdin_used:
@@ -74,7 +74,7 @@ if ALLOW_DYNAMIC_LIBSTDCXX:
 
 # Ignore symbols that are exported as part of every executable
 IGNORE_EXPORTS = {
-    '_edata', '_end', '_init', '__bss_start', '_fini', '_IO_stdin_used'
+    b'_edata', b'_end', b'_init', b'__bss_start', b'_fini', b'_IO_stdin_used'
 }
 READELF_CMD = os.getenv('READELF', '/usr/bin/readelf')
 CPPFILT_CMD = os.getenv('CPPFILT', '/usr/bin/c++filt')
@@ -82,19 +82,22 @@ CPPFILT_CMD = os.getenv('CPPFILT', '/usr/bin/c++filt')
 # Allowed NEEDED libraries
 ALLOWED_LIBRARIES = {
     # zcashd
-    'libgcc_s.so.1',        # GCC support library (also used by clang)
-    'libc.so.6',            # C library
-    'libpthread.so.0',      # threading
-    'libanl.so.1',          # DNS resolver
-    'libm.so.6',            # math library
-    'librt.so.1',           # real-time (POSIX compatibility)
-    'ld-linux-x86-64.so.2', # 64-bit dynamic linker
-    'ld-linux.so.2',        # 32-bit dynamic linker
-    'libdl.so.2'            # programming interface to dynamic linker
+    b'libgcc_s.so.1',        # GCC support library (also used by clang)
+    b'libc.so.6',            # C library
+    b'libpthread.so.0',      # threading
+    b'libanl.so.1',          # DNS resolver
+    b'libm.so.6',            # math library
+    b'librt.so.1',           # real-time (POSIX compatibility)
+    b'ld-linux-x86-64.so.2', # 64-bit dynamic linker
+    b'ld-linux.so.2',        # 32-bit dynamic linker
+    b'libdl.so.2'            # programming interface to dynamic linker
 }
 if ALLOW_DYNAMIC_LIBSTDCXX:
-    ALLOWED_LIBRARIES.add('libstdc++.so.6')  # C++ standard library
+    ALLOWED_LIBRARIES.add(b'libstdc++.so.6')  # C++ standard library
 
+
+def escape(s):
+    return s.decode('us-ascii', 'backslashreplace')
 
 class CPPFilt(object):
     '''
@@ -106,7 +109,8 @@ class CPPFilt(object):
         self.proc = subprocess.Popen(CPPFILT_CMD, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
     def __call__(self, mangled):
-        self.proc.stdin.write(mangled + '\n')
+        self.proc.stdin.write(mangled + b'\n')
+        self.proc.stdin.flush()
         return self.proc.stdout.readline().rstrip()
 
     def close(self):
@@ -122,26 +126,26 @@ def read_symbols(executable, imports=True):
     p = subprocess.Popen([READELF_CMD, '--dyn-syms', '-W', executable], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
     (stdout, stderr) = p.communicate()
     if p.returncode:
-        raise IOError('Could not read symbols for %s: %s' % (executable, stderr.strip()))
+        raise IOError(u"Could not read symbols for %s: %s" % (executable, escape(stderr.strip())))
     syms = []
-    for line in stdout.split('\n'):
+    for line in stdout.split(b'\n'):
         line = line.split()
-        if len(line)>7 and re.match('[0-9]+:$', line[0]):
-            (sym, _, version) = line[7].partition('@')
-            is_import = line[6] == 'UND'
-            if version.startswith('@'):
+        if len(line)>7 and re.match(b'[0-9]+:$', line[0]):
+            (sym, _, version) = line[7].partition(b'@')
+            is_import = line[6] == b'UND'
+            if version.startswith(b'@'):
                 version = version[1:]
             if is_import == imports:
                 syms.append((sym, version))
     return syms
 
 def check_version(max_versions, version):
-    if '_' in version:
-        (lib, _, ver) = version.rpartition('_')
+    if b'_' in version:
+        (lib, _, ver) = version.rpartition(b'_')
     else:
         lib = version
-        ver = '0'
-    ver = tuple([int(x) for x in ver.split('.')])
+        ver = b'0'
+    ver = tuple([int(x) for x in ver.split(b'.')])
     if not lib in max_versions:
         return False
     return ver <= max_versions[lib]
@@ -150,38 +154,38 @@ def read_libraries(filename):
     p = subprocess.Popen([READELF_CMD, '-d', '-W', filename], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
     (stdout, stderr) = p.communicate()
     if p.returncode:
-        raise IOError('Error opening file')
+        raise IOError("Error opening file")
     libraries = []
-    for line in stdout.split('\n'):
+    for line in stdout.split(b'\n'):
         tokens = line.split()
-        if len(tokens)>2 and tokens[1] == '(NEEDED)':
-            match = re.match('^Shared library: \[(.*)\]$', ' '.join(tokens[2:]))
+        if len(tokens) > 2 and tokens[1] == b'(NEEDED)':
+            match = re.match(b'^Shared library: \[(.*)\]$', b' '.join(tokens[2:]))
             if match:
                 libraries.append(match.group(1))
             else:
-                raise ValueError('Unparseable (NEEDED) specification')
+                raise ValueError("Unparseable (NEEDED) specification")
     return libraries
 
 if __name__ == '__main__':
     cppfilt = CPPFilt()
     retval = 0
     for filename in sys.argv[1:]:
-        print("Checking %s..." % (filename,))
+        print(u"Checking %s..." % (filename,))
         # Check imported symbols
         for sym,version in read_symbols(filename, True):
             if version and not check_version(MAX_VERSIONS, version):
-                print('%s: symbol %s from unsupported version %s' % (filename, cppfilt(sym), version))
+                print(u"%s: symbol %s from unsupported version %s" % (filename, escape(cppfilt(sym)), escape(version)))
                 retval = 1
         # Check exported symbols
         for sym,version in read_symbols(filename, False):
             if sym in IGNORE_EXPORTS:
                 continue
-            print('%s: export of symbol %s not allowed' % (filename, cppfilt(sym)))
+            print(u"%s: export of symbol %s not allowed" % (filename, escape(cppfilt(sym))))
             retval = 1
         # Check dependency libraries
         for library_name in read_libraries(filename):
             if library_name not in ALLOWED_LIBRARIES:
-                print('%s: NEEDED library %s is not allowed' % (filename, library_name))
+                print(u"%s: NEEDED library %s is not allowed" % (filename, escape(library_name)))
                 retval = 1
         print()
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -737,17 +737,13 @@ clean-local:
 	  $(CPPFLAGS) $(AM_CXXFLAGS) $(AM_CXXFLAGS) $(PIE_FLAGS) $(CXXFLAGS) -c -o $@ $<
 
 check-symbols: $(bin_PROGRAMS) $(bin_SCRIPTS)
-if GLIBC_BACK_COMPAT
 	@echo "Checking glibc back compat of [$(bin_PROGRAMS) $(bin_SCRIPTS)]..."
 	$(AM_V_at) READELF=$(READELF) CPPFILT=$(CPPFILT) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS) $(bin_SCRIPTS)
-endif
 
 check-security: $(bin_PROGRAMS) $(bin_SCRIPTS)
-if HARDEN
 	@echo "Checking binary security of [$(bin_PROGRAMS) $(bin_SCRIPTS)]..."
 	$(AM_V_at) READELF=$(READELF) OBJDUMP=$(OBJDUMP) $(top_srcdir)/contrib/devtools/security-check.py $(bin_PROGRAMS)
 	$(AM_V_at) READELF=$(READELF) OBJDUMP=$(OBJDUMP) $(top_srcdir)/contrib/devtools/security-check.py --allow-no-canary $(bin_SCRIPTS)
-endif
 
 %.pb.cc %.pb.h: %.proto
 	@test -f $(PROTOC)


### PR DESCRIPTION
Also enable the `check-symbols` and `check-security` Makefile targets unconditionally. (Previously they would silently do nothing if the `GLIBC_BACK_COMPAT` and `HARDEN` variables, respectively, were not set.)
fixes #5669
