### PR TITLE
Additions and cleanups for contrib/debian/copyright

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -106,7 +106,7 @@ Copyright: 2014-2015, Brian Davis
 License: BSD-3-clause-Tobias-Klein
 
 Files: depends/sources/libsodium-*.tar.gz
-Copyright: 2013-2016 Frank Denis
+Copyright: 2013-2022 Frank Denis
 License: ISC
 
 Files: depends/sources/boost_*.tar.gz
@@ -139,8 +139,7 @@ Copyright: 2000-2007 Niels Provos <provos@citi.umich.edu>
 License: BSD-3-clause
 
 Files: depends/sources/zeromq-*.tar.gz
-Copyright:
- 1994, 1995, 1996, 1999, 2000, 2001, 2002, 2004, 2005, 2006, 2007 Free Software Foundation, Inc.
+Copyright: 1994, 1995, 1996, 1999, 2000, 2001, 2002, 2004, 2005, 2006, 2007 Free Software Foundation, Inc.
  2007-2014 iMatix Corporation
  2009-2011 250bpm s.r.o.
  2010-2011 Miru Limited
@@ -161,28 +160,30 @@ License: Boost-Software-License-1.0
 
 Files: depends/*/vendored-sources/halo2/*
  depends/*/vendored-sources/orchard/*
-Copyright: 2020-2021 The Electric Coin Company
+Copyright: 2020-2022 The Electric Coin Company
 License: BOSL-1+ with Zcash exception
 
 Files: src/crypto/ctaes/*
-Copyright: Copyright (c) 2016 Pieter Wuille
+Copyright: 2016 Pieter Wuille
 License: Expat
 
 Files: src/rust/include/rust/map.h
-Copyright: Copyright (c) 2012 William Swanson
+Copyright: 2012 William Swanson
+ 2020 The Zcash developers
 License: Expat-with-advertising-clause
 
 Files: src/rust/include/rust/VA_OPT.hpp
-Copyright: Copyright (c) 2019 Will Wray
+Copyright: 2019 Will Wray
+ 2020 The Zcash developers
 License: Boost-Software-License-1.0
 
 Files: src/rust/include/tracing.h
  src/rust/src/tracing_ffi.rs
-Copyright: Copyright (c) 2020 Jack Grigg
+Copyright: 2020 Jack Grigg
 License: Expat
 
 Files: src/secp256k1/*
-Copyright: Copyright (c) 2013 Pieter Wuille
+Copyright: 2013 Pieter Wuille
 License: Expat
 Comment: This copyright entry excludes files explicitly listed below.
 
@@ -194,8 +195,8 @@ Files: src/secp256k1/build-aux/m4/ax_prog_cc_for_build.m4
 Copyright: 2008 Paolo Bonzini <bonzini@gnu.org>
 License: GNU-All-permissive-License
 
-Files src/leveldb/*
-Copyright: 2011, The LevelDB Authors
+Files: src/leveldb/*
+Copyright: 2011 The LevelDB Authors
 License: BSD-3-clause-Google
 Comment: The LevelDB Authors are listed in src/leveldb/AUTHORS.
 

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -78,6 +78,27 @@ Copyright: 2008, Steven G. Johnson <stevenj@alum.mit.edu>
  2011, Daniel Richard G. <skunk@iSKUNK.ORG>
 License: GPL-3+ with Autoconf exception
 
+Files: build-aux/m4/libtool.m4
+Copyright: 1996-2001, 2003-2015 Free Software Foundation, Inc.
+ Written by Gordon Matzigkeit, 1996
+License: GNU-All-permissive-License or GPL-2+ with Libtool exception
+
+Files: build-aux/m4/lt~obsolete.m4
+Copyright: 2004-2005, 2007, 2009, 2011-2015 Free Software Foundation, Inc.
+ Written by Scott James Remnant, 2004.
+License: GNU-All-permissive-License
+
+Files: build-aux/m4/ltoptions.m4
+ build-aux/m4/ltsugar.m4
+Copyright: 2004-2005, 2007-2009, 2011-2015 Free Software Foundation, Inc.
+ Written by Gary V. Vaughan, 2004
+License: GNU-All-permissive-License
+
+Files: build-aux/m4/ltversion.m4
+Copyright: 2004, 2011-2015 Free Software Foundation, Inc.
+ Written by Scott James Remnant, 2004
+License: GNU-All-permissive-License
+
 Files: qa/zcash/checksec.sh
 Copyright: 2014-2015, Brian Davis
  2013, Robin David
@@ -1176,6 +1197,28 @@ License: GPL-3+ with Autoconf exception
 Comment:
  The "special exception" is extended to the versions of files covered by
  this license that are distributed with this software.
+
+License: GPL-2+ with Libtool exception
+ This is free software; see the source for copying conditions.  There is NO
+ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ .
+ GNU Libtool is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of of the License, or
+ (at your option) any later version.
+ .
+ As a special exception to the GNU General Public License, if you
+ distribute this file as part of a program or library that is built
+ using GNU Libtool, you may include this file under the  same
+ distribution terms that you use for the rest of that program.
+ .
+ GNU Libtool is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 License: Expat-with-advertising-clause
  Permission is hereby granted, free of charge, to any person

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -234,11 +234,6 @@ Copyright: 2019 Will Wray
  2020 The Zcash developers
 License: Boost-Software-License-1.0
 
-Files: src/rust/include/tracing.h
- src/rust/src/tracing_ffi.rs
-Copyright: 2020 Jack Grigg
-License: Expat
-
 Files: src/secp256k1/*
 Copyright: 2013 Pieter Wuille
 License: Expat

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -257,6 +257,10 @@ Copyright: 2011 The LevelDB Authors
 License: BSD-3-clause-Google
 Comment: The LevelDB Authors are listed in src/leveldb/AUTHORS.
 
+License: Apache-2.0
+ On Debian systems, the full text of the Apache License v2.0 can be found in the
+ file `/usr/share/common-licenses/Apache-2.0`.
+
 License: Apache-2 with LLVM exception
  ==============================================================================
  The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -12,6 +12,8 @@ Comment: The Bitcoin Core developers encompasses the current developers listed o
  bitcoin.org, as well as the numerous contributors to the project.
  The Zcash developers are listed at https://z.cash/team.html and in doc/authors.md.
  This copyright entry excludes files explicitly listed below.
+ We do not explicitly list Rust crates that have Expat/MIT as a licensing option
+ (as determined by "cargo license").
 
 Files: build-aux/m4/ax_boost_base.m4
 Copyright: 2008, Thomas Porschberg <thomas@randspringer.de>
@@ -162,6 +164,61 @@ Files: depends/*/vendored-sources/halo2/*
  depends/*/vendored-sources/orchard/*
 Copyright: 2020-2022 The Electric Coin Company
 License: BOSL-1+ with Zcash exception
+
+Files: depends/*/vendored-sources/sketches-ddsketch/*
+Copyright: 2019-2020 Mike Heffner <mikeh@fesnel.com>
+License: Apache-2.0
+
+Files: depends/*/vendored-sources/arrayref/*
+Copyright: 2015-2022 David Roundy <roundyd@physics.oregonstate.edu>
+License: BSD-2-clause
+
+Files: depends/*/vendored-sources/mach/*
+Copyright: 2015-2022 Nick Fitzgerald
+License: BSD-2-clause
+
+Files: depends/*/vendored-sources/curve25519-dalek/*
+Copyright: 2016-2021 isis agora lovecruft
+ 2016-2021 Henry de Valence
+ 2012-2017 Adam Langley
+ 2012 The Go Authors
+License: BSD-3-clause and BSD-3-clause-Google
+
+Files: depends/*/vendored-sources/instant/*
+Copyright: 2019 Sébastien Crozet
+License: BSD-3-clause
+
+Files: depends/*/vendored-sources/subtle/*
+Copyright: 2016-2017 isis agora lovecruft, Henry de Valence
+License: BSD-3-clause
+
+Files: depends/*/vendored-sources/constant_time_eq/*
+Copyright: 2015-2022 Cesar Eduardo Barros <cesarb@cesarb.eti.br>
+License: CC0-1.0
+
+Files: depends/*/vendored-sources/secp256k1/*
+Copyright: 2014-2022 Dawid Ciężarkiewicz <dpc@ucore.info>, Andrew Poelstra <apoelstra@wpsoftware.net>
+License: CC0-1.0
+
+Files: depends/*/vendored-sources/secp256k1-sys/*
+Copyright: 2014-2022 Dawid Ciężarkiewicz <dpc@ucore.info>, Andrew Poelstra <apoelstra@wpsoftware.net>, Steven Roose <steven@stevenroose.org>
+License: CC0-1.0
+
+Files: depends/*/vendored-sources/untrusted/*
+Copyright: 2015-2016 Brian Smith
+License: ISC
+
+Files: depends/*/vendored-sources/ring/*
+Copyright: 2015-2016 Brian Smith
+ 1998-2011 The OpenSSL Project
+ 1995-1998 Eric Young <eay@cryptsoft.com>
+ 2015 Google Inc.
+ 2015-2016 the fiat-crypto authors
+License: Ring-BoringSSL
+
+Files: depends/*/vendored-sources/terminfo/*
+Copyright: 2016-2020 meh <meh@schizofreni.co>
+License: WTFPL
 
 Files: src/crypto/ctaes/*
 Copyright: 2016 Pieter Wuille
@@ -1006,6 +1063,31 @@ License: BDB
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+License: BSD-2-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ .
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ .
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the
+    distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 License: BSD-3-clause
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
@@ -1245,6 +1327,348 @@ License: Expat-with-advertising-clause
  their institutions shall not be used in advertising or otherwise to
  promote the sale, use or other dealings in this Software without
  prior written authorization from the authors.
+
+License: CC0-1.0
+ Creative Commons Legal Code
+ .
+ CC0 1.0 Universal
+ .
+     CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+     LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+     ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+     INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+     REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+     PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+     THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+     HEREUNDER.
+ .
+ Statement of Purpose
+ .
+ The laws of most jurisdictions throughout the world automatically confer
+ exclusive Copyright and Related Rights (defined below) upon the creator
+ and subsequent owner(s) (each and all, an "owner") of an original work of
+ authorship and/or a database (each, a "Work").
+ .
+ Certain owners wish to permanently relinquish those rights to a Work for
+ the purpose of contributing to a commons of creative, cultural and
+ scientific works ("Commons") that the public can reliably and without fear
+ of later claims of infringement build upon, modify, incorporate in other
+ works, reuse and redistribute as freely as possible in any form whatsoever
+ and for any purposes, including without limitation commercial purposes.
+ These owners may contribute to the Commons to promote the ideal of a free
+ culture and the further production of creative, cultural and scientific
+ works, or to gain reputation or greater distribution for their Work in
+ part through the use and efforts of others.
+ .
+ For these and/or other purposes and motivations, and without any
+ expectation of additional consideration or compensation, the person
+ associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+ is an owner of Copyright and Related Rights in the Work, voluntarily
+ elects to apply CC0 to the Work and publicly distribute the Work under its
+ terms, with knowledge of his or her Copyright and Related Rights in the
+ Work and the meaning and intended legal effect of CC0 on those rights.
+ .
+ 1. Copyright and Related Rights. A Work made available under CC0 may be
+ protected by copyright and related or neighboring rights ("Copyright and
+ Related Rights"). Copyright and Related Rights include, but are not
+ limited to, the following:
+ .
+   i. the right to reproduce, adapt, distribute, perform, display,
+      communicate, and translate a Work;
+  ii. moral rights retained by the original author(s) and/or performer(s);
+ iii. publicity and privacy rights pertaining to a person's image or
+      likeness depicted in a Work;
+  iv. rights protecting against unfair competition in regards to a Work,
+      subject to the limitations in paragraph 4(a), below;
+   v. rights protecting the extraction, dissemination, use and reuse of data
+      in a Work;
+  vi. database rights (such as those arising under Directive 96/9/EC of the
+      European Parliament and of the Council of 11 March 1996 on the legal
+      protection of databases, and under any national implementation
+      thereof, including any amended or successor version of such
+      directive); and
+ vii. other similar, equivalent or corresponding rights throughout the
+      world based on applicable law or treaty, and any national
+      implementations thereof.
+ .
+ 2. Waiver. To the greatest extent permitted by, but not in contravention
+ of, applicable law, Affirmer hereby overtly, fully, permanently,
+ irrevocably and unconditionally waives, abandons, and surrenders all of
+ Affirmer's Copyright and Related Rights and associated claims and causes
+ of action, whether now known or unknown (including existing as well as
+ future claims and causes of action), in the Work (i) in all territories
+ worldwide, (ii) for the maximum duration provided by applicable law or
+ treaty (including future time extensions), (iii) in any current or future
+ medium and for any number of copies, and (iv) for any purpose whatsoever,
+ including without limitation commercial, advertising or promotional
+ purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+ member of the public at large and to the detriment of Affirmer's heirs and
+ successors, fully intending that such Waiver shall not be subject to
+ revocation, rescission, cancellation, termination, or any other legal or
+ equitable action to disrupt the quiet enjoyment of the Work by the public
+ as contemplated by Affirmer's express Statement of Purpose.
+ .
+ 3. Public License Fallback. Should any part of the Waiver for any reason
+ be judged legally invalid or ineffective under applicable law, then the
+ Waiver shall be preserved to the maximum extent permitted taking into
+ account Affirmer's express Statement of Purpose. In addition, to the
+ extent the Waiver is so judged Affirmer hereby grants to each affected
+ person a royalty-free, non transferable, non sublicensable, non exclusive,
+ irrevocable and unconditional license to exercise Affirmer's Copyright and
+ Related Rights in the Work (i) in all territories worldwide, (ii) for the
+ maximum duration provided by applicable law or treaty (including future
+ time extensions), (iii) in any current or future medium and for any number
+ of copies, and (iv) for any purpose whatsoever, including without
+ limitation commercial, advertising or promotional purposes (the
+ "License"). The License shall be deemed effective as of the date CC0 was
+ applied by Affirmer to the Work. Should any part of the License for any
+ reason be judged legally invalid or ineffective under applicable law, such
+ partial invalidity or ineffectiveness shall not invalidate the remainder
+ of the License, and in such case Affirmer hereby affirms that he or she
+ will not (i) exercise any of his or her remaining Copyright and Related
+ Rights in the Work or (ii) assert any associated claims and causes of
+ action with respect to the Work, in either case contrary to Affirmer's
+ express Statement of Purpose.
+ .
+ 4. Limitations and Disclaimers.
+ .
+  a. No trademark or patent rights held by Affirmer are waived, abandoned,
+     surrendered, licensed or otherwise affected by this document.
+  b. Affirmer offers the Work as-is and makes no representations or
+     warranties of any kind concerning the Work, express, implied,
+     statutory or otherwise, including without limitation warranties of
+     title, merchantability, fitness for a particular purpose, non
+     infringement, or the absence of latent or other defects, accuracy, or
+     the present or absence of errors, whether or not discoverable, all to
+     the greatest extent permissible under applicable law.
+  c. Affirmer disclaims responsibility for clearing rights of other persons
+     that may apply to the Work or any use thereof, including without
+     limitation any person's Copyright and Related Rights in the Work.
+     Further, Affirmer disclaims responsibility for obtaining any necessary
+     consents, permissions or other rights required for any use of the
+     Work.
+  d. Affirmer understands and acknowledges that Creative Commons is not a
+     party to this document and has no duty or obligation with respect to
+     this CC0 or use of the Work.
+
+License: WTFPL
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                    Version 2, December 2004
+ .
+ Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+ .
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+ .
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+ .
+ 0. You just DO WHAT THE FUCK YOU WANT TO.
+
+License: Ring-BoringSSL
+ Note that it is easy for this file to get out of sync with the licenses in the
+ source code files. It's recommended to compare the licenses in the source code
+ with what's mentioned here.
+ .
+ *ring* is derived from BoringSSL, so the licensing situation in *ring* is
+ similar to BoringSSL.
+ .
+ *ring* uses an ISC-style license like BoringSSL for code in new files,
+ including in particular all the Rust code:
+ .
+    Copyright 2015-2016 Brian Smith.
+ .
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+ .
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+    SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+    OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+    CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ .
+ BoringSSL is a fork of OpenSSL. As such, large parts of it fall under OpenSSL
+ licensing. Files that are completely new have a Google copyright and an ISC
+ license. This license is reproduced at the bottom of this file.
+ .
+ Contributors to BoringSSL are required to follow the CLA rules for Chromium:
+ https://cla.developers.google.com/clas
+ .
+ Files in third_party/ have their own licenses, as described therein. The MIT
+ license, for third_party/fiat, which, unlike other third_party directories, is
+ compiled into non-test libraries, is included below.
+ .
+ The OpenSSL toolkit stays under a dual license, i.e. both the conditions of the
+ OpenSSL License and the original SSLeay license apply to the toolkit. See below
+ for the actual license texts. Actually both licenses are BSD-style Open Source
+ licenses. In case of any license issues related to OpenSSL please contact
+ openssl-core@openssl.org.
+ .
+ The following are Google-internal bug numbers where explicit permission from
+ some authors is recorded for use of their work:
+   27287199
+   27287880
+   27287883
+ .
+   OpenSSL License
+   ---------------
+ .
+ /* ====================================================================
+  * Copyright (c) 1998-2011 The OpenSSL Project.  All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions
+  * are met:
+  *
+  * 1. Redistributions of source code must retain the above copyright
+  *    notice, this list of conditions and the following disclaimer.
+  *
+  * 2. Redistributions in binary form must reproduce the above copyright
+  *    notice, this list of conditions and the following disclaimer in
+  *    the documentation and/or other materials provided with the
+  *    distribution.
+  *
+  * 3. All advertising materials mentioning features or use of this
+  *    software must display the following acknowledgment:
+  *    "This product includes software developed by the OpenSSL Project
+  *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+  *
+  * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+  *    endorse or promote products derived from this software without
+  *    prior written permission. For written permission, please contact
+  *    openssl-core@openssl.org.
+  *
+  * 5. Products derived from this software may not be called "OpenSSL"
+  *    nor may "OpenSSL" appear in their names without prior written
+  *    permission of the OpenSSL Project.
+  *
+  * 6. Redistributions of any form whatsoever must retain the following
+  *    acknowledgment:
+  *    "This product includes software developed by the OpenSSL Project
+  *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+  * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+  * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+  * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+  * OF THE POSSIBILITY OF SUCH DAMAGE.
+  * ====================================================================
+  *
+  * This product includes cryptographic software written by Eric Young
+  * (eay@cryptsoft.com).  This product includes software written by Tim
+  * Hudson (tjh@cryptsoft.com).
+  *
+  */
+ .
+ Original SSLeay License
+ -----------------------
+ .
+ /* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+  * All rights reserved.
+  *
+  * This package is an SSL implementation written
+  * by Eric Young (eay@cryptsoft.com).
+  * The implementation was written so as to conform with Netscapes SSL.
+  *
+  * This library is free for commercial and non-commercial use as long as
+  * the following conditions are aheared to.  The following conditions
+  * apply to all code found in this distribution, be it the RC4, RSA,
+  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+  * included with this distribution is covered by the same copyright terms
+  * except that the holder is Tim Hudson (tjh@cryptsoft.com).
+  *
+  * Copyright remains Eric Young's, and as such any Copyright notices in
+  * the code are not to be removed.
+  * If this package is used in a product, Eric Young should be given attribution
+  * as the author of the parts of the library used.
+  * This can be in the form of a textual message at program startup or
+  * in documentation (online or textual) provided with the package.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions
+  * are met:
+  * 1. Redistributions of source code must retain the copyright
+  *    notice, this list of conditions and the following disclaimer.
+  * 2. Redistributions in binary form must reproduce the above copyright
+  *    notice, this list of conditions and the following disclaimer in the
+  *    documentation and/or other materials provided with the distribution.
+  * 3. All advertising materials mentioning features or use of this software
+  *    must display the following acknowledgement:
+  *    "This product includes cryptographic software written by
+  *     Eric Young (eay@cryptsoft.com)"
+  *    The word 'cryptographic' can be left out if the rouines from the library
+  *    being used are not cryptographic related :-).
+  * 4. If you include any Windows specific code (or a derivative thereof) from
+  *    the apps directory (application code) you must include an acknowledgement:
+  *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+  *
+  * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+  * SUCH DAMAGE.
+  *
+  * The licence and distribution terms for any publically available version or
+  * derivative of this code cannot be changed.  i.e. this code cannot simply be
+  * copied and put under another distribution licence
+  * [including the GNU Public Licence.]
+  */
+ .
+ ISC license used for completely new code in BoringSSL:
+ .
+ /* Copyright (c) 2015, Google Inc.
+  *
+  * Permission to use, copy, modify, and/or distribute this software for any
+  * purpose with or without fee is hereby granted, provided that the above
+  * copyright notice and this permission notice appear in all copies.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+  * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+  * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+ .
+ The code in third_party/fiat carries the MIT license:
+ .
+ Copyright (c) 2015-2016 the fiat-crypto authors (see
+ https://github.com/mit-plv/fiat-crypto/blob/master/AUTHORS).
+ .
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
 
 License: BOSL-1+ with Zcash exception
  This package ("Original Work") is licensed under the terms of the Bootstrap Open

--- a/src/rust/include/tracing.h
+++ b/src/rust/include/tracing.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Jack Grigg
+// Copyright (c) 2020-2021 The Zcash developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 


### PR DESCRIPTION
This solves some syntax issues and adds missing copyright entries, including entries for Rust dependencies that cannot be Expat/MIT-licensed.