### PR TITLE
RPC Parallel Groups V1

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -187,6 +187,8 @@ def main():
     parser.add_argument('--force', '-f', action='store_true', help='run tests even on platforms where they are disabled by default (e.g. windows).')
     parser.add_argument('--help', '-h', '-?', action='store_true', help='print help text and exit')
     parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
+    parser.add_argument('--machines', '-m', type=int, default=4, help='how many machines run in parallel. Default=4.')
+    parser.add_argument('--rpcgroup', '-r', type=int, default=4, help='how many test on each machine to run in parallel. Default=4.')
     parser.add_argument('--nozmq', action='store_true', help='do not run the zmq tests')
     args, unknown_args = parser.parse_known_args()
 
@@ -263,7 +265,18 @@ def main():
         subprocess.check_call((config["environment"]["SRCDIR"] + '/qa/rpc-tests/' + test_list[0]).split() + ['-h'])
         sys.exit(0)
 
-    run_tests(test_list, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)
+    if args.machines:
+        #check if we have evenly divisble groups of test to ensure all tests are included
+        if len(test_list) % args.machines !=0:
+            n = int(len(test_list) // args.machines + 1)
+            split_list = [test_list[i:n] for i in range(0, len(test_list), args.machines)]
+            run_tests(split_list[args.rpcgroup], config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)    
+        else:
+            n = int(len(test_list) / args.machines)
+            split_list = [test_list[i:n+i] for i in range(0, len(test_list),n)]
+            run_tests(split_list[args.rpcgroup], config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)    
+    else:   
+        run_tests(test_list, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)
 
 def run_tests(test_list, src_dir, build_dir, exeext, jobs=1, enable_coverage=False, args=[]):
     BOLD = ("","")

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -187,7 +187,7 @@ def main():
     parser.add_argument('--force', '-f', action='store_true', help='run tests even on platforms where they are disabled by default (e.g. windows).')
     parser.add_argument('--help', '-h', '-?', action='store_true', help='print help text and exit')
     parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
-    parser.add_argument('--machines', '-m', type=int, default=4, help='how many machines run in parallel. Default=4.')
+    parser.add_argument('--machines', '-m', type=int, default=-1, help='how many machines run in parallel. Default=4.')
     parser.add_argument('--rpcgroup', '-r', type=int, default=4, help='how many test on each machine to run in parallel. Default=4.')
     parser.add_argument('--nozmq', action='store_true', help='do not run the zmq tests')
     args, unknown_args = parser.parse_known_args()
@@ -265,7 +265,7 @@ def main():
         subprocess.check_call((config["environment"]["SRCDIR"] + '/qa/rpc-tests/' + test_list[0]).split() + ['-h'])
         sys.exit(0)
 
-    if args.machines:
+    if args.machines != -1:
         #check if we have evenly divisble groups of test to ensure all tests are included
         if len(test_list) % args.machines !=0:
             n = int(len(test_list) // args.machines + 1)

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -175,6 +175,10 @@ STAGES = [
     'secp256k1',
     'univalue',
     'rpc',
+    'rpc_group0',
+    'rpc_group1',
+    'rpc_group2',
+    'rpc_group3',
 ]
 
 STAGE_COMMANDS = {
@@ -187,6 +191,10 @@ STAGE_COMMANDS = {
     'secp256k1': ['make', '-C', repofile('src/secp256k1'), 'check'],
     'univalue': ['make', '-C', repofile('src/univalue'), 'check'],
     'rpc': [repofile('qa/pull-tester/rpc-tests.py')],
+    'rpc_group0': [repofile('qa/pull-tester/rpc-tests.py'), '-m4', '-r0'],
+    'rpc_group1': [repofile('qa/pull-tester/rpc-tests.py'), '-m4', '-r1'],
+    'rpc_group2': [repofile('qa/pull-tester/rpc-tests.py'), '-m4', '-r2'],
+    'rpc_group3': [repofile('qa/pull-tester/rpc-tests.py'), '-m4', '-r3'],
 }
 
 


### PR DESCRIPTION
(Do not merge yet until devsecops gives final approval)

This PR is intended as the initial implementation of RPC groups mentioned in https://github.com/zcash/zcash/issues/5497.

Features:
- Split tests evenly by number of machines
- Ensure all tests are included when there are odd and even number of tests
- Ensure all tests are included when there are odd or even number of machines
- Minimal code diff to existing legacy testing stack (e.g. rpc-tests.py, full_test_suite.py)
- Lacks dynamic abilities both on dev and operator side currently (KISS model for now because this is a larger discussion with lots of moving pieces on core and devsecops)

The goal of the grouping is to reduce the overall RPC test times of 45+ minutes and provide a test template for current/future CI. During testing of this implementation we found other issues that don't always allow graceful groupings to consistently pass like existing production testing. This instability can be exaggerated using upstream's `-j` option. Additionally, this instability is a complete blocker in terms of adding additional hardware to reduce timings and/or scheduling on a single machine.


