### PR TITLE
Rename fields in RPC results: unifiedaddress->address and type->(pool or address_type)

### DIFF
--- a/qa/rpc-tests/mining_shielded_coinbase.py
+++ b/qa/rpc-tests/mining_shielded_coinbase.py
@@ -128,7 +128,7 @@ class ShieldCoinbaseTest (BitcoinTestFramework):
         node1_addr0 = self.nodes[1].z_getaddressforaccount(0)
         assert_equal(node1_addr0['account'], 0)
         assert_equal(set(node1_addr0['pools']), set(['transparent', 'sapling', 'orchard']))
-        node1_ua = node1_addr0['unifiedaddress']
+        node1_ua = node1_addr0['address']
 
         # Set node 1's miner address to the UA
         self.nodes[1].stop()

--- a/qa/rpc-tests/mining_shielded_coinbase.py
+++ b/qa/rpc-tests/mining_shielded_coinbase.py
@@ -127,7 +127,7 @@ class ShieldCoinbaseTest (BitcoinTestFramework):
         self.nodes[1].z_getnewaccount()
         node1_addr0 = self.nodes[1].z_getaddressforaccount(0)
         assert_equal(node1_addr0['account'], 0)
-        assert_equal(set(node1_addr0['pools']), set(['transparent', 'sapling', 'orchard']))
+        assert_equal(set(node1_addr0['receiver_types']), set(['p2pkh', 'sapling', 'orchard']))
         node1_ua = node1_addr0['address']
 
         # Set node 1's miner address to the UA

--- a/qa/rpc-tests/orchard_reorg.py
+++ b/qa/rpc-tests/orchard_reorg.py
@@ -51,7 +51,7 @@ class OrchardReorgTest(BitcoinTestFramework):
         account = self.nodes[0].z_getnewaccount()['account']
         addr = self.nodes[0].z_getaddressforaccount(account, ['orchard'])
         assert_equal(addr['account'], account)
-        assert_equal(set(addr['pools']), set(['orchard']))
+        assert_equal(set(addr['receiver_types']), set(['orchard']))
         ua = addr['address']
 
         # Before mining any Orchard notes, finalorchardroot should be the empty Orchard root.

--- a/qa/rpc-tests/orchard_reorg.py
+++ b/qa/rpc-tests/orchard_reorg.py
@@ -52,7 +52,7 @@ class OrchardReorgTest(BitcoinTestFramework):
         addr = self.nodes[0].z_getaddressforaccount(account, ['orchard'])
         assert_equal(addr['account'], account)
         assert_equal(set(addr['pools']), set(['orchard']))
-        ua = addr['unifiedaddress']
+        ua = addr['address']
 
         # Before mining any Orchard notes, finalorchardroot should be the empty Orchard root.
         assert_equal(

--- a/qa/rpc-tests/remove_sprout_shielding.py
+++ b/qa/rpc-tests/remove_sprout_shielding.py
@@ -85,7 +85,7 @@ class RemoveSproutShieldingTest (BitcoinTestFramework):
         sprout_addr = self.nodes[1].z_getnewaddress('sprout')
         assert_raises_message(
             JSONRPCException,
-            "Sending funds into the Sprout pool is not supported by z_sendmany",
+            "Sending funds into the Sprout value pool is not supported by z_sendmany",
             self.nodes[0].z_sendmany,
             taddr_0, [{"address": sprout_addr, "amount": 1}])
         print("taddr -> Sprout z_sendmany tx rejected at Canopy activation on node 0")

--- a/qa/rpc-tests/wallet_accounts.py
+++ b/qa/rpc-tests/wallet_accounts.py
@@ -106,11 +106,11 @@ class WalletAccountsTest(BitcoinTestFramework):
         assert(ua0 != ua1)
 
         # The UA contains the expected receiver kinds.
-        self.check_receiver_types(ua0,   ['transparent', 'sapling', 'orchard'])
-        self.check_receiver_types(ua0_2, ['transparent', 'sapling', 'orchard'])
+        self.check_receiver_types(ua0,   ['p2pkh', 'sapling', 'orchard'])
+        self.check_receiver_types(ua0_2, ['p2pkh', 'sapling', 'orchard'])
         self.check_receiver_types(ua0_3, [               'sapling', 'orchard'])
-        self.check_receiver_types(ua0_4, ['transparent',            'orchard'])
-        self.check_receiver_types(ua1,   ['transparent', 'sapling', 'orchard'])
+        self.check_receiver_types(ua0_4, ['p2pkh',            'orchard'])
+        self.check_receiver_types(ua1,   ['p2pkh', 'sapling', 'orchard'])
 
         # The balances of the accounts are all zero.
         self.check_balance(0, 0, ua0, {})

--- a/qa/rpc-tests/wallet_accounts.py
+++ b/qa/rpc-tests/wallet_accounts.py
@@ -65,7 +65,7 @@ class WalletAccountsTest(BitcoinTestFramework):
         addr0 = self.nodes[0].z_getaddressforaccount(0)
         assert_equal(addr0['account'], 0)
         assert_equal(set(addr0['pools']), set(['transparent', 'sapling', 'orchard']))
-        ua0 = addr0['unifiedaddress']
+        ua0 = addr0['address']
 
         # We pick mnemonic phrases to ensure that we can always generate the default
         # address in account 0; this is however not necessarily at diversifier index 0.
@@ -83,26 +83,26 @@ class WalletAccountsTest(BitcoinTestFramework):
         addr0_2 = self.nodes[0].z_getaddressforaccount(0)
         assert_equal(addr0_2['account'], 0)
         assert_equal(set(addr0_2['pools']), set(['transparent', 'sapling', 'orchard']))
-        ua0_2 = addr0_2['unifiedaddress']
+        ua0_2 = addr0_2['address']
         assert(ua0 != ua0_2)
 
         # We can generate a fully-shielded address.
         addr0_3 = self.nodes[0].z_getaddressforaccount(0, ['sapling', 'orchard'])
         assert_equal(addr0_3['account'], 0)
         assert_equal(set(addr0_3['pools']), set(['sapling', 'orchard']))
-        ua0_3 = addr0_3['unifiedaddress']
+        ua0_3 = addr0_3['address']
 
         # We can generate an address without a Sapling receiver.
         addr0_4 = self.nodes[0].z_getaddressforaccount(0, ['transparent', 'orchard'])
         assert_equal(addr0_4['account'], 0)
         assert_equal(set(addr0_4['pools']), set(['transparent', 'orchard']))
-        ua0_4 = addr0_4['unifiedaddress']
+        ua0_4 = addr0_4['address']
 
         # The first address for account 1 is different to account 0.
         addr1 = self.nodes[0].z_getaddressforaccount(1)
         assert_equal(addr1['account'], 1)
         assert_equal(set(addr1['pools']), set(['transparent', 'sapling', 'orchard']))
-        ua1 = addr1['unifiedaddress']
+        ua1 = addr1['address']
         assert(ua0 != ua1)
 
         # The UA contains the expected receiver kinds.
@@ -195,7 +195,7 @@ class WalletAccountsTest(BitcoinTestFramework):
         # Send Orchard funds from the UA.
         print('Sending account funds to Orchard-only UA')
         node1account = self.nodes[1].z_getnewaccount()['account']
-        node1orchard = self.nodes[1].z_getaddressforaccount(node1account, ['orchard'])['unifiedaddress']
+        node1orchard = self.nodes[1].z_getaddressforaccount(node1account, ['orchard'])['address']
         recipients = [{'address': node1orchard, 'amount': Decimal('1')}]
         opid = self.nodes[0].z_sendmany(ua0, recipients, 1, 0)
         txid = wait_and_assert_operationid_status(self.nodes[0], opid)

--- a/qa/rpc-tests/wallet_accounts.py
+++ b/qa/rpc-tests/wallet_accounts.py
@@ -64,7 +64,7 @@ class WalletAccountsTest(BitcoinTestFramework):
         # Generate the first address for account 0.
         addr0 = self.nodes[0].z_getaddressforaccount(0)
         assert_equal(addr0['account'], 0)
-        assert_equal(set(addr0['pools']), set(['transparent', 'sapling', 'orchard']))
+        assert_equal(set(addr0['receiver_types']), set(['p2pkh', 'sapling', 'orchard']))
         ua0 = addr0['address']
 
         # We pick mnemonic phrases to ensure that we can always generate the default
@@ -82,26 +82,26 @@ class WalletAccountsTest(BitcoinTestFramework):
         # The second address for account 0 is different to the first address.
         addr0_2 = self.nodes[0].z_getaddressforaccount(0)
         assert_equal(addr0_2['account'], 0)
-        assert_equal(set(addr0_2['pools']), set(['transparent', 'sapling', 'orchard']))
+        assert_equal(set(addr0_2['receiver_types']), set(['p2pkh', 'sapling', 'orchard']))
         ua0_2 = addr0_2['address']
         assert(ua0 != ua0_2)
 
         # We can generate a fully-shielded address.
         addr0_3 = self.nodes[0].z_getaddressforaccount(0, ['sapling', 'orchard'])
         assert_equal(addr0_3['account'], 0)
-        assert_equal(set(addr0_3['pools']), set(['sapling', 'orchard']))
+        assert_equal(set(addr0_3['receiver_types']), set(['sapling', 'orchard']))
         ua0_3 = addr0_3['address']
 
         # We can generate an address without a Sapling receiver.
-        addr0_4 = self.nodes[0].z_getaddressforaccount(0, ['transparent', 'orchard'])
+        addr0_4 = self.nodes[0].z_getaddressforaccount(0, ['p2pkh', 'orchard'])
         assert_equal(addr0_4['account'], 0)
-        assert_equal(set(addr0_4['pools']), set(['transparent', 'orchard']))
+        assert_equal(set(addr0_4['receiver_types']), set(['p2pkh', 'orchard']))
         ua0_4 = addr0_4['address']
 
         # The first address for account 1 is different to account 0.
         addr1 = self.nodes[0].z_getaddressforaccount(1)
         assert_equal(addr1['account'], 1)
-        assert_equal(set(addr1['pools']), set(['transparent', 'sapling', 'orchard']))
+        assert_equal(set(addr1['receiver_types']), set(['p2pkh', 'sapling', 'orchard']))
         ua1 = addr1['address']
         assert(ua0 != ua1)
 

--- a/qa/rpc-tests/wallet_addresses.py
+++ b/qa/rpc-tests/wallet_addresses.py
@@ -68,7 +68,7 @@ class WalletAddressesTest(BitcoinTestFramework):
         account = self.nodes[0].z_getnewaccount()['account']
         sprout_1 = self.nodes[0].z_getnewaddress('sprout')
         sapling_1 = self.nodes[0].z_getnewaddress('sapling')
-        unified_1 = self.nodes[0].z_getaddressforaccount(account)['unifiedaddress']
+        unified_1 = self.nodes[0].z_getaddressforaccount(account)['address']
         types_and_addresses = [
             ('sprout', sprout_1),
             ('sapling', sapling_1),
@@ -111,7 +111,7 @@ class WalletAddressesTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getblockcount(), 2)
         # Sprout address generation is no longer allowed
         sapling_2 = self.nodes[0].z_getnewaddress('sapling')
-        unified_2 = self.nodes[0].z_getaddressforaccount(account)['unifiedaddress']
+        unified_2 = self.nodes[0].z_getaddressforaccount(account)['address']
         types_and_addresses = [
             ('sapling', sapling_2),
             ('unified', unified_2),

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -389,13 +389,13 @@ class ListReceivedTest (BitcoinTestFramework):
         unified_addr = r['address']
         receivers = node.z_listunifiedreceivers(unified_addr)
         assert_equal(len(receivers), 3)
-        assert 'transparent' in receivers
+        assert 'p2pkh' in receivers
         assert 'sapling' in receivers
         assert 'orchard' in receivers
         assert_raises_message(
             JSONRPCException,
             "The provided address is a bare receiver from a Unified Address in this wallet.",
-            node.z_listreceivedbyaddress, receivers['transparent'], 0)
+            node.z_listreceivedbyaddress, receivers['p2pkh'], 0)
         assert_raises_message(
             JSONRPCException,
             "The provided address is a bare receiver from a Unified Address in this wallet.",
@@ -411,7 +411,7 @@ class ListReceivedTest (BitcoinTestFramework):
         self.generate_and_sync(height+5)
 
         # Create a UTXO that unified_address's transparent component references, on node1
-        outputs = {receivers['transparent']: 0.2}
+        outputs = {receivers['p2pkh']: 0.2}
         txid_taddr = node.sendmany("", outputs)
 
         r = node.z_listreceivedbyaddress(unified_addr, 0)

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -449,11 +449,11 @@ class ListReceivedTest (BitcoinTestFramework):
         acct2 = self.nodes[1].z_getnewaccount()['account']
 
         addrResO = self.nodes[1].z_getaddressforaccount(acct1, ['orchard'])
-        assert_equal(addrResO['pools'], ['orchard'])
+        assert_equal(addrResO['receiver_types'], ['orchard'])
         uao = addrResO['address']
 
         addrResSO = self.nodes[1].z_getaddressforaccount(acct2, ['sapling', 'orchard'])
-        assert_equal(addrResSO['pools'], ['sapling', 'orchard'])
+        assert_equal(addrResSO['receiver_types'], ['sapling', 'orchard'])
         uaso = addrResSO['address']
 
         self.nodes[0].sendtoaddress(taddr, 4.0)

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -375,7 +375,7 @@ class ListReceivedTest (BitcoinTestFramework):
         # Create a unified address on one node, try z_listreceivedbyaddress on another node
         account = self.nodes[0].z_getnewaccount()['account']
         r = self.nodes[0].z_getaddressforaccount(account)
-        unified_addr = r['unifiedaddress']
+        unified_addr = r['address']
         # this address isn't in node1's wallet
         assert_raises_message(
             JSONRPCException,
@@ -386,7 +386,7 @@ class ListReceivedTest (BitcoinTestFramework):
         r = node.z_getnewaccount()
         account = r['account']
         r = node.z_getaddressforaccount(account)
-        unified_addr = r['unifiedaddress']
+        unified_addr = r['address']
         receivers = node.z_listunifiedreceivers(unified_addr)
         assert_equal(len(receivers), 3)
         assert 'transparent' in receivers
@@ -450,17 +450,17 @@ class ListReceivedTest (BitcoinTestFramework):
 
         addrResO = self.nodes[1].z_getaddressforaccount(acct1, ['orchard'])
         assert_equal(addrResO['pools'], ['orchard'])
-        uao = addrResO['unifiedaddress']
+        uao = addrResO['address']
 
         addrResSO = self.nodes[1].z_getaddressforaccount(acct2, ['sapling', 'orchard'])
         assert_equal(addrResSO['pools'], ['sapling', 'orchard'])
-        uaso = addrResSO['unifiedaddress']
+        uaso = addrResSO['address']
 
         self.nodes[0].sendtoaddress(taddr, 4.0)
         self.generate_and_sync(height+2)
 
         acct_node0 = self.nodes[0].z_getnewaccount()['account']
-        ua_node0 = self.nodes[0].z_getaddressforaccount(acct_node0, ['sapling', 'orchard'])['unifiedaddress']
+        ua_node0 = self.nodes[0].z_getaddressforaccount(acct_node0, ['sapling', 'orchard'])['address']
 
         opid = self.nodes[1].z_sendmany(taddr, [
             {'address': uao, 'amount': 1, 'memo': my_memo},

--- a/qa/rpc-tests/wallet_orchard.py
+++ b/qa/rpc-tests/wallet_orchard.py
@@ -36,7 +36,7 @@ class WalletOrchardTest(BitcoinTestFramework):
         acct1 = self.nodes[1].z_getnewaccount()['account']
         addrRes1 = self.nodes[1].z_getaddressforaccount(acct1, ['orchard'])
         assert_equal(acct1, addrRes1['account'])
-        assert_equal(addrRes1['pools'], ['orchard'])
+        assert_equal(addrRes1['receiver_types'], ['orchard'])
         ua1 = addrRes1['address']
 
         # Verify that we have only an Orchard component

--- a/qa/rpc-tests/wallet_orchard.py
+++ b/qa/rpc-tests/wallet_orchard.py
@@ -37,7 +37,7 @@ class WalletOrchardTest(BitcoinTestFramework):
         addrRes1 = self.nodes[1].z_getaddressforaccount(acct1, ['orchard'])
         assert_equal(acct1, addrRes1['account'])
         assert_equal(addrRes1['pools'], ['orchard'])
-        ua1 = addrRes1['unifiedaddress']
+        ua1 = addrRes1['address']
 
         # Verify that we have only an Orchard component
         receiver_types = self.nodes[0].z_listunifiedreceivers(ua1)
@@ -50,7 +50,7 @@ class WalletOrchardTest(BitcoinTestFramework):
         acct2 = self.nodes[2].z_getnewaccount()['account']
         addrRes2 = self.nodes[2].z_getaddressforaccount(acct2, ['sapling', 'orchard'])
         assert_equal(acct2, addrRes2['account'])
-        ua2 = addrRes2['unifiedaddress']
+        ua2 = addrRes2['address']
         saplingAddr2 = self.nodes[2].z_listunifiedreceivers(ua2)['sapling']
 
         recipients = [{"address": saplingAddr2, "amount": Decimal('10')}]
@@ -102,7 +102,7 @@ class WalletOrchardTest(BitcoinTestFramework):
         acct3 = self.nodes[3].z_getnewaccount()['account']
         addrRes3 = self.nodes[3].z_getaddressforaccount(acct3, ['sapling', 'orchard'])
         assert_equal(acct3, addrRes3['account'])
-        ua3 = addrRes3['unifiedaddress']
+        ua3 = addrRes3['address']
 
         recipients = [{"address": ua3, "amount": Decimal('1')}]
         myopid = self.nodes[2].z_sendmany(ua2, recipients, 1, 0)

--- a/qa/rpc-tests/wallet_sapling.py
+++ b/qa/rpc-tests/wallet_sapling.py
@@ -169,7 +169,7 @@ class WalletSaplingTest(BitcoinTestFramework):
             )
             raise AssertionError("Should have thrown an exception")
         except JSONRPCException as e:
-            assert_equal("Sending funds into the Sprout pool is not supported by z_sendmany", e.error['message'])
+            assert_equal("Sending funds into the Sprout value pool is not supported by z_sendmany", e.error['message'])
 
 if __name__ == '__main__':
     WalletSaplingTest().main()

--- a/qa/rpc-tests/wallet_shieldcoinbase_ua_nu5.py
+++ b/qa/rpc-tests/wallet_shieldcoinbase_ua_nu5.py
@@ -15,7 +15,7 @@ class WalletShieldCoinbaseUANU5(WalletShieldCoinbaseTest):
         # this function may be called no more than once
         assert(self.account is None)
         self.account = node.z_getnewaccount()['account']
-        self.addr = node.z_getaddressforaccount(self.account)['unifiedaddress']
+        self.addr = node.z_getaddressforaccount(self.account)['address']
         return self.addr
 
     def test_check_balance_zaddr(self, node, expected):

--- a/qa/rpc-tests/wallet_shieldcoinbase_ua_nu5.py
+++ b/qa/rpc-tests/wallet_shieldcoinbase_ua_nu5.py
@@ -22,16 +22,21 @@ class WalletShieldCoinbaseUANU5(WalletShieldCoinbaseTest):
         balances = node.z_getbalanceforaccount(self.account)
         assert('transparent' not in balances['pools'])
         assert('sprout' not in balances['pools'])
-        # assert('sapling' not in balances['pools'])
+        # Remove the following after Orchard support is added to z_shieldcoinbase
         sapling_balance = balances['pools']['sapling']['valueZat']
         assert_equal(sapling_balance, expected * COIN)
-        # assert_equal(balances['pools']['orchard']['valueZat'], expected * COIN)
+        # TODO: Uncomment after Orchard support is added to z_shieldcoinbase
+        #assert('sapling' not in balances['pools'])
+        #orchard_balance = balances['pools']['orchard']['valueZat']
+        #assert_equal(orchard_balance, expected * COIN)
 
         # While we're at it, check that z_listunspent only shows outputs with
         # the Unified Address (not the Orchard receiver), and of the expected
         # type.
         unspent = node.z_listunspent(1, 999999, False, [self.addr])
         assert_equal(
+            # TODO: Fix after Orchard support is added to z_shieldcoinbase
+            #[{'type': 'orchard', 'address': self.addr} for _ in unspent],
             [{'type': 'sapling', 'address': self.addr} for _ in unspent],
             [{'type': x['type'], 'address': x['address']} for x in unspent],
         )

--- a/qa/rpc-tests/wallet_shieldcoinbase_ua_sapling.py
+++ b/qa/rpc-tests/wallet_shieldcoinbase_ua_sapling.py
@@ -14,7 +14,7 @@ class WalletShieldCoinbaseUASapling(WalletShieldCoinbaseTest):
         # this function may be called no more than once
         assert(self.account is None)
         self.account = node.z_getnewaccount()['account']
-        self.addr = node.z_getaddressforaccount(self.account)['unifiedaddress']
+        self.addr = node.z_getaddressforaccount(self.account)['address']
         return self.addr
 
     def test_check_balance_zaddr(self, node, expected):

--- a/qa/rpc-tests/wallet_z_sendmany.py
+++ b/qa/rpc-tests/wallet_z_sendmany.py
@@ -167,7 +167,7 @@ class WalletZSendmanyTest(BitcoinTestFramework):
 
         # Get a new unified account on node 2 & generate a UA
         n0account0 = self.nodes[0].z_getnewaccount()['account']
-        n0ua0 = self.nodes[0].z_getaddressforaccount(n0account0)['unifiedaddress']
+        n0ua0 = self.nodes[0].z_getaddressforaccount(n0account0)['address']
 
         # Change went to a fresh address, so use `ANY_TADDR` which
         # should hold the rest of our transparent funds.
@@ -297,8 +297,8 @@ class WalletZSendmanyTest(BitcoinTestFramework):
 
         # Generate a new account with two new addresses.
         n1account = self.nodes[1].z_getnewaccount()['account']
-        n1ua0 = self.nodes[1].z_getaddressforaccount(n1account)['unifiedaddress']
-        n1ua1 = self.nodes[1].z_getaddressforaccount(n1account)['unifiedaddress']
+        n1ua0 = self.nodes[1].z_getaddressforaccount(n1account)['address']
+        n1ua1 = self.nodes[1].z_getaddressforaccount(n1account)['address']
 
         # Send funds to the transparent receivers of both addresses.
         for ua in [n1ua0, n1ua1]:

--- a/qa/rpc-tests/wallet_z_sendmany.py
+++ b/qa/rpc-tests/wallet_z_sendmany.py
@@ -302,7 +302,7 @@ class WalletZSendmanyTest(BitcoinTestFramework):
 
         # Send funds to the transparent receivers of both addresses.
         for ua in [n1ua0, n1ua1]:
-            taddr = self.nodes[1].z_listunifiedreceivers(ua)['transparent']
+            taddr = self.nodes[1].z_listunifiedreceivers(ua)['p2pkh']
             self.nodes[0].sendtoaddress(taddr, 2)
 
         self.sync_all()

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -726,7 +726,8 @@ UniValue z_importkey(const UniValue& params, bool fHelp)
             "\nNote: This call can take a long time to complete if rescan is true.\n"
             "\nResult:\n"
             "{\n"
-            "  \"type\" : \"xxxx\",                         (string) \"sprout\" or \"sapling\"\n"
+            "  \"address_type\" : \"xxxx\",                 (string) \"sprout\" or \"sapling\"\n"
+            "  \"type\" : \"xxxx\",                         (string) \"sprout\" or \"sapling\" (DEPRECATED, legacy attribute)\n"
             "  \"address\" : \"address|DefaultAddress\",    (string) The address corresponding to the spending key (for Sapling, this is the default address).\n"
             "}\n"
             "\nExamples:\n"
@@ -792,7 +793,8 @@ UniValue z_importkey(const UniValue& params, bool fHelp)
 
     auto addrInfo = std::visit(libzcash::AddressInfoFromSpendingKey{}, spendingkey.value());
     UniValue result(UniValue::VOBJ);
-    result.pushKV("type", addrInfo.first);
+    result.pushKV("address_type", addrInfo.first);
+    result.pushKV("type", addrInfo.first); //deprecated
     result.pushKV("address", keyIO.EncodePaymentAddress(addrInfo.second));
 
     // Sapling support
@@ -832,7 +834,8 @@ UniValue z_importviewingkey(const UniValue& params, bool fHelp)
             "\nNote: This call can take a long time to complete if rescan is true. Import of Unified viewing keys is not yet supported.\n"
             "\nResult:\n"
             "{\n"
-            "  \"type\" : \"xxxx\",                         (string) \"sprout\" or \"sapling\"\n"
+            "  \"address_type\" : \"xxxx\",                 (string) \"sprout\" or \"sapling\"\n"
+            "  \"type\" : \"xxxx\",                         (string) \"sprout\" or \"sapling\" (DEPRECATED, legacy attribute)\n"
             "  \"address\" : \"address|DefaultAddress\",    (string) The address corresponding to the viewing key (for Sapling, this is the default address).\n"
             "}\n"
             "\nExamples:\n"
@@ -889,7 +892,8 @@ UniValue z_importviewingkey(const UniValue& params, bool fHelp)
     auto addrInfo = std::visit(libzcash::AddressInfoFromViewingKey(chainparams), viewingkey.value());
     UniValue result(UniValue::VOBJ);
     const string strAddress = keyIO.EncodePaymentAddress(addrInfo.second);
-    result.pushKV("type", addrInfo.first);
+    result.pushKV("address_type", addrInfo.first);
+    result.pushKV("type", addrInfo.first); //deprecated
     result.pushKV("address", strAddress);
 
     auto addResult = std::visit(AddViewingKeyToWallet(pwalletMain, true), viewingkey.value());

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3271,7 +3271,7 @@ UniValue z_getaddressforaccount(const UniValue& params, bool fHelp)
             "  \"account\": n,                    (numeric) the specified account number\n"
             "  \"diversifier_index\": n,          (numeric) the index specified or chosen\n"
             "  \"pools\": [\"pool\",...]\",         (json array of string) the pools (e.g. \"transparent\", \"orchard\") for which the UA contains receivers\n"
-            "  \"unifiedaddress\"                 (string) The corresponding address\n"
+            "  \"address\"                        (string) The corresponding address\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("z_getaddressforaccount", "4")
@@ -3344,7 +3344,7 @@ UniValue z_getaddressforaccount(const UniValue& params, bool fHelp)
 
     std::visit(match {
         [&](std::pair<libzcash::UnifiedAddress, libzcash::diversifier_index_t> addr) {
-            result.pushKV("unifiedaddress", KeyIO(Params()).EncodePaymentAddress(addr.first));
+            result.pushKV("address", KeyIO(Params()).EncodePaymentAddress(addr.first));
             UniValue j;
             j.setNumStr(ArbitraryIntStr(std::vector(addr.second.begin(), addr.second.end())));
             result.pushKV("diversifier_index", j);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3535,10 +3535,10 @@ UniValue z_listunifiedreceivers(const UniValue& params, bool fHelp)
                 result.pushKV("sapling", keyIO.EncodePaymentAddress(addr));
             },
             [&](const CScriptID& addr) {
-                result.pushKV("transparent", keyIO.EncodePaymentAddress(addr));
+                result.pushKV("p2sh", keyIO.EncodePaymentAddress(addr));
             },
             [&](const CKeyID& addr) {
-                result.pushKV("transparent", keyIO.EncodePaymentAddress(addr));
+                result.pushKV("p2pkh", keyIO.EncodePaymentAddress(addr));
             },
             [](auto rest) {},
         }, receiver);


### PR DESCRIPTION
Fixes #5432 