### PR TITLE
Fix typo in getaddressbalance RPC help

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -997,7 +997,7 @@ UniValue getaddressbalance(const UniValue& params, bool fHelp)
             + disabledMsg +
             "\nArguments:\n"
             "{\n"
-            "  \"addresses:\"\n"
+            "  \"addresses\":\n"
             "    [\n"
             "      \"address\"  (string) The base58check encoded address\n"
             "      ,...\n"


### PR DESCRIPTION
In JSON, the colon needs to be outside the field name.

The multi-argument form is wrong, but the example command is correct.

## Required Checks

Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.
* [ ] Relevant documentation for this PR has to be completed and reviewed by @mdr0id before the PR can be merged
* [ ] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release

As a note, all buildbot tests need to be passing and all appropriate code reviews need to be done before this PR can be merged

### Documentation

This is a documentation fix.

### Test Plan

Copy and paste the updated multi-argument syntax, and test it using `zcash-cli`.
