### PR TITLE
Make shielded requirements error "debug" level rather than an error.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2568,7 +2568,7 @@ bool CheckTxShieldedInputs(
         auto txid = tx.GetHash().ToString();
         auto rejectCode = ShieldedReqRejectCode(*unmetShieldedReq);
         auto rejectReason = ShieldedReqRejectReason(*unmetShieldedReq);
-        TracingError(
+        TracingDebug(
             "main", "CheckTxShieldedInputs(): shielded requirements not met",
             "txid", txid.c_str(),
             "reason", rejectReason.c_str());


### PR DESCRIPTION
These errors are getting annoying; they're not actually "errors" for the user it's displayed for, so let's make them debug events.