### PR TITLE
Switch to a version of librustzcash that prepares ivk and epk when doing trial decryption

### DIFF
--- a/.cargo/config.offline
+++ b/.cargo/config.offline
@@ -6,7 +6,7 @@ replace-with = "vendored-sources"
 
 [source."https://github.com/zcash/librustzcash.git"]
 git = "https://github.com/zcash/librustzcash.git"
-rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
+rev = "913aa0a9885acbd6af9cf3525221d632e4f5a6e4"
 replace-with = "vendored-sources"
 
 [source."https://github.com/zcash/orchard.git"]
@@ -16,7 +16,7 @@ replace-with = "vendored-sources"
 
 [source."https://github.com/zkcrypto/group.git"]
 git = "https://github.com/zkcrypto/group.git"
-rev = "a7f3ceb2373e9fe536996f7b4d55c797f3e667f0"
+rev = "f61e3e420ed1220c8f1f80988f8c6c5e202d8715"
 replace-with = "vendored-sources"
 
 [source.vendored-sources]

--- a/.cargo/config.offline
+++ b/.cargo/config.offline
@@ -6,7 +6,17 @@ replace-with = "vendored-sources"
 
 [source."https://github.com/zcash/librustzcash.git"]
 git = "https://github.com/zcash/librustzcash.git"
-rev = "abe452d8a5a3d3bce102c3445f9e321d68296d8f"
+rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
+replace-with = "vendored-sources"
+
+[source."https://github.com/zcash/orchard.git"]
+git = "https://github.com/zcash/orchard.git"
+rev = "f206b3f5d4e31bba75d03d9d03d5fa25825a9384"
+replace-with = "vendored-sources"
+
+[source."https://github.com/zkcrypto/group.git"]
+git = "https://github.com/zkcrypto/group.git"
+rev = "a7f3ceb2373e9fe536996f7b4d55c797f3e667f0"
 replace-with = "vendored-sources"
 
 [source.vendored-sources]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,10 +19,11 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
 dependencies = [
+ "crypto-common",
  "generic-array",
 ]
 
@@ -33,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug",
 ]
@@ -218,7 +219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
 dependencies = [
  "block-padding",
- "cipher",
+ "cipher 0.3.0",
 ]
 
 [[package]]
@@ -293,25 +294,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
+checksum = "c7fc89c7c5b9e7a02dfe45cd2367bae382f9ed31c61ca8debe5f827c420a2f08"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher",
+ "cipher 0.4.3",
  "cpufeatures",
- "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20",
- "cipher",
+ "cipher 0.4.3",
  "poly1305",
  "zeroize",
 ]
@@ -323,6 +323,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -411,6 +422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.3",
  "typenum",
 ]
 
@@ -539,7 +551,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=abe452d8a5a3d3bce102c3445f9e321d68296d8f#abe452d8a5a3d3bce102c3445f9e321d68296d8f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -548,7 +560,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=abe452d8a5a3d3bce102c3445f9e321d68296d8f#abe452d8a5a3d3bce102c3445f9e321d68296d8f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
 dependencies = [
  "blake2b_simd",
 ]
@@ -589,7 +601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd910db5f9ca4dc3116f8c46367825807aa2b942f72565f16b4be0b208a00a9e"
 dependencies = [
  "block-modes",
- "cipher",
+ "cipher 0.3.0",
  "libm",
  "num-bigint",
  "num-integer",
@@ -676,10 +688,8 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 [[package]]
 name = "group"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
+source = "git+https://github.com/zkcrypto/group.git?rev=a7f3ceb2373e9fe536996f7b4d55c797f3e667f0#a7f3ceb2373e9fe536996f7b4d55c797f3e667f0"
 dependencies = [
- "byteorder",
  "ff",
  "rand_core 0.6.3",
  "subtle",
@@ -878,6 +888,15 @@ checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1245,8 +1264,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7619db7f917afd9b1139044c595fab1b6166de2db62317794b5f5e34a2104ae1"
+source = "git+https://github.com/zcash/orchard.git?rev=f206b3f5d4e31bba75d03d9d03d5fa25825a9384#f206b3f5d4e31bba75d03d9d03d5fa25825a9384"
 dependencies = [
  "aes",
  "bitvec",
@@ -1418,9 +1436,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "poly1305"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
@@ -2102,11 +2120,11 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
 dependencies = [
- "generic-array",
+ "crypto-common",
  "subtle",
 ]
 
@@ -2308,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=abe452d8a5a3d3bce102c3445f9e321d68296d8f#abe452d8a5a3d3bce102c3445f9e321d68296d8f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
 dependencies = [
  "bech32",
  "bs58",
@@ -2319,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=abe452d8a5a3d3bce102c3445f9e321d68296d8f#abe452d8a5a3d3bce102c3445f9e321d68296d8f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2328,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=abe452d8a5a3d3bce102c3445f9e321d68296d8f#abe452d8a5a3d3bce102c3445f9e321d68296d8f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -2338,10 +2356,12 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=abe452d8a5a3d3bce102c3445f9e321d68296d8f#abe452d8a5a3d3bce102c3445f9e321d68296d8f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
+ "cipher 0.4.3",
+ "group",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -2349,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.7.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=abe452d8a5a3d3bce102c3445f9e321d68296d8f#abe452d8a5a3d3bce102c3445f9e321d68296d8f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
 dependencies = [
  "aes",
  "bip0039",
@@ -2386,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.7.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=abe452d8a5a3d3bce102c3445f9e321d68296d8f#abe452d8a5a3d3bce102c3445f9e321d68296d8f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -2405,9 +2425,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
+source = "git+https://github.com/zcash/librustzcash.git?rev=913aa0a9885acbd6af9cf3525221d632e4f5a6e4#913aa0a9885acbd6af9cf3525221d632e4f5a6e4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
+source = "git+https://github.com/zcash/librustzcash.git?rev=913aa0a9885acbd6af9cf3525221d632e4f5a6e4#913aa0a9885acbd6af9cf3525221d632e4f5a6e4"
 dependencies = [
  "blake2b_simd",
 ]
@@ -688,9 +688,10 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 [[package]]
 name = "group"
 version = "0.12.0"
-source = "git+https://github.com/zkcrypto/group.git?rev=a7f3ceb2373e9fe536996f7b4d55c797f3e667f0#a7f3ceb2373e9fe536996f7b4d55c797f3e667f0"
+source = "git+https://github.com/zkcrypto/group.git?rev=f61e3e420ed1220c8f1f80988f8c6c5e202d8715#f61e3e420ed1220c8f1f80988f8c6c5e202d8715"
 dependencies = [
  "ff",
+ "memuse",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -1079,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "memuse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69d25cd7528769ad3d897e99eb942774bff8b23165012af490351a44c5b583b"
+checksum = "2145869435ace5ea6ea3d35f59be559317ec9a0d04e1812d5f185a87b6d36f1a"
 dependencies = [
  "nonempty",
 ]
@@ -2326,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
+source = "git+https://github.com/zcash/librustzcash.git?rev=913aa0a9885acbd6af9cf3525221d632e4f5a6e4#913aa0a9885acbd6af9cf3525221d632e4f5a6e4"
 dependencies = [
  "bech32",
  "bs58",
@@ -2337,7 +2338,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
+source = "git+https://github.com/zcash/librustzcash.git?rev=913aa0a9885acbd6af9cf3525221d632e4f5a6e4#913aa0a9885acbd6af9cf3525221d632e4f5a6e4"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2346,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
+source = "git+https://github.com/zcash/librustzcash.git?rev=913aa0a9885acbd6af9cf3525221d632e4f5a6e4#913aa0a9885acbd6af9cf3525221d632e4f5a6e4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -2356,7 +2357,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
+source = "git+https://github.com/zcash/librustzcash.git?rev=913aa0a9885acbd6af9cf3525221d632e4f5a6e4#913aa0a9885acbd6af9cf3525221d632e4f5a6e4"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -2369,7 +2370,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.7.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
+source = "git+https://github.com/zcash/librustzcash.git?rev=913aa0a9885acbd6af9cf3525221d632e4f5a6e4#913aa0a9885acbd6af9cf3525221d632e4f5a6e4"
 dependencies = [
  "aes",
  "bip0039",
@@ -2406,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.7.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec#f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec"
+source = "git+https://github.com/zcash/librustzcash.git?rev=913aa0a9885acbd6af9cf3525221d632e4f5a6e4#913aa0a9885acbd6af9cf3525221d632e4f5a6e4"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,12 +111,12 @@ panic = 'abort'
 codegen-units = 1
 
 [patch.crates-io]
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "913aa0a9885acbd6af9cf3525221d632e4f5a6e4" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "913aa0a9885acbd6af9cf3525221d632e4f5a6e4" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "913aa0a9885acbd6af9cf3525221d632e4f5a6e4" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "913aa0a9885acbd6af9cf3525221d632e4f5a6e4" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "913aa0a9885acbd6af9cf3525221d632e4f5a6e4" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "913aa0a9885acbd6af9cf3525221d632e4f5a6e4" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "913aa0a9885acbd6af9cf3525221d632e4f5a6e4" }
 orchard = { git = "https://github.com/zcash/orchard.git", rev = "f206b3f5d4e31bba75d03d9d03d5fa25825a9384" }
-group = { git = "https://github.com/zkcrypto/group.git", rev = "a7f3ceb2373e9fe536996f7b4d55c797f3e667f0" }
+group = { git = "https://github.com/zkcrypto/group.git", rev = "f61e3e420ed1220c8f1f80988f8c6c5e202d8715" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,10 +111,12 @@ panic = 'abort'
 codegen-units = 1
 
 [patch.crates-io]
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "abe452d8a5a3d3bce102c3445f9e321d68296d8f" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "abe452d8a5a3d3bce102c3445f9e321d68296d8f" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "abe452d8a5a3d3bce102c3445f9e321d68296d8f" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "abe452d8a5a3d3bce102c3445f9e321d68296d8f" }
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "abe452d8a5a3d3bce102c3445f9e321d68296d8f" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "abe452d8a5a3d3bce102c3445f9e321d68296d8f" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "abe452d8a5a3d3bce102c3445f9e321d68296d8f" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "f78c91fd0cc9ac3ee9e183b1140da8745fcc8fec" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "f206b3f5d4e31bba75d03d9d03d5fa25825a9384" }
+group = { git = "https://github.com/zkcrypto/group.git", rev = "a7f3ceb2373e9fe536996f7b4d55c797f3e667f0" }

--- a/qa/supply-chain/audits.toml
+++ b/qa/supply-chain/audits.toml
@@ -7,6 +7,12 @@ description = "The cryptographic code in this crate has been reviewed for correc
 [criteria.license-reviewed]
 description = "The license of this crate has been reviewed for compatibility with its usage in this repository. If the crate is not available under the MIT license, `contrib/debian/copyright` has been updated with a corresponding copyright notice for files under `depends/*/vendored-sources/CRATE_NAME`."
 
+[[audits.aead]]
+who = "Daira Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.3 -> 0.5.1"
+notes = "Adds an AeadCore::generate_nonce function to generate random nonces, given a CryptoRng."
+
 [[audits.anyhow]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = "safe-to-deploy"
@@ -25,11 +31,28 @@ criteria = ["crypto-reviewed", "safe-to-deploy"]
 delta = "0.8.1 -> 0.8.2"
 notes = "Unpins zeroize."
 
+[[audits.chacha20]]
+who = "Daira Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.8.2 -> 0.9.0"
+
 [[audits.chacha20poly1305]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = ["crypto-reviewed", "safe-to-deploy"]
 delta = "0.9.0 -> 0.9.1"
 notes = "Unpins zeroize."
+
+[[audits.chacha20poly1305]]
+who = "Daira Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.1 -> 0.10.1"
+notes = "This mainly adapts to API changes between aead 0.4 and aead 0.5."
+
+[[audits.cipher]]
+who = "Daira Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.4.3"
+notes = "Significant rework of (mainly RustCrypto-internal) APIs."
 
 [[audits.clearscreen]]
 who = "Jack Grigg <jack@z.cash>"
@@ -125,6 +148,12 @@ criteria = ["crypto-reviewed", "safe-to-deploy"]
 delta = "0.1.0 -> 0.2.0"
 notes = "The ECC core team maintains this crate, and we have reviewed every line."
 
+[[audits.inout]]
+who = "Daira Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+notes = "Reviewed in full."
+
 [[audits.itoa]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = "safe-to-deploy"
@@ -169,6 +198,12 @@ criteria = ["crypto-reviewed", "safe-to-deploy"]
 delta = "0.1.0 -> 0.2.0"
 notes = "The ECC core team maintains this crate, and we have reviewed every line."
 
+[[audits.poly1305]]
+who = "Daira Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.7.2 -> 0.8.0"
+notes = "Changes to unsafe (avx2) code look reasonable."
+
 [[audits.proc-macro2]]
 who = "Daira Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-deploy"
@@ -207,6 +242,12 @@ notes = "Only change is to refine an error message."
 who = "Daira Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-deploy"
 version = "1.0.2"
+
+[[audits.universal-hash]]
+who = "Daira Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.1 -> 0.5.0"
+notes = "I checked correctness of to_blocks which uses unsafe code in a safe function."
 
 [[audits.windows_aarch64_msvc]]
 who = "Jack Grigg <jack@z.cash>"
@@ -316,4 +357,10 @@ who = "Jack Grigg <jack@z.cash>"
 criteria = ["crypto-reviewed", "safe-to-deploy"]
 delta = "0.7.0 -> 0.7.1"
 notes = "The ECC core team maintains this crate, and we have reviewed every line."
+
+[[audits.zeroize]]
+who = "Daira Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "1.4.3 -> 1.5.7"
+notes = "The zeroize_c_string unit test has UB, but that's very unlikely to cause a problem in practice."
 

--- a/qa/supply-chain/audits.toml
+++ b/qa/supply-chain/audits.toml
@@ -160,6 +160,12 @@ criteria = "safe-to-deploy"
 delta = "1.0.1 -> 1.0.3"
 notes = "Update makes no changes to code."
 
+[[audits.memuse]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = "Exposes an existing macro. Note that I am the author of the crate."
+
 [[audits.mio]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = "safe-to-deploy"

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -7,6 +7,12 @@ audit-as-crates-io = true
 [policy.f4jumble]
 audit-as-crates-io = true
 
+[policy.group]
+audit-as-crates-io = true
+
+[policy.orchard]
+audit-as-crates-io = true
+
 [policy.zcash_address]
 audit-as-crates-io = true
 

--- a/src/rust/src/wallet_scanner.rs
+++ b/src/rust/src/wallet_scanner.rs
@@ -98,6 +98,24 @@ pub enum Network {
     },
 }
 
+impl DynamicUsage for Network {
+    fn dynamic_usage(&self) -> usize {
+        match self {
+            Network::Consensus(params) => params.dynamic_usage(),
+            // We know that `Option<BlockHeight>` allocates no memory.
+            Network::RegTest { .. } => 0,
+        }
+    }
+
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        match self {
+            Network::Consensus(params) => params.dynamic_usage_bounds(),
+            // We know that `Option<BlockHeight>` allocates no memory.
+            Network::RegTest { .. } => (0, Some(0)),
+        }
+    }
+}
+
 /// Constructs a `Network` from the given network string.
 ///
 /// The heights are only for constructing a regtest network, and are ignored otherwise.
@@ -392,32 +410,33 @@ struct Batch<A, D: BatchDomain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>> 
     repliers: Vec<OutputReplier<A, D>>,
 }
 
-fn base_vec_usage<T>(c: &Vec<T>) -> usize {
-    c.capacity() * mem::size_of::<T>()
-}
-
 impl<A, D, Output> DynamicUsage for Batch<A, D, Output>
 where
-    D: BatchDomain,
-    Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>,
+    A: DynamicUsage,
+    D: BatchDomain + DynamicUsage,
+    D::IncomingViewingKey: DynamicUsage,
+    Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE> + DynamicUsage,
 {
     fn dynamic_usage(&self) -> usize {
-        // We don't have a `DynamicUsage` bound on `D::IncomingViewingKey`, `D`, or
-        // `Output`, and we can't use newtypes because the batch decryption API takes
-        // slices. TODO: this does not include memory allocated inside self.ivks.
-        base_vec_usage(&self.tags)
-            + base_vec_usage(&self.ivks)
-            + base_vec_usage(&self.outputs)
+        self.tags.dynamic_usage()
+            + self.ivks.dynamic_usage()
+            + self.outputs.dynamic_usage()
             + self.repliers.dynamic_usage()
     }
 
     fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
-        let base_usage =
-            base_vec_usage(&self.tags) + base_vec_usage(&self.ivks) + base_vec_usage(&self.outputs);
-        let bounds = self.repliers.dynamic_usage_bounds();
+        let (tags_lower, tags_upper) = self.tags.dynamic_usage_bounds();
+        let (ivks_lower, ivks_upper) = self.ivks.dynamic_usage_bounds();
+        let (outputs_lower, outputs_upper) = self.outputs.dynamic_usage_bounds();
+        let (repliers_lower, repliers_upper) = self.repliers.dynamic_usage_bounds();
+
         (
-            base_usage + bounds.0,
-            bounds.1.map(|upper| base_usage + upper),
+            tags_lower + ivks_lower + outputs_lower + repliers_lower,
+            tags_upper
+                .zip(ivks_upper)
+                .zip(outputs_upper)
+                .zip(repliers_upper)
+                .map(|(((a, b), c), d)| a + b + c + d),
         )
     }
 }
@@ -587,8 +606,10 @@ where
 
 impl<A, D, Output, T> DynamicUsage for BatchRunner<A, D, Output, T>
 where
-    D: BatchDomain,
-    Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>,
+    A: DynamicUsage,
+    D: BatchDomain + DynamicUsage,
+    D::IncomingViewingKey: DynamicUsage,
+    Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE> + DynamicUsage,
     T: Tasks<Batch<A, D, Output>> + DynamicUsage,
 {
     fn dynamic_usage(&self) -> usize {

--- a/src/rust/src/wallet_scanner.rs
+++ b/src/rust/src/wallet_scanner.rs
@@ -301,13 +301,16 @@ where
     fn dynamic_usage(&self) -> usize {
         // We don't have a `DynamicUsage` bound on `D::IncomingViewingKey`, `D`, or
         // `Output`, and we can't use newtypes because the batch decryption API takes
-        // slices. But we know that we don't allocate memory inside either of these, so we
-        // just compute the size directly.
-        base_vec_usage(&self.ivks) + base_vec_usage(&self.outputs) + self.repliers.dynamic_usage()
+        // slices. TODO: this does not include memory allocated inside self.ivks.
+        base_vec_usage(&self.tags)
+            + base_vec_usage(&self.ivks)
+            + base_vec_usage(&self.outputs)
+            + self.repliers.dynamic_usage()
     }
 
     fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
-        let base_usage = base_vec_usage(&self.ivks) + base_vec_usage(&self.outputs);
+        let base_usage =
+            base_vec_usage(&self.tags) + base_vec_usage(&self.ivks) + base_vec_usage(&self.outputs);
         let bounds = self.repliers.dynamic_usage_bounds();
         (
             base_usage + bounds.0,


### PR DESCRIPTION
This is intended to improve efficiency and memory usage. fixes #6157