### PR TITLE
Include algorithm.h in cuckoocache.h

### DIFF
--- a/src/cuckoocache.h
+++ b/src/cuckoocache.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_CUCKOOCACHE_H
 #define BITCOIN_CUCKOOCACHE_H
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cmath>


### PR DESCRIPTION
This came up while updating [`zcash_script`](https://github.com/ZcashFoundation/zcash_script/). Since `cuckoocache.h` uses `std::find`, it needs `<algorithm>`. I guess it works in zcash because it's probably included by whatever uses `cuckoocache.h`.