### PR TITLE
fix smoke_tests.py accounting math to remove the warning before test 4r

### DIFF
--- a/qa/zcash/smoke_tests.py
+++ b/qa/zcash/smoke_tests.py
@@ -421,6 +421,7 @@ def transaction_chain(zcash):
         ])
         sapling_balance -= DEFAULT_FEE
         taddr_balance -= DEFAULT_FEE
+        taddr_2_balance = taddr_balance
 
         #
         # Inter-pool tests
@@ -455,7 +456,7 @@ def transaction_chain(zcash):
         taddr_balance -= (starting_balance / Decimal('10')) * Decimal('2')
 
         # multiple Sapling -> taddr
-        check_z_mergetoaddress(None, '', zcash, [sapling_zaddr_1, sapling_zaddr_2, sapling_zaddr_3], taddr_2, sapling_balance - DEFAULT_FEE)
+        check_z_mergetoaddress(None, '', zcash, [sapling_zaddr_1, sapling_zaddr_2, sapling_zaddr_3], taddr_2, taddr_2_balance + sapling_balance - DEFAULT_FEE)
         taddr_balance += sapling_balance - DEFAULT_FEE
         sapling_balance = Decimal('0')
 


### PR DESCRIPTION
the warning before test 4r is generated by the check_z_mergetoaddress
at line 459, which moves all the sapling funds into taddr_2 and thus
expects (sapling_balance - DEFAULT_FEE) to show up into taddr_2.

However, the check_z_mergetoaddress_parallel at line 418 had already
funded taddr_2 (with the sum of taddr_1 and taddr_3), and so we need to
add that to the amount of money that check_z_mergetoaddress at line 459
expects to find.
