### PR TITLE
Backport sanity checks that verify that std::chrono::time agrees with time()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -686,6 +686,22 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]],
  [ AC_MSG_RESULT(no)]
 )
 
+dnl check for gmtime_r(), fallback to gmtime_s() if that is unavailable
+dnl fail if neither are available.
+AC_MSG_CHECKING(for gmtime_r)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctime>]],
+  [[ gmtime_r((const time_t *) nullptr, (struct tm *) nullptr); ]])],
+  [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_GMTIME_R, 1, [Define this symbol if gmtime_r is available]) ],
+  [ AC_MSG_RESULT(no);
+    AC_MSG_CHECKING(for gmtime_s);
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctime>]],
+       [[ gmtime_s((struct tm *) nullptr, (const time_t *) nullptr); ]])],
+       [ AC_MSG_RESULT(yes)],
+       [ AC_MSG_RESULT(no); AC_MSG_ERROR(Both gmtime_r and gmtime_s are unavailable) ]
+    )
+  ]
+)
+
 AC_MSG_CHECKING([for visibility attribute])
 AC_LINK_IFELSE([AC_LANG_SOURCE([
   int foo_def( void ) __attribute__((visibility("default")));
@@ -1008,6 +1024,7 @@ AC_SUBST(LEVELDB_TARGET_FLAGS)
 AC_SUBST(EVENT_LIBS)
 AC_SUBST(EVENT_PTHREADS_LIBS)
 AC_SUBST(ZMQ_LIBS)
+AC_SUBST(HAVE_GMTIME_R)
 AC_SUBST(LIBZCASH_LIBS)
 AC_CONFIG_FILES([Makefile src/Makefile doc/man/Makefile src/test/buildenv.py])
 AC_CONFIG_FILES([qa/pull-tester/tests_config.ini],[chmod +x qa/pull-tester/tests_config.ini])

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -833,6 +833,10 @@ bool InitSanityCheck(void)
     if (!glibc_sanity_test() || !glibcxx_sanity_test())
         return false;
 
+    if (!ChronoSanityCheck()) {
+        return InitError("Clock epoch mismatch. Aborting.");
+    }
+
     return true;
 }
 

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -6,6 +6,7 @@
 #include "compat/sanity.h"
 #include "key.h"
 #include "test/test_bitcoin.h"
+#include "util/time.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -16,6 +17,7 @@ BOOST_AUTO_TEST_CASE(basic_sanity)
   BOOST_CHECK_MESSAGE(glibc_sanity_test() == true, "libc sanity test");
   BOOST_CHECK_MESSAGE(glibcxx_sanity_test() == true, "stdlib sanity test");
   BOOST_CHECK_MESSAGE(CKey::ECC_InitSanityCheck() == true, "ECC sanity test");
+  BOOST_CHECK_MESSAGE(ChronoSanityCheck() == true, "chrono epoch test");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -25,6 +25,50 @@ int64_t GetTime()
     return time(NULL);
 }
 
+bool ChronoSanityCheck()
+{
+    // std::chrono::system_clock.time_since_epoch and time_t(0) are not guaranteed
+    // to use the Unix epoch timestamp, prior to C++20, but in practice they almost
+    // certainly will. Any differing behavior will be assumed to be an error, unless
+    // certain platforms prove to consistently deviate, at which point we'll cope
+    // with it by adding offsets.
+
+    // Create a new clock from time_t(0) and make sure that it represents 0
+    // seconds from the system_clock's time_since_epoch. Then convert that back
+    // to a time_t and verify that it's the same as before.
+    const time_t time_t_epoch{};
+    auto clock = std::chrono::system_clock::from_time_t(time_t_epoch);
+    if (std::chrono::duration_cast<std::chrono::seconds>(clock.time_since_epoch()).count() != 0) {
+        return false;
+    }
+
+    time_t time_val = std::chrono::system_clock::to_time_t(clock);
+    if (time_val != time_t_epoch) {
+        return false;
+    }
+
+    // Check that the above zero time is actually equal to the known unix timestamp.
+    struct tm epoch;
+#ifdef HAVE_GMTIME_R
+    if (gmtime_r(&time_val, &epoch) == nullptr) {
+#else
+    if (gmtime_s(&epoch, &time_val) != 0) {
+#endif
+        return false;
+    }
+
+    if ((epoch.tm_sec != 0)  ||
+       (epoch.tm_min  != 0)  ||
+       (epoch.tm_hour != 0)  ||
+       (epoch.tm_mday != 1)  ||
+       (epoch.tm_mon  != 0)  ||
+       (epoch.tm_year != 70)) {
+        return false;
+    }
+    return true;
+}
+
+
 void SetMockTime(int64_t nMockTimeIn)
 {
     nMockTime = nMockTimeIn;

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -18,4 +18,7 @@ void MilliSleep(int64_t n);
 
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);
 
+/** Sanity check epoch match normal Unix epoch */
+bool ChronoSanityCheck();
+
 #endif // BITCOIN_UTIL_TIME_H


### PR DESCRIPTION
Backport of the first commit of bitcoin/bitcoin#21110 and of bitcoin/bitcoin#18358