### PR TITLE
zcutil/build.sh: Run zcutil/clean.sh before building

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,3 +4,9 @@ release-notes at release time)
 Notable changes
 ===============
 
+Build system
+------------
+
+- `zcutil/build.sh` now automatically runs `zcutil/clean.sh` to remove
+  files created by previous builds. We previously recommended to do this
+  manually.

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -84,6 +84,7 @@ then
     exit 0
 fi
 
+./zcutil/clean.sh
 ./autogen.sh
 CONFIG_SITE="$PWD/depends/$HOST/share/config.site" ./configure $CONFIGURE_FLAGS
 "$MAKE" "$@"


### PR DESCRIPTION
fixes #3625

We use clean.sh rather than distclean.sh because the checksumming and redownloading of C++ dependencies is pretty robust.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>