### PR TITLE
Postpone native_clang and libcxx 14.0.0

### DIFF
--- a/qa/zcash/postponed-updates.txt
+++ b/qa/zcash/postponed-updates.txt
@@ -18,6 +18,8 @@ native_ccache 4.5.1 2022-05-01
 native_ccache 4.6 2022-05-01
 
 # Clang is currently pinned to LLVM 13
+native_clang 14.0.0 2022-05-01
+libcxx 14.0.0 2022-05-01
 
 # Rust is currently pinned to 1.59.0
 

--- a/qa/zcash/updatecheck.py
+++ b/qa/zcash/updatecheck.py
@@ -199,6 +199,8 @@ class GithubTagReleaseLister:
         url = "https://api.github.com/repos/" + safe(self.org) + "/" + safe(self.repo) + "/git/refs/tags"
         r = requests.get(url, auth=requests.auth.HTTPBasicAuth(self.token.user(), self.token.password()))
         if r.status_code != 200:
+            print("API request failed (error %d)" % (r.status_code,), file=sys.stderr)
+            print(r.text, file=sys.stderr)
             raise RuntimeError("Request to GitHub tag API failed.")
         json = r.json()
         return list(map(lambda t: t["ref"].split("/")[-1], json))
@@ -208,6 +210,8 @@ class BerkeleyDbReleaseLister:
         url = "https://www.oracle.com/database/technologies/related/berkeleydb-downloads.html"
         r = requests.get(url)
         if r.status_code != 200:
+            print("API request failed (error %d)" % (r.status_code,), file=sys.stderr)
+            print(r.text, file=sys.stderr)
             raise RuntimeError("Request to Berkeley DB download directory failed.")
         page = r.text
 


### PR DESCRIPTION
I have verified that the release notes at:

* https://releases.llvm.org/14.0.0/tools/clang/docs/ReleaseNotes.html
* https://releases.llvm.org/14.0.0/projects/libcxx/docs/ReleaseNotes.html

do not mention any security-relevant bugs, or correctness bugs on platforms we support, that were fixed in the clang or libcxx 14.0.0 release cycles.

This PR also improves error reporting for failed API requests in the `qa/zcash/updatecheck.py` script.