### PR TITLE
Update test scripts to support initial parallel RPCs 

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -190,6 +190,8 @@ def main():
     parser.add_argument('--force', '-f', action='store_true', help='run tests even on platforms where they are disabled by default (e.g. windows).')
     parser.add_argument('--help', '-h', '-?', action='store_true', help='print help text and exit')
     parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
+    parser.add_argument('--machines', '-m', type=int, default=-1, help='how many machines to shard the tests over. must also provide individual shard index. Default=-1 (no sharding).')
+    parser.add_argument('--rpcgroup', '-r', type=int, default=-1, help='individual shard index. must also provide how many machines to shard the tests over. Default=-1 (no sharding).')
     parser.add_argument('--nozmq', action='store_true', help='do not run the zmq tests')
     args, unknown_args = parser.parse_known_args()
 
@@ -266,7 +268,25 @@ def main():
         subprocess.check_call((config["environment"]["SRCDIR"] + '/qa/rpc-tests/' + test_list[0]).split() + ['-h'])
         sys.exit(0)
 
-    run_tests(test_list, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)
+
+    if (args.rpcgroup == -1) != (args.machines == -1):
+        print("ERROR: Please use both -m and -r options when using parallel rpc_groups.")
+        sys.exit(0)
+    if args.machines == 0:
+        print("ERROR: -m/--machines must be greater than 0")
+        sys.exit(0)
+    if args.machines > 0 and (args.rpcgroup >= args.machines):
+        print("ERROR: -r/--rpcgroup must be less than -m/--machines")
+        sys.exit(0)
+    if args.rpcgroup != -1 and args.machines != -1 and args.machines > args.rpcgroup:
+        # Ceiling division using floor division, by inverting the world.
+        # https://stackoverflow.com/a/17511341
+        k = -(len(test_list) // -args.machines)
+        split_list = list(test_list[i*k:(i+1)*k] for i in range(args.machines))
+        tests_to_run = split_list[args.rpcgroup]
+    else:
+        tests_to_run = test_list
+    run_tests(tests_to_run, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)
 
 def run_tests(test_list, src_dir, build_dir, exeext, jobs=1, enable_coverage=False, args=[]):
     BOLD = ("","")


### PR DESCRIPTION
Ever onward from https://github.com/zcash/zcash/pull/6017.

## Test Cases for Sort 1
```
   k, m = divmod(len(test_list), args.machines)
   split_list = list(test_list[i*k+min(i, m):(i+1)*k+min(i+1, m)] for i in range(args.machines))
```
### Test Case 1(default):
```
mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc
Running stage rpc
=================

rpc test list size: 106
Traceback (most recent call last):
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 467, in <module>
    main()
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 278, in main
    print("rpc group size: ", len(split_list[args.rpcgroup]))
IndexError: list index out of range

------------------
Finished stage rpc

!!! Stage rpc failed !!!
!!! One or more test stages failed !!!
mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group0
Running stage rpc_group0
========================

rpc test list size: 106
rpc group size:  27
['mergetoaddress_sapling.py', 'mergetoaddress_sprout.py', 'wallet_shieldingcoinbase.py', 'wallet.py', 'wallet_shieldcoinbase_sprout.py', 'sprout_sapling_migration.py', 'remove_sprout_shielding.py', 'zcjoinsplitdoublespend.py', 'zcjoinsplit.py', 'mergetoaddress_mixednotes.py', 'wallet_shieldcoinbase_sapling.py', 'wallet_shieldcoinbase_ua_sapling.py', 'wallet_shieldcoinbase_ua_nu5.py', 'turnstile.py', 'walletbackup.py', 'zkey_import_export.py', 'prioritisetransaction.py', 'wallet_changeaddresses.py', 'wallet_listreceived.py', 'mempool_tx_expiry.py', 'finalsaplingroot.py', 'wallet_orchard.py', 'wallet_overwintertx.py', 'wallet_persistence.py', 'wallet_listnotes.py', 'orchard_reorg.py', 'fundrawtransaction.py']

-------------------------
Finished stage rpc_group0

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group1
Running stage rpc_group1
========================

rpc test list size: 106
rpc group size:  27
['reorg_limit.py', 'mempool_limit.py', 'p2p-fullblocktest.py', 'wallet_1941.py', 'wallet_accounts.py', 'wallet_addresses.py', 'wallet_anchorfork.py', 'wallet_changeindicator.py', 'wallet_deprecation.py', 'wallet_doublespend.py', 'wallet_import_export.py', 'wallet_isfromme.py', 'wallet_orchard_change.py', 'wallet_orchard_init.py', 'wallet_orchard_persistence.py', 'wallet_nullifiers.py', 'wallet_sapling.py', 'wallet_sendmany_any_taddr.py', 'wallet_treestate.py', 'wallet_unified_change.py', 'listtransactions.py', 'mempool_resurrect_test.py', 'txn_doublespend.py', 'txn_doublespend.py --mineblock', 'getchaintips.py', 'rawtransactions.py', 'getrawtransaction_insight.py']

-------------------------
Finished stage rpc_group1

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group2
Running stage rpc_group2
========================

rpc test list size: 106
rpc group size:  26
['rest.py', 'mempool_spendcoinbase.py', 'mempool_reorg.py', 'mempool_nu_activation.py', 'httpbasics.py', 'multi_rpc.py', 'zapwallettxes.py', 'proxy_test.py', 'merkle_blocks.py', 'signrawtransactions.py', 'signrawtransaction_offline.py', 'key_import_export.py', 'nodehandling.py', 'reindex.py', 'addressindex.py', 'spentindex.py', 'timestampindex.py', 'decodescript.py', 'blockchain.py', 'disablewallet.py', 'keypool.py', 'getblocktemplate.py', 'getmininginfo.py', 'bip65-cltv-p2p.py', 'bipdersig-p2p.py', 'invalidblockrequest.py']

-------------------------
Finished stage rpc_group2

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group3
Running stage rpc_group3
========================

rpc test list size: 106
rpc group size:  26
['invalidtxrequest.py', 'p2p_nu_peer_management.py', 'rewind_index.py', 'p2p_txexpiry_dos.py', 'p2p_txexpiringsoon.py', 'p2p_node_bloom.py', 'regtest_signrawtransaction.py', 'shorter_block_times.py', 'mining_shielded_coinbase.py', 'coinbase_funding_streams.py', 'framework.py', 'sapling_rewind_check.py', 'feature_zip221.py', 'feature_zip239.py', 'feature_zip244_blockcommitments.py', 'upgrade_golden.py', 'nuparams.py', 'post_heartwood_rollback.py', 'feature_logging.py', 'feature_walletfile.py', 'wallet_parsing_amounts.py', 'wallet_broadcast.py', 'wallet_z_sendmany.py', 'wallet_zero_value.py', 'threeofthreerestore.py', 'zmq_test.py']

-------------------------
Finished stage rpc_group3
```

### Test Case 2: (even sort):
```
mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc
Running stage rpc
=================

rpc test list size: 108
Traceback (most recent call last):
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 469, in <module>
    main()
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 280, in main
    print("rpc group size: ", len(split_list[args.rpcgroup]))
IndexError: list index out of range

------------------
Finished stage rpc

!!! Stage rpc failed !!!
!!! One or more test stages failed !!!
mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group0
Running stage rpc_group0
========================

rpc test list size: 108
rpc group size:  27
['mergetoaddress_sapling.py', 'mergetoaddress_sprout.py', 'wallet_shieldingcoinbase.py', 'wallet.py', 'wallet_shieldcoinbase_sprout.py', 'sprout_sapling_migration.py', 'remove_sprout_shielding.py', 'zcjoinsplitdoublespend.py', 'zcjoinsplit.py', 'mergetoaddress_mixednotes.py', 'wallet_shieldcoinbase_sapling.py', 'wallet_shieldcoinbase_ua_sapling.py', 'wallet_shieldcoinbase_ua_nu5.py', 'turnstile.py', 'walletbackup.py', 'zkey_import_export.py', 'prioritisetransaction.py', 'wallet_changeaddresses.py', 'wallet_listreceived.py', 'mempool_tx_expiry.py', 'finalsaplingroot.py', 'wallet_orchard.py', 'wallet_overwintertx.py', 'wallet_persistence.py', 'wallet_listnotes.py', 'orchard_reorg.py', 'fundrawtransaction.py']

-------------------------
Finished stage rpc_group0

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group1
Running stage rpc_group1
========================

rpc test list size: 108
rpc group size:  27
['reorg_limit.py', 'mempool_limit.py', 'p2p-fullblocktest.py', 'wallet_1941.py', 'wallet_accounts.py', 'wallet_addresses.py', 'wallet_anchorfork.py', 'wallet_changeindicator.py', 'wallet_deprecation.py', 'wallet_doublespend.py', 'wallet_import_export.py', 'wallet_isfromme.py', 'wallet_orchard_change.py', 'wallet_orchard_init.py', 'wallet_orchard_persistence.py', 'wallet_nullifiers.py', 'wallet_sapling.py', 'wallet_sendmany_any_taddr.py', 'wallet_treestate.py', 'wallet_unified_change.py', 'listtransactions.py', 'mempool_resurrect_test.py', 'txn_doublespend.py', 'txn_doublespend.py --mineblock', 'getchaintips.py', 'rawtransactions.py', 'getrawtransaction_insight.py']

-------------------------
Finished stage rpc_group1

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group2
Running stage rpc_group2
========================

rpc test list size: 108
rpc group size:  27
['rest.py', 'mempool_spendcoinbase.py', 'mempool_reorg.py', 'mempool_nu_activation.py', 'httpbasics.py', 'multi_rpc.py', 'zapwallettxes.py', 'proxy_test.py', 'merkle_blocks.py', 'signrawtransactions.py', 'signrawtransaction_offline.py', 'key_import_export.py', 'nodehandling.py', 'reindex.py', 'addressindex.py', 'spentindex.py', 'timestampindex.py', 'decodescript.py', 'blockchain.py', 'disablewallet.py', 'keypool.py', 'getblocktemplate.py', 'getmininginfo.py', 'bip65-cltv-p2p.py', 'bipdersig-p2p.py', 'invalidblockrequest.py', 'invalidtxrequest.py']

-------------------------
Finished stage rpc_group2

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group3
Running stage rpc_group3
========================

rpc test list size: 108
rpc group size:  27
['p2p_nu_peer_management.py', 'rewind_index.py', 'p2p_txexpiry_dos.py', 'p2p_txexpiringsoon.py', 'p2p_node_bloom.py', 'regtest_signrawtransaction.py', 'shorter_block_times.py', 'mining_shielded_coinbase.py', 'coinbase_funding_streams.py', 'framework.py', 'sapling_rewind_check.py', 'feature_zip221.py', 'feature_zip239.py', 'feature_zip244_blockcommitments.py', 'upgrade_golden.py', 'nuparams.py', 'post_heartwood_rollback.py', 'feature_logging.py', 'feature_walletfile.py', 'wallet_parsing_amounts.py', 'wallet_broadcast.py', 'wallet_z_sendmany.py', 'wallet_zero_value.py', 'threeofthreerestore.py', 'bucket1.py', 'bucket2.py', 'zmq_test.py']

-------------------------
Finished stage rpc_group3
```
### Test Case 3 (another uneven)
```
mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc
Running stage rpc
=================

rpc test list size: 109
Traceback (most recent call last):
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 470, in <module>
    main()
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 281, in main
    print("rpc group size: ", len(split_list[args.rpcgroup]))
IndexError: list index out of range

------------------
Finished stage rpc

!!! Stage rpc failed !!!
!!! One or more test stages failed !!!
mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group0
Running stage rpc_group0
========================

rpc test list size: 109
rpc group size:  28
['mergetoaddress_sapling.py', 'mergetoaddress_sprout.py', 'wallet_shieldingcoinbase.py', 'wallet.py', 'wallet_shieldcoinbase_sprout.py', 'sprout_sapling_migration.py', 'remove_sprout_shielding.py', 'zcjoinsplitdoublespend.py', 'zcjoinsplit.py', 'mergetoaddress_mixednotes.py', 'wallet_shieldcoinbase_sapling.py', 'wallet_shieldcoinbase_ua_sapling.py', 'wallet_shieldcoinbase_ua_nu5.py', 'turnstile.py', 'walletbackup.py', 'zkey_import_export.py', 'prioritisetransaction.py', 'wallet_changeaddresses.py', 'wallet_listreceived.py', 'mempool_tx_expiry.py', 'finalsaplingroot.py', 'wallet_orchard.py', 'wallet_overwintertx.py', 'wallet_persistence.py', 'wallet_listnotes.py', 'orchard_reorg.py', 'fundrawtransaction.py', 'reorg_limit.py']

-------------------------
Finished stage rpc_group0

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group1
Running stage rpc_group1
========================

rpc test list size: 109
rpc group size:  27
['mempool_limit.py', 'p2p-fullblocktest.py', 'wallet_1941.py', 'wallet_accounts.py', 'wallet_addresses.py', 'wallet_anchorfork.py', 'wallet_changeindicator.py', 'wallet_deprecation.py', 'wallet_doublespend.py', 'wallet_import_export.py', 'wallet_isfromme.py', 'wallet_orchard_change.py', 'wallet_orchard_init.py', 'wallet_orchard_persistence.py', 'wallet_nullifiers.py', 'wallet_sapling.py', 'wallet_sendmany_any_taddr.py', 'wallet_treestate.py', 'wallet_unified_change.py', 'listtransactions.py', 'mempool_resurrect_test.py', 'txn_doublespend.py', 'txn_doublespend.py --mineblock', 'getchaintips.py', 'rawtransactions.py', 'getrawtransaction_insight.py', 'rest.py']

-------------------------
Finished stage rpc_group1

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group2
Running stage rpc_group2
========================

rpc test list size: 109
rpc group size:  27
['mempool_spendcoinbase.py', 'mempool_reorg.py', 'mempool_nu_activation.py', 'httpbasics.py', 'multi_rpc.py', 'zapwallettxes.py', 'proxy_test.py', 'merkle_blocks.py', 'signrawtransactions.py', 'signrawtransaction_offline.py', 'key_import_export.py', 'nodehandling.py', 'reindex.py', 'addressindex.py', 'spentindex.py', 'timestampindex.py', 'decodescript.py', 'blockchain.py', 'disablewallet.py', 'keypool.py', 'getblocktemplate.py', 'getmininginfo.py', 'bip65-cltv-p2p.py', 'bipdersig-p2p.py', 'invalidblockrequest.py', 'invalidtxrequest.py', 'p2p_nu_peer_management.py']

-------------------------
Finished stage rpc_group2

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group3
Running stage rpc_group3
========================

rpc test list size: 109
rpc group size:  27
['rewind_index.py', 'p2p_txexpiry_dos.py', 'p2p_txexpiringsoon.py', 'p2p_node_bloom.py', 'regtest_signrawtransaction.py', 'shorter_block_times.py', 'mining_shielded_coinbase.py', 'coinbase_funding_streams.py', 'framework.py', 'sapling_rewind_check.py', 'feature_zip221.py', 'feature_zip239.py', 'feature_zip244_blockcommitments.py', 'upgrade_golden.py', 'nuparams.py', 'post_heartwood_rollback.py', 'feature_logging.py', 'feature_walletfile.py', 'wallet_parsing_amounts.py', 'wallet_broadcast.py', 'wallet_z_sendmany.py', 'wallet_zero_value.py', 'threeofthreerestore.py', 'bucket1.py', 'bucket2.py', 'bucket3.py', 'zmq_test.py']

-------------------------
Finished stage rpc_group3
```
## Test Cases for Sort 2 :
```
    k, m = divmod(len(test_list), args.machines)
    k = k if m == 0 else k+1
    split_list = list(test_list[i*k:min((i+1)*k, len(test_list))] for i in range(args.machines))
```
### Test Case 1(default):
```mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc
Running stage rpc
=================

rpc test list size: 106
Traceback (most recent call last):
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 467, in <module>
    main()
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 278, in main
    print("rpc group size: ", len(split_list[args.rpcgroup]))
IndexError: list index out of range

------------------
Finished stage rpc

!!! Stage rpc failed !!!
!!! One or more test stages failed !!!
mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group0
Running stage rpc_group0
========================

rpc test list size: 106
rpc group size:  27
['mergetoaddress_sapling.py', 'mergetoaddress_sprout.py', 'wallet_shieldingcoinbase.py', 'wallet.py', 'wallet_shieldcoinbase_sprout.py', 'sprout_sapling_migration.py', 'remove_sprout_shielding.py', 'zcjoinsplitdoublespend.py', 'zcjoinsplit.py', 'mergetoaddress_mixednotes.py', 'wallet_shieldcoinbase_sapling.py', 'wallet_shieldcoinbase_ua_sapling.py', 'wallet_shieldcoinbase_ua_nu5.py', 'turnstile.py', 'walletbackup.py', 'zkey_import_export.py', 'prioritisetransaction.py', 'wallet_changeaddresses.py', 'wallet_listreceived.py', 'mempool_tx_expiry.py', 'finalsaplingroot.py', 'wallet_orchard.py', 'wallet_overwintertx.py', 'wallet_persistence.py', 'wallet_listnotes.py', 'orchard_reorg.py', 'fundrawtransaction.py']

-------------------------
Finished stage rpc_group0

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group1
Running stage rpc_group1
========================

rpc test list size: 106
rpc group size:  27
['reorg_limit.py', 'mempool_limit.py', 'p2p-fullblocktest.py', 'wallet_1941.py', 'wallet_accounts.py', 'wallet_addresses.py', 'wallet_anchorfork.py', 'wallet_changeindicator.py', 'wallet_deprecation.py', 'wallet_doublespend.py', 'wallet_import_export.py', 'wallet_isfromme.py', 'wallet_orchard_change.py', 'wallet_orchard_init.py', 'wallet_orchard_persistence.py', 'wallet_nullifiers.py', 'wallet_sapling.py', 'wallet_sendmany_any_taddr.py', 'wallet_treestate.py', 'wallet_unified_change.py', 'listtransactions.py', 'mempool_resurrect_test.py', 'txn_doublespend.py', 'txn_doublespend.py --mineblock', 'getchaintips.py', 'rawtransactions.py', 'getrawtransaction_insight.py']

-------------------------
Finished stage rpc_group1

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group2
Running stage rpc_group2
========================

rpc test list size: 106
rpc group size:  27
['rest.py', 'mempool_spendcoinbase.py', 'mempool_reorg.py', 'mempool_nu_activation.py', 'httpbasics.py', 'multi_rpc.py', 'zapwallettxes.py', 'proxy_test.py', 'merkle_blocks.py', 'signrawtransactions.py', 'signrawtransaction_offline.py', 'key_import_export.py', 'nodehandling.py', 'reindex.py', 'addressindex.py', 'spentindex.py', 'timestampindex.py', 'decodescript.py', 'blockchain.py', 'disablewallet.py', 'keypool.py', 'getblocktemplate.py', 'getmininginfo.py', 'bip65-cltv-p2p.py', 'bipdersig-p2p.py', 'invalidblockrequest.py', 'invalidtxrequest.py']

-------------------------
Finished stage rpc_group2

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group3
Running stage rpc_group3
========================

rpc test list size: 106
rpc group size:  25
['p2p_nu_peer_management.py', 'rewind_index.py', 'p2p_txexpiry_dos.py', 'p2p_txexpiringsoon.py', 'p2p_node_bloom.py', 'regtest_signrawtransaction.py', 'shorter_block_times.py', 'mining_shielded_coinbase.py', 'coinbase_funding_streams.py', 'framework.py', 'sapling_rewind_check.py', 'feature_zip221.py', 'feature_zip239.py', 'feature_zip244_blockcommitments.py', 'upgrade_golden.py', 'nuparams.py', 'post_heartwood_rollback.py', 'feature_logging.py', 'feature_walletfile.py', 'wallet_parsing_amounts.py', 'wallet_broadcast.py', 'wallet_z_sendmany.py', 'wallet_zero_value.py', 'threeofthreerestore.py', 'zmq_test.py']

-------------------------
Finished stage rpc_group3
```

### Test Case 2 (even sort):
```
mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc
Running stage rpc
=================

rpc test list size: 108
Traceback (most recent call last):
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 469, in <module>
    main()
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 280, in main
    print("rpc group size: ", len(split_list[args.rpcgroup]))
IndexError: list index out of range

------------------
Finished stage rpc

!!! Stage rpc failed !!!
!!! One or more test stages failed !!!
mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group0
Running stage rpc_group0
========================

rpc test list size: 108
rpc group size:  27
['mergetoaddress_sapling.py', 'mergetoaddress_sprout.py', 'wallet_shieldingcoinbase.py', 'wallet.py', 'wallet_shieldcoinbase_sprout.py', 'sprout_sapling_migration.py', 'remove_sprout_shielding.py', 'zcjoinsplitdoublespend.py', 'zcjoinsplit.py', 'mergetoaddress_mixednotes.py', 'wallet_shieldcoinbase_sapling.py', 'wallet_shieldcoinbase_ua_sapling.py', 'wallet_shieldcoinbase_ua_nu5.py', 'turnstile.py', 'walletbackup.py', 'zkey_import_export.py', 'prioritisetransaction.py', 'wallet_changeaddresses.py', 'wallet_listreceived.py', 'mempool_tx_expiry.py', 'finalsaplingroot.py', 'wallet_orchard.py', 'wallet_overwintertx.py', 'wallet_persistence.py', 'wallet_listnotes.py', 'orchard_reorg.py', 'fundrawtransaction.py']

-------------------------
Finished stage rpc_group0

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group1
Running stage rpc_group1
========================

rpc test list size: 108
rpc group size:  27
['reorg_limit.py', 'mempool_limit.py', 'p2p-fullblocktest.py', 'wallet_1941.py', 'wallet_accounts.py', 'wallet_addresses.py', 'wallet_anchorfork.py', 'wallet_changeindicator.py', 'wallet_deprecation.py', 'wallet_doublespend.py', 'wallet_import_export.py', 'wallet_isfromme.py', 'wallet_orchard_change.py', 'wallet_orchard_init.py', 'wallet_orchard_persistence.py', 'wallet_nullifiers.py', 'wallet_sapling.py', 'wallet_sendmany_any_taddr.py', 'wallet_treestate.py', 'wallet_unified_change.py', 'listtransactions.py', 'mempool_resurrect_test.py', 'txn_doublespend.py', 'txn_doublespend.py --mineblock', 'getchaintips.py', 'rawtransactions.py', 'getrawtransaction_insight.py']

-------------------------
Finished stage rpc_group1

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group2
Running stage rpc_group2
========================

rpc test list size: 108
rpc group size:  27
['rest.py', 'mempool_spendcoinbase.py', 'mempool_reorg.py', 'mempool_nu_activation.py', 'httpbasics.py', 'multi_rpc.py', 'zapwallettxes.py', 'proxy_test.py', 'merkle_blocks.py', 'signrawtransactions.py', 'signrawtransaction_offline.py', 'key_import_export.py', 'nodehandling.py', 'reindex.py', 'addressindex.py', 'spentindex.py', 'timestampindex.py', 'decodescript.py', 'blockchain.py', 'disablewallet.py', 'keypool.py', 'getblocktemplate.py', 'getmininginfo.py', 'bip65-cltv-p2p.py', 'bipdersig-p2p.py', 'invalidblockrequest.py', 'invalidtxrequest.py']

-------------------------
Finished stage rpc_group2

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group3
Running stage rpc_group3
========================

rpc test list size: 108
rpc group size:  27
['p2p_nu_peer_management.py', 'rewind_index.py', 'p2p_txexpiry_dos.py', 'p2p_txexpiringsoon.py', 'p2p_node_bloom.py', 'regtest_signrawtransaction.py', 'shorter_block_times.py', 'mining_shielded_coinbase.py', 'coinbase_funding_streams.py', 'framework.py', 'sapling_rewind_check.py', 'feature_zip221.py', 'feature_zip239.py', 'feature_zip244_blockcommitments.py', 'upgrade_golden.py', 'nuparams.py', 'post_heartwood_rollback.py', 'feature_logging.py', 'feature_walletfile.py', 'wallet_parsing_amounts.py', 'wallet_broadcast.py', 'wallet_z_sendmany.py', 'wallet_zero_value.py', 'threeofthreerestore.py', 'bucket1.py', 'bucket2.py', 'zmq_test.py']

-------------------------
Finished stage rpc_group3
```
### Test Case 3(another uneven sort):
```
mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc
Running stage rpc
=================

rpc test list size: 109
Traceback (most recent call last):
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 470, in <module>
    main()
  File "/home/mdr0id/Code/github_so_cool/zcash/qa/pull-tester/rpc-tests.py", line 281, in main
    print("rpc group size: ", len(split_list[args.rpcgroup]))
IndexError: list index out of range

------------------
Finished stage rpc

!!! Stage rpc failed !!!
!!! One or more test stages failed !!!
mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group0
Running stage rpc_group0
========================

rpc test list size: 109
rpc group size:  28
['mergetoaddress_sapling.py', 'mergetoaddress_sprout.py', 'wallet_shieldingcoinbase.py', 'wallet.py', 'wallet_shieldcoinbase_sprout.py', 'sprout_sapling_migration.py', 'remove_sprout_shielding.py', 'zcjoinsplitdoublespend.py', 'zcjoinsplit.py', 'mergetoaddress_mixednotes.py', 'wallet_shieldcoinbase_sapling.py', 'wallet_shieldcoinbase_ua_sapling.py', 'wallet_shieldcoinbase_ua_nu5.py', 'turnstile.py', 'walletbackup.py', 'zkey_import_export.py', 'prioritisetransaction.py', 'wallet_changeaddresses.py', 'wallet_listreceived.py', 'mempool_tx_expiry.py', 'finalsaplingroot.py', 'wallet_orchard.py', 'wallet_overwintertx.py', 'wallet_persistence.py', 'wallet_listnotes.py', 'orchard_reorg.py', 'fundrawtransaction.py', 'reorg_limit.py']

-------------------------
Finished stage rpc_group0

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group1
Running stage rpc_group1
========================

rpc test list size: 109
rpc group size:  28
['mempool_limit.py', 'p2p-fullblocktest.py', 'wallet_1941.py', 'wallet_accounts.py', 'wallet_addresses.py', 'wallet_anchorfork.py', 'wallet_changeindicator.py', 'wallet_deprecation.py', 'wallet_doublespend.py', 'wallet_import_export.py', 'wallet_isfromme.py', 'wallet_orchard_change.py', 'wallet_orchard_init.py', 'wallet_orchard_persistence.py', 'wallet_nullifiers.py', 'wallet_sapling.py', 'wallet_sendmany_any_taddr.py', 'wallet_treestate.py', 'wallet_unified_change.py', 'listtransactions.py', 'mempool_resurrect_test.py', 'txn_doublespend.py', 'txn_doublespend.py --mineblock', 'getchaintips.py', 'rawtransactions.py', 'getrawtransaction_insight.py', 'rest.py', 'mempool_spendcoinbase.py']

-------------------------
Finished stage rpc_group1

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group2
Running stage rpc_group2
========================

rpc test list size: 109
rpc group size:  28
['mempool_reorg.py', 'mempool_nu_activation.py', 'httpbasics.py', 'multi_rpc.py', 'zapwallettxes.py', 'proxy_test.py', 'merkle_blocks.py', 'signrawtransactions.py', 'signrawtransaction_offline.py', 'key_import_export.py', 'nodehandling.py', 'reindex.py', 'addressindex.py', 'spentindex.py', 'timestampindex.py', 'decodescript.py', 'blockchain.py', 'disablewallet.py', 'keypool.py', 'getblocktemplate.py', 'getmininginfo.py', 'bip65-cltv-p2p.py', 'bipdersig-p2p.py', 'invalidblockrequest.py', 'invalidtxrequest.py', 'p2p_nu_peer_management.py', 'rewind_index.py', 'p2p_txexpiry_dos.py']

-------------------------
Finished stage rpc_group2

mdr0id@pop-os:~/Code/github_so_cool/zcash$ ./qa/zcash/full_test_suite.py rpc_group3
Running stage rpc_group3
========================

rpc test list size: 109
rpc group size:  25
['p2p_txexpiringsoon.py', 'p2p_node_bloom.py', 'regtest_signrawtransaction.py', 'shorter_block_times.py', 'mining_shielded_coinbase.py', 'coinbase_funding_streams.py', 'framework.py', 'sapling_rewind_check.py', 'feature_zip221.py', 'feature_zip239.py', 'feature_zip244_blockcommitments.py', 'upgrade_golden.py', 'nuparams.py', 'post_heartwood_rollback.py', 'feature_logging.py', 'feature_walletfile.py', 'wallet_parsing_amounts.py', 'wallet_broadcast.py', 'wallet_z_sendmany.py', 'wallet_zero_value.py', 'threeofthreerestore.py', 'bucket1.py', 'bucket2.py', 'bucket3.py', 'zmq_test.py']

-------------------------
Finished stage rpc_group3
```

