### PR TITLE
Don't recommend -reindex-chainstate.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1732,7 +1732,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
                 // Check for changed -txindex state
                 if (fTxIndex != GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-                    strLoadError = _("You need to rebuild the database using -reindex-chainstate to change -txindex");
+                    // TODO: Recommend `-reindex-chainstate` instead of
+                    //      `-reindex` after #5964 and/or #5977 are fixed.
+                    strLoadError = _("You need to rebuild the database using -reindex to change -txindex");
                     break;
                 }
 
@@ -1803,7 +1805,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             if (!fReset) {
                 bool fRet = uiInterface.ThreadSafeQuestion(
                     strLoadError + ".\n\n" + _("Do you want to rebuild the block database now?"),
-                    strLoadError + ".\nPlease restart with -reindex or -reindex-chainstate to recover.",
+                    // TODO: Recommend `-reindex or -reindex-chainstate` after
+                    //       #5964 and/or #5977 are fixed.
+                    strLoadError + ".\nPlease restart with -reindex to recover.",
                     "", CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT);
                 if (fRet) {
                     fReindex = true;


### PR DESCRIPTION
As mentioned in #5964 and #5977, `-reindex-chainstate` is currently broken. This removes it from error messages so that we don't suggest its use, but rather a full `-reindex`.

This change should be reverted if/when those issues are fixed.
