### PR TITLE
Move LoadProofParameters to gtest/utils.cpp

### DIFF
--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -5,6 +5,7 @@
 #include "primitives/transaction.h"
 #include "consensus/validation.h"
 #include "transaction_builder.h"
+#include "gtest/utils.h"
 #include "utiltest.h"
 #include "zcash/JoinSplit.hpp"
 

--- a/src/gtest/test_dynamicusage.cpp
+++ b/src/gtest/test_dynamicusage.cpp
@@ -9,6 +9,7 @@
 #include "init.h"
 #include "key.h"
 #include "transaction_builder.h"
+#include "gtest/utils.h"
 #include "utiltest.h"
 
 #include <optional>

--- a/src/gtest/test_joinsplit.cpp
+++ b/src/gtest/test_joinsplit.cpp
@@ -11,6 +11,7 @@
 #include "primitives/transaction.h"
 #include "proof_verifier.h"
 #include "transaction_builder.h"
+#include "gtest/utils.h"
 #include "utiltest.h"
 #include "zcash/JoinSplit.hpp"
 #include "zcash/Note.hpp"

--- a/src/gtest/test_mempoollimit.cpp
+++ b/src/gtest/test_mempoollimit.cpp
@@ -7,6 +7,7 @@
 
 #include "arith_uint256.h"
 #include "mempool_limit.h"
+#include "gtest/utils.h"
 #include "utiltime.h"
 #include "utiltest.h"
 #include "transaction_builder.h"

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -8,6 +8,7 @@
 #include "rpc/protocol.h"
 #include "transaction_builder.h"
 #include "gtest/test_transaction_builder.h"
+#include "gtest/utils.h"
 #include "utiltest.h"
 #include "zcash/Address.hpp"
 #include "zcash/address/mnemonic.h"

--- a/src/gtest/utils.cpp
+++ b/src/gtest/utils.cpp
@@ -9,3 +9,25 @@ int GenMax(int n)
 {
     return n-1;
 }
+
+void LoadProofParameters() {
+    fs::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
+    fs::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
+    fs::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
+
+    static_assert(
+        sizeof(fs::path::value_type) == sizeof(codeunit),
+        "librustzcash not configured correctly");
+    auto sapling_spend_str = sapling_spend.native();
+    auto sapling_output_str = sapling_output.native();
+    auto sprout_groth16_str = sprout_groth16.native();
+
+    librustzcash_init_zksnark_params(
+        reinterpret_cast<const codeunit*>(sapling_spend_str.c_str()),
+        sapling_spend_str.length(),
+        reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
+        sapling_output_str.length(),
+        reinterpret_cast<const codeunit*>(sprout_groth16_str.c_str()),
+        sprout_groth16_str.length()
+    );
+}

--- a/src/gtest/utils.h
+++ b/src/gtest/utils.h
@@ -1,7 +1,11 @@
 #ifndef BITCOIN_GTEST_UTILS_H
 #define BITCOIN_GTEST_UTILS_H
 
+#include "util.h"
+#include "key_io.h"
+
 int GenZero(int n);
 int GenMax(int n);
+void LoadProofParameters();
 
 #endif

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -358,27 +358,3 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
     CWalletTx wtx {NULL, tx};
     return wtx;
 }
-
-
-
-void LoadProofParameters() {
-    fs::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
-    fs::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
-    fs::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
-
-    static_assert(
-        sizeof(fs::path::value_type) == sizeof(codeunit),
-        "librustzcash not configured correctly");
-    auto sapling_spend_str = sapling_spend.native();
-    auto sapling_output_str = sapling_output.native();
-    auto sprout_groth16_str = sprout_groth16.native();
-
-    librustzcash_init_zksnark_params(
-        reinterpret_cast<const codeunit*>(sapling_spend_str.c_str()),
-        sapling_spend_str.length(),
-        reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
-        sapling_output_str.length(),
-        reinterpret_cast<const codeunit*>(sprout_groth16_str.c_str()),
-        sprout_groth16_str.length()
-    );
-}

--- a/src/utiltest.h
+++ b/src/utiltest.h
@@ -76,6 +76,4 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
                                  const libzcash::SaplingExtendedSpendingKey &sk,
                                  CAmount value);
 
-void LoadProofParameters();
-
 #endif // ZCASH_UTILTEST_H

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -9,6 +9,7 @@
 #include "primitives/block.h"
 #include "random.h"
 #include "transaction_builder.h"
+#include "gtest/utils.h"
 #include "utiltest.h"
 #include "wallet/wallet.h"
 #include "zcash/JoinSplit.hpp"


### PR DESCRIPTION
In https://github.com/zcash/zcash/pull/5636 i created `LoadProofParameters` that loads the proof parameters for the gtests, so each individual test can load proof params, rather than having it be suite-wide or loaded in `gtest/main.cpp`.

This PR moves that function --  only ever called by the gtests -- to `gtest/utils.cpp` (it's currently in `utiltest.cpp`).