### PR TITLE
Fix assertion in wallet initialization when wallet best block is ahead of the main chain.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1500,25 +1500,20 @@ void CWallet::SetBestChain(const CBlockLocator& loc)
     SetBestChainINTERNAL(walletdb, loc);
 }
 
-CBlockIndex* CWallet::GetPersistedBestBlock()
+std::optional<uint256> CWallet::GetPersistedBestBlock()
 {
-    AssertLockHeld(cs_main);
     AssertLockHeld(cs_wallet);
 
     CWalletDB walletdb(strWalletFile);
     CBlockLocator locator;
     if (walletdb.ReadBestBlock(locator)) {
         if (!locator.vHave.empty()) {
-            BlockMap::iterator mi = mapBlockIndex.find(locator.vHave[0]);
-            if (mi != mapBlockIndex.end()) {
-                return (*mi).second;
-            }
+            return locator.vHave[0];
         }
     }
 
-    // The wallet's best block is not known to the node. This can occur when a
-    // wallet file is transplanted between disparate nodes.
-    return nullptr;
+    // The wallet has never persisted a best block to disk.
+    return std::nullopt;
 }
 
 std::set<std::pair<libzcash::SproutPaymentAddress, uint256>> CWallet::GetSproutNullifiers(

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1810,15 +1810,16 @@ public:
     /** Saves witness caches and best block locator to disk. */
     void SetBestChain(const CBlockLocator& loc);
     /**
-     * Returns the block index corresponding to the wallet's most recently
+     * Returns the block hash corresponding to the wallet's most recently
      * persisted best block. This is the state to which the wallet will revert
      * if restarted immediately, and does not necessarily match the current
      * in-memory state.
      *
-     * Returns nullptr if the wallet's best block is not known to this node
-     * (e.g. if the wallet was transplanted from another node).
+     * Returns std::nullopt if the wallet has never written a best block,
+     * i.e. this is a brand new wallet, or the node was shut down before
+     * SetBestChain was ever called to persist wallet state.
      */
-    CBlockIndex* GetPersistedBestBlock();
+    std::optional<uint256> GetPersistedBestBlock();
 
     std::set<std::pair<libzcash::SproutPaymentAddress, uint256>> GetSproutNullifiers(
             const std::set<libzcash::SproutPaymentAddress>& addresses);


### PR DESCRIPTION
In #5809, we attempted to fix the assumption that on startup, the
wallet's best chain was at the same position as the node's chain tip.
This did not account for a condition where the node's block index
might not contain the block corresponding to the wallet's best chain,
because the node had crashed before the block index containing that
block could be written to disk.

This commit adds handling so that the `ThreadNotifyWallets` thread
will not start until the wallet's best block has been restored
to the node's block index and we're able to obtain a pointer to
that state.

Fixes #5846 