### PR TITLE
Add a clock for testing with an offset from the system clock.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -686,6 +686,22 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]],
  [ AC_MSG_RESULT(no)]
 )
 
+dnl check for gmtime_r(), fallback to gmtime_s() if that is unavailable
+dnl fail if neither are available.
+AC_MSG_CHECKING(for gmtime_r)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctime>]],
+  [[ gmtime_r((const time_t *) nullptr, (struct tm *) nullptr); ]])],
+  [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_GMTIME_R, 1, [Define this symbol if gmtime_r is available]) ],
+  [ AC_MSG_RESULT(no);
+    AC_MSG_CHECKING(for gmtime_s);
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctime>]],
+       [[ gmtime_s((struct tm *) nullptr, (const time_t *) nullptr); ]])],
+       [ AC_MSG_RESULT(yes)],
+       [ AC_MSG_RESULT(no); AC_MSG_ERROR(Both gmtime_r and gmtime_s are unavailable) ]
+    )
+  ]
+)
+
 AC_MSG_CHECKING([for visibility attribute])
 AC_LINK_IFELSE([AC_LANG_SOURCE([
   int foo_def( void ) __attribute__((visibility("default")));
@@ -1008,6 +1024,7 @@ AC_SUBST(LEVELDB_TARGET_FLAGS)
 AC_SUBST(EVENT_LIBS)
 AC_SUBST(EVENT_PTHREADS_LIBS)
 AC_SUBST(ZMQ_LIBS)
+AC_SUBST(HAVE_GMTIME_R)
 AC_SUBST(LIBZCASH_LIBS)
 AC_CONFIG_FILES([Makefile src/Makefile doc/man/Makefile src/test/buildenv.py])
 AC_CONFIG_FILES([qa/pull-tester/tests_config.ini],[chmod +x qa/pull-tester/tests_config.ini])

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -122,12 +122,18 @@ class MaxUploadTest(BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, 2)
 
     def setup_network(self):
+        # We will start the node mocking the time otherwise things break
+        # because the CNode time counters can't be reset backward after
+        # initialization
+        old_time = int(time.time() - 60*60*24*9)
+
         # Start a node with maxuploadtarget of 200 MB (/24h)
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, [
             "-debug",
             '-nuparams=2bb40e60:1', # Blossom
-            "-maxuploadtarget=2200"]))
+            "-maxuploadtarget=2200",
+            "-mocktime=%d" % old_time ]))
 
     def mine_full_block(self, node, address):
         # Want to create a full block
@@ -155,12 +161,6 @@ class MaxUploadTest(BitcoinTestFramework):
         node.generate(1)
 
     def run_test(self):
-        # Before we connect anything, we first set the time on the node
-        # to be in the past, otherwise things break because the CNode
-        # time counters can't be reset backward after initialization
-        old_time = int(time.time() - 60*60*24*9)
-        self.nodes[0].setmocktime(old_time)
-
         # Generate some old blocks
         self.nodes[0].generate(260)
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -262,12 +262,14 @@ def initialize_chain(test_dir, num_nodes, cachedir):
                 shutil.rmtree(os.path.join(cachedir,"node"+str(i)))
 
         # Create cache directories, run bitcoinds:
+        block_time = int(time.time()) - (200 * PRE_BLOSSOM_BLOCK_TARGET_SPACING)
         for i in range(MAX_NODES):
             datadir=initialize_datadir(cachedir, i)
             args = [ os.getenv("ZCASHD", ZCASHD_BINARY), "-keypool=1", "-datadir="+datadir, "-discover=0" ]
             args.extend([
                 '-nuparams=5ba81b19:1', # Overwinter
                 '-nuparams=76b809bb:1', # Sapling
+                '-mocktime=%d' % block_time
             ])
             if i > 0:
                 args.append("-connect=127.0.0.1:"+str(p2p_port(0)))
@@ -294,7 +296,6 @@ def initialize_chain(test_dir, num_nodes, cachedir):
         # Blocks are created with timestamps 2.5 minutes apart (matching the
         # chain defaulting above to Sapling active), starting 200 * 2.5 minutes
         # before the current time.
-        block_time = int(time.time()) - (200 * PRE_BLOSSOM_BLOCK_TARGET_SPACING)
         for i in range(2):
             for peer in range(4):
                 for j in range(25):

--- a/qa/rpc-tests/wallet_1941.py
+++ b/qa/rpc-tests/wallet_1941.py
@@ -23,28 +23,37 @@ class Wallet1941RegressionTest (BitcoinTestFramework):
 
     # Start nodes with -regtestshieldcoinbase to set fCoinbaseMustBeShielded to true.
     def setup_network(self, split=False):
-        self.nodes = start_nodes(1, self.options.tmpdir, extra_args=[['-regtestshieldcoinbase','-debug=zrpc']] )
+        self.nodes = start_nodes(1, self.options.tmpdir, extra_args=[[
+            '-regtestshieldcoinbase',
+            '-debug=zrpc',
+            '-mocktime=%d' % starttime
+            ]] )
         self.is_network_split=False
 
     def add_second_node(self):
         initialize_datadir(self.options.tmpdir, 1)
-        self.nodes.append(start_node(1, self.options.tmpdir, extra_args=['-regtestshieldcoinbase','-debug=zrpc']))
-        self.nodes[1].setmocktime(starttime + 9000)
+        self.nodes.append(start_node(1, self.options.tmpdir, extra_args=[
+            '-regtestshieldcoinbase',
+            '-debug=zrpc',
+            '-mocktime=%d' % (starttime + 9000)
+            ]))
         connect_nodes_bi(self.nodes,0,1)
         self.sync_all()
 
     def restart_second_node(self, extra_args=[]):
         self.nodes[1].stop()
         bitcoind_processes[1].wait()
-        self.nodes[1] = start_node(1, self.options.tmpdir, extra_args=['-regtestshieldcoinbase','-debug=zrpc'] + extra_args)
-        self.nodes[1].setmocktime(starttime + 9000)
+        self.nodes[1] = start_node(1, self.options.tmpdir, extra_args=[
+            '-regtestshieldcoinbase',
+            '-debug=zrpc',
+            '-mocktime=%d' % (starttime + 9000)
+            ] + extra_args)
         connect_nodes_bi(self.nodes, 0, 1)
         self.sync_all()
 
     def run_test (self):
         print("Mining blocks...")
 
-        self.nodes[0].setmocktime(starttime)
         self.nodes[0].generate(101)
         self.sync_all()
 

--- a/src/gtest/test_mempoollimit.cpp
+++ b/src/gtest/test_mempoollimit.cpp
@@ -19,8 +19,8 @@ const uint256 TX_ID3 = ArithToUint256(3);
 
 TEST(MempoolLimitTests, RecentlyEvictedListAddWrapsAfterMaxSize)
 {
-    RecentlyEvictedList recentlyEvicted(2, 100);
-    SetMockTime(1);
+    FixedClock clock(std::chrono::seconds(1));
+    RecentlyEvictedList recentlyEvicted(&clock, 2, 100);
     recentlyEvicted.add(TX_ID1);
     recentlyEvicted.add(TX_ID2);
     recentlyEvicted.add(TX_ID3);
@@ -32,23 +32,23 @@ TEST(MempoolLimitTests, RecentlyEvictedListAddWrapsAfterMaxSize)
 
 TEST(MempoolLimitTests, RecentlyEvictedListDoesNotContainAfterExpiry)
 {
-    SetMockTime(1);
+    FixedClock clock(std::chrono::seconds(1));
     // maxSize=3, timeToKeep=1
-    RecentlyEvictedList recentlyEvicted(3, 1);
+    RecentlyEvictedList recentlyEvicted(&clock, 3, 1);
     recentlyEvicted.add(TX_ID1);
-    SetMockTime(2);
+    clock.Set(std::chrono::seconds(2));
     recentlyEvicted.add(TX_ID2);
     recentlyEvicted.add(TX_ID3);
     // After 1 second the txId will still be there
     EXPECT_TRUE(recentlyEvicted.contains(TX_ID1));
     EXPECT_TRUE(recentlyEvicted.contains(TX_ID2));
     EXPECT_TRUE(recentlyEvicted.contains(TX_ID3));
-    SetMockTime(3);
+    clock.Set(std::chrono::seconds(3));
     // After 2 seconds it is gone
     EXPECT_FALSE(recentlyEvicted.contains(TX_ID1));
     EXPECT_TRUE(recentlyEvicted.contains(TX_ID2));
     EXPECT_TRUE(recentlyEvicted.contains(TX_ID3));
-    SetMockTime(4);
+    clock.Set(std::chrono::seconds(4));
     EXPECT_FALSE(recentlyEvicted.contains(TX_ID1));
     EXPECT_FALSE(recentlyEvicted.contains(TX_ID2));
     EXPECT_FALSE(recentlyEvicted.contains(TX_ID3));
@@ -56,25 +56,25 @@ TEST(MempoolLimitTests, RecentlyEvictedListDoesNotContainAfterExpiry)
 
 TEST(MempoolLimitTests, RecentlyEvictedDropOneAtATime)
 {
-    SetMockTime(1);
-    RecentlyEvictedList recentlyEvicted(3, 2);
+    FixedClock clock(std::chrono::seconds(1));
+    RecentlyEvictedList recentlyEvicted(&clock, 3, 2);
     recentlyEvicted.add(TX_ID1);
-    SetMockTime(2);
+    clock.Set(std::chrono::seconds(2));
     recentlyEvicted.add(TX_ID2);
-    SetMockTime(3);
+    clock.Set(std::chrono::seconds(3));
     recentlyEvicted.add(TX_ID3);
     EXPECT_TRUE(recentlyEvicted.contains(TX_ID1));
     EXPECT_TRUE(recentlyEvicted.contains(TX_ID2));
     EXPECT_TRUE(recentlyEvicted.contains(TX_ID3));
-    SetMockTime(4);
+    clock.Set(std::chrono::seconds(4));
     EXPECT_FALSE(recentlyEvicted.contains(TX_ID1));
     EXPECT_TRUE(recentlyEvicted.contains(TX_ID2));
     EXPECT_TRUE(recentlyEvicted.contains(TX_ID3));
-    SetMockTime(5);
+    clock.Set(std::chrono::seconds(5));
     EXPECT_FALSE(recentlyEvicted.contains(TX_ID1));
     EXPECT_FALSE(recentlyEvicted.contains(TX_ID2));
     EXPECT_TRUE(recentlyEvicted.contains(TX_ID3));
-    SetMockTime(6);
+    clock.Set(std::chrono::seconds(6));
     EXPECT_FALSE(recentlyEvicted.contains(TX_ID1));
     EXPECT_FALSE(recentlyEvicted.contains(TX_ID2));
     EXPECT_FALSE(recentlyEvicted.contains(TX_ID3));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -833,6 +833,10 @@ bool InitSanityCheck(void)
     if (!glibc_sanity_test() || !glibcxx_sanity_test())
         return false;
 
+    if (!ChronoSanityCheck()) {
+        return InitError("Clock epoch mismatch. Aborting.");
+    }
+
     return true;
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -46,6 +46,7 @@
 #include "wallet/walletdb.h"
 #endif
 #include "warnings.h"
+#include <chrono>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -1244,8 +1245,21 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     fAlerts = GetBoolArg("-alerts", DEFAULT_ALERTS);
 
-    // Option to startup with mocktime set (used for regression testing):
-    SetMockTime(GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op
+    // Option to startup with mocktime set (used for regression testing);
+    // a mocktime of 0 (the default) selects the system clock.
+    int64_t nMockTime = GetArg("-mocktime", 0);
+    int64_t nOffsetTime = GetArg("-clockoffset", 0);
+    if (nMockTime != 0 && nOffsetTime != 0) {
+        return InitError(_("-mocktime and -clockoffset cannot be used together"));
+    } else if (nMockTime != 0) {
+        FixedClock::SetGlobal();
+        FixedClock::Instance()->Set(std::chrono::seconds(nMockTime));
+    } else if (nOffsetTime != 0) {
+        // Option to start a node with the system clock offset by a constant
+        // value throughout the life of the node (used for regression testing):
+        OffsetClock::SetGlobal();
+        OffsetClock::Instance()->Set(std::chrono::seconds(nOffsetTime));
+    }
 
     if (GetBoolArg("-peerbloomfilters", DEFAULT_PEERBLOOMFILTERS))
         nLocalServices |= NODE_BLOOM;

--- a/src/mempool_limit.cpp
+++ b/src/mempool_limit.cpp
@@ -19,7 +19,7 @@ void RecentlyEvictedList::pruneList()
     if (txIdSet.empty()) {
         return;
     }
-    int64_t now = GetTime();
+    int64_t now = clock->GetTime();
     while (txIdsAndTimes.size() > 0 && now - txIdsAndTimes.front().second > timeToKeep) {
         txIdSet.erase(txIdsAndTimes.front().first);
         txIdsAndTimes.pop_front();
@@ -33,7 +33,7 @@ void RecentlyEvictedList::add(const uint256& txId)
         txIdSet.erase(txIdsAndTimes.front().first);
         txIdsAndTimes.pop_front();
     }
-    txIdsAndTimes.push_back(std::make_pair(txId, GetTime()));
+    txIdsAndTimes.push_back(std::make_pair(txId, clock->GetTime()));
     txIdSet.insert(txId);
 }
 

--- a/src/mempool_limit.h
+++ b/src/mempool_limit.h
@@ -14,6 +14,7 @@
 #include "primitives/transaction.h"
 #include "policy/fees.h"
 #include "uint256.h"
+#include "util/time.h"
 
 const size_t DEFAULT_MEMPOOL_TOTAL_COST_LIMIT = 80000000;
 const int64_t DEFAULT_MEMPOOL_EVICTION_MEMORY_MINUTES = 60;
@@ -27,6 +28,8 @@ const uint64_t LOW_FEE_PENALTY = 16000;
 // in order to prevent them from being re-accepted for a given amount of time.
 class RecentlyEvictedList
 {
+    const CClock* const clock;
+
     const size_t capacity;
 
     const int64_t timeToKeep;
@@ -39,11 +42,13 @@ class RecentlyEvictedList
     void pruneList();
 
 public:
-    RecentlyEvictedList(size_t capacity_, int64_t timeToKeep_) : capacity(capacity_), timeToKeep(timeToKeep_)
+    RecentlyEvictedList(const CClock* clock_, size_t capacity_, int64_t timeToKeep_) :
+        clock(clock_), capacity(capacity_), timeToKeep(timeToKeep_)
     {
         assert(capacity <= EVICTION_MEMORY_ENTRIES);
     }
-    RecentlyEvictedList(int64_t timeToKeep_) : RecentlyEvictedList(EVICTION_MEMORY_ENTRIES, timeToKeep_) {}
+    RecentlyEvictedList(const CClock* clock_, int64_t timeToKeep_) :
+        RecentlyEvictedList(clock_, EVICTION_MEMORY_ENTRIES, timeToKeep_) {}
 
     void add(const uint256& txId);
     bool contains(const uint256& txId);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -500,8 +500,7 @@ UniValue setmocktime(const UniValue& params, bool fHelp)
             "\nSet the local time to given timestamp (-regtest only).\n"
             "The node must be started with `-mocktime` in order to use this API.\n"
             "\nArguments:\n"
-            "1. timestamp  (integer, required) Unix seconds-since-epoch timestamp\n"
-            "   Pass 0 to go back to using the system time."
+            "1. timestamp  (integer, required) Unix seconds-since-epoch timestamp."
         );
 
     if (!Params().MineBlocksOnDemand())

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -289,7 +289,8 @@ BOOST_FIXTURE_TEST_SUITE(Alert_tests, ReadAlerts)
 
 BOOST_AUTO_TEST_CASE(AlertApplies)
 {
-    SetMockTime(11);
+    FixedClock::SetGlobal();
+    FixedClock::Instance()->Set(std::chrono::seconds(11));
     const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::MAIN).AlertKey();
 
     for (const CAlert& alert : alerts)
@@ -342,13 +343,14 @@ BOOST_AUTO_TEST_CASE(AlertApplies)
     // SubVer without comment doesn't match SubVer pattern with
     BOOST_CHECK(!alerts[3].AppliesTo(1, "/MagicBean:0.2.1/"));
 
-    SetMockTime(0);
+    SystemClock::SetGlobal();
 }
 
 
 BOOST_AUTO_TEST_CASE(AlertNotify)
 {
-    SetMockTime(11);
+    FixedClock::SetGlobal();
+    FixedClock::Instance()->Set(std::chrono::seconds(11));
     const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::MAIN).AlertKey();
 
     fs::path temp = fs::temp_directory_path() /
@@ -382,13 +384,14 @@ BOOST_AUTO_TEST_CASE(AlertNotify)
 #endif
     fs::remove(temp);
 
-    SetMockTime(0);
+    SystemClock::SetGlobal();
     mapAlerts.clear();
 }
 
 BOOST_AUTO_TEST_CASE(AlertDisablesRPC)
 {
-    SetMockTime(11);
+    FixedClock::SetGlobal();
+    FixedClock::Instance()->Set(std::chrono::seconds(11));
     const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::MAIN).AlertKey();
 
     // Command should work before alerts
@@ -404,7 +407,7 @@ BOOST_AUTO_TEST_CASE(AlertDisablesRPC)
     BOOST_CHECK_EQUAL(alerts[8].strRPCError, "");
     BOOST_CHECK_EQUAL(GetWarnings("rpc").first, "");
 
-    SetMockTime(0);
+    SystemClock::SetGlobal();
     mapAlerts.clear();
 }
 

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -47,8 +47,11 @@ BOOST_AUTO_TEST_CASE(May15)
     // idea, so this test is only run if you manually download
     // test/data/Mar12Fork.dat from
     // http://sourceforge.net/projects/bitcoin/files/Bitcoin/blockchain/Mar12Fork.dat/download
-    unsigned int tMay15 = 1368576000;
-    SetMockTime(tMay15); // Test as if it was right at May 15
+    FixedClock::SetGlobal();
+
+    // Test as if the time is exactly 2013-05-15 00:00:00Z
+    int64_t tMay15 = 1368576000;
+    FixedClock::Instance()->Set(std::chrono::seconds(tMay15));
 
     CBlock forkingBlock;
     if (read_block("Mar12Fork.dat", forkingBlock))
@@ -61,7 +64,7 @@ BOOST_AUTO_TEST_CASE(May15)
         BOOST_CHECK(CheckBlock(forkingBlock, state, Params(), verifier, false, false, true));
     }
 
-    SetMockTime(0);
+    SystemClock::SetGlobal();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -6,6 +6,7 @@
 #include "compat/sanity.h"
 #include "key.h"
 #include "test/test_bitcoin.h"
+#include "util/time.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -16,6 +17,7 @@ BOOST_AUTO_TEST_CASE(basic_sanity)
   BOOST_CHECK_MESSAGE(glibc_sanity_test() == true, "libc sanity test");
   BOOST_CHECK_MESSAGE(glibcxx_sanity_test() == true, "stdlib sanity test");
   BOOST_CHECK_MESSAGE(CKey::ECC_InitSanityCheck() == true, "ECC sanity test");
+  BOOST_CHECK_MESSAGE(ChronoSanityCheck() == true, "chrono epoch test");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -938,7 +938,7 @@ void CTxMemPool::SetMempoolCostLimit(int64_t totalCostLimit, int64_t evictionMem
     LogPrint("mempool", "Setting mempool cost limit: (limit=%d, time=%d)\n", totalCostLimit, evictionMemorySeconds);
     delete recentlyEvicted;
     delete weightedTxTree;
-    recentlyEvicted = new RecentlyEvictedList(evictionMemorySeconds);
+    recentlyEvicted = new RecentlyEvictedList(GetNodeClock(), evictionMemorySeconds);
     weightedTxTree = new WeightedTxTree(totalCostLimit);
 }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -18,6 +18,7 @@
 #include "random.h"
 #include "addressindex.h"
 #include "spentindex.h"
+#include "util/time.h"
 
 #undef foreach
 #include "boost/multi_index_container.hpp"
@@ -209,7 +210,7 @@ private:
     std::map<uint256, const CTransaction*> mapSproutNullifiers;
     std::map<uint256, const CTransaction*> mapSaplingNullifiers;
     std::map<uint256, const CTransaction*> mapOrchardNullifiers;
-    RecentlyEvictedList* recentlyEvicted = new RecentlyEvictedList(DEFAULT_MEMPOOL_EVICTION_MEMORY_MINUTES * 60);
+    RecentlyEvictedList* recentlyEvicted = new RecentlyEvictedList(GetNodeClock(), DEFAULT_MEMPOOL_EVICTION_MEMORY_MINUTES * 60);
     WeightedTxTree* weightedTxTree = new WeightedTxTree(DEFAULT_MEMPOOL_TOTAL_COST_LIMIT);
 
     void checkNullifiers(ShieldedType type) const;

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -25,6 +25,50 @@ int64_t GetTime()
     return time(NULL);
 }
 
+bool ChronoSanityCheck()
+{
+    // std::chrono::system_clock.time_since_epoch and time_t(0) are not guaranteed
+    // to use the Unix epoch timestamp, prior to C++20, but in practice they almost
+    // certainly will. Any differing behavior will be assumed to be an error, unless
+    // certain platforms prove to consistently deviate, at which point we'll cope
+    // with it by adding offsets.
+
+    // Create a new clock from time_t(0) and make sure that it represents 0
+    // seconds from the system_clock's time_since_epoch. Then convert that back
+    // to a time_t and verify that it's the same as before.
+    const time_t time_t_epoch{};
+    auto clock = std::chrono::system_clock::from_time_t(time_t_epoch);
+    if (std::chrono::duration_cast<std::chrono::seconds>(clock.time_since_epoch()).count() != 0) {
+        return false;
+    }
+
+    time_t time_val = std::chrono::system_clock::to_time_t(clock);
+    if (time_val != time_t_epoch) {
+        return false;
+    }
+
+    // Check that the above zero time is actually equal to the known unix timestamp.
+    struct tm epoch;
+#ifdef HAVE_GMTIME_R
+    if (gmtime_r(&time_val, &epoch) == nullptr) {
+#else
+    if (gmtime_s(&epoch, &time_val) != 0) {
+#endif
+        return false;
+    }
+
+    if ((epoch.tm_sec != 0)  ||
+       (epoch.tm_min  != 0)  ||
+       (epoch.tm_hour != 0)  ||
+       (epoch.tm_mday != 1)  ||
+       (epoch.tm_mon  != 0)  ||
+       (epoch.tm_year != 70)) {
+        return false;
+    }
+    return true;
+}
+
+
 void SetMockTime(int64_t nMockTimeIn)
 {
     nMockTime = nMockTimeIn;

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -15,7 +15,9 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
 
+// This guards accesses to FixedClock and OffsetClock.
 RecursiveMutex cs_clock;
+
 static CClock* zcashdClock = SystemClock::Instance();
 
 const CClock* GetNodeClock() {

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -18,4 +18,7 @@ void MilliSleep(int64_t n);
 
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);
 
+/** Sanity check epoch match normal Unix epoch */
+bool ChronoSanityCheck();
+
 #endif // BITCOIN_UTIL_TIME_H

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -24,8 +24,8 @@ class SystemClock: public CClock {
 private:
     SystemClock() {}
     ~SystemClock() {}
-    SystemClock(SystemClock const&)    = delete;
-    SystemClock& operator=(const SystemClock&)= delete;
+    SystemClock(SystemClock const&) = delete;
+    SystemClock& operator=(const SystemClock&) = delete;
 public:
     static SystemClock* Instance() {
         static SystemClock instance;
@@ -33,8 +33,8 @@ public:
     }
 
     /**
-     * Sets the clock used by zcashd to the system clock.  This must only be
-     * called by `init()`, or in tests.
+     * Sets the clock used by zcashd to the system clock. This is not thread-safe,
+     * and must only be called in a single-threaded context such as `init`.
      */
     static void SetGlobal();
 
@@ -56,8 +56,8 @@ public:
     }
 
     /**
-     * Sets the clock used by zcashd to a fixed clock. This must only be used
-     * by `init()`, or in tests.
+     * Sets the clock used by zcashd to a fixed clock. This is not thread-safe
+     * and must only be called in a single-threaded context such as `init`.
      */
     static void SetGlobal();
 
@@ -81,8 +81,8 @@ public:
 
     /**
      * Sets the clock used by zcashd to a clock that returns the current system
-     * time modified by the specified offset.  This must only be called by
-     * `init()`, or in tests.
+     * time modified by the specified offset. This is not thread-safe and must
+     * only be called in a single-threaded context such as `init`.
      */
     static void SetGlobal();
 

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -10,10 +10,93 @@
 #include <stdint.h>
 #include <string>
 
+class CClock {
+public:
+    /** Returns the current time in seconds since the POSIX epoch. */
+    virtual int64_t GetTime() const = 0;
+    /** Returns the current time in milliseconds since the POSIX epoch. */
+    virtual int64_t GetTimeMillis() const = 0;
+    /** Returns the current time in microseconds since the POSIX epoch. */
+    virtual int64_t GetTimeMicros() const = 0;
+};
+
+class SystemClock: public CClock {
+private:
+    SystemClock() {}
+    ~SystemClock() {}
+    SystemClock(SystemClock const&)    = delete;
+    SystemClock& operator=(const SystemClock&)= delete;
+public:
+    static SystemClock* Instance() {
+        static SystemClock instance;
+        return &instance;
+    }
+
+    /**
+     * Sets the clock used by zcashd to the system clock.  This must only be
+     * called by `init()`, or in tests.
+     */
+    static void SetGlobal();
+
+    int64_t GetTime() const;
+    int64_t GetTimeMillis() const;
+    int64_t GetTimeMicros() const;
+};
+
+class FixedClock: public CClock {
+private:
+    std::chrono::seconds fixedSeconds;
+
+public:
+    FixedClock(std::chrono::seconds fixedSeconds): fixedSeconds(fixedSeconds) {}
+
+    static FixedClock* Instance() {
+        static FixedClock instance(std::chrono::seconds(0));
+        return &instance;
+    }
+
+    /**
+     * Sets the clock used by zcashd to a fixed clock. This must only be used
+     * by `init()`, or in tests.
+     */
+    static void SetGlobal();
+
+    void Set(std::chrono::seconds fixedSeconds);
+    int64_t GetTime() const;
+    int64_t GetTimeMillis() const;
+    int64_t GetTimeMicros() const;
+};
+
+class OffsetClock: public CClock {
+private:
+    std::chrono::seconds offsetSeconds;
+
+public:
+    OffsetClock(std::chrono::seconds offsetSeconds): offsetSeconds(offsetSeconds) {}
+
+    static OffsetClock* Instance() {
+        static OffsetClock instance(std::chrono::seconds(0));
+        return &instance;
+    }
+
+    /**
+     * Sets the clock used by zcashd to a clock that returns the current system
+     * time modified by the specified offset.  This must only be called by
+     * `init()`, or in tests.
+     */
+    static void SetGlobal();
+
+    void Set(std::chrono::seconds offsetSeconds);
+    int64_t GetTime() const;
+    int64_t GetTimeMillis() const;
+    int64_t GetTimeMicros() const;
+};
+
+const CClock* GetNodeClock();
 int64_t GetTime();
 int64_t GetTimeMillis();
 int64_t GetTimeMicros();
-void SetMockTime(int64_t nMockTimeIn);
+
 void MilliSleep(int64_t n);
 
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);


### PR DESCRIPTION
This change improves clock management for zcashd by ensuring
that all clock methods (obtaining seconds, milliseconds, and
microseconds since the epoch) agree under testing conditions
using `-mocktime`, and also adds a feature that allows tests
to specify an offset to the system clock; this is useful to
allow comprehensive testing of the "timejacking attack mitigation"
consensus rules.

This replaces the prematurely-merged #6037.

Includes code backported from the following upstream PRs:
- bitcoin/bitcoin#18358
- bitcoin/bitcoin#21110
  - Only the first commit.
