### PR TITLE
Build releases from a commit hash, rather than a named branch.

### DIFF
--- a/doc/hotfix-process.md
+++ b/doc/hotfix-process.md
@@ -30,30 +30,17 @@ except that the branches are based on the hotfix branch instead of master:
 ## Merge hotfix PRs
 
 Hotfix PRs are created like regular PRs, except using the hotfix branch as the
-base instead of master. Each PR should be reviewed as normal, and then the
-following process should be used to merge:
-
-- A CI merge build is manually run by logging into the CI server, going to the
-  pr-merge builder, clicking the "force" button, and entering the following
-  values:
-
-  - Repository: https://github.com/<DevUser>/zcash
-    - <DevUser> must be in the set of "safe" users as-specified in the CI
-      config.
-  - Branch: name of the hotfix PR branch (not the hotfix release branch).
-
-- A link to the build and its result is manually added to the PR as a comment.
-
-- If the build was successful, the PR is merged via the GitHub button.
+base instead of `master`. Each PR should be reviewed and merged as normal.
 
 ## Release process
 
 The majority of this process is identical to the standard release process.
 However, there are a few notable differences:
 
-- When running the release script, use the `--hotfix` flag:
+- When running the release script, use the `--hotfix` flag. Provide the hash of 
+  the commit to be released as the first argument:
 
-    $ ./zcutil/make-release.py --hotfix <RELEASE> <RELEASE_PREV> <APPROX_RELEASE_HEIGHT>
+    $ ./zcutil/make-release.py --hotfix <COMMIT_ID> <RELEASE> <RELEASE_PREV> <APPROX_RELEASE_HEIGHT>
 
 - To review the automated changes in git:
 

--- a/doc/hotfix-process.md
+++ b/doc/hotfix-process.md
@@ -35,7 +35,9 @@ base instead of `master`. Each PR should be reviewed and merged as normal.
 ## Release process
 
 The majority of this process is identical to the standard release process.
-However, there are a few notable differences:
+Release candidates for hotfixes should be created and tested as normal, using
+the `hotfix-<RELEASE>` branch in place of the release stabilization branch,
+with a couple of minor differences:
 
 - When running the release script, use the `--hotfix` flag. Provide the hash of 
   the commit to be released as the first argument:
@@ -45,17 +47,3 @@ However, there are a few notable differences:
 - To review the automated changes in git:
 
     $ git log hotfix-<RELEASE>..HEAD
-
-- After the standard review process, use the hotfix merge process outlined above
-  instead of the regular merge process.
-
-- When making the tag, check out the hotfix branch instead of master.
-
-## Post-release
-
-Once the hotfix release has been created, a new PR should be opened for merging
-the hotfix release branch into master. This may require fixing merge conflicts
-(e.g. changing the version number in the hotfix branch to match master, if
-master is ahead). Such conflicts **MUST** be addressed with additional commits
-to the hotfix branch; specifically, the branch **MUST NOT** be rebased on
-master.

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -65,7 +65,7 @@ progress bar displayed during the build process.
 
 ## Release process
 
-Identify the commit from which the release will be made. This is frequently the current
+Identify the commit from which the release will be made. This could be the current
 `HEAD` of `master`, but it's also often useful to instead use a release stabilization
 branch based upon a previous release candidate when producing a release, so that
 development can proceed unblocked on the `master` branch during the release candidate
@@ -160,20 +160,16 @@ Notify the Zcash DevOps engineer/sysadmin that the release has been tagged. They
 some variables in the company's automation code and then run an Ansible playbook, which:
 
 * builds Zcash based on the specified branch
-* deploys it as a public service (e.g. betatestnet.z.cash, mainnet.z.cash)
+* deploys it as a public service (e.g. testnet.z.cash, mainnet.z.cash)
 * often the same server can be re-used, and the role idempotently handles upgrades, but if
   not then they also need to update DNS records
 * possible manual steps: blowing away the `testnet3` dir, deleting old parameters,
-  restarting DNS seeder
+  restarting DNS seeder.
 
-Then, verify that nodes can connect to the testnet server, and update the guide on the
-wiki to ensure the correct hostname is listed in the recommended zcash.conf.
+Verify that nodes can connect to the mainnet and testnet servers.
 
-### Update the 1.0 User Guide
-
-This also means updating [the translations](https://github.com/zcash/zcash-docs).
-Coordinate with the translation team for now. Suggestions for improving this
-part of the process should be added to #2596.
+Update the [Zcashd Full Node and CLI](https://zcash.readthedocs.io/en/latest/rtd_pages/zcashd.html)
+documentation on ReadTheDocs to give the new version number.
 
 ### Publish the release announcement (blog, github, zcash-dev, slack)
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -63,23 +63,47 @@ The release script has the following dependencies:
 You can optionally install the `progressbar2` Python module with pip to have a
 progress bar displayed during the build process.
 
-## Release process
+## Versioning
 
-Identify the commit from which the release will be made. This could be the current
-`HEAD` of `master`, but it's also often useful to instead use a release stabilization
-branch based upon a previous release candidate when producing a release, so that
-development can proceed unblocked on the `master` branch during the release candidate
-testing and bug-fixing process.
+Zcash version identifiers have the format `vX.Y.Z` with the following conventions:
 
-In the commands below, <RELEASE> and <RELEASE_PREV> must be prefixed with a v, i.e. v1.0.9
-(not 1.0.9). <COMMIT_ID> is the `git` hash identifying the commit on which the release
-branch will be based. It is recommended to use the entire hash value to identify the
-commit, although a prefix of at least 10 characters is also permitted.
+* Increments to the `X` component (the "major version") correspond to network
+  upgrades. A network upgrade occurs only when there is a change to the
+  consensus rules.
+* Increments to the `Y` component (the "minor version") correspond to regular
+  Zcash releases. These occur approximately every 6 weeks and may include breaking
+  changes to public APIs.
+* Increments to the `Z` component occur only in the case of hotfix releases.
 
-### Create the release branch
+## Release candidate & release process
 
-Run the release script, which will create a branch based upon the specified commit ID,
-then commit standard automated changes to that branch locally:
+Identify the commit from which the release stabilization branch will be made.
+Release stabilization branches are used so that development can proceed
+unblocked on the `master` branch during the release candidate testing and
+bug-fixing process. By convention, release stabilization branches are named
+`version-X.Y.0` where `X` and `Y` are the major and minor versions for the
+release.
+
+In the commands below, <RELEASE> and <RELEASE_PREV> must identify `git` tags
+prefixed with the character `v`, i.e. `v1.0.9` (not `1.0.9`). <COMMIT_ID> is a
+`git` hash identifying the commit on which a release stabilization or release
+branch will be based. It is recommended to use the entire hash value to
+identify the commit, although a prefix of at least 10 characters is also
+permitted.
+
+### Create the release stabilization branch
+
+Having identified the commit from which the release will be made, the release
+manager constructs the release stabilization branch as follows:
+
+    $ git checkout -b version-X.Y.0 <COMMIT_ID>
+    $ git push 'git@github.com:zcash/zcash' $(git rev-parse --abrev-ref HEAD)
+
+### Create the release candidate branch
+
+Run the release script to create the first release candidate. This will create
+a branch based upon the specified commit ID, then commit standard automated
+changes to that branch locally:
 
     $ ./zcutil/make-release.py <COMMIT_ID> <RELEASE> <RELEASE_PREV> <RELEASE_FROM> <APPROX_RELEASE_HEIGHT>
 
@@ -92,37 +116,52 @@ Examples:
 
 Review the automated changes in git:
 
-    $ git log master..HEAD
+    $ git log version-X.Y.0..HEAD
 
 Push the resulting branch to github:
 
     $ git push 'git@github.com:$YOUR_GITHUB_NAME/zcash' $(git rev-parse --abbrev-ref HEAD)
 
-Then create the PR on github. Complete the standard review process and wait
-for CI to complete.
+Then create the PR on github targeting the `version-X.Y.0` branch. Complete the
+standard review process and wait for CI to complete. 
 
-## Make tag for the the tip of the release branch
+## Make a tag for the tip of the release candidate branch
 
-NOTE: This has changed from the previously recommended process. The tag should be created
-at the tip of the release branch; this ensures that any changes made to the `master`
-branch since the initiation of the release process are not accidentally tagged as being
-part of the release as a consequence of having been included in a merge commit.
+NOTE: This has changed from the previously recommended process. The tag should
+be created at the tip of the automatically-generated release branch created by
+the release script; this ensures that any changes made to the release
+stabilization branch since the initiation of the release process are not
+accidentally tagged as being part of the release as a consequence of having
+been included in a merge commit.
 
-Check the last commit on the local and remote versions of the release branch to make sure
-they are the same:
+Check the last commit on the local and remote versions of the release branch to
+make sure they are the same:
 
     $ git log -1
 
-If you haven't previously done so, set the gpg key id you intend to use for signing:
+If you haven't previously done so, set the gpg key id you intend to use for
+signing:
 
     git config --global user.signingkey <keyid>
 
-Then create the git tag. The `-s` means the release tag will be signed.
-Enter "Release <version>." and save when prompted for a commit message.
-**CAUTION:** Remember the `v` at the beginning here:
+Then create the git tag. The `-s` means the release tag will be signed.  Enter
+"Release <version>." and save when prompted for a commit message.  **CAUTION:**
+Remember the `v` at the beginning here:
 
-    $ git tag -s v1.1.0
-    $ git push origin v1.1.0
+    $ git tag -s vX.Y.Z-rcN
+    $ git push origin vX.Y.Z-rcN
+
+## Merge the release candidate branch to the release stabilization branch
+
+Once CI has completed and the release candidate branch has sufficient approving
+reviews, merge the release candidate branch back to the release stabilization
+branch. Testing proceeds as normal. Any changes that need to be made during the
+release candidate period are made by submitting PRs targeting the release 
+stabilization branch.
+
+Subsequent release candidates, and the creation of the final release, follow
+the same process as for release candidates, omitting the `-rcN` suffix for the
+final release. 
 
 ## Make and deploy deterministic builds
 
@@ -149,10 +188,18 @@ the marking to see what GitHub wants to be done.
 
 ## Post Release Task List
 
-### Merge the release branch
+### Merge the release stabilization branch
 
-Merge the release branch back to `master` to ensure that any changes made during
-release stabilization are reflected in the master branch's history. 
+Once the final release branch has merged to the release stabilization branch, a
+new PR should be opened for merging the release stabilization branch into
+master. This may require fixing merge conflicts (e.g. changing the version
+number in the release stabilization branch to match master, if master is
+ahead). Such conflicts **MUST** be addressed with additional commits to the
+release stabilization branch; specifically, the branch **MUST NOT** be rebased
+on master.
+
+Once any conflicts have been resolved, the release stabilization branch should
+be merged back to the `master` branch, and then deleted.
 
 ### Deploy testnet
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -2,7 +2,9 @@ Release Process
 ====================
 Meta: There should always be a single release engineer to disambiguate responsibility.
 
-If this is a hotfix release, please see the [Hotfix Release Process](https://github.com/zcash/zcash/blob/master/doc/hotfix-process.md) documentation before proceeding.
+If this is a hotfix release, please see the [Hotfix Release
+Process](https://github.com/zcash/zcash/blob/master/doc/hotfix-process.md) documentation
+before proceeding.
 
 ## Pre-release
 
@@ -63,21 +65,28 @@ progress bar displayed during the build process.
 
 ## Release process
 
-In the commands below, <RELEASE> and <RELEASE_PREV> are prefixed with a v, ie.
-v1.1.0 (not 1.1.0).
+Identify the commit from which the release will be made. This is frequently the current
+`HEAD` of `master`, but it's also often useful to instead use a release stabilization
+branch based upon a previous release candidate when producing a release, so that
+development can proceed unblocked on the `master` branch during the release candidate
+testing and bug-fixing process.
+
+In the commands below, <RELEASE> and <RELEASE_PREV> must be prefixed with a v, i.e. v1.0.9
+(not 1.0.9). <COMMIT_ID> is the `git` hash identifying the commit on which the release
+branch will be based. It is recommended to use the entire hash value to identify the
+commit, although a prefix of at least 10 characters is also permitted.
 
 ### Create the release branch
 
-Run the release script, which will verify you are on the latest clean
-checkout of master, create a branch, then commit standard automated
-changes to that branch locally:
+Run the release script, which will create a branch based upon the specified commit ID,
+then commit standard automated changes to that branch locally:
 
-    $ ./zcutil/make-release.py <RELEASE> <RELEASE_PREV> <RELEASE_FROM> <APPROX_RELEASE_HEIGHT>
+    $ ./zcutil/make-release.py <COMMIT_ID> <RELEASE> <RELEASE_PREV> <RELEASE_FROM> <APPROX_RELEASE_HEIGHT>
 
 Examples:
 
-    $ ./zcutil/make-release.py v1.1.0 v1.0.0 v1.0.0 120000
-    $ ./zcutil/make-release.py v1.1.0 v1.1.0-rc1 v1.0.0 222900
+    $ ./zcutil/make-release.py 600c4acee1 v1.1.0-rc1 v1.0.0 v1.0.0 280300
+    $ ./zcutil/make-release.py b89b48cda1 v1.1.0 v1.1.0-rc1 v1.0.0 300600
 
 ### Create, Review, and Merge the release branch pull request
 
@@ -89,23 +98,20 @@ Push the resulting branch to github:
 
     $ git push 'git@github.com:$YOUR_GITHUB_NAME/zcash' $(git rev-parse --abbrev-ref HEAD)
 
-Then create the PR on github. Complete the standard review process,
-then merge, then wait for CI to complete.
+Then create the PR on github. Complete the standard review process and wait
+for CI to complete.
 
-## Make tag for the newly merged result
+## Make tag for the the tip of the release branch
 
-Checkout master and pull the latest version to ensure master is up to date with the release PR which was merged in before.
+NOTE: This has changed from the previously recommended process. The tag should be created
+at the tip of the release branch; this ensures that any changes made to the `master`
+branch since the initiation of the release process are not accidentally tagged as being
+part of the release as a consequence of having been included in a merge commit.
 
-    $ git checkout master
-    $ git pull --ff-only
-
-Check the last commit on the local and remote versions of master to make sure they are the same:
+Check the last commit on the local and remote versions of the release branch to make sure
+they are the same:
 
     $ git log -1
-
-The output should include something like, which is created by Homu:
-
-    Auto merge of #4242 - nathan-at-least:release-v1.0.9, r=nathan-at-least
 
 If you haven't previously done so, set the gpg key id you intend to use for signing:
 
@@ -143,16 +149,25 @@ the marking to see what GitHub wants to be done.
 
 ## Post Release Task List
 
+### Merge the release branch
+
+Merge the release branch back to `master` to ensure that any changes made during
+release stabilization are reflected in the master branch's history. 
+
 ### Deploy testnet
 
-Notify the Zcash DevOps engineer/sysadmin that the release has been tagged. They update some variables in the company's automation code and then run an Ansible playbook, which:
+Notify the Zcash DevOps engineer/sysadmin that the release has been tagged. They update
+some variables in the company's automation code and then run an Ansible playbook, which:
 
 * builds Zcash based on the specified branch
 * deploys it as a public service (e.g. betatestnet.z.cash, mainnet.z.cash)
-* often the same server can be re-used, and the role idempotently handles upgrades, but if not then they also need to update DNS records
-* possible manual steps: blowing away the `testnet3` dir, deleting old parameters, restarting DNS seeder
+* often the same server can be re-used, and the role idempotently handles upgrades, but if
+  not then they also need to update DNS records
+* possible manual steps: blowing away the `testnet3` dir, deleting old parameters,
+  restarting DNS seeder
 
-Then, verify that nodes can connect to the testnet server, and update the guide on the wiki to ensure the correct hostname is listed in the recommended zcash.conf.
+Then, verify that nodes can connect to the testnet server, and update the guide on the
+wiki to ensure the correct hostname is listed in the recommended zcash.conf.
 
 ### Update the 1.0 User Guide
 

--- a/zcutil/make-release.py
+++ b/zcutil/make-release.py
@@ -488,7 +488,7 @@ def sh_progress(markers, *args):
 class GitHash (object):
     '''A git commit hash.'''
     RGX = re.compile(
-        r'^([0-9a-f]{8,40})$',
+        r'^([0-9a-f]{10,40})$',
     )
 
     @staticmethod

--- a/zcutil/make-release.py
+++ b/zcutil/make-release.py
@@ -137,7 +137,7 @@ def verify_dependency_updates():
     try:
         sh_log('./qa/zcash/updatecheck.py')
     except SystemExit:
-        raise SystemExit("Dependency update check failed. Either some updates not been correctly postponed, or the .updatecheck-token file is missing.")
+        raise SystemExit("Dependency update check failed. Either some updates have not been correctly postponed, or the .updatecheck-token file is missing.")
 
 @phase('Checking tags.')
 def verify_tags(revision, releaseprev, releasefrom):


### PR DESCRIPTION
This modifies the release script to take as its first argument
the hash of the git commit to be released. It also improves the
verification of the previous commit tag by ensuring that the tag
exists in the history of the specified commit.

