### PR TITLE
Add cuckoocache.h to Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -233,6 +233,7 @@ BITCOIN_CORE_H = \
   consensus/validation.h \
   core_io.h \
   core_memusage.h \
+  cuckoocache.h \
   deprecation.h \
   experimental_features.h \
   fs.h \


### PR DESCRIPTION
Like #5701 and #5730, the missing header ref means that the `make dist` step of gitian builds don't include it in the tarball, causing an error upon build.
