### PR TITLE
qa: Postpone update to Rust 1.60

### DIFF
--- a/qa/zcash/postponed-updates.txt
+++ b/qa/zcash/postponed-updates.txt
@@ -17,11 +17,10 @@ native_ccache 4.5 2022-05-01
 native_ccache 4.5.1 2022-05-01
 native_ccache 4.6 2022-05-01
 
-# Clang is currently pinned to LLVM 13
+# Clang and Rust are currently pinned to LLVM 13
 native_clang 14.0.0 2022-05-01
 libcxx 14.0.0 2022-05-01
-
-# Rust is currently pinned to 1.59.0
+native_rust 1.60.0 2022-05-01
 
 # We're never updating to this version
 bdb 18.1.40 2024-02-01


### PR DESCRIPTION
Rust 1.60 migrates to LLVM 14, and we want to keep our Clang and Rust compilers on matching LLVM versions.