### PR TITLE
ThreadStartWalletNotifier: wait until !IBD, rather than !reindex

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -629,17 +629,10 @@ void ThreadStartWalletNotifier()
 
         if (walletBestBlockHash.has_value()) {
             int64_t slept{0};
-            bool isReindexing{true};
             auto timedOut = [&]() -> bool {
                 MilliSleep(500);
-                // re-check whether we're reindexing
-                if (isReindexing) {
-                    LOCK(cs_main);
-                    pblocktree->ReadReindexing(isReindexing);
-                }
-
                 // once we're out of reindexing, we can start incrementing the slept counter
-                if (!isReindexing) {
+                if (!IsInitialBlockDownload(Params().GetConsensus())) {
                     slept += 500;
                 }
 


### PR DESCRIPTION
The -reindex option causes the node to first read the block files,
adding each block to the block index, then reset the reindexing flag,
then build the best chain (the "UpdateTip: new best" logging messages).
Before the wallet notification thread begins to actually do
notifications, it should wait until we're no longer in initial block
download, rather than waiting until the reindexing flag is reset (which
is too early).