### PR TITLE
Ensure that the node has position information before attempting to read block data.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -712,8 +712,8 @@ void ThreadStartWalletNotifier()
                     // We know we have the genesis block.
                     assert(pindexFork != nullptr);
 
-                    if (pindexLastTip->nHeight < pindexFork->nHeight ||
-                        pindexLastTip->nHeight - pindexFork->nHeight < 100)
+                    if ((pindexLastTip->nHeight < pindexFork->nHeight || pindexLastTip->nHeight - pindexFork->nHeight < 100) &&
+                        !pindexLastTip->GetBlockPos().IsNull())
                     {
                         break;
                     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2241,6 +2241,11 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus:
 
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
 {
+    if (pindex->GetBlockPos().IsNull()) {
+        return error("ReadBlockFromDisk(CBlock&, CBlockIndex*): block index entry does not provide a valid disk position for block %s at %s",
+                pindex->ToString(), pindex->GetBlockPos().ToString());
+    }
+
     if (!ReadBlockFromDisk(block, pindex->GetBlockPos(), consensusParams))
         return false;
     if (block.GetHash() != pindex->GetBlockHash())


### PR DESCRIPTION
Potential fix for #6044
