### PR TITLE
halo2 is now under MIT/Apache-2.0, so does not need a declaration in contrib/debian/copyright

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -160,8 +160,7 @@ Files: depends/sources/utfcpp-*.tar.gz
 Copyright: 2006 Nemanja Trifunovic
 License: Boost-Software-License-1.0
 
-Files: depends/*/vendored-sources/halo2/*
- depends/*/vendored-sources/orchard/*
+Files: depends/*/vendored-sources/orchard/*
 Copyright: 2020-2022 The Electric Coin Company
 License: BOSL-1+ with Zcash exception
 


### PR DESCRIPTION
Partial fix for #5203 (the other thing needed is zcash/orchard#333 and then updating the orchard crate).