### PR TITLE
add tx-orchard-duplicate-nullifiers.h to Makefile.gtest.include

### DIFF
--- a/src/Makefile.gtest.include
+++ b/src/Makefile.gtest.include
@@ -26,6 +26,7 @@ zcash_gtest_SOURCES += \
 endif
 zcash_gtest_SOURCES += \
 	test/data/merkle_roots_orchard.h \
+	gtest/data/tx-orchard-duplicate-nullifiers.h \
 	gtest/test_tautology.cpp \
 	gtest/test_allocator.cpp \
 	gtest/test_checkblock.cpp \


### PR DESCRIPTION
Like 562f5add878219042c6ff30e85cebf79e5369cfe / https://github.com/zcash/zcash/pull/5701 and https://github.com/zcash/zcash/pull/5730; the missing header reference means that the make dist step of gitian builds don't include it in the tarball, causing an error upon build.
