### PR TITLE
`README.md`: Clarify distinction between protocol vs zcashd implementation; link to Zebra; line wrapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,28 @@ What is Zcash?
 --------------
 
 [Zcash](https://z.cash/) is an implementation of the "Zerocash" protocol.
-Based on Bitcoin's code, Zcash intends to offer a far higher standard of privacy
-through a sophisticated zero-knowledge proving scheme that preserves
-confidentiality of transaction metadata. More technical details are available
-in our [Protocol Specification](https://zips.z.cash/protocol/protocol.pdf).
+Initially based on Bitcoin's design, Zcash intends to offer a far
+higher standard of privacy through a sophisticated zero-knowledge
+proving scheme that preserves confidentiality of transaction
+metadata. More technical details are available in our [Protocol
+Specification](https://zips.z.cash/protocol/protocol.pdf).
 
-This software is the Zcash client. It downloads and stores the entire history
-of Zcash transactions; depending on the speed of your computer and network
-connection, the synchronization process could take a day or more once the
-blockchain has reached a significant size.
+## The `zcashd` Full Node
+
+This repository hosts the `zcashd` software, a Zcash consensus node
+implementation. It downloads and stores the entire history of Zcash
+transactions; depending on the speed of your computer and network
+connection, the synchronization process could take a day or more once
+the blockchain has reached a significant size.
 
 <p align="center">
   <img src="doc/imgs/zcashd_screen.gif" height="500">
 </p>
+
+The `zcashd` code is derived from a source fork of
+[`bitcoind`](https://github.com/bitcoin/bitcoin). The code was forked
+initially from the `bitcoind v0.9.*` era, and the two codebases have
+diverged substantially.
 
 #### :lock: Security Warnings
 
@@ -34,9 +43,17 @@ is an automatic deprecation shutdown feature which will halt the node some
 time after this 16-week period. The automatic feature is based on block
 height.
 
+## Other Zcash Implementations
+
+The [zebra](https://github.com/ZcashFoundation/zebra) project offers a
+different Zcash consensus node implementation, written largely from the
+ground up.
+
 ## Getting Started
 
-Please see our [user guide](https://zcash.readthedocs.io/en/latest/rtd_pages/rtd_docs/user_guide.html) for joining the main Zcash network.
+Please see our [user
+guide](https://zcash.readthedocs.io/en/latest/rtd_pages/rtd_docs/user_guide.html)
+for joining the main Zcash network.
 
 ### Need Help?
 

--- a/README.md
+++ b/README.md
@@ -16,18 +16,17 @@ Specification](https://zips.z.cash/protocol/protocol.pdf).
 
 This repository hosts the `zcashd` software, a Zcash consensus node
 implementation. It downloads and stores the entire history of Zcash
-transactions; depending on the speed of your computer and network
-connection, the synchronization process could take a day or more once
-the blockchain has reached a significant size.
+transactions. Depending on the speed of your computer and network
+connection, the synchronization process could take several days.
 
 <p align="center">
   <img src="doc/imgs/zcashd_screen.gif" height="500">
 </p>
 
 The `zcashd` code is derived from a source fork of
-[`bitcoind`](https://github.com/bitcoin/bitcoin). The code was forked
-initially from the `bitcoind v0.9.*` era, and the two codebases have
-diverged substantially.
+[Bitcoin Core](https://github.com/bitcoin/bitcoin). The code was forked
+initially from Bitcoin Core v0.11.2, and the two codebases have diverged
+substantially.
 
 #### :lock: Security Warnings
 
@@ -45,7 +44,7 @@ height.
 
 ## Other Zcash Implementations
 
-The [zebra](https://github.com/ZcashFoundation/zebra) project offers a
+The [Zebra](https://github.com/ZcashFoundation/zebra) project offers a
 different Zcash consensus node implementation, written largely from the
 ground up.
 
@@ -53,7 +52,7 @@ ground up.
 
 Please see our [user
 guide](https://zcash.readthedocs.io/en/latest/rtd_pages/rtd_docs/user_guide.html)
-for joining the main Zcash network.
+for instructions on joining the main Zcash network.
 
 ### Need Help?
 


### PR DESCRIPTION
A docs-only change to the `README.md` to clarify the distinction between `zcash` protocol and `zcashd` implementation.

In particular, I prefer calling `zcashd` "a consensus implementation" instead of "the consensus implementation" especially now that Zebra's on the scene, and I explicitly link to Zebra. My hope is this gives users and devs more options and a clearer picture of the protocol / implementation / project distinctions.

> Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.
> * [ ] Relevant documentation for this PR has to be completed and reviewed by @mdr0id before the PR can be merged

This is a docs-only change.

> * [X] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release

**Test Plan:**

- Check github rendering.
- Check mdbook rendering on a local machine (I have already done this as I wrote the patch, but reviewer verification would be helpful).
- English review/editing.