### PR TITLE
Fix a bug in initialization of the Orchard wallet after NU5 activation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,7 +855,7 @@ dependencies = [
 [[package]]
 name = "incrementalmerkletree"
 version = "0.3.0-beta.1"
-source = "git+https://github.com/nuttycom/incrementalmerkletree?rev=027a98e53ad59699662d258ac22cd2095ae02aea#027a98e53ad59699662d258ac22cd2095ae02aea"
+source = "git+https://github.com/nuttycom/incrementalmerkletree?rev=f19cf9c381d70547d170216f844b62c86befb6c3#f19cf9c381d70547d170216f844b62c86befb6c3"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ codegen-units = 1
 
 [patch.crates-io]
 hdwallet = { git = "https://github.com/nuttycom/hdwallet", rev = "576683b9f2865f1118c309017ff36e01f84420c9" }
-incrementalmerkletree = { git = "https://github.com/nuttycom/incrementalmerkletree", rev = "027a98e53ad59699662d258ac22cd2095ae02aea" }
+incrementalmerkletree = { git = "https://github.com/nuttycom/incrementalmerkletree", rev = "f19cf9c381d70547d170216f844b62c86befb6c3" }
 zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }
 zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }
 zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -76,6 +76,7 @@ BASE_SCRIPTS= [
     'wallet_import_export.py',
     'wallet_isfromme.py',
     'wallet_orchard_change.py',
+    'wallet_orchard_init.py',
     'wallet_orchard_persistence.py',
     'wallet_nullifiers.py',
     'wallet_sapling.py',

--- a/qa/rpc-tests/wallet_orchard_init.py
+++ b/qa/rpc-tests/wallet_orchard_init.py
@@ -6,6 +6,8 @@
 import os
 import os.path
 
+from decimal import Decimal
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     NU5_BRANCH_ID,
@@ -78,6 +80,15 @@ class OrchardWalletInitTest(BitcoinTestFramework):
                 {'pools': {'orchard': {'valueZat': 1_0000_0000}}, 'minimum_confirmations': 1},
                 self.nodes[0].z_getbalanceforaccount(acct0))
 
+        # Split the network. We'll advance the state of nodes 0/1 so that after 
+        # we re-join the network, we need to roll back more than one block after
+        # the wallet is restored, into a chain state that the wallet never observed.
+        self.split_network()
+
+        self.sync_all()
+        self.nodes[0].generate(2)
+        self.sync_all()
+
         # Shut down the network and delete node 0's wallet
         stop_nodes(self.nodes)
         wait_bitcoinds()
@@ -85,8 +96,8 @@ class OrchardWalletInitTest(BitcoinTestFramework):
         tmpdir = self.options.tmpdir
         os.remove(os.path.join(tmpdir, "node0", "regtest", "wallet.dat"))
 
-        # Restart the network split; the split here is note necessary to reproduce the
-        # error but it is sufficient, and we will later use the split to check the
+        # Restart the network, still split; the split here is note necessary to reproduce
+        # the error but it is sufficient, and we will later use the split to check the
         # corresponding rewind.
         self.setup_network(True)
 
@@ -103,7 +114,7 @@ class OrchardWalletInitTest(BitcoinTestFramework):
         # the state of the global note commitment tree.
         recipients = [{"address": ua0new, "amount": 1}]
         myopid = self.nodes[1].z_sendmany(ua1, recipients, 1, 0)
-        wait_and_assert_operationid_status(self.nodes[1], myopid)
+        rollback_tx = wait_and_assert_operationid_status(self.nodes[1], myopid)
 
         self.sync_all()
         self.nodes[0].generate(1)
@@ -112,6 +123,39 @@ class OrchardWalletInitTest(BitcoinTestFramework):
         assert_equal(
                 {'pools': {'orchard': {'valueZat': 1_0000_0000}}, 'minimum_confirmations': 1},
                 self.nodes[0].z_getbalanceforaccount(acct0new))
+
+        # Node 2 has no progress since the network was first split, so this should roll
+        # everything back to the original fork point.
+        self.nodes[2].generate(10)
+
+        # Re-join the network
+        self.join_network()
+
+        assert_equal(set([rollback_tx]), set(self.nodes[1].getrawmempool()))
+
+        # Resend un-mined transactions and sync the network
+        self.nodes[1].resendwallettransactions()
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        assert_equal(
+                {'pools': {'orchard': {'valueZat': 1_0000_0000}}, 'minimum_confirmations': 1},
+                self.nodes[0].z_getbalanceforaccount(acct0new))
+
+        # Spend from the note that was just received
+        recipients = [{"address": ua1, "amount": Decimal('0.3')}]
+        myopid = self.nodes[0].z_sendmany(ua0new, recipients, 1, 0)
+        wait_and_assert_operationid_status(self.nodes[0], myopid)
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        assert_equal(
+                {'pools': {'orchard': {'valueZat': 8_3000_0000}}, 'minimum_confirmations': 1},
+                self.nodes[1].z_getbalanceforaccount(acct1))
+
 
 if __name__ == '__main__':
     OrchardWalletInitTest().main()

--- a/qa/rpc-tests/wallet_orchard_init.py
+++ b/qa/rpc-tests/wallet_orchard_init.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+import os
+import os.path
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    NU5_BRANCH_ID,
+    assert_equal,
+    get_coinbase_address,
+    nuparams,
+    start_nodes,
+    stop_nodes,
+    wait_bitcoinds,
+    wait_and_assert_operationid_status,
+)
+
+# Test wallet behaviour with the Orchard protocol
+class OrchardWalletInitTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, [[
+            nuparams(NU5_BRANCH_ID, 205),
+            '-regtestwalletsetbestchaineveryblock'
+        ]] * self.num_nodes)
+
+    def run_test(self):
+        # Sanity-check the test harness
+        assert_equal(self.nodes[0].getblockcount(), 200)
+        
+        # Get a new Orchard account on node 0
+        acct0 = self.nodes[0].z_getnewaccount()['account']
+        ua0 = self.nodes[0].z_getaddressforaccount(acct0, ['orchard'])['address']
+
+        # Activate NU5
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        # Get a recipient address
+        acct1 = self.nodes[1].z_getnewaccount()['account']
+        ua1 = self.nodes[1].z_getaddressforaccount(acct1, ['orchard'])['address']
+
+        # Send a transaction to node 1 so that it has an Orchard note to spend.
+        recipients = [{"address": ua1, "amount": 10}]
+        myopid = self.nodes[0].z_sendmany(get_coinbase_address(self.nodes[0]), recipients, 1, 0, 'AllowRevealedSenders')
+        wait_and_assert_operationid_status(self.nodes[0], myopid)
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # Check the value sent to ua1 was received
+        assert_equal(
+                {'pools': {'orchard': {'valueZat': 10_0000_0000}}, 'minimum_confirmations': 1},
+                self.nodes[1].z_getbalanceforaccount(acct1))
+
+        # Create an Orchard spend, so that the note commitment tree root gets altered.
+        recipients = [{"address": ua0, "amount": 1}]
+        myopid = self.nodes[1].z_sendmany(ua1, recipients, 1, 0)
+        wait_and_assert_operationid_status(self.nodes[1], myopid)
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # Verify the balance on both nodes
+        assert_equal(
+                {'pools': {'orchard': {'valueZat': 9_0000_0000}}, 'minimum_confirmations': 1},
+                self.nodes[1].z_getbalanceforaccount(acct1))
+
+        assert_equal(
+                {'pools': {'orchard': {'valueZat': 1_0000_0000}}, 'minimum_confirmations': 1},
+                self.nodes[0].z_getbalanceforaccount(acct0))
+
+        # Shut down the network and delete node 0's wallet
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+        tmpdir = self.options.tmpdir
+        os.remove(os.path.join(tmpdir, "node0", "regtest", "wallet.dat"))
+
+        # Restart the network split; the split here is note necessary to reproduce the
+        # error but it is sufficient, and we will later use the split to check the
+        # corresponding rewind.
+        self.setup_network(True)
+
+        assert_equal(
+                {'pools': {'orchard': {'valueZat': 9_0000_0000}}, 'minimum_confirmations': 1},
+                self.nodes[1].z_getbalanceforaccount(acct1))
+
+        # Get a new account with an Orchard UA on node 0
+        acct0new = self.nodes[0].z_getnewaccount()['account']
+        ua0new = self.nodes[0].z_getaddressforaccount(acct0, ['orchard'])['address']
+
+        # Send a transaction to the Orchard account. When we mine this transaction,
+        # the bug causes the state of note commitment tree in the wallet to not match
+        # the state of the global note commitment tree.
+        recipients = [{"address": ua0new, "amount": 1}]
+        myopid = self.nodes[1].z_sendmany(ua1, recipients, 1, 0)
+        wait_and_assert_operationid_status(self.nodes[1], myopid)
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        assert_equal(
+                {'pools': {'orchard': {'valueZat': 1_0000_0000}}, 'minimum_confirmations': 1},
+                self.nodes[0].z_getbalanceforaccount(acct0new))
+
+if __name__ == '__main__':
+    OrchardWalletInitTest().main()
+

--- a/src/rust/include/rust/orchard/wallet.h
+++ b/src/rust/include/rust/orchard/wallet.h
@@ -5,6 +5,7 @@
 #ifndef ZCASH_RUST_INCLUDE_RUST_ORCHARD_WALLET_H
 #define ZCASH_RUST_INCLUDE_RUST_ORCHARD_WALLET_H
 
+#include "rust/orchard/incremental_merkle_tree.h"
 #include "rust/orchard/keys.h"
 #include "rust/builder.h"
 
@@ -65,18 +66,26 @@ bool orchard_wallet_get_last_checkpoint(
  *
  * The `blockHeight` argument provides the height to which the witness tree should be
  * rewound, such that after the rewind this height corresponds to the latest block
- * appended to the tree. The number of blocks that were removed from the witness
- * tree in the rewind process is returned via `blocksRewoundRet`.
+ * appended to the tree.
  *
- * Returns `true` if the rewind is successful, in which case the number of blocks that were
- * removed from the witness tree in the rewind process is returned via `blocksRewoundRet`;
- * this returns `false` and leaves `blocksRewoundRet` unmodified.
+ * Returns `true` if the rewind is successful, in which case `resultHeight` will contain
+ * the height to which the tree has been rewound; otherwise, this returns `false` and
+ * leaves `resultHeight` unmodified.
  */
 bool orchard_wallet_rewind(
         OrchardWalletPtr* wallet,
         uint32_t blockHeight,
-        uint32_t* blocksRewoundRet
+        uint32_t* resultHeight
         );
+
+/**
+ * Initialize the wallet's note commitment tree to the empty tree starting from the
+ * specified Merkle frontier. This will return `false` and leave the wallet unmodified if
+ * it would cause any checkpoint or witness state to be invalidated.
+ */
+bool orchard_wallet_init_from_frontier(
+        OrchardWalletPtr* wallet,
+        const OrchardMerkleFrontierPtr* frontier);
 
 /**
  * A C struct used to transfer action_idx/IVK pairs back from Rust across the FFI

--- a/src/rust/src/wallet.rs
+++ b/src/rust/src/wallet.rs
@@ -1,5 +1,5 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use incrementalmerkletree::{bridgetree::BridgeTree, Frontier, Position, Tree};
+use incrementalmerkletree::{bridgetree, bridgetree::BridgeTree, Frontier, Position, Tree};
 use libc::c_uchar;
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
@@ -266,39 +266,37 @@ impl Wallet {
         self.last_checkpoint
     }
 
-    /// Rewinds the note commitment tree to the given height, removes notes and
-    /// spentness information for transactions mined in the removed blocks, and returns
-    /// the number of blocks by which the tree has been rewound if successful. Returns  
-    /// `RewindError` if not enough checkpoints exist to execute the full rewind
-    /// requested. If the requested height is greater than or equal to the height of the
-    /// latest checkpoint, this returns `Ok(0)` and leaves the wallet unmodified.
-    pub fn rewind(&mut self, to_height: BlockHeight) -> Result<u32, RewindError> {
+    /// Rewinds the note commitment tree to the given height, removes notes and spentness
+    /// information for transactions mined in the removed blocks, and returns the height to which
+    /// the tree has been rewound if successful. Returns  `RewindError` if not enough checkpoints
+    /// exist to execute the full rewind requested and the wallet has witness information that
+    /// would be invalidated by the rewind. If the requested height is greater than or equal to the
+    /// height of the latest checkpoint, this returns a successful result containing the height of
+    /// the last checkpoint.
+    ///
+    /// In the case that no checkpoints exist but the note commitment tree also records no witness
+    /// information, we allow the wallet to continue to rewind, under the assumption that the state
+    /// of the note commitment tree will be overwritten prior to the next append.
+    pub fn rewind(&mut self, to_height: BlockHeight) -> Result<BlockHeight, RewindError> {
         if let Some(checkpoint_height) = self.last_checkpoint {
             if to_height >= checkpoint_height {
-                return Ok(0);
+                return Ok(checkpoint_height);
             }
 
             let blocks_to_rewind = <u32>::from(checkpoint_height) - <u32>::from(to_height);
-
-            // if the rewind length exceeds the number of checkpoints we have stored,
-            // return failure.
             let checkpoint_count = self.witness_tree.checkpoints().len();
-            if blocks_to_rewind as usize > checkpoint_count {
-                return Err(RewindError::InsufficientCheckpoints(checkpoint_count));
-            }
-
             for _ in 0..blocks_to_rewind {
-                // we've already checked that we have enough checkpoints to fully
-                // rewind by the requested amount.
-                assert!(self.witness_tree.rewind());
+                // If the rewind fails, we have no more checkpoints. This is fine in the
+                // case that we have a recently-initialized tree, so long as we have no
+                // witnessed indices. In the case that we have any witnessed notes, we
+                // have hit the maximum rewind limit, and this is an error.
+                if !self.witness_tree.rewind() {
+                    assert!(self.witness_tree.checkpoints().is_empty());
+                    if !self.witness_tree.witnessed_indices().is_empty() {
+                        return Err(RewindError::InsufficientCheckpoints(checkpoint_count));
+                    }
+                }
             }
-
-            // reset our last observed height to ensure that notes added in the future are
-            // from a new block
-            let last_observed = LastObserved {
-                block_height: checkpoint_height - blocks_to_rewind,
-                block_tx_idx: None,
-            };
 
             // retain notes that correspond to transactions that are not "un-mined" after
             // the rewind
@@ -306,7 +304,7 @@ impl Wallet {
                 .wallet_note_positions
                 .iter()
                 .filter_map(|(txid, n)| {
-                    if n.tx_height <= last_observed.block_height {
+                    if n.tx_height <= to_height {
                         Some(*txid)
                     } else {
                         None
@@ -315,21 +313,39 @@ impl Wallet {
                 .collect();
 
             self.mined_notes.retain(|_, v| to_retain.contains(&v.txid));
+
             // nullifier and received note data are retained, because these values are stable
             // once we've observed a note for the first time. The block height at which we
             // observed the note is removed along with the note positions, because the
             // transaction will no longer have been observed as having been mined.
             self.wallet_note_positions
                 .retain(|txid, _| to_retain.contains(txid));
-            self.last_observed = Some(last_observed);
+
+            // reset our last observed height to ensure that notes added in the future are
+            // from a new block
+            self.last_observed = Some(LastObserved {
+                block_height: to_height,
+                block_tx_idx: None,
+            });
+
             self.last_checkpoint = if checkpoint_count > blocks_to_rewind as usize {
-                Some(checkpoint_height - blocks_to_rewind)
+                Some(to_height)
             } else {
-                // checkpoint_count == blocks_to_rewind
+                // checkpoint_count <= blocks_to_rewind
                 None
             };
 
-            Ok(blocks_to_rewind)
+            Ok(to_height)
+        } else if self.witness_tree.witnessed_indices().is_empty() {
+            // If we have no witnessed notes, it's okay to keep "rewinding" even though
+            // we have no checkpoints. We then allow last_observed to assume the height
+            // to which we have reset the tree state.
+            self.last_observed = Some(LastObserved {
+                block_height: to_height,
+                block_tx_idx: None,
+            });
+
+            Ok(to_height)
         } else {
             Err(RewindError::InsufficientCheckpoints(0))
         }
@@ -728,14 +744,14 @@ pub extern "C" fn orchard_wallet_get_last_checkpoint(
 pub extern "C" fn orchard_wallet_rewind(
     wallet: *mut Wallet,
     to_height: BlockHeight,
-    blocks_rewound: *mut u32,
+    result_height: *mut BlockHeight,
 ) -> bool {
     let wallet = unsafe { wallet.as_mut() }.expect("Wallet pointer may not be null");
-    let blocks_rewound =
-        unsafe { blocks_rewound.as_mut() }.expect("Return value pointer may not be null.");
+    let result_height =
+        unsafe { result_height.as_mut() }.expect("Return value pointer may not be null.");
     match wallet.rewind(to_height) {
-        Ok(rewound) => {
-            *blocks_rewound = rewound;
+        Ok(result) => {
+            *result_height = result;
             true
         }
         Err(e) => {
@@ -1271,5 +1287,34 @@ pub extern "C" fn orchard_wallet_load_note_commitment_tree(
             );
             false
         }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn orchard_wallet_init_from_frontier(
+    wallet: *mut Wallet,
+    frontier: *const bridgetree::Frontier<MerkleHashOrchard, MERKLE_DEPTH>,
+) -> bool {
+    let wallet = unsafe { wallet.as_mut() }.expect("Wallet pointer may not be null.");
+    let frontier = unsafe { frontier.as_ref() }.expect("Wallet pointer may not be null.");
+
+    if wallet.witness_tree.checkpoints().is_empty()
+        && wallet.witness_tree.witnessed_indices().is_empty()
+    {
+        wallet.witness_tree = frontier.value().map_or_else(
+            || BridgeTree::new(MAX_CHECKPOINTS),
+            |nonempty_frontier| {
+                BridgeTree::from_frontier(MAX_CHECKPOINTS, nonempty_frontier.clone())
+            },
+        );
+        true
+    } else {
+        // if we have any checkpoints in the tree, or if we have any witnessed notes,
+        // don't allow reinitialization
+        error!(
+            "Invalid attempt to reinitialize note commitment tree: {} checkpoints present.",
+            wallet.witness_tree.checkpoints().len()
+        );
+        false
     }
 }

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -152,7 +152,19 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
                     assert(pcoinsTip->GetSaplingAnchorAt(SaplingMerkleTree::empty_root(), oldFrontiers.sapling));
                 }
 
-                // TODO: Add the Orchard frontier to oldFrontiers
+                // Get the Orchard Merkle frontier as of the start of this block.
+                // We can get this from the `hashFinalOrchardRoot` of the last block
+                // However, this is only reliable if the last block was on or after
+                // the Orchard activation height. Otherwise, the last anchor was the
+                // empty root.
+                if (chainParams.GetConsensus().NetworkUpgradeActive(
+                    pindex->pprev->nHeight, Consensus::UPGRADE_NU5)) {
+                    assert(pcoinsTip->GetOrchardAnchorAt(
+                        pindex->pprev->hashFinalOrchardRoot, oldFrontiers.orchard));
+                } else {
+                    assert(pcoinsTip->GetOrchardAnchorAt(
+                        OrchardMerkleFrontier::empty_root(), oldFrontiers.orchard));
+                }
 
                 blockStack.emplace_back(
                     pindex,

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -26,6 +26,7 @@ class uint256;
 struct MerkleFrontiers {
     SproutMerkleTree sprout;
     SaplingMerkleTree sapling;
+    OrchardMerkleFrontier orchard;
 };
 
 // These functions dispatch to one or all registered wallets

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -23,6 +23,11 @@ class CValidationInterface;
 class CValidationState;
 class uint256;
 
+struct MerkleFrontiers {
+    SproutMerkleTree sprout;
+    SaplingMerkleTree sapling;
+};
+
 // These functions dispatch to one or all registered wallets
 
 /** Register a wallet to receive updates from core */
@@ -37,7 +42,7 @@ protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindex) {}
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock, const int nHeight) {}
     virtual void EraseFromWallet(const uint256 &hash) {}
-    virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, std::optional<std::pair<SproutMerkleTree, SaplingMerkleTree>> added) {}
+    virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, std::optional<MerkleFrontiers> added) {}
     virtual void UpdatedTransaction(const uint256 &hash) {}
     virtual void Inventory(const uint256 &hash) {}
     virtual void ResendWalletTransactions(int64_t nBestBlockTime) {}
@@ -59,7 +64,7 @@ struct CMainSignals {
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming visible). */
     boost::signals2::signal<void (const uint256 &)> UpdatedTransaction;
     /** Notifies listeners of a change to the tip of the active block chain. */
-    boost::signals2::signal<void (const CBlockIndex *, const CBlock *, std::optional<std::pair<SproutMerkleTree, SaplingMerkleTree>>)> ChainTip;
+    boost::signals2::signal<void (const CBlockIndex *, const CBlock *, std::optional<MerkleFrontiers>)> ChainTip;
     /** Notifies listeners about an inventory item being seen on the network. */
     boost::signals2::signal<void (const uint256 &)> Inventory;
     /** Tells listeners to broadcast their data. */

--- a/src/wallet/orchard.h
+++ b/src/wallet/orchard.h
@@ -13,6 +13,7 @@
 #include "rust/orchard/keys.h"
 #include "rust/orchard/wallet.h"
 #include "zcash/address/orchard.hpp"
+#include "zcash/IncrementalMerkleTree.hpp"
 
 class OrchardWallet;
 class OrchardWalletNoteCommitmentTreeWriter;
@@ -219,6 +220,16 @@ public:
     }
 
     /**
+     * Overwrite the first bridge of the Orchard note commitment tree to have the
+     * provided frontier as its latest state. This will fail with an assertion error
+     * if any checkpoints exist in the tree.
+     */
+    void InitNoteCommitmentTree(const OrchardMerkleFrontier& frontier) {
+        assert(!GetLastCheckpointHeight().has_value());
+        assert(orchard_wallet_init_from_frontier(inner.get(), frontier.inner.get()));
+    }
+
+    /**
      * Checkpoint the note commitment tree. This returns `false` and leaves the note
      * commitment tree unmodified if the block height specified is not the successor
      * to the last block height checkpointed.
@@ -245,9 +256,9 @@ public:
      * previously identified as having been spent by transactions in the
      * latest block.
      */
-    bool Rewind(int nBlockHeight, uint32_t& blocksRewoundRet) {
+    bool Rewind(int nBlockHeight, uint32_t& uResultHeight) {
         assert(nBlockHeight >= 0);
-        return orchard_wallet_rewind(inner.get(), (uint32_t) nBlockHeight, &blocksRewoundRet);
+        return orchard_wallet_rewind(inner.get(), (uint32_t) nBlockHeight, &uResultHeight);
     }
 
     static void PushOrchardActionIVK(void* rec, RawOrchardActionIVK actionIVK) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2742,7 +2742,11 @@ void CWallet::DecrementNoteWitnesses(const Consensus::Params& consensus, const C
         assert(pindex->nHeight >= 1);
         assert(orchardWallet.Rewind(pindex->nHeight - 1, uResultHeight));
         assert(uResultHeight == pindex->nHeight - 1);
-        if (consensus.NetworkUpgradeActive(pindex->nHeight - 1, Consensus::UPGRADE_NU5)) {
+        // If we have no checkpoints after the rewind, then the latest anchor of the
+        // wallet's Orchard note commitment tree will be in an indeterminate state and it
+        // will be overwritten in the next `IncrementNoteWitnesses` call, so we can skip
+        // the check against `hashFinalOrchardRoot`.
+        if (orchardWallet.GetLastCheckpointHeight().has_value()) {
             assert(pindex->pprev->hashFinalOrchardRoot == orchardWallet.GetLatestAnchor());
         }
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1086,8 +1086,7 @@ protected:
             const Consensus::Params& consensus,
             const CBlockIndex* pindex,
             const CBlock* pblock,
-            SproutMerkleTree& sproutTree,
-            SaplingMerkleTree& saplingTree,
+            MerkleFrontiers& frontiers,
             bool performOrchardWalletUpdates
             );
     /**
@@ -1158,8 +1157,7 @@ private:
     void ChainTipAdded(
             const CBlockIndex *pindex,
             const CBlock *pblock,
-            SproutMerkleTree sproutTree,
-            SaplingMerkleTree saplingTree,
+            MerkleFrontiers frontiers,
             bool performOrchardWalletUpdates);
 
     /* Add a transparent secret key to the wallet. Internal use only. */
@@ -1806,7 +1804,7 @@ public:
     void ChainTip(
         const CBlockIndex *pindex,
         const CBlock *pblock,
-        std::optional<std::pair<SproutMerkleTree, SaplingMerkleTree>> added);
+        std::optional<MerkleFrontiers> added);
     void RunSaplingMigration(int blockHeight);
     void AddPendingSaplingMigrationTx(const CTransaction& tx);
     /** Saves witness caches and best block locator to disk. */

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -259,12 +259,16 @@ typedef libzcash::IncrementalMerkleTree<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, l
 typedef libzcash::IncrementalWitness<SAPLING_INCREMENTAL_MERKLE_TREE_DEPTH, libzcash::PedersenHash> SaplingWitness;
 typedef libzcash::IncrementalWitness<INCREMENTAL_MERKLE_TREE_DEPTH_TESTING, libzcash::PedersenHash> SaplingTestingWitness;
 
+class OrchardWallet;
+
 class OrchardMerkleFrontier
 {
 private:
     /// An incremental Sinsemilla tree; this pointer may never be null.
     /// Memory is allocated by Rust.
     std::unique_ptr<OrchardMerkleFrontierPtr, decltype(&orchard_merkle_frontier_free)> inner;
+
+    friend class OrchardWallet;
 public:
     OrchardMerkleFrontier() : inner(orchard_merkle_frontier_empty(), orchard_merkle_frontier_free) {}
 

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -335,8 +335,7 @@ double benchmark_increment_sprout_note_witnesses(size_t nTxs)
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
     CWallet wallet(Params());
-    SproutMerkleTree sproutTree;
-    SaplingMerkleTree saplingTree;
+    MerkleFrontiers frontiers;
 
     auto sproutSpendingKey = libzcash::SproutSpendingKey::random();
     wallet.AddSproutSpendingKey(sproutSpendingKey);
@@ -353,7 +352,7 @@ double benchmark_increment_sprout_note_witnesses(size_t nTxs)
     index1.nHeight = 1;
 
     // Increment to get transactions witnessed
-    wallet.ChainTip(&index1, &block1, std::make_pair(sproutTree, saplingTree));
+    wallet.ChainTip(&index1, &block1, frontiers);
 
     // Second block
     CBlock block2;
@@ -369,7 +368,7 @@ double benchmark_increment_sprout_note_witnesses(size_t nTxs)
 
     struct timeval tv_start;
     timer_start(tv_start);
-    wallet.ChainTip(&index2, &block2, std::make_pair(sproutTree, saplingTree));
+    wallet.ChainTip(&index2, &block2, frontiers);
     return timer_stop(tv_start);
 }
 
@@ -397,8 +396,7 @@ double benchmark_increment_sapling_note_witnesses(size_t nTxs)
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
     CWallet wallet(Params());
-    SproutMerkleTree sproutTree;
-    SaplingMerkleTree saplingTree;
+    MerkleFrontiers frontiers;
 
     auto saplingSpendingKey = GetTestMasterSaplingSpendingKey();
     wallet.AddSaplingSpendingKey(saplingSpendingKey);
@@ -415,7 +413,7 @@ double benchmark_increment_sapling_note_witnesses(size_t nTxs)
     index1.nHeight = 1;
 
     // Increment to get transactions witnessed
-    wallet.ChainTip(&index1, &block1, std::make_pair(sproutTree, saplingTree));
+    wallet.ChainTip(&index1, &block1, frontiers);
 
     // Second block
     CBlock block2;
@@ -431,7 +429,7 @@ double benchmark_increment_sapling_note_witnesses(size_t nTxs)
 
     struct timeval tv_start;
     timer_start(tv_start);
-    wallet.ChainTip(&index2, &block2, std::make_pair(sproutTree, saplingTree));
+    wallet.ChainTip(&index2, &block2, frontiers);
     return timer_stop(tv_start);
 }
 


### PR DESCRIPTION
When initializing a new Orchard wallet after NU5 activation, it is
not valid to start from the empty note commitment tree; instead,
the note commitment tree needs to be initialized from the state of
the global Orchard Merkle frontier.

In addition, this change necessitates a change to how rewinds work,
such that in a rollback scenario with a newly initialized wallet
that does not have sufficient checkpoints to fully satisfy a requested
rewind, the rewind is allowed to proceed so long as it does not
invalidate any persisted witness data.