### PR TITLE
Cargo.toml: Rename hdwallet source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "hdwallet"
 version = "0.3.0"
-source = "git+https://github.com/nuttycom/hdwallet?rev=9b4c1bdbe0517e3a7a8f285d6048a37d472ba3bc#9b4c1bdbe0517e3a7a8f285d6048a37d472ba3bc"
+source = "git+https://github.com/nuttycom/hdwallet.git?rev=9b4c1bdbe0517e3a7a8f285d6048a37d472ba3bc#9b4c1bdbe0517e3a7a8f285d6048a37d472ba3bc"
 dependencies = [
  "lazy_static",
  "rand_core 0.6.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ panic = 'abort'
 codegen-units = 1
 
 [patch.crates-io]
-hdwallet = { git = "https://github.com/nuttycom/hdwallet", rev = "9b4c1bdbe0517e3a7a8f285d6048a37d472ba3bc" }
+hdwallet = { git = "https://github.com/nuttycom/hdwallet.git", rev = "9b4c1bdbe0517e3a7a8f285d6048a37d472ba3bc" }
 zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "d14e7a707ce01cefcbc82651dad48f002185dded" }
 zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "d14e7a707ce01cefcbc82651dad48f002185dded" }
 zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "d14e7a707ce01cefcbc82651dad48f002185dded" }


### PR DESCRIPTION
This change fixes the following build error on Nix:

```
error: source `https://github.com/nuttycom/hdwallet` defines source https://github.com/nuttycom/hdwallet?rev=9b4c1bdbe0517e3a7a8f285d6048a37d472ba3bc, but that source is already defined by `https://github.com/nuttycom/hdwallet.git`
note: Sources are not allowed to be defined multiple times.
make[2]: *** [Makefile:9325: cargo-build-bins] Error 101
```
