### PR TITLE
Add a new gitian descriptor to enable parallel gitian builds

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux-parallel.yml
+++ b/contrib/gitian-descriptors/gitian-linux-parallel.yml
@@ -1,0 +1,143 @@
+---
+name: "zcash-5.3.0-rc1"
+enable_cache: true
+distro: "debian"
+suites:
+- "buster"
+- "bullseye"
+architectures:
+- "amd64"
+packages:
+- "curl"
+- "autoconf"
+- "automake"
+- "bsdmainutils"
+- "binutils-gold"
+- "ca-certificates"
+- "faketime"
+- "g++-multilib"
+- "git-core"
+- "libc6-dev"
+- "libtinfo5"
+- "libtool"
+- "libxml2"
+- "m4"
+- "ncurses-dev"
+- "pkg-config"
+- "python"
+- "unzip"
+- "wget"
+- "zlib1g-dev"
+remotes:
+- "url": "https://github.com/zcash/zcash.git"
+  "dir": "zcash"
+files: []
+script: |
+  WRAP_DIR=$HOME/wrapped
+  HOSTS="x86_64-linux-gnu"
+  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --enable-hardening --enable-werror"
+  MAKEOPTS="V=1"
+  FAKETIME_HOST_PROGS=""
+  FAKETIME_PROGS="date ar ranlib nm strip objcopy"
+  HOST_CFLAGS=""
+  HOST_CXXFLAGS=""
+  HOST_LDFLAGS=-static-libstdc++
+
+  export QT_RCC_TEST=0
+  export GZIP="-9n"
+  export TAR_OPTIONS="--mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
+  export TZ="UTC"
+  export BUILD_DIR="$PWD"
+  mkdir -p ${WRAP_DIR}
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    export SOURCES_PATH=${GBUILD_COMMON_CACHE}
+    export BASE_CACHE=${GBUILD_PACKAGE_CACHE}
+    mkdir -p ${BASE_CACHE} ${SOURCES_PATH}
+  fi
+
+  function create_global_faketime_wrappers {
+  for prog in ${FAKETIME_PROGS}; do
+    echo '#!/usr/bin/env bash' > ${WRAP_DIR}/${prog}
+    echo "REAL=\`which -a ${prog} | grep -v ${WRAP_DIR}/${prog} | head -1\`" >> ${WRAP_DIR}/${prog}
+    echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/${prog}
+    echo "export FAKETIME=\"$1\"" >> ${WRAP_DIR}/${prog}
+    echo "\$REAL \$@" >> $WRAP_DIR/${prog}
+    chmod +x ${WRAP_DIR}/${prog}
+  done
+  }
+
+  function create_per-host_faketime_wrappers {
+  for i in $HOSTS; do
+    for prog in ${FAKETIME_HOST_PROGS}; do
+        echo '#!/usr/bin/env bash' > ${WRAP_DIR}/${i}-${prog}
+        echo "REAL=\`which -a ${i}-${prog} | grep -v ${WRAP_DIR}/${i}-${prog} | head -1\`" >> ${WRAP_DIR}/${i}-${prog}
+        echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/${i}-${prog}
+        echo "export FAKETIME=\"$1\"" >> ${WRAP_DIR}/${i}-${prog}
+        echo "\$REAL \$@" >> $WRAP_DIR/${i}-${prog}
+        chmod +x ${WRAP_DIR}/${i}-${prog}
+    done
+  done
+  }
+
+  export PATH=${WRAP_DIR}:${PATH}
+
+  # Faketime for depends so intermediate results are comparable
+  create_global_faketime_wrappers "2000-01-01 12:00:00"
+  create_per-host_faketime_wrappers "2000-01-01 12:00:00"
+
+  cd zcash
+  BASEPREFIX="${PWD}/depends"
+  # Build dependencies for each host
+  for i in $HOSTS; do
+    make ${MAKEOPTS} -C ${BASEPREFIX} HOST="${i}"
+  done
+
+  # Faketime for binaries
+  create_global_faketime_wrappers "${REFERENCE_DATETIME}"
+  create_per-host_faketime_wrappers "${REFERENCE_DATETIME}"
+
+  # Create the release tarball using (arbitrarily) the first host
+  export GIT_DIR="$PWD/.git"
+  ./autogen.sh
+  CONFIG_SITE=${BASEPREFIX}/$(echo "${HOSTS}" | awk '{print $1;}')/share/config.site ./configure --prefix=/
+  make dist
+  SOURCEDIST=$(echo zcash-*.tar.gz)
+  DISTNAME=${SOURCEDIST/%.tar.gz}
+
+  # Correct tar file order
+  mkdir -p temp
+  pushd temp
+  tar xf ../$SOURCEDIST
+  find zcash* | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ../$SOURCEDIST
+  popd
+
+  ORIGPATH="$PATH"
+  # Extract the release tarball into a dir for each host and build
+  for i in ${HOSTS}; do
+    export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
+    mkdir -p distsrc-${i}
+    cd distsrc-${i}
+    INSTALLPATH="${PWD}/installed/${DISTNAME}"
+    mkdir -p ${INSTALLPATH}
+    tar --strip-components=1 -xf ../$SOURCEDIST
+
+    CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}"
+    make ${MAKEOPTS}
+    make ${MAKEOPTS} -C src check-security
+    make install DESTDIR=${INSTALLPATH}
+    cd installed
+    find . -name "lib*.la" -delete
+    find . -name "lib*.a" -delete
+    rm -rf ${DISTNAME}/lib/pkgconfig
+    find ${DISTNAME}/bin -type f -executable -exec objcopy --only-keep-debug {} {}.dbg \; -exec strip -s {} \; -exec objcopy --add-gnu-debuglink={}.dbg {} \;
+    # Commented out while we don't build any libraries
+    #find ${DISTNAME}/lib -type f -exec objcopy --only-keep-debug {} {}.dbg \; -exec strip -s {} \; -exec objcopy --add-gnu-debuglink={}.dbg {} \;
+    find ${DISTNAME} -not -name "*.dbg" | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    find ${DISTNAME} -name "*.dbg" | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}-debug.tar.gz
+    cd ../../
+    rm -rf distsrc-${i}
+  done
+  mkdir -p $OUTDIR/src
+  mv $SOURCEDIST $OUTDIR/src
+  mv ${OUTDIR}/${DISTNAME}-x86_64-*-debug.tar.gz ${OUTDIR}/${DISTNAME}-linux64-debug.tar.gz
+  mv ${OUTDIR}/${DISTNAME}-x86_64-*.tar.gz ${OUTDIR}/${DISTNAME}-linux64.tar.gz

--- a/contrib/gitian-descriptors/gitian-linux-parallel.yml
+++ b/contrib/gitian-descriptors/gitian-linux-parallel.yml
@@ -36,7 +36,7 @@ script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-linux-gnu"
   CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --enable-hardening --enable-werror"
-  MAKEOPTS="V=1"
+  MAKEOPTS="V=1 -j$(nproc)"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="date ar ranlib nm strip objcopy"
   HOST_CFLAGS=""

--- a/zcutil/make-release.py
+++ b/zcutil/make-release.py
@@ -246,7 +246,8 @@ def patch_version_in_files(release, releaseprev):
     patch_README(release, releaseprev)
     patch_clientversion_h(release)
     patch_configure_ac(release)
-    patch_gitian_linux_yml(release, releaseprev)
+    patch_gitian_linux_yml(release, releaseprev, 'contrib/gitian-descriptors/gitian-linux.yml')
+    patch_gitian_linux_yml(release, releaseprev, 'contrib/gitian-descriptors/gitian-linux-parallel.yml')
 
 
 @phase('Patching release height for end-of-support halt.')
@@ -374,8 +375,7 @@ def patch_configure_ac(release):
     )
 
 
-def patch_gitian_linux_yml(release, releaseprev):
-    path = 'contrib/gitian-descriptors/gitian-linux.yml'
+def patch_gitian_linux_yml(release, releaseprev, path):
     with PathPatcher(path) as (inf, outf):
         outf.write(inf.readline())
 


### PR DESCRIPTION
To try it out, run `git clone https://github.com/superbaud/zcash-gitian -b parallel-build` (or do `git switch parallel-build` in your `zcash-gitian` repo), and set the `.env` therein to:
```
GPG_KEY_ID=16460E1BC0E0507E
GPG_KEY_NAME=sasha
ZCASH_GIT_REPO_URL=https://github.com/superbaud/zcash
ZCASH_VERSION=parallel-gitian-descriptor

GITIAN_BUILDER_URL=https://github.com/devrandom/gitian-builder
GITIAN_BUILDER_VERSION=master
``` 

Until this PR is merged, you will need to target a `ZCASH_VERSION` which has the new parallel gitian descriptor included.

Run `vagrant destroy zcash-build && vagrant up zcash-build`, and once the Vagrant VM is up, run `./gitian-parallel-build.sh`. `./gitian-build.sh` works as previously.

To be sure that we still have reproducibility, it would be good if someone else ran both `./gitian-build.sh`  and `./gitian-parallel-build.sh` (**in clean instances of the Vagrant VM, be sure you run** `vagrant destroy zcash-build` **before each time you run either command**) targeting the above repo URL and branch name to verify that they get the same hashes as I do.