### PR TITLE
Add missing wallet/orchard.h to src/Makefile.am and gtest/test_transaction_builder.h to Makefile.gtest.include

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -259,6 +259,7 @@ BITCOIN_CORE_H = \
   wallet/asyncrpcoperation_shieldcoinbase.h \
   wallet/crypter.h \
   wallet/db.h \
+  wallet/orchard.h \
   wallet/paymentdisclosure.h \
   wallet/paymentdisclosuredb.h \
   wallet/rpcwallet.h \

--- a/src/Makefile.gtest.include
+++ b/src/Makefile.gtest.include
@@ -53,6 +53,7 @@ zcash_gtest_SOURCES += \
 	gtest/test_timedata.cpp \
 	gtest/test_transaction.cpp \
 	gtest/test_transaction_builder.cpp \
+	gtest/test_transaction_builder.h \
 	gtest/test_txid.cpp \
 	gtest/test_upgrades.cpp \
 	gtest/test_validation.cpp \


### PR DESCRIPTION
Like 562f5add878219042c6ff30e85cebf79e5369cfe / https://github.com/zcash/zcash/pull/5701 the missing header reference means that the make dist step of gitian builds don't include it in the tarball, causing an error upon build.
