### PR TITLE
rust: Update some of the pinned dependencies

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -21,15 +21,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --git https://github.com/mozilla/cargo-vet.git cargo-vet
-
-      # This is necessary because `cargo vet --locked` implies `cargo metadata --frozen`,
-      # preventing all network access.
-      - name: Ensure dependency sources are present
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
-          args: --locked
+          args: cargo-vet
 
       - name: Run cargo vet --locked
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
  "once_cell",
  "version_check",
 ]
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
 
 [[package]]
 name = "arrayref"
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "clearscreen"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ed49b0e894fe6264a58496c7ec4e9d3c46f66b59efae527cd5bee429d0a418"
+checksum = "c969a6b6dadff9f3349b1f783f553e2411104763ca4789e1c6ca6a41f46a57b0"
 dependencies = [
  "nix",
  "terminfo",
@@ -406,9 +406,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -660,13 +660,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -899,9 +899,9 @@ checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
@@ -1129,38 +1129,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "nix"
-version = "0.22.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if 1.0.0",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -1180,15 +1167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1570,7 +1548,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
 ]
 
 [[package]]
@@ -1673,7 +1651,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
  "redox_syscall",
  "thiserror",
 ]
@@ -1773,18 +1751,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1903,18 +1881,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1965,12 +1943,14 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
+ "autocfg",
  "libc",
  "mio",
+ "once_cell",
  "pin-project-lite",
  "socket2",
  "winapi",
@@ -2249,6 +2229,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "wyz"

--- a/qa/supply-chain/audits.toml
+++ b/qa/supply-chain/audits.toml
@@ -7,11 +7,41 @@ description = "The cryptographic code in this crate has been reviewed for correc
 [criteria.license-reviewed]
 description = "The license of this crate has been reviewed for compatibility with its usage in this repository. If the crate is not available under the MIT license, `contrib/debian/copyright` has been updated with a corresponding copyright notice for files under `depends/*/vendored-sources/CRATE_NAME`."
 
+[[audits.anyhow]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "1.0.56 -> 1.0.61"
+notes = "Update does not introduce new code. Minor build script changes look fine."
+
 [[audits.bellman]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = ["crypto-reviewed", "safe-to-deploy"]
 delta = "0.13.0 -> 0.13.1"
 notes = "Adds multi-threaded batch validation, which I checked against the existing single-threaded batch validation."
+
+[[audits.chacha20]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = ["crypto-reviewed", "safe-to-deploy"]
+delta = "0.8.1 -> 0.8.2"
+notes = "Unpins zeroize."
+
+[[audits.chacha20poly1305]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = ["crypto-reviewed", "safe-to-deploy"]
+delta = "0.9.0 -> 0.9.1"
+notes = "Unpins zeroize."
+
+[[audits.clearscreen]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "1.0.9 -> 1.0.10"
+notes = "Bumps nix and removes some of its default features."
+
+[[audits.crypto-common]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = ["crypto-reviewed", "safe-to-deploy"]
+delta = "0.1.3 -> 0.1.6"
+notes = "New trait and type alias look fine."
 
 [[audits.cxx]]
 who = "Daira Hopwood <daira@jacaranda.org>"
@@ -46,6 +76,15 @@ criteria = ["crypto-reviewed", "safe-to-deploy"]
 version = "0.1.0"
 notes = "The ECC core team maintains this crate, and we have reviewed every line."
 
+[[audits.getrandom]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "0.2.6 -> 0.2.7"
+notes = """
+Checked that getrandom::wasi::getrandom_inner matches wasi::random_get.
+Checked that getrandom::util_libc::Weak lock ordering matches std::sys::unix::weak::DlsymWeak.
+"""
+
 [[audits.halo2_gadgets]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = ["crypto-reviewed", "safe-to-deploy"]
@@ -69,6 +108,38 @@ who = "Jack Grigg <jack@z.cash>"
 criteria = ["crypto-reviewed", "safe-to-deploy"]
 delta = "0.1.0 -> 0.2.0"
 notes = "The ECC core team maintains this crate, and we have reviewed every line."
+
+[[audits.itoa]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "1.0.1 -> 1.0.3"
+notes = "Update makes no changes to code."
+
+[[audits.mio]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "0.8.2 -> 0.8.4"
+notes = """
+Migrates from winapi to windows-sys. The changes to API usage look reasonable
+based on what I've seen in other uses of the windows-sys crate. Unsafe code
+falls into two categories:
+- Usage of `mem::zeroed()`, which doesn't look obviously wrong. The
+  `..unsafe { mem::zeroed() }` in `sys::unix::selector::kqueue` looks weird
+  but AFAICT is saying \"take any unspecified fields from an instance of this
+  struct that has been zero-initialized\", which is fine for integer fields. It
+  would be nice if there was documentation to this effect (explaining why this
+  is done instead of `..Default::default()`).
+- Calls to Windows API methods. These are either pre-existing (and altered for
+  the differences in the crate abstractions), or newly added in logic that
+  appears to be copied from miow 0.3.6 (I scanned this by eye and didn't see
+  any noteworthy changes other than handling windows-sys API differences).
+"""
+
+[[audits.num-integer]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "0.1.44 -> 0.1.45"
+notes = "Fixes some argument-handling panic bugs."
 
 [[audits.orchard]]
 who = "Jack Grigg <jack@z.cash>"
@@ -87,15 +158,94 @@ who = "Daira Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.37 -> 1.0.41"
 
+[[audits.serde]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "1.0.136 -> 1.0.143"
+notes = "Bumps serde-derive and adds some constructors."
+
+[[audits.serde_derive]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "1.0.136 -> 1.0.143"
+notes = "Bumps syn, inverts some build flags."
+
 [[audits.syn]]
 who = "Daira Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.91 -> 1.0.98"
 
+[[audits.thiserror]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "1.0.30 -> 1.0.32"
+notes = "Bumps thiserror-impl, no code changes."
+
+[[audits.thiserror-impl]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "1.0.30 -> 1.0.32"
+notes = "Only change is to refine an error message."
+
 [[audits.unicode-ident]]
 who = "Daira Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-deploy"
 version = "1.0.2"
+
+[[audits.windows_aarch64_msvc]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-run"
+version = "0.36.1"
+notes = """
+Adds a binary blob to the library search path, that contains a subset of
+the Windows SDK to avoid a direct dependency on the latter. See
+https://github.com/microsoft/windows-rs/pull/1217 for context. I did not
+audit the binary blob, but the build script looks fine.
+"""
+
+[[audits.windows_i686_gnu]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-run"
+version = "0.36.1"
+notes = """
+Adds a binary blob to the library search path, that contains a subset of
+the Windows SDK to avoid a direct dependency on the latter. See
+https://github.com/microsoft/windows-rs/pull/1217 for context. I did not
+audit the binary blob, but the build script looks fine.
+"""
+
+[[audits.windows_i686_msvc]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-run"
+version = "0.36.1"
+notes = """
+Adds a binary blob to the library search path, that contains a subset of
+the Windows SDK to avoid a direct dependency on the latter. See
+https://github.com/microsoft/windows-rs/pull/1217 for context. I did not
+audit the binary blob, but the build script looks fine.
+"""
+
+[[audits.windows_x86_64_gnu]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-run"
+version = "0.36.1"
+notes = """
+Adds a binary blob to the library search path, that contains a subset of
+the Windows SDK to avoid a direct dependency on the latter. See
+https://github.com/microsoft/windows-rs/pull/1217 for context. I did not
+audit the binary blob, but the build script looks fine.
+"""
+
+[[audits.windows_x86_64_msvc]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-run"
+version = "0.36.1"
+notes = """
+Adds a binary blob to the library search path, that contains a subset of
+the Windows SDK to avoid a direct dependency on the latter. See
+https://github.com/microsoft/windows-rs/pull/1217 for context. I did not
+audit the binary blob, but the build script looks fine.
+"""
 
 [[audits.zcash_address]]
 who = "Jack Grigg <jack@z.cash>"

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -437,12 +437,8 @@ criteria = "safe-to-deploy"
 version = "0.8.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.miow]]
-version = "0.3.7"
-criteria = "safe-to-deploy"
-
 [[exemptions.nix]]
-version = "0.22.3"
+version = "0.24.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.nom]]
@@ -451,10 +447,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.nonempty]]
 version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ntapi]]
-version = "0.3.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.num-bigint]]
@@ -770,7 +762,7 @@ version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
-version = "1.17.0"
+version = "1.20.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml]]
@@ -892,6 +884,17 @@ criteria = "safe-to-deploy"
 [[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.windows-sys]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[exemptions.windows-sys.dependency-criteria]
+windows_aarch64_msvc = "safe-to-run"
+windows_i686_gnu = "safe-to-run"
+windows_i686_msvc = "safe-to-run"
+windows_x86_64_gnu = "safe-to-run"
+windows_x86_64_msvc = "safe-to-run"
 
 [[exemptions.wyz]]
 version = "0.5.0"


### PR DESCRIPTION
The primary purpose of this commit is an exercise in using `cargo vet` for tracking audits of our Rust dependency updates. `cargo update` was run, and then a simple-to-audit subset of the dependency updates were audited and committed.