### PR TITLE
Update incrementalmerkletree version to fix GC bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,8 +855,7 @@ dependencies = [
 [[package]]
 name = "incrementalmerkletree"
 version = "0.3.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad6be282c89afc05aebe4801b0d5f9d6b7c556a8f398e447f4b26ea56a6b45e"
+source = "git+https://github.com/nuttycom/incrementalmerkletree?rev=fc1d1ab9fc988c8c16a6713f80c1809dfbb697d0#fc1d1ab9fc988c8c16a6713f80c1809dfbb697d0"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ codegen-units = 1
 
 [patch.crates-io]
 hdwallet = { git = "https://github.com/nuttycom/hdwallet", rev = "576683b9f2865f1118c309017ff36e01f84420c9" }
+incrementalmerkletree = { git = "https://github.com/nuttycom/incrementalmerkletree", rev = "fc1d1ab9fc988c8c16a6713f80c1809dfbb697d0" }
 zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }
 zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }
 zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }


### PR DESCRIPTION
This also modifies the serialized form of the wallet's incremental
merkle tree. This will require a complete reindex for testnet wallets
built from the in-progress master branch. This will be necessary 
anyway after the 4.7.0 testnet reset.
