### PR TITLE
add walletrequirebackup=false to the zcash argument list in smoke_tests.py

### DIFF
--- a/qa/zcash/smoke_tests.py
+++ b/qa/zcash/smoke_tests.py
@@ -583,6 +583,7 @@ class ZcashNode(object):
             '-showmetrics=0',
             '-experimentalfeatures',
             '-zmergetoaddress',
+            '-walletrequirebackup=false'
         ]
         if self.__testnet:
             args.append('-testnet=1')


### PR DESCRIPTION
otherwise we get stuff like this when we run the smoke tests, and nothing works:
```
----- 0:00:52.049223 -----                                                                                                                                
3f  $ zcash-cli z_getnewaddress sapling                                                                                                                   
ERROR: z_getnewaddress: Error: Please acknowledge that you have backed up the wallet's emergency recovery phrase by using zcashd-wallet-tool first. (code 
-18)                                                                                                                                                      
----- 0:00:52.049370 -----                                                                                                                                
5a  $ zcash-cli z_listaddresses                                                                                                                           
[]                                                                                                                                                        
                                                                                                                                                          
----- 0:00:52.049510 -----                                                                                                                                5c  $ zcash-cli z_validateaddress None                                                                                                                    
ERROR: z_validateaddress: JSON value is not a string as expected (code -1)                                                                                
Traceback (most recent call last):                                                                                                                        
  File "/home/sasha_work/repos/zcash/./qa/zcash/smoke_tests.py", line 734, in <module>                                                                    
    main()                                                                                                                                                
  File "/home/sasha_work/repos/zcash/./qa/zcash/smoke_tests.py", line 696, in main                                                                        
    results.update(run_stage(s, zcash))                                                                                                                   
  File "/home/sasha_work/repos/zcash/./qa/zcash/smoke_tests.py", line 535, in run_stage                                                                   
    ret = cmd(zcash)                                                                                                                                      
  File "/home/sasha_work/repos/zcash/./qa/zcash/smoke_tests.py", line 336, in transaction_chain                                                           
    if not ret['isvalid'] or ret['type'] != 'sapling':                                                                                                    
TypeError: 'NoneType' object is not subscriptable                                             
```