### PR TITLE
Add UnifiedAddress variant to ZTXOSelector

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1683,7 +1683,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             if (!zaddr.has_value()) {
                 return InitError(_("-mineraddress is not a valid " PACKAGE_NAME " address."));
             }
-            auto ztxoSelector = pwalletMain->ZTXOSelectorForAddress(zaddr.value(), true);
+            auto ztxoSelector = pwalletMain->ZTXOSelectorForAddress(zaddr.value(), true, false);
             minerAddressInLocalWallet = ztxoSelector.has_value();
         }
         if (GetBoolArg("-minetolocalwallet", true) && !minerAddressInLocalWallet) {

--- a/src/wallet/gtest/test_note_selection.cpp
+++ b/src/wallet/gtest/test_note_selection.cpp
@@ -6,6 +6,8 @@
 #include "zcash/address/sapling.hpp"
 #include "zcash/address/sprout.hpp"
 
+using namespace libzcash;
+
 void PrintTo(const OutputPool& pool, std::ostream* os) {
     switch (pool) {
         case OutputPool::Orchard: *os << "Orchard"; break;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3707,7 +3707,7 @@ UniValue z_getbalance(const UniValue& params, bool fHelp)
             nBalance = getBalanceZaddr(addr, nMinDepth, INT_MAX, false);
         },
         [&](const libzcash::UnifiedAddress& addr) {
-            auto selector = pwalletMain->ZTXOSelectorForAddress(addr, true);
+            auto selector = pwalletMain->ZTXOSelectorForAddress(addr, true, false);
             if (!selector.has_value()) {
                 throw JSONRPCError(
                     RPC_INVALID_ADDRESS_OR_KEY,
@@ -4525,7 +4525,7 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
                         "Invalid from address: should be a taddr, zaddr, UA, or the string 'ANY_TADDR'.");
             }
 
-            auto ztxoSelectorOpt = pwalletMain->ZTXOSelectorForAddress(decoded.value(), true);
+            auto ztxoSelectorOpt = pwalletMain->ZTXOSelectorForAddress(decoded.value(), true, false);
             if (!ztxoSelectorOpt.has_value()) {
                 throw JSONRPCError(
                         RPC_INVALID_ADDRESS_OR_KEY,

--- a/src/wallet/test/rpc_wallet_tests.cpp
+++ b/src/wallet/test/rpc_wallet_tests.cpp
@@ -799,7 +799,7 @@ void CheckHaveAddr(const std::optional<libzcash::PaymentAddress>& addr) {
     auto addr_of_type = std::get_if<ADDR_TYPE>(&(addr.value()));
     BOOST_ASSERT(addr_of_type != nullptr);
 
-    BOOST_CHECK(pwalletMain->ZTXOSelectorForAddress(*addr_of_type, true).has_value());
+    BOOST_CHECK(pwalletMain->ZTXOSelectorForAddress(*addr_of_type, true, false).has_value());
 }
 
 BOOST_AUTO_TEST_CASE(rpc_wallet_z_getnewaddress) {
@@ -1233,7 +1233,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
 
     // there are no utxos to spend
     {
-        auto selector = pwalletMain->ZTXOSelectorForAddress(taddr1, true).value();
+        auto selector = pwalletMain->ZTXOSelectorForAddress(taddr1, true, false).value();
         TransactionBuilder builder(consensusParams, nHeight + 1, std::nullopt, pwalletMain);
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(std::nullopt, zaddr1, 100*COIN, "DEADBEEF") };
         std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 1));
@@ -1245,7 +1245,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
 
     // there are no unspent notes to spend
     {
-        auto selector = pwalletMain->ZTXOSelectorForAddress(zaddr1, true).value();
+        auto selector = pwalletMain->ZTXOSelectorForAddress(zaddr1, true, false).value();
         TransactionBuilder builder(consensusParams, nHeight + 1, std::nullopt, pwalletMain);
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(std::nullopt, taddr1, 100*COIN, "DEADBEEF") };
         std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 1));
@@ -1257,7 +1257,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
 
     // get_memo_from_hex_string())
     {
-        auto selector = pwalletMain->ZTXOSelectorForAddress(zaddr1, true).value();
+        auto selector = pwalletMain->ZTXOSelectorForAddress(zaddr1, true, false).value();
         TransactionBuilder builder(consensusParams, nHeight + 1, std::nullopt, pwalletMain);
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(std::nullopt, zaddr1, 100*COIN, "DEADBEEF") };
         std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 1));
@@ -1358,7 +1358,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_taddr_to_sapling)
     auto builder = TransactionBuilder(consensusParams, nextBlockHeight, std::nullopt, pwalletMain);
     mtx = CreateNewContextualCMutableTransaction(consensusParams, nextBlockHeight);
 
-    auto selector = pwalletMain->ZTXOSelectorForAddress(taddr, true).value();
+    auto selector = pwalletMain->ZTXOSelectorForAddress(taddr, true, false).value();
     std::vector<SendManyRecipient> recipients = { SendManyRecipient(std::nullopt, pa, 1*COIN, "ABCD") };
     std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 0));
     std::shared_ptr<AsyncRPCOperation_sendmany> ptr = std::dynamic_pointer_cast<AsyncRPCOperation_sendmany> (operation);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1773,25 +1773,10 @@ std::optional<libzcash::AccountId> CWallet::FindAccountForSelector(const ZTXOSel
             }
         },
         [&](const libzcash::UnifiedAddress& addr) {
-            std::optional<libzcash::AccountId> singleAccount;
-            for (const auto& receiver : addr) {
-                auto meta = GetUFVKMetadataForReceiver(receiver);
-                if (meta.has_value()) {
-                    auto tmp = self->GetUnifiedAccountId(meta.value().first);
-                    if (singleAccount.has_value()) {
-                        // If a UA corresponds to more than one account, we cannot return
-                        // a sensible result, so we report it as corresponding to no
-                        // account.
-                        if (tmp.has_value() && singleAccount.value() != tmp.value()) {
-                            singleAccount = std::nullopt;
-                            break;
-                        }
-                    } else {
-                        singleAccount = tmp;
-                    }
-                }
+            auto meta = GetUFVKMetadataForAddress(addr);
+            if (meta.has_value()) {
+                result = self->GetUnifiedAccountId(meta.value().first);
             }
-            result = singleAccount;
         },
         [&](const libzcash::UnifiedFullViewingKey& vk) {
             result = self->GetUnifiedAccountId(vk.GetKeyID(Params()));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1644,7 +1644,11 @@ std::optional<ZTXOSelector> CWallet::ZTXOSelectorForAccount(
     }
 }
 
-std::optional<ZTXOSelector> CWallet::ZTXOSelectorForAddress(const libzcash::PaymentAddress& addr, bool requireSpendingKey) const {
+std::optional<ZTXOSelector> CWallet::ZTXOSelectorForAddress(
+        const libzcash::PaymentAddress& addr,
+        bool requireSpendingKey,
+        bool allowAddressLinkability) const
+{
     auto self = this;
     std::optional<ZTXOPattern> pattern = std::nullopt;
     std::visit(match {
@@ -1678,8 +1682,14 @@ std::optional<ZTXOSelector> CWallet::ZTXOSelectorForAddress(const libzcash::Paym
                 // determine a local account.
                 auto accountId = this->GetUnifiedAccountId(ufvkId.value());
                 if (accountId.has_value()) {
-                    pattern = AccountZTXOPattern(accountId.value(), ua.GetKnownReceiverTypes());
+                    if (allowAddressLinkability) {
+                        pattern = AccountZTXOPattern(accountId.value(), ua.GetKnownReceiverTypes());
+                    } else {
+                        pattern = ua;
+                    }
                 }
+            } else {
+                pattern = ua;
             }
         }
     }, addr);
@@ -1762,6 +1772,27 @@ std::optional<libzcash::AccountId> CWallet::FindAccountForSelector(const ZTXOSel
                 result = self->GetUnifiedAccountId(ufvkid.value());
             }
         },
+        [&](const libzcash::UnifiedAddress& addr) {
+            std::optional<libzcash::AccountId> singleAccount;
+            for (const auto& receiver : addr) {
+                auto meta = GetUFVKMetadataForReceiver(receiver);
+                if (meta.has_value()) {
+                    auto tmp = self->GetUnifiedAccountId(meta.value().first);
+                    if (singleAccount.has_value()) {
+                        // If a UA corresponds to more than one account, we cannot return
+                        // a sensible result, so we report it as corresponding to no
+                        // account.
+                        if (tmp.has_value() && singleAccount.value() != tmp.value()) {
+                            singleAccount = std::nullopt;
+                            break;
+                        }
+                    } else {
+                        singleAccount = tmp;
+                    }
+                }
+            }
+            result = singleAccount;
+        },
         [&](const libzcash::UnifiedFullViewingKey& vk) {
             result = self->GetUnifiedAccountId(vk.GetKeyID(Params()));
         },
@@ -1796,6 +1827,27 @@ bool CWallet::SelectorMatchesAddress(
         [&](const libzcash::SproutViewingKey& vk) { return false; },
         [&](const libzcash::SaplingPaymentAddress& addr) { return false; },
         [&](const libzcash::SaplingExtendedFullViewingKey& extfvk) { return false; },
+        [&](const libzcash::UnifiedAddress& uaSelector) {
+            // for a UA selector when matching transparent addresses, we only match addresses
+            // that explicitly appear as receivers in the UA.
+            for (const auto& receiver : uaSelector) {
+                bool matches = std::visit(match {
+                    [&](const libzcash::OrchardRawAddress& orchardAddr) { return false; },
+                    [&](const libzcash::SaplingPaymentAddress& saplingAddr) { return false; },
+                    [&](const libzcash::UnknownReceiver& receiver) { return false; },
+                    [&](const CScriptID& scriptId) {
+                        CTxDestination scriptIdDest = scriptId;
+                        return address == scriptIdDest;
+                    },
+                    [&](const CKeyID& keyId) {
+                        CTxDestination keyIdDest = keyId;
+                        return address == keyIdDest;
+                    }
+                }, receiver);
+                if (matches) return true;
+            }
+            return false;
+        },
         [&](const libzcash::UnifiedFullViewingKey& ufvk) {
             std::optional<std::pair<libzcash::UFVKId, std::optional<libzcash::diversifier_index_t>>> meta;
             std::visit(match {
@@ -1853,6 +1905,19 @@ bool CWallet::SelectorMatchesAddress(
             auto j = extfvk.DecryptDiversifier(a0.d);
             auto addr = extfvk.Address(j);
             return addr.has_value() && addr.value() == a0;
+        },
+        [&](const libzcash::UnifiedAddress& ua) {
+            const auto a0Meta = self->GetUFVKMetadataForReceiver(a0);
+            auto saplingReceiver = ua.GetSaplingReceiver();
+            if (saplingReceiver.has_value()) {
+                const auto uaMeta = self->GetUFVKMetadataForReceiver(saplingReceiver.value());
+                // if the Sapling address is derived from any UFVK corresponding to
+                // the Sapling component of the unified address, we consider that a
+                // match
+                return  a0Meta.has_value() && uaMeta.has_value() &&
+                        a0Meta.value().first == uaMeta.value().first;
+            }
+            return false;
         },
         [&](const libzcash::UnifiedFullViewingKey& ufvk) {
             auto saplingKey = ufvk.GetSaplingKey();
@@ -2067,6 +2132,22 @@ SpendableInputs CWallet::FindSpendableInputs(
     if (selectOrchard) {
         // for Orchard, we select both the internal and external IVKs.
         auto orchardIvks = std::visit(match {
+            [&](const libzcash::UnifiedAddress& selectorUA) -> std::vector<OrchardIncomingViewingKey> {
+                auto orchardReceiver = selectorUA.GetOrchardReceiver();
+                if (orchardReceiver.has_value()) {
+                    auto meta = GetUFVKMetadataForReceiver(orchardReceiver.value());
+                    if (meta.has_value()) {
+                        auto ufvk = GetUnifiedFullViewingKey(meta.value().first);
+                        if (ufvk.has_value()) {
+                            auto fvk = ufvk->GetOrchardKey();
+                            if (fvk.has_value()) {
+                                return {fvk->ToIncomingViewingKey(), fvk->ToInternalIncomingViewingKey()};
+                            }
+                        }
+                    }
+                }
+                return {};
+            },
             [&](const libzcash::UnifiedFullViewingKey& ufvk) -> std::vector<OrchardIncomingViewingKey> {
                 auto fvk = ufvk.GetOrchardKey();
                 if (fvk.has_value()) {
@@ -7061,6 +7142,9 @@ bool ZTXOSelector::SelectsTransparent() const {
         [](const libzcash::SproutViewingKey& vk) { return false; },
         [](const libzcash::SaplingPaymentAddress& addr) { return false; },
         [](const libzcash::SaplingExtendedFullViewingKey& vk) { return false; },
+        [](const libzcash::UnifiedAddress& ua) {
+            return ua.GetP2PKHReceiver().has_value() || ua.GetP2SHReceiver().has_value();
+        },
         [](const libzcash::UnifiedFullViewingKey& ufvk) { return ufvk.GetTransparentKey().has_value(); },
         [](const AccountZTXOPattern& acct) { return acct.IncludesP2PKH() || acct.IncludesP2SH(); }
     }, this->pattern);
@@ -7076,6 +7160,7 @@ bool ZTXOSelector::SelectsSapling() const {
     return std::visit(match {
         [](const libzcash::SaplingPaymentAddress& addr) { return true; },
         [](const libzcash::SaplingExtendedSpendingKey& extfvk) { return true; },
+        [](const libzcash::UnifiedAddress& ua) { return ua.GetSaplingReceiver().has_value(); },
         [](const libzcash::UnifiedFullViewingKey& ufvk) { return ufvk.GetSaplingKey().has_value(); },
         [](const AccountZTXOPattern& acct) { return acct.IncludesSapling(); },
         [](const auto& addr) { return false; }
@@ -7083,6 +7168,7 @@ bool ZTXOSelector::SelectsSapling() const {
 }
 bool ZTXOSelector::SelectsOrchard() const {
     return std::visit(match {
+        [](const libzcash::UnifiedAddress& ua) { return ua.GetOrchardReceiver().has_value(); },
         [](const libzcash::UnifiedFullViewingKey& ufvk) { return ufvk.GetOrchardKey().has_value(); },
         [](const AccountZTXOPattern& acct) { return acct.IncludesOrchard(); },
         [](const auto& addr) { return false; }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -778,6 +778,7 @@ typedef std::variant<
     libzcash::SproutViewingKey,
     libzcash::SaplingPaymentAddress,
     libzcash::SaplingExtendedFullViewingKey,
+    libzcash::UnifiedAddress,
     libzcash::UnifiedFullViewingKey,
     AccountZTXOPattern> ZTXOPattern;
 
@@ -805,17 +806,6 @@ public:
     bool SelectsOrchard() const;
 };
 
-/**
- * An enumeration of the fund pools for which a transaction may produce outputs.
- * It is sorted in descending preference order, so that when iterating over a
- * set of output pools the most-preferred pool is selected first.
- */
-enum class OutputPool {
-    Orchard,
-    Sapling,
-    Transparent,
-};
-
 class SpendableInputs {
 private:
     bool limited = false;
@@ -840,7 +830,7 @@ public:
     bool LimitToAmount(
         CAmount amount,
         CAmount dustThreshold,
-        std::set<OutputPool> recipientPools);
+        std::set<libzcash::OutputPool> recipientPools);
 
     /**
      * Compute the total ZEC amount of spendable inputs.
@@ -1335,7 +1325,8 @@ public:
      */
     std::optional<ZTXOSelector> ZTXOSelectorForAddress(
             const libzcash::PaymentAddress& addr,
-            bool requireSpendingKey) const;
+            bool requireSpendingKey,
+            bool allowAddressLinkability) const;
 
     /**
      * Returns the ZTXO selector for the specified viewing key, if that key
@@ -1377,7 +1368,7 @@ public:
      */
     std::optional<libzcash::RecipientAddress> GenerateChangeAddressForAccount(
             libzcash::AccountId accountId,
-            std::set<OutputPool> changeOptions);
+            std::set<libzcash::OutputPool> changeOptions);
 
     SpendableInputs FindSpendableInputs(
             ZTXOSelector paymentSource,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1586,11 +1586,16 @@ public:
     //! failures in reconstructing the cache.
     bool LoadCaches();
 
-    std::optional<libzcash::UFVKId> FindUnifiedFullViewingKey(const libzcash::UnifiedAddress& addr) const;
     std::optional<libzcash::AccountId> GetUnifiedAccountId(const libzcash::UFVKId& ufvkId) const;
 
-    std::optional<libzcash::ZcashdUnifiedFullViewingKey> FindUFVKByReceiver(const libzcash::Receiver& receiver) const;
-    std::optional<libzcash::UnifiedAddress> FindUnifiedAddressByReceiver(const libzcash::Receiver& receiver) const;
+    /**
+     * Reconstructs a unified address by determining the UFVK that the receiver
+     * is associated with, combined with the set of receiver types that were
+     * associated with the diversifier index that the provided receiver
+     * corresponds to.
+     */
+    std::optional<libzcash::UnifiedAddress> FindUnifiedAddressByReceiver(
+            const libzcash::Receiver& receiver) const;
 
     /**
      * Increment the next transaction order id

--- a/src/zcash/address/unified.cpp
+++ b/src/zcash/address/unified.cpp
@@ -188,14 +188,15 @@ std::optional<RecipientAddress> ZcashdUnifiedFullViewingKey::GetChangeAddress(co
     return addr;
 }
 
-std::optional<RecipientAddress> ZcashdUnifiedFullViewingKey::GetChangeAddress() const {
-    if (orchardKey.has_value()) {
+std::optional<RecipientAddress> ZcashdUnifiedFullViewingKey::GetChangeAddress(
+        const std::set<OutputPool>& allowedPools) const {
+    if (orchardKey.has_value() && allowedPools.count(OutputPool::Orchard) > 0) {
         return orchardKey.value().GetChangeAddress();
     }
-    if (saplingKey.has_value()) {
+    if (saplingKey.has_value() && allowedPools.count(OutputPool::Sapling) > 0) {
         return saplingKey.value().GetChangeAddress();
     }
-    if (transparentKey.has_value()) {
+    if (transparentKey.has_value() && allowedPools.count(OutputPool::Transparent) > 0) {
         auto changeAddr = transparentKey.value().GetChangeAddress(diversifier_index_t(0));
         if (changeAddr.has_value()) {
             return changeAddr.value();

--- a/src/zcash/address/unified.h
+++ b/src/zcash/address/unified.h
@@ -27,6 +27,17 @@ enum class ReceiverType: uint32_t {
     Orchard = 0x03
 };
 
+/**
+ * An enumeration of the fund pools for which a transaction may produce outputs.
+ * It is sorted in descending preference order, so that when iterating over a
+ * set of output pools the most-preferred pool is selected first.
+ */
+enum class OutputPool {
+    Orchard,
+    Sapling,
+    Transparent,
+};
+
 enum class UnifiedAddressGenerationError {
     ShieldedReceiverNotFound,
     ReceiverTypeNotAvailable,
@@ -226,7 +237,7 @@ public:
      * *any* shielded pool) in which case the change address returned will be
      * associated with diversifier index 0.
      */
-    std::optional<RecipientAddress> GetChangeAddress() const;
+    std::optional<RecipientAddress> GetChangeAddress(const std::set<OutputPool>& allowedPools) const;
 
     UnifiedFullViewingKey ToFullViewingKey() const;
 


### PR DESCRIPTION
When a user supplies a unified address as the source of funds
for z_sendmany, the previous behavior could have risked user
privacy by spending transparent UTXOs belonging to different
diversified addresses in the same transaction, thereby linking
those addresses, and consequently any diversified shielded
receivers of unified addresses containing those transparent
receivers.

This change limits selection of transparent UTXOs to only those
explicitly associated with the unified receivers of the provided
source UA. Also, if a UA is provided as the source, the behavior
is maintained that only shielded notes in pools corresponding to
the receivers of that UA will be selected.
