### PR TITLE
Change error message in getHeightRange

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -825,7 +825,7 @@ static void getHeightRange(const UniValue& params, int& start, int& end)
             }
             if (end < start) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
-                    "End value is expected to be greater than or equal to start.");
+                    "End value is expected to be greater than or equal to start");
             }
         }
     }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -825,7 +825,7 @@ static void getHeightRange(const UniValue& params, int& start, int& end)
             }
             if (end < start) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
-                    "End value is expected to be greater or equal than start");
+                    "End value is expected to be greater than or equal to start.");
             }
         }
     }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -825,7 +825,7 @@ static void getHeightRange(const UniValue& params, int& start, int& end)
             }
             if (end < start) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
-                    "End value is expected to be greater than start");
+                    "End value is expected to be greater or equal than start");
             }
         }
     }

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(rpc_insightexplorer)
     CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":0,\"end\":0,\"chainInfo\":true}",
         "Start and end are expected to be greater than zero");
     CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":3,\"end\":2,\"chainInfo\":true}",
-        "End value is expected to be greater than start");
+        "End value is expected to be greater or equal than start");
     // in this test environment, only the genesis block (0) exists
     CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":2,\"end\":3,\"chainInfo\":true}",
         "Start or end is outside chain range");
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(rpc_insightexplorer)
     CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":0,\"end\":0,\"chainInfo\":true}",
         "Start and end are expected to be greater than zero");
     CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":3,\"end\":2,\"chainInfo\":true}",
-        "End value is expected to be greater than start");
+        "End value is expected to be greater or equal than start");
     // in this test environment, only the genesis block (0) exists
     CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":2,\"end\":3,\"chainInfo\":true}",
         "Start or end is outside chain range");

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(rpc_insightexplorer)
     CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":0,\"end\":0,\"chainInfo\":true}",
         "Start and end are expected to be greater than zero");
     CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":3,\"end\":2,\"chainInfo\":true}",
-        "End value is expected to be greater than or equal to start.");
+        "End value is expected to be greater than or equal to start");
     // in this test environment, only the genesis block (0) exists
     CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":2,\"end\":3,\"chainInfo\":true}",
         "Start or end is outside chain range");
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(rpc_insightexplorer)
     CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":0,\"end\":0,\"chainInfo\":true}",
         "Start and end are expected to be greater than zero");
     CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":3,\"end\":2,\"chainInfo\":true}",
-        "End value is expected to be greater than or equal to start.");
+        "End value is expected to be greater than or equal to start");
     // in this test environment, only the genesis block (0) exists
     CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":2,\"end\":3,\"chainInfo\":true}",
         "Start or end is outside chain range");

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(rpc_insightexplorer)
     CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":0,\"end\":0,\"chainInfo\":true}",
         "Start and end are expected to be greater than zero");
     CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":3,\"end\":2,\"chainInfo\":true}",
-        "End value is expected to be greater or equal than start");
+        "End value is expected to be greater than or equal to start.");
     // in this test environment, only the genesis block (0) exists
     CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":2,\"end\":3,\"chainInfo\":true}",
         "Start or end is outside chain range");
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(rpc_insightexplorer)
     CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":0,\"end\":0,\"chainInfo\":true}",
         "Start and end are expected to be greater than zero");
     CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":3,\"end\":2,\"chainInfo\":true}",
-        "End value is expected to be greater or equal than start");
+        "End value is expected to be greater than or equal to start.");
     // in this test environment, only the genesis block (0) exists
     CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":2,\"end\":3,\"chainInfo\":true}",
         "Start or end is outside chain range");


### PR DESCRIPTION
`getHeightRange` makes sure the range provided by rpc methods like `getaddresstxids` is valid. If `start` and `end` arguments are the same then currently the range is valid however the error message states that end has to be greater than start. I think the code is fine as having an equal start and end should allow to get data from a single block.