### PR TITLE
miner: fix MAXSOLS

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1072,7 +1072,7 @@ void static BitcoinMiner(const CChainParams& chainparams)
                     ehSolverRuns.increment();
 
                     // Convert solution indices to byte array (decompress) and pass it to validBlock method.
-                    for (size_t s = 0; s < eq.nsols; s++) {
+                    for (size_t s = 0; s < std::min(MAXSOLS, eq.nsols); s++) {
                         LogPrint("pow", "Checking solution %d\n", s+1);
                         std::vector<eh_index> index_vector(PROOFSIZE);
                         for (size_t i = 0; i < PROOFSIZE; i++) {

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
             // Convert solution indices to byte array (decompress) and pass it to validBlock method.
             std::set<std::vector<unsigned char>> solns;
-            for (size_t s = 0; s < eq.nsols; s++) {
+            for (size_t s = 0; s < std::min(MAXSOLS, eq.nsols); s++) {
                 LogPrint("pow", "Checking solution %d\n", s+1);
                 std::vector<eh_index> index_vector(PROOFSIZE);
                 for (size_t i = 0; i < PROOFSIZE; i++) {


### PR DESCRIPTION
Max number of solutions to check in tromp solver should be limited to MAXSOLS.

- https://github.com/tromp/equihash/commit/882bc1ff7a49b92ad9d80a7a59aaa159ecdc2ce0
- https://github.com/KomodoPlatform/komodo/pull/556
