### PR TITLE
Replace "Disabled" Orchard AuthValidator with std::nullopt

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -402,7 +402,7 @@ bool ContextualCheckShieldedInputs(
         const PrecomputedTransactionData& txdata,
         CValidationState &state,
         const CCoinsViewCache &view,
-        orchard::AuthValidator& orchardAuth,
+        std::optional<orchard::AuthValidator>& orchardAuth,
         const Consensus::Params& consensus,
         uint32_t consensusBranchId,
         bool nu5Active,

--- a/src/rust/include/rust/orchard.h
+++ b/src/rust/include/rust/orchard.h
@@ -161,8 +161,8 @@ public:
 
     /// Creates a validation context that performs no validation. This can be
     /// used when avoiding duplicate effort such as during reindexing.
-    static AuthValidator Disabled() {
-        return AuthValidator();
+    static std::optional<AuthValidator> Disabled() {
+        return std::nullopt;
     }
 
     /// Queues an Orchard bundle for validation.


### PR DESCRIPTION
The disabled validator was previously erroneously causing a validation failure in AcceptToMemoryPool