### PR TITLE
Don't rename main thread

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -43,10 +43,6 @@ static bool fDaemon;
 
 void WaitForShutdown(boost::thread_group* threadGroup)
 {
-    // This is the main process thread, but after this point, all we do here is wait for
-    // shutdown, and then shut down the node.
-    RenameThread("zc-wait-to-stop");
-
     bool fShutdown = ShutdownRequested();
     // Tell the main threads to shutdown.
     while (!fShutdown)


### PR DESCRIPTION
This reverts part of 1f1810c37d00cb46d00d8553e6de3c6fdb991010 in #5959.
Leaving the main thread unnamed causes it to be displayed as the executable name (i.e. `zcashd`)
or command line in process monitoring tools. fixes #6066