### PR TITLE
Eliminate indirection for debug log

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -22,7 +22,7 @@ main(int argc, char** argv)
     ECC_Start();
     auto globalVerifyHandle = new ECCVerifyHandle();
     SetupEnvironment();
-    fPrintToDebugLog = false; // don't want to write to debug.log file
+    fPrintToDebugLog = false; // don't want to write to debug log file
 
     fs::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
     fs::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -208,7 +208,7 @@ static bool InitRPCAuthentication()
         LogPrintf("No rpcpassword set - using random cookie authentication\n");
         if (!GenerateAuthCookie(&strRPCUserColonPass)) {
             uiInterface.ThreadSafeMessageBox(
-                _("Error: A fatal internal error occurred, see debug.log for details"), // Same message as AbortNode
+                strprintf(_("Error: A fatal internal error occurred, see %s for details"), GetDebugLogPath()), // Same message as AbortNode
                 "", CClientUIInterface::MSG_ERROR);
             return false;
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -474,12 +474,12 @@ std::string HelpMessage(HelpMessageMode mode)
         CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)));
     strUsage += HelpMessageOpt("-maxtxfee=<amt>", strprintf(_("Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)"),
         CURRENCY_UNIT, FormatMoney(DEFAULT_TRANSACTION_MAXFEE)));
-    strUsage += HelpMessageOpt("-printtoconsole", _("Send trace/debug info to console instead of debug.log file"));
+    strUsage += HelpMessageOpt("-printtoconsole", strprintf(_("Send trace/debug info to console instead of %s"), GetDebugLogPath()));
     if (showDebug)
     {
         strUsage += HelpMessageOpt("-printpriority", strprintf("Log transaction priority and fee per kB when mining blocks (default: %u)", DEFAULT_PRINTPRIORITY));
     }
-    // strUsage += HelpMessageOpt("-shrinkdebugfile", _("Shrink debug.log file on client startup (default: 1 when no -debug)"));
+    // strUsage += HelpMessageOpt("-shrinkdebugfile", strprintf(_("Shrink %s on client startup (default: 1 when no -debug)"), GetDebugLogPath()));
 
     AppendParamsHelpMessages(strUsage, showDebug);
 
@@ -670,7 +670,7 @@ void ThreadStartWalletNotifier()
 
                     LogError("main", "*** %s: %s", __func__, errmsg);
                     uiInterface.ThreadSafeMessageBox(
-                        _("Error: A fatal wallet synchronization error occurred, see debug.log for details"),
+                        strprintf(_("Error: A fatal wallet synchronization error occurred, see %s for details"), GetDebugLogPath()),
                         "", CClientUIInterface::MSG_ERROR);
                     StartShutdown();
                     return true;
@@ -1071,7 +1071,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     sigaction(SIGTERM, &sa, NULL);
     sigaction(SIGINT, &sa, NULL);
 
-    // Reopen debug.log on SIGHUP
+    // Reopen debug log on SIGHUP
     assert(fReopenDebugLog.is_lock_free());
     struct sigaction sa_hup;
     sa_hup.sa_handler = HandleSIGHUP;
@@ -1507,7 +1507,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     {
         uiInterface.InitMessage.connect(SetRPCWarmupStatus);
         if (!AppInitServers(threadGroup))
-            return InitError(_("Unable to start HTTP server. See debug log for details."));
+            return InitError(strprintf(_("Unable to start HTTP server. See %s for details."), GetDebugLogPath()));
     }
 
     int64_t nStart;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -126,7 +126,7 @@ bool LogAcceptCategory(const char* category)
 
 void ShrinkDebugFile()
 {
-    // Scroll debug.log if it's getting too big
+    // Scroll debug log if it's getting too big
     fs::path pathLog = GetDebugLogPath();
     FILE* file = fsbridge::fopen(pathLog, "r");
     if (file && fs::file_size(pathLog) > 10 * 1000000)

--- a/src/logging.h
+++ b/src/logging.h
@@ -33,10 +33,10 @@ std::string LogConfigFilter();
 /** Return true if log accepts specified category */
 bool LogAcceptCategory(const char* category);
 
-/** Print to debug.log with level INFO and category "main". */
+/** Print to debug log with level INFO and category "main". */
 #define LogPrintf(...) LogPrintInner("info", "main", __VA_ARGS__)
 
-/** Print to debug.log with level DEBUG. */
+/** Print to debug log with level DEBUG. */
 #define LogPrint(category, ...) LogPrintInner("debug", category, __VA_ARGS__)
 
 #define LogPrintInner(level, category, ...) do {           \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -163,7 +163,7 @@ namespace {
         SetMiscWarning(strMessage, GetTime());
         LogError("main", "*** %s\n", strMessage);
         uiInterface.ThreadSafeMessageBox(
-            userMessage.empty() ? _("Error: A fatal internal error occurred, see debug.log for details") : userMessage,
+            userMessage.empty() ? strprintf(_("Error: A fatal internal error occurred, see %s for details"), GetDebugLogPath()) : userMessage,
             "", CClientUIInterface::MSG_ERROR);
         StartShutdown();
         return false;

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -311,7 +311,7 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
                             "*** %s: Failed to read block %s while collecting shielded outputs",
                             __func__, pindexScan->GetBlockHash().GetHex());
                     uiInterface.ThreadSafeMessageBox(
-                        _("Error: A fatal internal error occurred, see debug.log for details"),
+                        strprintf(_("Error: A fatal internal error occurred, see %s for details"), GetDebugLogPath()),
                         "", CClientUIInterface::MSG_ERROR);
                     StartShutdown();
                     return;
@@ -340,7 +340,7 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
                             "*** %s: Failed to read block %s while collecting shielded outputs from block connects",
                             __func__, blockData.pindex->GetBlockHash().GetHex());
                     uiInterface.ThreadSafeMessageBox(
-                        _("Error: A fatal internal error occurred, see debug.log for details"),
+                        strprintf(_("Error: A fatal internal error occurred, see %s for details"), GetDebugLogPath()),
                         "", CClientUIInterface::MSG_ERROR);
                     StartShutdown();
                     return;
@@ -382,7 +382,7 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
                         "*** %s: Failed to read block %s while notifying wallets of block disconnects",
                         __func__, pindexLastTip->GetBlockHash().GetHex());
                 uiInterface.ThreadSafeMessageBox(
-                    _("Error: A fatal internal error occurred, see debug.log for details"),
+                    strprintf(_("Error: A fatal internal error occurred, see %s for details"), GetDebugLogPath()),
                     "", CClientUIInterface::MSG_ERROR);
                 StartShutdown();
                 return;
@@ -416,7 +416,7 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
                         "*** %s: Failed to read block %s while notifying wallets of block connects",
                         __func__, blockData.pindex->GetBlockHash().GetHex());
                 uiInterface.ThreadSafeMessageBox(
-                    _("Error: A fatal internal error occurred, see debug.log for details"),
+                    strprintf(_("Error: A fatal internal error occurred, see %s for details"), GetDebugLogPath()),
                     "", CClientUIInterface::MSG_ERROR);
                 StartShutdown();
                 return;

--- a/src/wallet/asyncrpcoperation_common.h
+++ b/src/wallet/asyncrpcoperation_common.h
@@ -36,7 +36,7 @@ UniValue SendTransaction(
         CWalletTx wtx(pwalletMain, tx);
         // save the mapping from (receiver, txid) to UA
         if (!pwalletMain->SaveRecipientMappings(tx.GetHash(), recipients)) {
-            // More details in debug.log
+            // More details in debug log
             throw JSONRPCError(RPC_WALLET_ERROR, "SendTransaction: SaveRecipientMappings failed");
         }
         CValidationState state;

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -530,7 +530,7 @@ uint256 AsyncRPCOperation_sendmany::main_impl() {
         {
             throw JSONRPCError(
                 RPC_WALLET_ERROR,
-                "Failed to add Orchard note to transaction (check debug.log for details)"
+                strprintf("Failed to add Orchard note to transaction (check %s for details)", GetDebugLogPath())
             );
         }
     }


### PR DESCRIPTION
In error messages, show the path to the debug log instead of saying "see debug.log".