### PR TITLE
wallet: Refactor `ThreadNotifyWallets` to support batch memory limits

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -7,6 +7,11 @@ Notable changes
 Wallet Performance Improvements
 -------------------------------
 
+`zcashd 5.2.0` improved the performance of wallet scanning with multithreaded
+batched trial decryption of Sapling outputs. However, for some nodes this
+resulted in growing memory usage that would eventually cause an OOM abort. The
+batch scanner now has a memory limit of 100 MiB.
+
 `zcashd` now reports the following new metrics when `-prometheusport` is set:
 
 - (counter) `zcashd.wallet.batchscanner.outputs.scanned`

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -9,8 +9,10 @@ Wallet Performance Improvements
 
 `zcashd 5.2.0` improved the performance of wallet scanning with multithreaded
 batched trial decryption of Sapling outputs. However, for some nodes this
-resulted in growing memory usage that would eventually cause an OOM abort. The
-batch scanner now has a memory limit of 100 MiB.
+resulted in growing memory usage that would eventually cause an OOM abort. We
+have identified the cause of the growth, and made significant improvements to
+reduce the memory usage of the batch scanner. In addition, the batch scanner now
+has a memory limit of 100 MiB.
 
 `zcashd` now reports the following new metrics when `-prometheusport` is set:
 

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -9,5 +9,6 @@ Wallet Performance Improvements
 
 `zcashd` now reports the following new metrics when `-prometheusport` is set:
 
+- (counter) `zcashd.wallet.batchscanner.outputs.scanned`
 - (gauge) `zcashd.wallet.batchscanner.size.transactions`
 - (gauge) `zcashd.wallet.batchscanner.usage.bytes`

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,3 +4,10 @@ release-notes at release time)
 Notable changes
 ===============
 
+Wallet Performance Improvements
+-------------------------------
+
+`zcashd` now reports the following new metrics when `-prometheusport` is set:
+
+- (gauge) `zcashd.wallet.batchscanner.size.transactions`
+- (gauge) `zcashd.wallet.batchscanner.usage.bytes`

--- a/src/rust/src/wallet_scanner.rs
+++ b/src/rust/src/wallet_scanner.rs
@@ -2,9 +2,14 @@ use core::fmt;
 use std::collections::HashMap;
 use std::io;
 use std::mem;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 
 use crossbeam_channel as channel;
 use group::GroupEncoding;
+use memuse::DynamicUsage;
 use zcash_note_encryption::{batch, BatchDomain, Domain, ShieldedOutput, ENC_CIPHERTEXT_SIZE};
 use zcash_primitives::{
     block::BlockHash,
@@ -47,6 +52,7 @@ mod ffi {
             network: &Network,
             sapling_ivks: &[[u8; 32]],
         ) -> Result<Box<BatchScanner>>;
+        fn get_dynamic_usage(self: &BatchScanner) -> usize;
         fn add_transaction(
             self: &mut BatchScanner,
             block_tag: [u8; 32],
@@ -68,6 +74,9 @@ mod ffi {
 ///
 /// TODO: Tune this.
 const BATCH_SIZE_THRESHOLD: usize = 20;
+
+const METRIC_SIZE_TXS: &str = "zcashd.wallet.batchscanner.size.transactions";
+const METRIC_USAGE_BYTES: &str = "zcashd.wallet.batchscanner.usage.bytes";
 
 /// Chain parameters for the networks supported by `zcashd`.
 #[derive(Clone, Copy)]
@@ -229,7 +238,23 @@ struct OutputIndex<V> {
     value: V,
 }
 
-type OutputReplier<D> = OutputIndex<channel::Sender<OutputIndex<Option<DecryptedNote<D>>>>>;
+type OutputItem<D> = OutputIndex<Option<DecryptedNote<D>>>;
+
+/// The sender for the result of batch scanning a specific transaction output.
+struct OutputReplier<D: Domain>(OutputIndex<channel::Sender<OutputItem<D>>>);
+
+impl<D: Domain> DynamicUsage for OutputReplier<D> {
+    #[inline(always)]
+    fn dynamic_usage(&self) -> usize {
+        // We count the memory usage of items in the channel on the receiver side.
+        0
+    }
+
+    #[inline(always)]
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        (0, Some(0))
+    }
+}
 
 /// A batch of outputs to trial decrypt.
 struct Batch<D: BatchDomain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>> {
@@ -243,6 +268,35 @@ struct Batch<D: BatchDomain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>> {
     /// (that is captured in the outer `OutputIndex` of each `OutputReplier`).
     outputs: Vec<(D, Output)>,
     repliers: Vec<OutputReplier<D>>,
+    // Pointer to the parent `BatchRunner`'s heap usage tracker for running batches.
+    running_usage: Arc<AtomicUsize>,
+}
+
+fn base_vec_usage<T>(c: &Vec<T>) -> usize {
+    c.capacity() * mem::size_of::<T>()
+}
+
+impl<D, Output> DynamicUsage for Batch<D, Output>
+where
+    D: BatchDomain,
+    Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>,
+{
+    fn dynamic_usage(&self) -> usize {
+        // We don't have a `DynamicUsage` bound on `D::IncomingViewingKey`, `D`, or
+        // `Output`, and we can't use newtypes because the batch decryption API takes
+        // slices. But we know that we don't allocate memory inside either of these, so we
+        // just compute the size directly.
+        base_vec_usage(&self.ivks) + base_vec_usage(&self.outputs) + self.repliers.dynamic_usage()
+    }
+
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        let base_usage = base_vec_usage(&self.ivks) + base_vec_usage(&self.outputs);
+        let bounds = self.repliers.dynamic_usage_bounds();
+        (
+            base_usage + bounds.0,
+            bounds.1.map(|upper| base_usage + upper),
+        )
+    }
 }
 
 impl<D, Output> Batch<D, Output>
@@ -252,11 +306,12 @@ where
     D::IncomingViewingKey: Clone,
 {
     /// Constructs a new batch.
-    fn new(ivks: Vec<D::IncomingViewingKey>) -> Self {
+    fn new(ivks: Vec<D::IncomingViewingKey>, running_usage: Arc<AtomicUsize>) -> Self {
         Self {
             ivks,
             outputs: vec![],
             repliers: vec![],
+            running_usage,
         }
     }
 
@@ -267,9 +322,16 @@ where
 
     /// Runs the batch of trial decryptions, and reports the results.
     fn run(self) {
+        // Approximate now as when the heap cost of this running batch begins. We use the
+        // size of `self` as a lower bound on the actual heap memory allocated by the
+        // rayon threadpool to store this `Batch`.
+        let own_usage = std::mem::size_of_val(&self) + self.dynamic_usage();
+        self.running_usage.fetch_add(own_usage, Ordering::SeqCst);
+
         assert_eq!(self.outputs.len(), self.repliers.len());
         let decryption_results = batch::try_note_decryption(&self.ivks, &self.outputs);
-        for (decryption_result, replier) in decryption_results.into_iter().zip(self.repliers.iter())
+        for (decryption_result, OutputReplier(replier)) in
+            decryption_results.into_iter().zip(self.repliers.iter())
         {
             let result = OutputIndex {
                 output_index: replier.output_index,
@@ -283,9 +345,12 @@ where
 
             if replier.value.send(result).is_err() {
                 tracing::debug!("BatchRunner was dropped before batch finished");
-                return;
+                break;
             }
         }
+
+        // Signal that the heap memory for this batch is about to be freed.
+        self.running_usage.fetch_sub(own_usage, Ordering::SeqCst);
     }
 }
 
@@ -297,24 +362,105 @@ impl<D: BatchDomain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE> + Clone> Bat
         &mut self,
         domain: impl Fn() -> D,
         outputs: &[Output],
-        replier: channel::Sender<OutputIndex<Option<DecryptedNote<D>>>>,
+        replier: channel::Sender<OutputItem<D>>,
     ) {
         self.outputs
             .extend(outputs.iter().cloned().map(|output| (domain(), output)));
-        self.repliers
-            .extend((0..outputs.len()).map(|output_index| OutputIndex {
+        self.repliers.extend((0..outputs.len()).map(|output_index| {
+            OutputReplier(OutputIndex {
                 output_index,
                 value: replier.clone(),
-            }));
+            })
+        }));
     }
 }
 
-type ResultKey = (BlockHash, TxId);
+/// A `HashMap` key for looking up the result of a batch scanning a specific transaction.
+#[derive(PartialEq, Eq, Hash)]
+struct ResultKey(BlockHash, TxId);
+
+impl DynamicUsage for ResultKey {
+    #[inline(always)]
+    fn dynamic_usage(&self) -> usize {
+        0
+    }
+
+    #[inline(always)]
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        (0, Some(0))
+    }
+}
+
+/// The receiver for the result of batch scanning a specific transaction.
+struct BatchReceiver<D: Domain>(channel::Receiver<OutputItem<D>>);
+
+impl<D: Domain> DynamicUsage for BatchReceiver<D> {
+    fn dynamic_usage(&self) -> usize {
+        // We count the memory usage of items in the channel on the receiver side.
+        let num_items = self.0.len();
+
+        // We know we use unbounded channels, so the items in the channel are stored as a
+        // linked list. `crossbeam_channel` allocates memory for the linked list in blocks
+        // of 31 items.
+        const ITEMS_PER_BLOCK: usize = 31;
+        let num_blocks = (num_items + ITEMS_PER_BLOCK - 1) / ITEMS_PER_BLOCK;
+
+        // The structure of a block is:
+        // - A pointer to the next block.
+        // - For each slot in the block:
+        //   - Space for an item.
+        //   - The state of the slot, stored as an AtomicUsize.
+        const PTR_SIZE: usize = std::mem::size_of::<usize>();
+        let item_size = std::mem::size_of::<OutputItem<D>>();
+        const ATOMIC_USIZE_SIZE: usize = std::mem::size_of::<AtomicUsize>();
+        let block_size = PTR_SIZE + ITEMS_PER_BLOCK * (item_size + ATOMIC_USIZE_SIZE);
+
+        num_blocks * block_size
+    }
+
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        let usage = self.dynamic_usage();
+        (usage, Some(usage))
+    }
+}
 
 /// Logic to run batches of trial decryptions on the global threadpool.
 struct BatchRunner<D: BatchDomain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>> {
+    // The batch currently being accumulated.
     acc: Batch<D, Output>,
-    pending_results: HashMap<ResultKey, channel::Receiver<OutputIndex<Option<DecryptedNote<D>>>>>,
+    // The dynamic memory usage of the running batches.
+    running_usage: Arc<AtomicUsize>,
+    // Receivers for the results of the running batches.
+    pending_results: HashMap<ResultKey, BatchReceiver<D>>,
+}
+
+impl<D, Output> DynamicUsage for BatchRunner<D, Output>
+where
+    D: BatchDomain,
+    Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>,
+{
+    fn dynamic_usage(&self) -> usize {
+        self.acc.dynamic_usage()
+            + self.running_usage.load(Ordering::Relaxed)
+            + self.pending_results.dynamic_usage()
+    }
+
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        let running_usage = self.running_usage.load(Ordering::Relaxed);
+
+        let bounds = (
+            self.acc.dynamic_usage_bounds(),
+            self.pending_results.dynamic_usage_bounds(),
+        );
+        (
+            bounds.0 .0 + running_usage + bounds.1 .0,
+            bounds
+                .0
+                 .1
+                .zip(bounds.1 .1)
+                .map(|(a, b)| a + running_usage + b),
+        )
+    }
 }
 
 impl<D, Output> BatchRunner<D, Output>
@@ -325,8 +471,10 @@ where
 {
     /// Constructs a new batch runner for the given incoming viewing keys.
     fn new(ivks: Vec<D::IncomingViewingKey>) -> Self {
+        let running_usage = Arc::new(AtomicUsize::new(0));
         Self {
-            acc: Batch::new(ivks),
+            acc: Batch::new(ivks, running_usage.clone()),
+            running_usage,
             pending_results: HashMap::default(),
         }
     }
@@ -359,7 +507,8 @@ where
     ) {
         let (tx, rx) = channel::unbounded();
         self.acc.add_outputs(domain, outputs, tx);
-        self.pending_results.insert((block_tag, txid), rx);
+        self.pending_results
+            .insert(ResultKey(block_tag, txid), BatchReceiver(rx));
 
         if self.acc.outputs.len() >= BATCH_SIZE_THRESHOLD {
             self.flush();
@@ -371,7 +520,7 @@ where
     /// Subsequent calls to `Self::add_outputs` will be accumulated into a new batch.
     fn flush(&mut self) {
         if !self.acc.is_empty() {
-            let mut batch = Batch::new(self.acc.ivks.clone());
+            let mut batch = Batch::new(self.acc.ivks.clone(), self.running_usage.clone());
             mem::swap(&mut batch, &mut self.acc);
             rayon::spawn_fifo(|| batch.run());
         }
@@ -388,10 +537,10 @@ where
         txid: TxId,
     ) -> HashMap<(TxId, usize), DecryptedNote<D>> {
         self.pending_results
-            .remove(&(block_tag, txid))
+            .remove(&ResultKey(block_tag, txid))
             // We won't have a pending result if the transaction didn't have outputs of
             // this runner's kind.
-            .map(|rx| {
+            .map(|BatchReceiver(rx)| {
                 rx.into_iter()
                     .filter_map(
                         |OutputIndex {
@@ -411,6 +560,16 @@ where
 struct BatchScanner {
     params: Network,
     sapling_runner: Option<BatchRunner<SaplingDomain<Network>, OutputDescription<GrothProofBytes>>>,
+}
+
+impl DynamicUsage for BatchScanner {
+    fn dynamic_usage(&self) -> usize {
+        self.sapling_runner.dynamic_usage()
+    }
+
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        self.sapling_runner.dynamic_usage_bounds()
+    }
 }
 
 fn init_batch_scanner(
@@ -438,6 +597,16 @@ fn init_batch_scanner(
 }
 
 impl BatchScanner {
+    /// FFI helper to access the `DynamicUsage` trait.
+    fn get_dynamic_usage(&self) -> usize {
+        let usage = self.dynamic_usage();
+
+        // Since we've measured it, we may as well update the metric.
+        metrics::gauge!(METRIC_USAGE_BYTES, usage as f64);
+
+        usage
+    }
+
     /// Adds the given transaction's shielded outputs to the various batch runners.
     ///
     /// `block_tag` is the hash of the block that triggered this txid being added to the
@@ -472,6 +641,10 @@ impl BatchScanner {
             );
         }
 
+        // Update the size of the batch scanner.
+        metrics::increment_gauge!(METRIC_SIZE_TXS, 1.0);
+        metrics::gauge!(METRIC_USAGE_BYTES, self.dynamic_usage() as f64);
+
         Ok(())
     }
 
@@ -500,6 +673,10 @@ impl BatchScanner {
             .as_mut()
             .map(|runner| runner.collect_results(block_tag, txid))
             .unwrap_or_default();
+
+        // Update the size of the batch scanner.
+        metrics::decrement_gauge!(METRIC_SIZE_TXS, 1.0);
+        metrics::gauge!(METRIC_USAGE_BYTES, self.dynamic_usage() as f64);
 
         Box::new(BatchResult { sapling })
     }

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -124,6 +124,8 @@ struct CachedBlockData {
 
 void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
 {
+    size_t nBatchScannerMemLimit = DEFAULT_BATCHSCANNERMEMLIMIT * 1024 * 1024;
+
     // If pindexLastTip == nullptr, the wallet is at genesis.
     // However, the genesis block is not loaded synchronously.
     // We need to wait for ThreadImport to finish.
@@ -304,10 +306,7 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
         // Closure that returns true if batchScanners is using less memory than
         // the desired limit.
         auto belowBatchMemoryLimit = [&]() {
-            // For now, set no limit. This should mean that the refactor to
-            // introduce blockStackScanned is a no-op, as we still add every
-            // block in blockStack to batchScanners at the start.
-            return true;
+            return RecursiveDynamicUsage(batchScanners) < nBatchScannerMemLimit;
         };
 
         // Closure that will add a block from blockStack to batchScanners.

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -365,7 +365,7 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
             }
 
             // Batch transactions in the mempool.
-            for (auto tx : recentlyAdded.first) {
+            for (auto& tx : recentlyAdded.first) {
                 AddTxToBatches(batchScanners, tx, uint256(), pindexLastTip->nHeight + 1);
             }
         }
@@ -406,8 +406,7 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
 
         // Notify block connections
         while (!blockStack.empty()) {
-            auto blockData = blockStack.back();
-            blockStack.pop_back();
+            auto& blockData = blockStack.back();
 
             // Read block from disk.
             CBlock block;
@@ -445,10 +444,11 @@ void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
 
             // This block is done!
             pindexLastTip = blockData.pindex;
+            blockStack.pop_back();
         }
 
         // Notify transactions in the mempool
-        for (auto tx : recentlyAdded.first) {
+        for (auto& tx : recentlyAdded.first) {
             try {
                 SyncWithWallets(batchScanners, tx, NULL, pindexLastTip->nHeight + 1);
             } catch (const boost::thread_interrupted&) {

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -68,6 +68,16 @@ void UnregisterAllValidationInterfaces() {
     g_signals.UpdatedBlockTip.disconnect_all_slots();
 }
 
+size_t RecursiveDynamicUsage(
+    std::vector<BatchScanner*> &batchScanners)
+{
+    size_t usage = 0;
+    for (auto& batchScanner : batchScanners) {
+        usage += batchScanner->RecursiveDynamicUsage();
+    }
+    return usage;
+}
+
 void AddTxToBatches(
     std::vector<BatchScanner*> &batchScanners,
     const CTransaction &tx,

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -27,6 +27,11 @@ class uint256;
 class BatchScanner {
 public:
     /**
+     * Returns the current dynamic memory usage of this batch scanner.
+     */
+    virtual size_t RecursiveDynamicUsage() = 0;
+
+    /**
      * Adds a transaction to the batch scanner.
      *
      * `block_tag` is the hash of the block that triggered this txid being added

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -15,6 +15,9 @@
 #include "miner.h"
 #include "zcash/IncrementalMerkleTree.hpp"
 
+/** Default limit on batch scanner memory usage in MiB. */
+static const size_t DEFAULT_BATCHSCANNERMEMLIMIT = 100;
+
 class CBlock;
 class CBlockIndex;
 struct CBlockLocator;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3590,6 +3590,11 @@ bool WalletBatchScanner::AddToWalletIfInvolvingMe(
 // BatchScanner APIs
 //
 
+size_t WalletBatchScanner::RecursiveDynamicUsage()
+{
+    return inner->get_dynamic_usage();
+}
+
 void WalletBatchScanner::AddTransaction(
     const CTransaction &tx,
     const std::vector<unsigned char> &txBytes,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1079,6 +1079,8 @@ public:
     // BatchScanner APIs
     //
 
+    size_t RecursiveDynamicUsage();
+
     void AddTransaction(
         const CTransaction &tx,
         const std::vector<unsigned char> &txBytes,


### PR DESCRIPTION
`ThreadNotifyWallets` was created in order to decouple wallet scanning of transactions from the main chain updates, avoiding timing leaks to network peers. To further ensure that not even lock contention could be used to extract timing information, `ThreadNotifyWallets` collects update information from the main chain on integer second boundaries.

In general this means that the wallet is processing the last second's worth of blocks between each synchronization point. However, when there are sequences of blocks that are costly for the wallet to scan, it may take the wallet longer than a second to process a second's worth of blocks connected to the main chain. This means that `ThreadNotifyWallets` needs to wait until the next integer second boundary before collecting the next set of updates, which means it will be processing at least two seconds' worth of blocks. For extended periods where the chain contains many outputs, the wallet will get progressively further behind the main chain.

At the time that `ThreadNotifyWallets` was created, the above behaviour was fine, because while the wallet scanning process consumed a lot of CPU time, it did not consume much memory (as blocks are stored on disk). However, we recently added batch scanning, which requires allocating memory for each output that is being scanned. For a wallet with a growing gap between its scanned-to height and the chain tip height, the size of the necessary allocation will grow with each integer second boundary crossed, until the node reaches OOM.

The solution is to implement backpressure: if we reach a memory limit before we've finished adding blocks to the batch scanners, then we start consuming the results from the batch scanner to free up memory space for subsequent batches.

This PR also fixes a few places in `ThreadNotifyWallets` where we were unnecessarily copying data.