### PR TITLE
bench: Fix ConnectBlock large block benchmarks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3094,8 +3094,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         fExpensiveChecks = false;
     }
 
-    // Don't cache results if we're actually connecting blocks (still consult the cache, though).
-    bool fCacheResults = fJustCheck;
+    // Don't cache results if we're actually connecting blocks or benchmarking
+    // (still consult the cache, though, which will be empty for benchmarks).
+    bool fCacheResults = fJustCheck && (blockChecks != CheckAs::SlowBenchmark);
 
     // proof verification is expensive, disable if possible
     auto verifier = fExpensiveChecks ? ProofVerifier::Strict() : ProofVerifier::Disabled();

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -594,7 +594,7 @@ double benchmark_connectblock_slow()
     CValidationState state;
     struct timeval tv_start;
     timer_start(tv_start);
-    assert(ConnectBlock(block, state, &index, view, Params(), true));
+    assert(ConnectBlock(block, state, &index, view, Params(), true, CheckAs::SlowBenchmark));
     auto duration = timer_stop(tv_start);
 
     // Undo alterations to global state


### PR DESCRIPTION
`zcbenchmark` internally loops within the same process to run the same benchmark multiple times. This meant it was being caught up in the global validity cache, giving faster results for every iteration except the first. This was not noticeable for the historic slow transparent block, but became noticeable once we started caching Sapling and Orchard bundle validity in zcash/zcash#6073.

As the intention of the benchmarks is to measure the worst case where the block in question has not had any of its transactions observed before (as is the case for IBD), we now disable cache storage if calling `ConnectBlock` from a slow block benchmark.