### PR TITLE
Fix missing initialization for `hasActions` in Orchard builder.

### DIFF
--- a/src/transaction_builder.h
+++ b/src/transaction_builder.h
@@ -82,7 +82,7 @@ private:
     /// `Builder::Build` has been called, and all subsequent operations will throw an
     /// exception.
     std::unique_ptr<OrchardBuilderPtr, decltype(&orchard_builder_free)> inner;
-    bool hasActions;
+    bool hasActions{false};
 
     Builder() : inner(nullptr, orchard_builder_free), hasActions(false) { }
 


### PR DESCRIPTION
The `hasActions` field of the Orchard transaction builder had no initializer, and so it was being populated with arbitrary data. This, on occasion, would result in the Orchard builder to add two dummy actions to a transaction, which would push the size of the transaction over the limits expected by the mempool_nu_activation test.