### PR TITLE
test_framework: fix AttributeError in sapling_spends_compact_digest

### DIFF
--- a/qa/rpc-tests/test_framework/zip244.py
+++ b/qa/rpc-tests/test_framework/zip244.py
@@ -91,7 +91,7 @@ def sapling_spends_noncompact_digest(saplingBundle):
     digest = blake2b(digest_size=32, person=b'ZTxIdSSpendNHash')
     for desc in saplingBundle.spends:
         digest.update(ser_uint256(desc.cv))
-        digest.update(ser_uint256(desc.anchor))
+        digest.update(ser_uint256(saplingBundle.anchor))
         digest.update(ser_uint256(desc.rk))
     return digest.digest()
 


### PR DESCRIPTION
Without this fix we will get:
```
AttributeError: 'SpendDescriptionV5' object has no attribute 'anchor'
``` 
On certain V5 transactions during `rehash` / `calc_sha256`, for example: [ca6abd8ef7d6ef158a4a35ea2c2c0cf122f2f664a88f8fa5b6fd79e48c5bed59](https://zecblockexplorer.com/tx/ca6abd8ef7d6ef158a4a35ea2c2c0cf122f2f664a88f8fa5b6fd79e48c5bed59)

Proof-of-concept:

Create `tx_deserialize.py` in `qa/rpc-tests/` and launch it:

```python
#!/usr/bin/env python3

from test_framework.mininode import CTransaction
from io import BytesIO

def main():
    # ca6abd8ef7d6ef158a4a35ea2c2c0cf122f2f664a88f8fa5b6fd79e48c5bed59
    rawtx = "050000800a27a726b4d0d6c20000000068be1900000001a05c5685b75252c400119ebc80878f8003e900b6a6ca9febdcd74d97a129e58ff6c66e590b881722930ff701bcd5381b7c82ea343da022617b6aea98fe9cb8c97eced1a714d6e8a649160b15ec659fc001e17ec405224389505926a0b4785a3401814cc194f3fc5eed11f6b11a3b5eee6675273537413c17a9da5411b832177e91121bc9572146c399626617403b55e502a941ab7fbff6708f8a417f24b98ddc582526d9e36bddef4234a4a70c24874cab827faf76d8b628065ee299dbdf728b56d152357b271efe7633420eb52d3dc381f04ff0924a52a83bdd0cb21ae393fac38b44aa95483da277f78054b58f7739f3fd4d52b7a2b980702415438d6b926d73e4a5205fcffb1d9c94e49638d796ee4fc164f49656fbb03735266dc9396ad2296a40850f91a0d0e2ef331ee7b73ceded08d7a183997f3c9de5d6fd0e7d2bcb5f0286128955048886b22e48e45e7d1a36e521d10eeb0b2e3620c99508213e2e69458ad1b59c71b399022092fe074ccbbb44601cc3ed3b029828f7c387e96dbfe02fe55a91db9d4ba22004e7921dba6dc202f559882ee8e0796e9fd28415e6301840fba7afda13ed92cd533258ef70170b3911f0bb67f03ddceca9d1481d28ddd3e249835052408499a6e84fb72ca33c95fcfd7bfb184ba4479bcba65c0f606885c546df02f373d748d2c3da3f7b8467674ddfa1ab6cae1c70c968983511669ad23e2c79d63bae301719831032e14333f2e50de3548c5a97227af4463fe89c8d26cf5b075fbc20677a67b629ce40466452071800a553e35a035e9f33f0a35736af85b617a95b828df0cc700cc9ada04cbe2c835f7838c17b87c7704600ac9e4469520395e64d0c3a1b3adae419c43671aef6e87b45da4e1993d620507f1ed7df0acfae3a0dae723ab8121ea71fbe90cf19f85685732538f89b039e9bf70684486b3d5c75777a2bf03d5f8c5afc0cbae11253a119e894bd7712e68c6489c9479163d3edabce29fba0d64350e7f95a688e4d138365731baf8abbe12fddd29157ecff161a43fd54237055bef0a734c5a05e95ec8e16aa2a47d485add9f1652f9b23aa11417184d10b5430e0a212cfbc86e76ec537f361a361fbd80286d6dc529528a6b29f52798cdf0397eaf892f6b7e2280c520521e3c92d3c7cd89d26965839dd7dc3ee0bcbbbd8e61afcad546e18537091ae98fca9e8030000000000009f600fe22c07fd60d49559791edcf74ecef542f800ab0adcfeda49684655044c92b7b64d4d49babad06049c4ea3f80fab97a0dabd0efbbddbf0f0da587f1a283f08751b05e84f9d94072052e3ef5daa38be31854f23a7addb15dbcee78c726b633d11fcf282df523fa60109e9b331488017222a74f594c0da57308a3d111776e0aacb93d56966cdc9ea880dde72f8b79044aa39effc78e4d2c096ffa32731c9e38d2f1b0674e653d6a4a3cf5e5a2b1cb9621ac41231cadb9896658b0e4c4f3e1806bd6cae2925406c59e15b62aa6eb3472114eecf6603134864d28d0c2c0759e30ec5be5f7cf2b7926e86a7d4e8a613caf063119e9be48064f64356a8a36a1ca6a1577b0120c536a68f70f56a32935e8868418eedc046fcf8581ed3c182e2c04a982d1cf6d14f5f3c23ad71be8d39a9c424171405cd96c9ca5a85d04b7db74ac552ec1e2f902cc0d272d05d47aaa203f966723939d77eb8600db51c1c8373e70825bd88184bf16f2cf6a9ac98790aed138882f0eb69d3d5d4e6bf4bf9b865bfc0fc5e7b54d184fe88c843884cc813773f00efd39d79067dbf8d67859c3afe42bdc041cf567a25d35527dbd7cfd4253fb90e4e90c570202824eb19faa1a1bc65b45ec99518d1ea5515e8e1f9139443ec4df871038000279342e980e4b354270c70e3b78749696f50aea162c0e52df94f6eb7b616a46131f9300dd00c251ee9b8adbf98f540c32f5c19a3c929453db7c5117eeb2fda9291cdd5314b2d6ae9f880000"
    tx = CTransaction()
    tx.deserialize(BytesIO(bytes.fromhex(rawtx)))
    tx.rehash()
    assert tx.hash == "ca6abd8ef7d6ef158a4a35ea2c2c0cf122f2f664a88f8fa5b6fd79e48c5bed59"

if __name__ == '__main__':
    main()
```
Without fix it will end-up with:
```
Traceback (most recent call last):
  File "/home/decker/zcash/qa/rpc-tests/./tx_deserialize.py", line 15, in <module>
    main()
  File "/home/decker/zcash/qa/rpc-tests/./tx_deserialize.py", line 11, in main
    tx.rehash()
  File "/home/decker/zcash/qa/rpc-tests/test_framework/mininode.py", line 1131, in rehash
    self.calc_sha256()
  File "/home/decker/zcash/qa/rpc-tests/test_framework/mininode.py", line 1136, in calc_sha256
    txid = zip244.txid_digest(self)
  File "/home/decker/zcash/qa/rpc-tests/test_framework/zip244.py", line 205, in txid_digest
    digest.update(sapling_digest(tx.saplingBundle))
  File "/home/decker/zcash/qa/rpc-tests/test_framework/zip244.py", line 53, in sapling_digest
    digest.update(sapling_spends_digest(saplingBundle))
  File "/home/decker/zcash/qa/rpc-tests/test_framework/zip244.py", line 80, in sapling_spends_digest
    digest.update(sapling_spends_noncompact_digest(saplingBundle))
  File "/home/decker/zcash/qa/rpc-tests/test_framework/zip244.py", line 94, in sapling_spends_noncompact_digest
    digest.update(ser_uint256(desc.anchor))
AttributeError: 'SpendDescriptionV5' object has no attribute 'anchor'
```

Link: https://github.com/spesmilo/electrumx/issues/181#issuecomment-1264714831