### PR TITLE
build: Add missing `util/match.h` to `src/Makefile.am`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -245,6 +245,7 @@ BITCOIN_CORE_H = \
   uint252.h \
   undo.h \
   util.h \
+  util/match.h \
   utilmoneystr.h \
   utilstrencodings.h \
   utiltest.h \


### PR DESCRIPTION
The missing header reference meant that Gitian builds didn't include the
file in its distribution step, causing subsequent builds to fail with a
'file not found' error.

Closes zcash/zcash#5697.