### PR TITLE
Use bullseye apt source in Dockerfile to match debian:11 base image

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -14,7 +14,7 @@ ARG ZCASHD_USER=zcashd
 ARG ZCASHD_UID=2001
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $ZCASH_SIGNING_KEY_ID \
-  && echo "deb [arch=amd64] https://apt.z.cash/ buster main" > /etc/apt/sources.list.d/zcash.list \
+  && echo "deb [arch=amd64] https://apt.z.cash/ bullseye main" > /etc/apt/sources.list.d/zcash.list \
   && apt-get update
 
 RUN if [ -z "$ZCASH_VERSION" ]; \


### PR DESCRIPTION
contrib/docker/Dockerfile references debian:11 on its first line, which is the bullseye release.
https://www.debian.org/releases/bullseye/

When adding an apt/sources.list line, it adds a line specifying a 'buster' source, which is debian 10.
https://www.debian.org/releases/buster/

This change updates the sources.list entry so that both refer to 11/bullseye.