### PR TITLE
build: Fix `zcash/address/orchard.hpp` filename in `src/Makefile.am`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -127,7 +127,7 @@ LIBZCASH_H = \
   zcash/Address.hpp \
   zcash/address/transparent.h \
   zcash/address/mnemonic.h \
-  zcash/address/orchard.h \
+  zcash/address/orchard.hpp \
   zcash/address/sapling.hpp \
   zcash/address/sprout.hpp \
   zcash/address/unified.h \


### PR DESCRIPTION
The incorrect extension caused `make distdir-am` to fail due to a
missing rule for the header file.

Closes zcash/zcash#5694.