### PR TITLE
Add tests to check auth data commitments committing to Orchard actions.

### DIFF
--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -28,6 +28,7 @@ def create_block(hashprev, coinbase, nTime=None, nBits=None, hashFinalSaplingRoo
         block.nBits = nBits
     block.vtx.append(coinbase)
     block.hashMerkleRoot = block.calc_merkle_root()
+    block.hashAuthDataRoot = block.calc_auth_data_root()
     block.calc_sha256()
     return block
 

--- a/qa/rpc-tests/test_framework/zip244.py
+++ b/qa/rpc-tests/test_framework/zip244.py
@@ -138,9 +138,9 @@ def orchard_digest(orchardBundle):
         digest.update(orchard_actions_compact_digest(orchardBundle))
         digest.update(orchard_actions_memos_digest(orchardBundle))
         digest.update(orchard_actions_noncompact_digest(orchardBundle))
-        digest.update(struct.pack('<B', orchardBundle.flags()))
+        digest.update(struct.pack('B', orchardBundle.flags()))
         digest.update(struct.pack('<q', orchardBundle.valueBalance))
-        digest.update(bytes(orchardBundle.anchor))
+        digest.update(ser_uint256(orchardBundle.anchor))
 
     return digest.digest()
 
@@ -148,7 +148,7 @@ def orchard_auth_digest(orchardBundle):
     digest = blake2b(digest_size=32, person=b'ZTxAuthOrchaHash')
 
     if len(orchardBundle.actions) > 0:
-        digest.update(orchardBundle.proofs)
+        digest.update(bytes(orchardBundle.proofs))
         for desc in orchardBundle.actions:
             digest.update(desc.spendAuthSig.serialize())
         digest.update(orchardBundle.bindingSig.serialize())


### PR DESCRIPTION
In the process of adding these tests, I also found and fixed a number
of type errors in Orchard auth data root computation.

Fixes #5223