### PR TITLE
Return useful error message on ATMP failure

### DIFF
--- a/src/wallet/asyncrpcoperation_common.h
+++ b/src/wallet/asyncrpcoperation_common.h
@@ -5,6 +5,7 @@
 #ifndef ZCASH_WALLET_ASYNCRPCOPERATION_COMMON_H
 #define ZCASH_WALLET_ASYNCRPCOPERATION_COMMON_H
 
+#include "consensus/validation.h"
 #include "core_io.h"
 #include "primitives/transaction.h"
 #include "rpc/protocol.h"
@@ -38,9 +39,10 @@ UniValue SendTransaction(
             // More details in debug.log
             throw JSONRPCError(RPC_WALLET_ERROR, "SendTransaction: SaveRecipientMappings failed");
         }
-        if (!pwalletMain->CommitTransaction(wtx, reservekey)) {
-            // More details in debug.log
-            throw JSONRPCError(RPC_WALLET_ERROR, "SendTransaction: CommitTransaction failed");
+        CValidationState state;
+        if (!pwalletMain->CommitTransaction(wtx, reservekey, state)) {
+            std::string strError = strprintf("SendTransaction: Transaction commit failed:: %s", state.GetRejectReason());
+            throw JSONRPCError(RPC_WALLET_ERROR, strError);
         }
         o.pushKV("txid", tx.GetHash().ToString());
     } else {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -420,7 +420,7 @@ public:
     bool IsInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChainINTERNAL(pindexRet) > 0; }
     int GetBlocksToMaturity() const;
     /** Pass this transaction to the mempool. Fails if absolute fee exceeds maxTxFee. */
-    bool AcceptToMemoryPool(bool fLimitFree=true, bool fRejectAbsurdFee=true);
+    bool AcceptToMemoryPool(CValidationState& state, bool fLimitFree=true, bool fRejectAbsurdFee=true);
 };
 
 enum class WalletUAGenerationError {
@@ -1742,7 +1742,7 @@ public:
         return true;
     }
 
-    bool CommitTransaction(CWalletTx& wtxNew, std::optional<std::reference_wrapper<CReserveKey>> reservekey);
+    bool CommitTransaction(CWalletTx& wtxNew, std::optional<std::reference_wrapper<CReserveKey>> reservekey, CValidationState& state);
 
     static CFeeRate minTxFee;
     /**


### PR DESCRIPTION
Zcash: Excludes changes to QT wallet, includes our own uses of CommitTransaction.

Cherry-picked from upstream PR:
- https://github.com/bitcoin/bitcoin/pull/9016