### PR TITLE
wallet: Treat `mnemonichdchain` records as key material

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -909,6 +909,7 @@ static bool IsKeyType(string strType)
     return (strType== "key" || strType == "wkey" ||
             strType == "hdseed" || strType == "chdseed" ||
             strType == "mnemonicphrase" || strType == "cmnemonicphrase" ||
+            strType == "mnemonichdchain" ||
             strType == "zkey" || strType == "czkey" ||
             strType == "sapzkey" || strType == "csapzkey" ||
             strType == "vkey" || strType == "sapextfvk" ||


### PR DESCRIPTION
This is a temporary change to ensure that if this record is unreadable, we immediately shut down the node and don't make any further changes that could impair our ability to recover from this state later.

Part of zcash/zcash#5806.