### PR TITLE
wallet: Persist Orchard note positions with the witness tree

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -75,6 +75,7 @@ BASE_SCRIPTS= [
     'wallet_doublespend.py',
     'wallet_import_export.py',
     'wallet_isfromme.py',
+    'wallet_orchard_change.py',
     'wallet_orchard_persistence.py',
     'wallet_nullifiers.py',
     'wallet_sapling.py',

--- a/qa/rpc-tests/wallet_orchard_change.py
+++ b/qa/rpc-tests/wallet_orchard_change.py
@@ -96,7 +96,7 @@ class WalletOrchardChangeTest(BitcoinTestFramework):
         wait_bitcoinds()
         self.setup_network()
 
-        # The node have unaltered balances.
+        # The nodes have unaltered balances.
         assert_equal(
             {'pools': {'orchard': {'valueZat': 9_0000_0000}}, 'minimum_confirmations': 1},
             self.nodes[0].z_getbalanceforaccount(acct0),

--- a/qa/rpc-tests/wallet_orchard_change.py
+++ b/qa/rpc-tests/wallet_orchard_change.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    NU5_BRANCH_ID,
+    assert_equal,
+    get_coinbase_address,
+    nuparams,
+    start_nodes,
+    stop_nodes,
+    wait_and_assert_operationid_status,
+    wait_bitcoinds,
+)
+
+# Test wallet behaviour with the Orchard protocol
+class WalletOrchardChangeTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, [[
+            nuparams(NU5_BRANCH_ID, 205),
+            '-regtestwalletsetbestchaineveryblock',
+        ]] * self.num_nodes)
+
+    def check_has_output(self, node, tx, expected):
+        tx_outputs = self.nodes[0].z_viewtransaction(tx)['outputs']
+        tx_outputs = [{x: y for (x, y) in output.items() if x in expected} for output in tx_outputs]
+        found = False
+        for output in tx_outputs:
+            if output == expected:
+                found = True
+                break
+        assert found, 'Node %s is missing output %s in tx %s (actual: %s)' % (node, expected, tx, tx_outputs)
+
+    def run_test(self):
+        # Sanity-check the test harness.
+        assert_equal(self.nodes[0].getblockcount(), 200)
+
+        # Create an account with funds in the Sapling receiver.
+        acct0 = self.nodes[0].z_getnewaccount()['account']
+        ua0 = self.nodes[0].z_getaddressforaccount(acct0, ['sapling', 'orchard'])['address']
+
+        recipients = [{"address": ua0, "amount": 10}]
+        myopid = self.nodes[0].z_sendmany(get_coinbase_address(self.nodes[0]), recipients, 1, 0, 'AllowRevealedSenders')
+        wait_and_assert_operationid_status(self.nodes[0], myopid)
+
+        # Mine the tx & activate NU5.
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        assert_equal(
+            {'pools': {'sapling': {'valueZat': 10_0000_0000}}, 'minimum_confirmations': 1},
+            self.nodes[0].z_getbalanceforaccount(acct0),
+        )
+
+        # We want to generate an Orchard change note on node 0. We do this by
+        # sending funds to an Orchard-only UA on node 1.
+        acct1 = self.nodes[1].z_getnewaccount()['account']
+        ua1 = self.nodes[1].z_getaddressforaccount(acct1, ['orchard'])['address']
+
+        recipients = [{"address": ua1, "amount": 1}]
+        myopid = self.nodes[0].z_sendmany(ua0, recipients, 1, 0)
+        source_tx = wait_and_assert_operationid_status(self.nodes[0], myopid)
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # The nodes have the expected split of funds.
+        assert_equal(
+            {'pools': {'orchard': {'valueZat': 9_0000_0000}}, 'minimum_confirmations': 1},
+            self.nodes[0].z_getbalanceforaccount(acct0),
+        )
+        assert_equal(
+            {'pools': {'orchard': {'valueZat': 1_0000_0000}}, 'minimum_confirmations': 1},
+            self.nodes[1].z_getbalanceforaccount(acct1),
+        )
+
+        # The Orchard note for node 0 is a change note.
+        self.check_has_output(0, source_tx, {
+            'pool': 'orchard',
+            'outgoing': False,
+            'walletInternal': True,
+            'value': 9,
+            'valueZat': 9_0000_0000,
+        })
+
+        # Shut down the nodes, and restart so that we can check wallet load
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+        self.setup_network()
+
+        # The node have unaltered balances.
+        assert_equal(
+            {'pools': {'orchard': {'valueZat': 9_0000_0000}}, 'minimum_confirmations': 1},
+            self.nodes[0].z_getbalanceforaccount(acct0),
+        )
+        assert_equal(
+            {'pools': {'orchard': {'valueZat': 1_0000_0000}}, 'minimum_confirmations': 1},
+            self.nodes[1].z_getbalanceforaccount(acct1),
+        )
+
+        # Send another Orchard transaction from node 0 to node 1.
+        myopid = self.nodes[0].z_sendmany(ua0, recipients, 1, 0)
+        wait_and_assert_operationid_status(self.nodes[0], myopid)
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        assert_equal(
+            {'pools': {'orchard': {'valueZat': 8_0000_0000}}, 'minimum_confirmations': 1},
+            self.nodes[0].z_getbalanceforaccount(acct0),
+        )
+
+if __name__ == '__main__':
+    WalletOrchardChangeTest().main()

--- a/src/rust/include/rust/orchard/wallet.h
+++ b/src/rust/include/rust/orchard/wallet.h
@@ -132,13 +132,9 @@ bool orchard_wallet_add_notes_from_bundle(
  *
  * The provided bundle must be a component of the transaction from which
  * `txid` was derived.
- *
- * The value the `blockHeight` pointer points to be set to the height at which the
- * transaction was mined, or `nullptr` if the transaction is not in the main chain.
  */
 bool orchard_wallet_load_bundle(
         OrchardWalletPtr* wallet,
-        const uint32_t* blockHeight,
         const unsigned char txid[32],
         const OrchardBundlePtr* bundle,
         const RawOrchardActionIVK* actionIvks,

--- a/src/rust/src/wallet.rs
+++ b/src/rust/src/wallet.rs
@@ -69,13 +69,13 @@ pub struct TxNotes {
     decrypted_notes: BTreeMap<usize, DecryptedNote>,
 }
 
-/// A data structure chain position information for a single transaction.
+/// A data structure holding chain position information for a single transaction.
 #[derive(Clone, Debug)]
 struct NotePositions {
     /// The height of the block containing the transaction.
     tx_height: BlockHeight,
     /// A map from the index of an Orchard action tracked by this wallet, to the position
-    /// of the note's commitment within the global Merkle tree.
+    /// of the output note's commitment within the global Merkle tree.
     note_positions: BTreeMap<usize, Position>,
 }
 
@@ -142,7 +142,7 @@ pub struct Wallet {
     /// been decrypted with the IVKs known to this wallet.
     wallet_received_notes: BTreeMap<TxId, TxNotes>,
     /// The in-memory index from txid to note positions from the associated transaction.
-    /// This map should always be a subset of `wallet_received_notes`.
+    /// This map should always have a subset of the keys in `wallet_received_notes`.
     wallet_note_positions: BTreeMap<TxId, NotePositions>,
     /// The in-memory index from nullifier to the outpoint of the note from which that
     /// nullifier was derived.
@@ -533,7 +533,7 @@ impl Wallet {
         });
 
         // update the block height recorded for the transaction
-        let mut my_notes_for_tx = self.wallet_received_notes.get_mut(txid);
+        let my_notes_for_tx = self.wallet_received_notes.get(txid);
         if my_notes_for_tx.is_some() {
             self.wallet_note_positions.insert(
                 *txid,
@@ -555,8 +555,8 @@ impl Wallet {
 
             // for notes that are ours, witness the current state of the tree
             if my_notes_for_tx
-                .as_mut()
-                .and_then(|n| n.decrypted_notes.get_mut(&action_idx))
+                .as_ref()
+                .and_then(|n| n.decrypted_notes.get(&action_idx))
                 .is_some()
             {
                 let (pos, cmx) = self.witness_tree.witness().expect("tree is not empty");

--- a/src/wallet/orchard.h
+++ b/src/wallet/orchard.h
@@ -485,6 +485,10 @@ public:
 
     template<typename Stream>
     void Serialize(Stream& s) const {
+        int nVersion = s.GetVersion();
+        if (!(s.GetType() & SER_GETHASH)) {
+            ::Serialize(s, nVersion);
+        }
         RustStream rs(s);
         if (!orchard_wallet_write_note_commitment_tree(
                     wallet.inner.get(),
@@ -503,6 +507,10 @@ public:
 
     template<typename Stream>
     void Unserialize(Stream& s) {
+        int nVersion = s.GetVersion();
+        if (!(s.GetType() & SER_GETHASH)) {
+            ::Unserialize(s, nVersion);
+        }
         RustStream rs(s);
         if (!orchard_wallet_load_note_commitment_tree(
                     wallet.inner.get(),

--- a/src/wallet/orchard.h
+++ b/src/wallet/orchard.h
@@ -288,7 +288,6 @@ public:
      * notes to the wallet.
      */
     bool LoadWalletTx(
-            const std::optional<int> nBlockHeight,
             const CTransaction& tx,
             const OrchardWalletTxMeta& txMeta
             ) {
@@ -296,10 +295,8 @@ public:
         for (const auto& [action_idx, ivk] : txMeta.mapOrchardActionData) {
             rawHints.push_back({ action_idx, ivk.inner.get() });
         }
-        uint32_t blockHeight = nBlockHeight.has_value() ? (uint32_t) nBlockHeight.value() : 0;
         return orchard_wallet_load_bundle(
                 inner.get(),
-                nBlockHeight.has_value() ? &blockHeight : nullptr,
                 tx.GetHash().begin(),
                 tx.GetOrchardBundle().inner.get(),
                 rawHints.data(),

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1402,8 +1402,9 @@ void CWallet::ChainTipAdded(const CBlockIndex *pindex,
                             SaplingMerkleTree saplingTree,
                             bool performOrchardWalletUpdates)
 {
+    const auto chainParams = Params();
     IncrementNoteWitnesses(
-            Params().GetConsensus(),
+            chainParams.GetConsensus(),
             pindex, pblock,
             sproutTree, saplingTree, performOrchardWalletUpdates);
     UpdateSaplingNullifierNoteMapForBlock(pblock);
@@ -1417,7 +1418,9 @@ void CWallet::ChainTipAdded(const CBlockIndex *pindex,
         nLastSetChain = nNow;
     }
     if (++nSetChainUpdates >= WITNESS_WRITE_UPDATES ||
-            nLastSetChain + (int64_t)WITNESS_WRITE_INTERVAL * 1000000 < nNow) {
+        nLastSetChain + (int64_t)WITNESS_WRITE_INTERVAL * 1000000 < nNow ||
+        (chainParams.NetworkIDString() == CBaseChainParams::REGTEST && mapArgs.count("-regtestwalletsetbestchaineveryblock")))
+    {
         nLastSetChain = nNow;
         nSetChainUpdates = 0;
         CBlockLocator loc;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1040,7 +1040,6 @@ void CWallet::LoadRecipientMapping(const uint256& txid, const RecipientMapping& 
 bool CWallet::LoadCaches()
 {
     AssertLockHeld(cs_wallet);
-    AssertLockHeld(cs_main);
 
     auto seed = GetMnemonicSeed();
 
@@ -1160,12 +1159,7 @@ bool CWallet::LoadCaches()
     // Restore decrypted Orchard notes.
     for (const auto& [_, walletTx] : mapWallet) {
         if (!walletTx.orchardTxMeta.empty()) {
-            const CBlockIndex* pTxIndex;
-            std::optional<int> blockHeight;
-            if (walletTx.GetDepthInMainChain(pTxIndex) > 0) {
-                blockHeight = pTxIndex->nHeight;
-            }
-            if (!orchardWallet.LoadWalletTx(blockHeight, walletTx, walletTx.orchardTxMeta)) {
+            if (!orchardWallet.LoadWalletTx(walletTx, walletTx.orchardTxMeta)) {
                 LogPrintf("%s: Error: Failed to decrypt previously decrypted notes for txid %s.\n",
                     __func__, walletTx.GetHash().GetHex());
                 return false;


### PR DESCRIPTION
We rewrite the entire witness tree each time we update the wallet's best chain state, and we need the note positions to always be consistent with the tree state (otherwise mined notes become unspendable after the node restarts).

Closes #5777.
Closes #5784.