### PR TITLE
Disallow testnet peers with a protocol version older than 170040

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6386,6 +6386,17 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             return false;
         }
 
+        if (chainparams.NetworkIDString() == "test" &&
+            pfrom->nVersion < MIN_TESTNET_PEER_PROTO_VERSION)
+        {
+            // disconnect from testnet peers older than this proto version
+            LogPrintf("peer=%d using obsolete version %i; disconnecting\n", pfrom->id, pfrom->nVersion);
+            pfrom->PushMessage("reject", strCommand, REJECT_OBSOLETE,
+                               strprintf("Version must be %d or greater", MIN_TESTNET_PEER_PROTO_VERSION));
+            pfrom->fDisconnect = true;
+            return false;
+        }
+
         // Reject incoming connections from nodes that don't know about the current epoch
         const Consensus::Params& consensusParams = chainparams.GetConsensus();
         auto currentEpoch = CurrentEpoch(GetHeight(), consensusParams);

--- a/src/version.h
+++ b/src/version.h
@@ -37,4 +37,7 @@ static const int NO_BLOOM_VERSION = 170004;
 //! - MSG_WTX type defined, which contains two 32-byte hashes.
 static const int CINV_WTX_VERSION = 170014;
 
+//! disconnect from testnet peers older than this proto version
+static const int MIN_TESTNET_PEER_PROTO_VERSION = 170040;
+
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
If we're on the testnet, we reject connections from nodes running versions that are older than `MIN_TESTNET_PEER_PROTO_VERSION` -- defined to be `170040`. 