### PR TITLE
test: Capture gtest log output and only print on error

### DIFF
--- a/src/gtest/main.cpp
+++ b/src/gtest/main.cpp
@@ -9,6 +9,8 @@
 #include <sodium.h>
 #include <tracing.h>
 
+#include <boost/filesystem.hpp>
+
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
 struct ECCryptoClosure
@@ -18,22 +20,72 @@ struct ECCryptoClosure
 
 ECCryptoClosure instance_of_eccryptoclosure;
 
+class LogGrabber : public ::testing::EmptyTestEventListener {
+    fs::path logPath;
+
+public:
+    LogGrabber(fs::path logPathIn) : logPath(logPathIn) {}
+
+    virtual void OnTestStart(const ::testing::TestInfo& test_info) {
+        // Test logs are written synchronously, so we can clear the log file to
+        // ensure that at the end of the test, the log lines are all related to
+        // the test itself.
+        std::ofstream logFile;
+        logFile.open(logPath.string(), std::ofstream::out | std::ofstream::trunc);
+        logFile.close();
+    }
+
+    virtual void OnTestEnd(const ::testing::TestInfo& test_info) {
+        // If the test failed, print the test logs.
+        auto result = test_info.result();
+        if (result && result->Failed()) {
+            std::cout << "\n--- Logs:";
+
+            std::ifstream logFile;
+            logFile.open(logPath.string(), std::ios::in | std::ios::ate);
+            ASSERT_TRUE(logFile.is_open());
+            logFile.seekg(0, logFile.beg);
+            std::string line;
+            while (logFile.good()) {
+                std::getline(logFile, line);
+                if (!line.empty()) {
+                    std::cout << "\n  " << line;
+                }
+            }
+
+            std::cout << "\n---" << std::endl;
+        }
+    }
+};
+
 int main(int argc, char **argv) {
   assert(sodium_init() != -1);
   ECC_Start();
 
-  // Log all errors to stdout so we see them in test output.
-  std::string initialFilter = "error";
-  pTracingHandle = tracing_init(
-      nullptr, 0,
-      initialFilter.c_str(),
-      false);
+    // Log all errors to a common test file.
+    fs::path tmpPath = fs::temp_directory_path();
+    fs::path tmpFilename = fs::unique_path("%%%%%%%%");
+    fs::path logPath = tmpPath / tmpFilename;
+    const fs::path::string_type& logPathStr = logPath.native();
+    static_assert(sizeof(fs::path::value_type) == sizeof(codeunit),
+                    "native path has unexpected code unit size");
+    const codeunit* logPathCStr = reinterpret_cast<const codeunit*>(logPathStr.c_str());
+    size_t logPathLen = logPathStr.length();
+
+    std::string initialFilter = "error";
+    pTracingHandle = tracing_init_test(
+        logPathCStr, logPathLen,
+        initialFilter.c_str());
 
   testing::InitGoogleMock(&argc, argv);
 
   // The "threadsafe" style is necessary for correct operation of death/exit
   // tests on macOS (https://github.com/zcash/zcash/issues/4802).
   testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+    ::testing::TestEventListeners& listeners =
+        ::testing::UnitTest::GetInstance()->listeners();
+    listeners.Append(new LogGrabber(logPath));
 
   auto ret = RUN_ALL_TESTS();
 

--- a/src/rust/include/tracing.h
+++ b/src/rust/include/tracing.h
@@ -30,6 +30,16 @@ TracingHandle* tracing_init(
     const char* initial_filter,
     bool log_timestamps);
 
+/// Initializes the tracing crate for use in tests, returning a handle for the
+/// logging component. The handle must be freed to close the logging component.
+///
+/// `log_path` is the path to a file that logs will be written to, and must not
+/// be NULL. Logs are written synchronously to avoid non-determinism in tests.
+TracingHandle* tracing_init_test(
+    const codeunit* log_path,
+    size_t log_path_len,
+    const char* initial_filter);
+
 /// Frees a tracing handle returned from `tracing_init`;
 void tracing_free(TracingHandle* handle);
 


### PR DESCRIPTION
In zcash/zcash#5762 we altered the gtest runner to turn on logging to stdout instead of dropping the logs, to make figuring out test failures easier. However, this also meant the logs would be displayed for tests that succeeded, and it was confusing to see `ERROR` log lines present.

We now have a test-specific initialization method for tracing that uses synchronous logging instead of a background thread, and only logs to a file. In the gtests, we initialize this with a new temporary file, and add a gtest event listener that clears the file at the start of each test, and then prints its contents if the test fails.

Example test output: (removed because CI has issues with code blocks; see commit message).

Closes zcash/zcash#5766.