### PR TITLE
Avoid calling tracing_span_enter with a null pointer.

### DIFF
--- a/src/rust/include/tracing.h
+++ b/src/rust/include/tracing.h
@@ -176,6 +176,7 @@ private:
     friend class Span;
     std::unique_ptr<TracingSpanGuard, decltype(&tracing_span_exit)> inner;
 
+    Entered() : inner(nullptr, tracing_span_exit) {}
     Entered(const TracingSpanHandle* span) : inner(tracing_span_enter(span), tracing_span_exit) {}
 };
 
@@ -237,7 +238,11 @@ public:
     /// nothing.
     Entered Enter()
     {
-        return Entered(inner.get());
+        if (inner.get() == nullptr) {
+            return Entered();
+        } else {
+            return Entered(inner.get());
+        }
     }
 };
 } // namespace tracing


### PR DESCRIPTION
This shouldn't be necessary; `tracing_span_enter` *appears* to handle the null pointer correctly. But after this change, I can't reproduce the segfault @daira reported.

Prior to this patch, a node would reliably segfault in response to:
```
./src/zcash-cli setlogfilter debug,pow=error,net=info,bench=error
```