### PR TITLE
Prevent a pindex == NULL case in the ScanForWalletTransactions traversal

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4303,7 +4303,7 @@ int CWallet::ScanForWalletTransactions(
 
         // no need to read and scan block, if block was created before
         // our wallet birthday (as adjusted for block time variability)
-        while (pindex && nTimeFirstKey && pindex->GetBlockTime() < nTimeFirstKey - TIMESTAMP_WINDOW) {
+        while (chainActive.Next(pindex) != NULL && nTimeFirstKey && pindex->GetBlockTime() < nTimeFirstKey - TIMESTAMP_WINDOW) {
             pindex = chainActive.Next(pindex);
         }
 


### PR DESCRIPTION
i believe this fixes the segfault in #5712.