### PR TITLE
run btests in parallel

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -51,6 +51,10 @@ RAW_TEST_FILES = test/data/alertTests.raw
 
 GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.raw.h)
 
+BITCOIN_TEST_SUITE = \
+  test/test_bitcoin.h \
+  test/test_bitcoin.cpp
+
 BITCOIN_TESTS =\
   test/arith_uint256_tests.cpp \
   test/scriptnum10.h \
@@ -103,8 +107,6 @@ BITCOIN_TESTS =\
   test/sigopcount_tests.cpp \
   test/skiplist_tests.cpp \
   test/streams_tests.cpp \
-  test/test_bitcoin.cpp \
-  test/test_bitcoin.h \
   test/test_random.h \
   test/test_util.cpp \
   test/test_util.h \
@@ -118,14 +120,16 @@ BITCOIN_TESTS =\
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \
-  wallet/test/wallet_test_fixture.cpp \
-  wallet/test/wallet_test_fixture.h \
   wallet/test/wallet_tests.cpp \
   wallet/test/crypto_tests.cpp \
   wallet/test/rpc_wallet_tests.cpp
+
+BITCOIN_TEST_SUITE += \
+  wallet/test/wallet_test_fixture.cpp \
+  wallet/test/wallet_test_fixture.h
 endif
 
-test_test_bitcoin_SOURCES = $(BITCOIN_TESTS) $(JSON_TEST_FILES) $(RAW_TEST_FILES)
+test_test_bitcoin_SOURCES = $(BITCOIN_TEST_SUITE) $(BITCOIN_TESTS) $(JSON_TEST_FILES) $(RAW_TEST_FILES)
 test_test_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -I$(builddir)/test/ $(TESTDEFS) $(EVENT_CFLAGS)
 test_test_bitcoin_LDADD =
 if ENABLE_WALLET

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -168,6 +168,15 @@ check-local:
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C secp256k1 check
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C univalue check
 
+
+SUITES = $(shell cat $(BITCOIN_TESTS) | grep "BOOST_FIXTURE_TEST_SUITE\|BOOST_AUTO_TEST_SUITE" | grep -v "DISABLED_TEST_SUITE" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1 | grep . | sed -e 's/^/testsuite./')
+
+testsuite.%: test/test_bitcoin
+	@echo $(SUITES)
+	$(TEST_BINARY) -t $* > $*.log 2>&1 || (cat $*.log && false)
+
+parallel_btests: $(SUITES)
+
 %.json.h: %.json
 	@$(MKDIR_P) $(@D)
 	@echo "namespace json_tests{" > $@

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -16,7 +16,7 @@
 
 using namespace std;
 
-BOOST_FIXTURE_TEST_SUITE(Checkpoints_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(Checkpoints_tests, BasicTestingSetup) // DISABLED_TEST_SUITE
 
 // TODO: checkpoints have been removed for now.
 /*

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -239,7 +239,7 @@ struct GenerateAlertTestsFixture : public TestingSetup {
   ~GenerateAlertTestsFixture() {}
 };
 
-BOOST_FIXTURE_TEST_SUITE(Generate_Alert_Test_Data, GenerateAlertTestsFixture);
+BOOST_FIXTURE_TEST_SUITE(Generate_Alert_Test_Data, GenerateAlertTestsFixture); // DISABLED_TEST_SUITE
 BOOST_AUTO_TEST_CASE(GenerateTheAlertTests)
 {
     GenerateAlertTests();


### PR DESCRIPTION
This is strongly based off Bitcoin Core's https://github.com/bitcoin/bitcoin/pull/12926; but has two improvements:

1) It handles multiple test suites found in a single file and calls the test runner with exactly one test suite every time, regardless of how the test suites are distributed across the files.

2) There are #if'd out test suites in our codebase. By adding a comment with DISABLED_TEST_SUITE in it, the grep will ignore them rather than trying to run a disabled test suite.

It can be run with `make -j16 parallel_btests` in `src/`, and reduces btest time from 3 minutes:

```
$ time ./test/test_bitcoin 
[...]
real    2m53.763s
user    7m7.199s
sys     0m46.010s

```
to 2 minutes:

```
$ time make -j16 parallel_btests
[...]
real    1m50.338s
user    15m39.326s
sys     0m45.342s
```

#5664 removes superfluous loading of proof parameters from the btests, and also ports the four btests which *do* use proofs to the gtests. In combination with #5664, this PR reduces the btest time to *45 seconds*:

```
$ time make -j16 parallel_btests
[...]
real    0m44.718s
user    2m16.218s
sys     0m57.621s
```