### PR TITLE
Add tl::expected and some examples of its use

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -160,6 +160,12 @@ Files: depends/sources/utfcpp-*.tar.gz
 Copyright: 2006 Nemanja Trifunovic
 License: Boost-Software-License-1.0
 
+Files: depends/sources/tl-expected-*.tar.gz
+Copyright: 2017-2021 Sy Brand <simonrbrand@gmail.com> (@TartanLlama)
+License: CC0-1.0
+Comment: Other contributors are Simon Truscott (@bobbleclank), Kévin Alexandre Boissonneault (@KABoissonneault),
+ and Björn Fahller (@rollbear).
+
 Files: depends/*/vendored-sources/orchard/*
 Copyright: 2020-2022 The Electric Coin Company
 License: BOSL-1+ with Zcash exception

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -161,7 +161,7 @@ Copyright: 2006 Nemanja Trifunovic
 License: Boost-Software-License-1.0
 
 Files: depends/sources/tl-expected-*.tar.gz
-Copyright: 2017-2021 Sy Brand <simonrbrand@gmail.com> (@TartanLlama)
+Copyright: 2017-2021 Sy Brand <simonrbrand@gmail.com> (@TartanLlama), 2022 The Zcash developers
 License: CC0-1.0
 Comment: Other contributors are Simon Truscott (@bobbleclank), Kévin Alexandre Boissonneault (@KABoissonneault),
  and Björn Fahller (@rollbear).

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,5 +1,5 @@
 zcash_packages := libsodium rustcxx utfcpp
-packages := boost libevent zeromq $(zcash_packages) googletest
+packages := boost libevent zeromq $(zcash_packages) googletest tl_expected
 native_packages := native_clang native_ccache native_rust native_cxxbridge
 
 ifneq (,$(wildcard /etc/arch-release))

--- a/depends/packages/tl_expected.mk
+++ b/depends/packages/tl_expected.mk
@@ -4,6 +4,11 @@ $(package)_download_path=https://github.com/TartanLlama/expected/archive
 $(package)_download_file=96d547c03d2feab8db64c53c3744a9b4a7c8f2c5.tar.gz
 $(package)_file_name=tl-expected-1.0.1.tar.gz
 $(package)_sha256_hash=64901df1de9a5a3737b331d3e1de146fa6ffb997017368b322c08f45c51b90a7
+$(package)_patches=remove-undefined-behaviour.diff
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/remove-undefined-behaviour.diff
+endef
 
 define $(package)_stage_cmds
   mkdir $($(package)_staging_dir)$(host_prefix)/include && \

--- a/depends/packages/tl_expected.mk
+++ b/depends/packages/tl_expected.mk
@@ -1,0 +1,11 @@
+package=tl_expected
+$(package)_version=1.0.1
+$(package)_download_path=https://github.com/TartanLlama/expected/archive
+$(package)_download_file=96d547c03d2feab8db64c53c3744a9b4a7c8f2c5.tar.gz
+$(package)_file_name=tl-expected-1.0.1.tar.gz
+$(package)_sha256_hash=64901df1de9a5a3737b331d3e1de146fa6ffb997017368b322c08f45c51b90a7
+
+define $(package)_stage_cmds
+  mkdir $($(package)_staging_dir)$(host_prefix)/include && \
+  cp include/tl/expected.hpp $($(package)_staging_dir)$(host_prefix)/include
+endef

--- a/depends/patches/tl_expected/remove-undefined-behaviour.diff
+++ b/depends/patches/tl_expected/remove-undefined-behaviour.diff
@@ -1,0 +1,78 @@
+diff --recursive --unified tl-expected-1.0.1-orig/include/tl/expected.hpp tl-expected-1.0.1/include/tl/expected.hpp
+--- tl-expected-1.0.1-orig/include/tl/expected.hpp	2022-08-30 20:10:13.269489852 +0100
++++ tl-expected-1.0.1/include/tl/expected.hpp	2022-08-30 20:17:35.744258828 +0100
+@@ -24,6 +24,7 @@
+ #include <functional>
+ #include <type_traits>
+ #include <utility>
++#include <cassert>
+ 
+ #if defined(__EXCEPTIONS) || defined(_CPPUNWIND)
+ #define TL_EXPECTED_EXCEPTIONS_ENABLED
+@@ -1862,27 +1863,37 @@
+     }
+   }
+ 
+-  constexpr const T *operator->() const { return valptr(); }
+-  TL_EXPECTED_11_CONSTEXPR T *operator->() { return valptr(); }
++  constexpr const T *operator->() const {
++    assert(has_value());
++    return valptr();
++  }
++  TL_EXPECTED_11_CONSTEXPR T *operator->() {
++    assert(has_value());
++    return valptr();
++  }
+ 
+   template <class U = T,
+             detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   constexpr const U &operator*() const & {
++    assert(has_value());
+     return val();
+   }
+   template <class U = T,
+             detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   TL_EXPECTED_11_CONSTEXPR U &operator*() & {
++    assert(has_value());
+     return val();
+   }
+   template <class U = T,
+             detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   constexpr const U &&operator*() const && {
++    assert(has_value());
+     return std::move(val());
+   }
+   template <class U = T,
+             detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   TL_EXPECTED_11_CONSTEXPR U &&operator*() && {
++    assert(has_value());
+     return std::move(val());
+   }
+ 
+@@ -1918,10 +1929,22 @@
+     return std::move(val());
+   }
+ 
+-  constexpr const E &error() const & { return err().value(); }
+-  TL_EXPECTED_11_CONSTEXPR E &error() & { return err().value(); }
+-  constexpr const E &&error() const && { return std::move(err().value()); }
+-  TL_EXPECTED_11_CONSTEXPR E &&error() && { return std::move(err().value()); }
++  constexpr const E &error() const & {
++    assert(!has_value());
++    return err().value();
++  }
++  TL_EXPECTED_11_CONSTEXPR E &error() & {
++    assert(!has_value());
++    return err().value();
++  }
++  constexpr const E &&error() const && {
++    assert(!has_value());
++    return std::move(err().value());
++  }
++  TL_EXPECTED_11_CONSTEXPR E &&error() && {
++    assert(!has_value());
++    return std::move(err().value());
++  }
+ 
+   template <class U> constexpr T value_or(U &&v) const & {
+     static_assert(std::is_copy_constructible<T>::value &&

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1003,7 +1003,7 @@ CAmount CCoinsViewCache::GetValueIn(const CTransaction& tx) const
     return nResult;
 }
 
-std::optional<UnsatisfiedShieldedReq> CCoinsViewCache::HaveShieldedRequirements(const CTransaction& tx) const
+tl::expected<void, UnsatisfiedShieldedReq> CCoinsViewCache::CheckShieldedRequirements(const CTransaction& tx) const
 {
     boost::unordered_map<uint256, SproutMerkleTree, SaltedTxidHasher> intermediates;
 
@@ -1019,7 +1019,7 @@ std::optional<UnsatisfiedShieldedReq> CCoinsViewCache::HaveShieldedRequirements(
                 TracingWarn("consensus", "Sprout double-spend detected",
                     "txid", txid.c_str(),
                     "nf", nf.c_str());
-                return UnsatisfiedShieldedReq::SproutDuplicateNullifier;
+                return tl::unexpected(UnsatisfiedShieldedReq::SproutDuplicateNullifier);
             }
         }
 
@@ -1033,7 +1033,7 @@ std::optional<UnsatisfiedShieldedReq> CCoinsViewCache::HaveShieldedRequirements(
             TracingWarn("consensus", "Transaction uses unknown Sprout anchor",
                 "txid", txid.c_str(),
                 "anchor", anchor.c_str());
-            return UnsatisfiedShieldedReq::SproutUnknownAnchor;
+            return tl::unexpected(UnsatisfiedShieldedReq::SproutUnknownAnchor);
         }
 
         for (const uint256& commitment : joinsplit.commitments)
@@ -1051,7 +1051,7 @@ std::optional<UnsatisfiedShieldedReq> CCoinsViewCache::HaveShieldedRequirements(
             TracingWarn("consensus", "Sapling double-spend detected",
                 "txid", txid.c_str(),
                 "nf", nf.c_str());
-            return UnsatisfiedShieldedReq::SaplingDuplicateNullifier;
+            return tl::unexpected(UnsatisfiedShieldedReq::SaplingDuplicateNullifier);
         }
 
         SaplingMerkleTree tree;
@@ -1061,7 +1061,7 @@ std::optional<UnsatisfiedShieldedReq> CCoinsViewCache::HaveShieldedRequirements(
             TracingWarn("consensus", "Transaction uses unknown Sapling anchor",
                 "txid", txid.c_str(),
                 "anchor", anchor.c_str());
-            return UnsatisfiedShieldedReq::SaplingUnknownAnchor;
+            return tl::unexpected(UnsatisfiedShieldedReq::SaplingUnknownAnchor);
         }
     }
 
@@ -1072,7 +1072,7 @@ std::optional<UnsatisfiedShieldedReq> CCoinsViewCache::HaveShieldedRequirements(
             TracingWarn("consensus", "Orchard double-spend detected",
                 "txid", txid.c_str(),
                 "nf", nf.c_str());
-            return UnsatisfiedShieldedReq::OrchardDuplicateNullifier;
+            return tl::unexpected(UnsatisfiedShieldedReq::OrchardDuplicateNullifier);
         }
     }
 
@@ -1085,11 +1085,11 @@ std::optional<UnsatisfiedShieldedReq> CCoinsViewCache::HaveShieldedRequirements(
             TracingWarn("consensus", "Transaction uses unknown Orchard anchor",
                 "txid", txid.c_str(),
                 "anchor", anchor.c_str());
-            return UnsatisfiedShieldedReq::OrchardUnknownAnchor;
+            return tl::unexpected(UnsatisfiedShieldedReq::OrchardUnknownAnchor);
         }
     }
 
-    return std::nullopt;
+    return {};
 }
 
 bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const

--- a/src/coins.h
+++ b/src/coins.h
@@ -18,6 +18,7 @@
 #include <stdint.h>
 
 #include <boost/unordered_map.hpp>
+#include <expected.hpp>
 #include "zcash/History.hpp"
 #include "zcash/IncrementalMerkleTree.hpp"
 
@@ -613,7 +614,7 @@ public:
     bool HaveInputs(const CTransaction& tx) const;
 
     //! Check whether all joinsplit and sapling spend requirements (anchors/nullifiers) are satisfied
-    std::optional<UnsatisfiedShieldedReq> HaveShieldedRequirements(const CTransaction& tx) const;
+    tl::expected<void, UnsatisfiedShieldedReq> CheckShieldedRequirements(const CTransaction& tx) const;
 
     //! Return priority of tx at height nHeight
     double GetPriority(const CTransaction &tx, int nHeight) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2570,11 +2570,11 @@ bool CheckTxShieldedInputs(
     int dosLevel)
 {
     // Are the shielded spends' requirements met?
-    auto unmetShieldedReq = view.HaveShieldedRequirements(tx);
-    if (unmetShieldedReq) {
+    auto unmetShieldedReq = view.CheckShieldedRequirements(tx);
+    if (!unmetShieldedReq.has_value()) {
         auto txid = tx.GetHash().ToString();
-        auto rejectCode = ShieldedReqRejectCode(*unmetShieldedReq);
-        auto rejectReason = ShieldedReqRejectReason(*unmetShieldedReq);
+        auto rejectCode = ShieldedReqRejectCode(unmetShieldedReq.error());
+        auto rejectReason = ShieldedReqRejectReason(unmetShieldedReq.error());
         TracingDebug(
             "main", "CheckTxShieldedInputs(): shielded requirements not met",
             "txid", txid.c_str(),

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -387,7 +387,7 @@ BOOST_AUTO_TEST_CASE(chained_joinsplits)
         CMutableTransaction mtx;
         mtx.vJoinSplit.push_back(js2);
 
-        BOOST_CHECK(cache.HaveShieldedRequirements(mtx) == std::optional<UnsatisfiedShieldedReq>(UnsatisfiedShieldedReq::SproutUnknownAnchor));
+        BOOST_CHECK(cache.CheckShieldedRequirements(mtx) == tl::unexpected(UnsatisfiedShieldedReq::SproutUnknownAnchor));
     }
 
     {
@@ -397,7 +397,7 @@ BOOST_AUTO_TEST_CASE(chained_joinsplits)
         mtx.vJoinSplit.push_back(js2);
         mtx.vJoinSplit.push_back(js1);
 
-        BOOST_CHECK(cache.HaveShieldedRequirements(mtx) == std::optional<UnsatisfiedShieldedReq>(UnsatisfiedShieldedReq::SproutUnknownAnchor));
+        BOOST_CHECK(cache.CheckShieldedRequirements(mtx) == tl::unexpected(UnsatisfiedShieldedReq::SproutUnknownAnchor));
     }
 
     {
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(chained_joinsplits)
         mtx.vJoinSplit.push_back(js1);
         mtx.vJoinSplit.push_back(js2);
 
-        BOOST_CHECK(cache.HaveShieldedRequirements(mtx) == std::nullopt);
+        BOOST_CHECK(cache.CheckShieldedRequirements(mtx).has_value());
     }
 
     {
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(chained_joinsplits)
         mtx.vJoinSplit.push_back(js2);
         mtx.vJoinSplit.push_back(js3);
 
-        BOOST_CHECK(cache.HaveShieldedRequirements(mtx) == std::nullopt);
+        BOOST_CHECK(cache.CheckShieldedRequirements(mtx).has_value());
     }
 
     {
@@ -424,7 +424,7 @@ BOOST_AUTO_TEST_CASE(chained_joinsplits)
         mtx.vJoinSplit.push_back(js2);
         mtx.vJoinSplit.push_back(js3);
 
-        BOOST_CHECK(cache.HaveShieldedRequirements(mtx) == std::nullopt);
+        BOOST_CHECK(cache.CheckShieldedRequirements(mtx).has_value());
     }
 }
 


### PR DESCRIPTION
We make some minor modifications to the `tl::expected` implementation, to cause assertion failures in cases that were previously undefined behaviour. This affects `operator->`, `operator*`, and `error()` on a `tl::expected` instance, which had the only [documented instances of undefined behaviour](https://tl.tartanllama.xyz/en/latest/api/expected.html) in the API. The performance impact is likely negligible for typical uses.

fixes #4816