### PR TITLE
Reduce memory usage of CBlockIndex

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -9,3 +9,9 @@ Fixed
 
 This release fixes an error "Assertion `uResultHeight == rewindHeight` failed" (#5958)
 that could sometimes happen when restarting a node.
+
+Memory Usage Improvement
+------------------------
+
+The memory usage of zcashd has been reduced by not keeping Equihash solutions for all
+block headers in memory.

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -214,7 +214,7 @@ def wait_for_bitcoind_start(process, url, i):
     '''
     while True:
         if process.poll() is not None:
-            raise Exception('%s exited with status %i during initialization' % (zcashd_binary(), process.returncode))
+            raise Exception('%s node %d exited with status %i during initialization' % (zcashd_binary(), i, process.returncode))
         try:
             rpc = get_rpc_proxy(url, i)
             rpc.getblockcount()
@@ -433,7 +433,7 @@ def assert_start_raises_init_error(i, dirname, extra_args=None, expected_msg=Non
             node = start_node(i, dirname, extra_args, stderr=log_stderr)
             stop_node(node, i)
         except Exception as e:
-            assert ("%s exited" % (zcashd_binary(),)) in str(e) #node must have shutdown
+            assert ("%s node %d exited" % (zcashd_binary(), i)) in str(e) # node must have shutdown
             if expected_msg is not None:
                 log_stderr.seek(0)
                 stderr = log_stderr.read().decode('utf-8')

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -6,6 +6,9 @@
 
 #include "chain.h"
 
+#include "main.h"
+#include "txdb.h"
+
 /**
  * CChain implementation
  */
@@ -56,6 +59,46 @@ const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
     while (pindex && !Contains(pindex))
         pindex = pindex->pprev;
     return pindex;
+}
+
+void CBlockIndex::TrimSolution()
+{
+    AssertLockHeld(cs_main);
+
+    // We can correctly trim a solution as soon as the block index entry has been added
+    // to leveldb. Updates to the block index entry (to update validity status) will be
+    // handled by re-reading the solution from the existing db entry. It does not help to
+    // try to avoid these reads by gating trimming on the validity status: the re-reads are
+    // efficient anyway because of caching in leveldb, and most of them are unavoidable.
+    if (HasSolution()) {
+        MetricsIncrementCounter("zcashd.trimmed_equihash_solutions");
+        std::vector<unsigned char> empty;
+        nSolution.swap(empty);
+    }
+}
+
+CBlockHeader CBlockIndex::GetBlockHeader() const
+{
+    AssertLockHeld(cs_main);
+
+    CBlockHeader header;
+    header.nVersion             = nVersion;
+    if (pprev) {
+        header.hashPrevBlock    = pprev->GetBlockHash();
+    }
+    header.hashMerkleRoot       = hashMerkleRoot;
+    header.hashBlockCommitments = hashBlockCommitments;
+    header.nTime                = nTime;
+    header.nBits                = nBits;
+    header.nNonce               = nNonce;
+    if (HasSolution()) {
+        header.nSolution        = nSolution;
+    } else {
+        CDiskBlockIndex dbindex;
+        assert(pblocktree->ReadDiskBlockIndex(GetBlockHash(), dbindex));
+        header.nSolution        = dbindex.GetSolution();
+    }
+    return header;
 }
 
 /** Turn the lowest '1' bit in the binary representation of a number into a '0'. */

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -95,7 +95,10 @@ CBlockHeader CBlockIndex::GetBlockHeader() const
         header.nSolution        = nSolution;
     } else {
         CDiskBlockIndex dbindex;
-        assert(pblocktree->ReadDiskBlockIndex(GetBlockHash(), dbindex));
+        if (!pblocktree->ReadDiskBlockIndex(GetBlockHash(), dbindex)) {
+            LogPrintf("%s: Failed to read index entry", __func__);
+            throw std::runtime_error("Failed to read index entry");
+        }
         header.nSolution        = dbindex.GetSolution();
     }
     return header;

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -9,6 +9,8 @@
 #include "main.h"
 #include "txdb.h"
 
+#include <rust/metrics.h>
+
 /**
  * CChain implementation
  */
@@ -71,7 +73,7 @@ void CBlockIndex::TrimSolution()
     // try to avoid these reads by gating trimming on the validity status: the re-reads are
     // efficient anyway because of caching in leveldb, and most of them are unavoidable.
     if (HasSolution()) {
-        MetricsIncrementCounter("zcashd.trimmed_equihash_solutions");
+        MetricsIncrementCounter("zcashd.debug.memory.trimmed_equihash_solutions");
         std::vector<unsigned char> empty;
         nSolution.swap(empty);
     }
@@ -94,6 +96,7 @@ CBlockHeader CBlockIndex::GetBlockHeader() const
     if (HasSolution()) {
         header.nSolution        = nSolution;
     } else {
+        MetricsIncrementCounter("zcashd.debug.blocktree.trimmed_equihash_read_dbindex");
         CDiskBlockIndex dbindex;
         if (!pblocktree->ReadDiskBlockIndex(GetBlockHash(), dbindex)) {
             LogPrintf("%s: Failed to read index entry", __func__);

--- a/src/chain.h
+++ b/src/chain.h
@@ -403,6 +403,7 @@ public:
 
     uint256 GetBlockHash() const
     {
+        assert(phashBlock);
         return *phashBlock;
     }
 
@@ -432,7 +433,7 @@ public:
         return strprintf("CBlockIndex(pprev=%p, nHeight=%d, merkle=%s, hashBlock=%s)",
             pprev, nHeight,
             hashMerkleRoot.ToString(),
-            GetBlockHash().ToString());
+            phashBlock ? GetBlockHash().ToString() : "(nil)");
     }
 
     //! Check whether this block index entry is valid up to the passed validity level.

--- a/src/chain.h
+++ b/src/chain.h
@@ -17,6 +17,8 @@
 #include <optional>
 #include <vector>
 
+#include <rust/metrics.h>
+
 static const int SPROUT_VALUE_VERSION = 1001400;
 static const int SAPLING_VALUE_VERSION = 1010100;
 static const int CHAIN_HISTORY_ROOT_VERSION = 2010200;
@@ -372,6 +374,7 @@ public:
         nBits          = block.nBits;
         nNonce         = block.nNonce;
         nSolution      = block.nSolution;
+        MetricsIncrementCounter("zcashd.debug.memory.allocated_equihash_solutions");
     }
 
     CDiskBlockPos GetBlockPos() const {

--- a/src/chain.h
+++ b/src/chain.h
@@ -12,6 +12,7 @@
 #include "pow.h"
 #include "tinyformat.h"
 #include "uint256.h"
+#include "util/strencodings.h"
 
 #include <optional>
 #include <vector>
@@ -308,8 +309,13 @@ public:
     unsigned int nTime;
     unsigned int nBits;
     uint256 nNonce;
+protected:
+    // The Equihash solution, if it is stored. Once we know that the block index
+    // entry is present in leveldb, this field can be cleared via the TrimSolution
+    // method to save memory.
     std::vector<unsigned char> nSolution;
 
+public:
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
 
@@ -386,20 +392,11 @@ public:
         return ret;
     }
 
-    CBlockHeader GetBlockHeader() const
-    {
-        CBlockHeader block;
-        block.nVersion       = nVersion;
-        if (pprev)
-            block.hashPrevBlock = pprev->GetBlockHash();
-        block.hashMerkleRoot = hashMerkleRoot;
-        block.hashBlockCommitments = hashBlockCommitments;
-        block.nTime          = nTime;
-        block.nBits          = nBits;
-        block.nNonce         = nNonce;
-        block.nSolution      = nSolution;
-        return block;
-    }
+    //! Get the block header for this block index. Requires cs_main.
+    CBlockHeader GetBlockHeader() const;
+
+    //! Clear the Equihash solution to save memory. Requires cs_main.
+    void TrimSolution();
 
     uint256 GetBlockHash() const
     {
@@ -430,10 +427,11 @@ public:
 
     std::string ToString() const
     {
-        return strprintf("CBlockIndex(pprev=%p, nHeight=%d, merkle=%s, hashBlock=%s)",
+        return strprintf("CBlockIndex(pprev=%p, nHeight=%d, merkle=%s, hashBlock=%s, HasSolution=%s)",
             pprev, nHeight,
             hashMerkleRoot.ToString(),
-            phashBlock ? GetBlockHash().ToString() : "(nil)");
+            phashBlock ? GetBlockHash().ToString() : "(nil)",
+            HasSolution());
     }
 
     //! Check whether this block index entry is valid up to the passed validity level.
@@ -443,6 +441,12 @@ public:
         if (nStatus & BLOCK_FAILED_MASK)
             return false;
         return ((nStatus & BLOCK_VALID_MASK) >= nUpTo);
+    }
+
+    //! Is the Equihash solution stored?
+    bool HasSolution() const
+    {
+        return !nSolution.empty();
     }
 
     //! Raise the validity level of this block index entry.
@@ -483,8 +487,11 @@ public:
         hashPrev = uint256();
     }
 
-    explicit CDiskBlockIndex(const CBlockIndex* pindex) : CBlockIndex(*pindex) {
+    explicit CDiskBlockIndex(const CBlockIndex* pindex, std::function<std::vector<unsigned char>()> getSolution) : CBlockIndex(*pindex) {
         hashPrev = (pprev ? pprev->GetBlockHash() : uint256());
+        if (!HasSolution()) {
+            nSolution = getSolution();
+        }
     }
 
     ADD_SERIALIZE_METHODS;
@@ -565,20 +572,31 @@ public:
         // them to CBlockTreeDB::LoadBlockIndexGuts() in txdb.cpp :)
     }
 
-    uint256 GetBlockHash() const
+    //! Get the block header for this block index.
+    CBlockHeader GetBlockHeader() const
     {
-        CBlockHeader block;
-        block.nVersion        = nVersion;
-        block.hashPrevBlock   = hashPrev;
-        block.hashMerkleRoot  = hashMerkleRoot;
-        block.hashBlockCommitments = hashBlockCommitments;
-        block.nTime           = nTime;
-        block.nBits           = nBits;
-        block.nNonce          = nNonce;
-        block.nSolution       = nSolution;
-        return block.GetHash();
+        CBlockHeader header;
+        header.nVersion             = nVersion;
+        header.hashPrevBlock        = hashPrev;
+        header.hashMerkleRoot       = hashMerkleRoot;
+        header.hashBlockCommitments = hashBlockCommitments;
+        header.nTime                = nTime;
+        header.nBits                = nBits;
+        header.nNonce               = nNonce;
+        header.nSolution            = nSolution;
+        return header;
     }
 
+    uint256 GetBlockHash() const
+    {
+        return GetBlockHeader().GetHash();
+    }
+
+    std::vector<unsigned char> GetSolution() const
+    {
+        assert(HasSolution());
+        return nSolution;
+    }
 
     std::string ToString() const
     {
@@ -588,6 +606,13 @@ public:
             GetBlockHash().ToString(),
             hashPrev.ToString());
         return str;
+    }
+
+private:
+    //! This method should not be called on a CDiskBlockIndex.
+    void TrimSolution()
+    {
+        assert(!"called CDiskBlockIndex::TrimSolution");
     }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6134,7 +6134,11 @@ void static CheckBlockIndex(const Consensus::Params& consensusParams)
                 }
             }
         }
-        // assert(pindex->GetBlockHash() == pindex->GetBlockHeader().GetHash()); // Perhaps too slow
+        // try {
+        //     assert(pindex->GetBlockHash() == pindex->GetBlockHeader().GetHash()); // Perhaps too slow
+        // } catch (const runtime_error&) {
+        //     assert(!"Failed to read index entry");
+        // }
         // End: actual consistency checks.
 
         // Try descending into the first subnode.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3715,7 +3715,7 @@ bool static FlushStateToDisk(
                 vFiles.push_back(make_pair(*it, &vinfoBlockFile[*it]));
                 it = setDirtyFileInfo.erase(it);
             }
-            std::vector<const CBlockIndex*> vBlocks;
+            std::vector<CBlockIndex*> vBlocks;
             vBlocks.reserve(setDirtyBlockIndex.size());
             for (set<CBlockIndex*>::iterator it = setDirtyBlockIndex.begin(); it != setDirtyBlockIndex.end(); ) {
                 vBlocks.push_back(*it);
@@ -3723,6 +3723,12 @@ bool static FlushStateToDisk(
             }
             if (!pblocktree->WriteBatchSync(vFiles, nLastBlockFile, vBlocks)) {
                 return AbortNode(state, "Files to write to block index database");
+            }
+            // Now that we have written the block indices to the database, we do not
+            // need to store solutions for these CBlockIndex objects in memory.
+            // cs_main must be held here.
+            for (CBlockIndex *pblockindex : vBlocks) {
+                pblockindex->TrimSolution();
             }
         }
         // Finally remove any pruned files

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -141,6 +141,7 @@ static bool rest_headers(HTTPRequest* req,
 
     std::vector<const CBlockIndex *> headers;
     headers.reserve(count);
+    CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
     {
         LOCK(cs_main);
         BlockMap::const_iterator it = mapBlockIndex.find(hash);
@@ -151,11 +152,12 @@ static bool rest_headers(HTTPRequest* req,
                 break;
             pindex = chainActive.Next(pindex);
         }
-    }
 
-    CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
-    for (const CBlockIndex *pindex : headers) {
-        ssHeader << pindex->GetBlockHeader();
+        if (rf == RF_BINARY || rf == RF_HEX) {
+            for (const CBlockIndex *pindex : headers) {
+                ssHeader << pindex->GetBlockHeader();
+            }
+        }
     }
 
     switch (rf) {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -154,8 +154,12 @@ static bool rest_headers(HTTPRequest* req,
         }
 
         if (rf == RF_BINARY || rf == RF_HEX) {
-            for (const CBlockIndex *pindex : headers) {
-                ssHeader << pindex->GetBlockHeader();
+            try {
+                for (const CBlockIndex *pindex : headers) {
+                    ssHeader << pindex->GetBlockHeader();
+                }
+            } catch (const std::runtime_error&) {
+                return RESTERR(req, HTTP_INTERNAL_SERVER_ERROR, "Failed to read index entry");
             }
         }
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -684,15 +684,18 @@ UniValue getblockheader(const UniValue& params, bool fHelp)
 
     CBlockIndex* pblockindex = mapBlockIndex[hash];
 
-    if (!fVerbose)
-    {
-        CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);
-        ssBlock << pblockindex->GetBlockHeader();
-        std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
-        return strHex;
+    try {
+        if (!fVerbose) {
+            CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);
+            ssBlock << pblockindex->GetBlockHeader();
+            std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
+            return strHex;
+        } else {
+            return blockheaderToJSON(pblockindex);
+        }
+    } catch (const runtime_error&) {
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Failed to read index entry");
     }
-
-    return blockheaderToJSON(pblockindex);
 }
 
 UniValue getblock(const UniValue& params, bool fHelp)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -118,7 +118,7 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.pushKV("finalsaplingroot", blockindex->hashFinalSaplingRoot.GetHex());
     result.pushKV("time", (int64_t)blockindex->nTime);
     result.pushKV("nonce", blockindex->nNonce.GetHex());
-    result.pushKV("solution", HexStr(blockindex->nSolution));
+    result.pushKV("solution", HexStr(blockindex->GetBlockHeader().nSolution));
     result.pushKV("bits", strprintf("%08x", blockindex->nBits));
     result.pushKV("difficulty", GetDifficulty(blockindex));
     result.pushKV("chainwork", blockindex->nChainWork.GetHex());

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -318,7 +318,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
 CBlockTreeDB::CBlockTreeDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapper(GetDataDir() / "blocks" / "index", nCacheSize, fMemory, fWipe) {
 }
 
-bool CBlockTreeDB::ReadBlockFileInfo(int nFile, CBlockFileInfo &info) {
+bool CBlockTreeDB::ReadBlockFileInfo(int nFile, CBlockFileInfo &info) const {
     return Read(make_pair(DB_BLOCK_FILES, nFile), info);
 }
 
@@ -329,12 +329,12 @@ bool CBlockTreeDB::WriteReindexing(bool fReindexing) {
         return Erase(DB_REINDEX_FLAG);
 }
 
-bool CBlockTreeDB::ReadReindexing(bool &fReindexing) {
+bool CBlockTreeDB::ReadReindexing(bool &fReindexing) const {
     fReindexing = Exists(DB_REINDEX_FLAG);
     return true;
 }
 
-bool CBlockTreeDB::ReadLastBlockFile(int &nFile) {
+bool CBlockTreeDB::ReadLastBlockFile(int &nFile) const {
     return Read(DB_LAST_BLOCK, nFile);
 }
 
@@ -421,11 +421,11 @@ bool CBlockTreeDB::EraseBatchSync(const std::vector<const CBlockIndex*>& blockin
     return WriteBatch(batch, true);
 }
 
-bool CBlockTreeDB::ReadDiskBlockIndex(const uint256 &blockhash, CDiskBlockIndex &dbindex) {
+bool CBlockTreeDB::ReadDiskBlockIndex(const uint256 &blockhash, CDiskBlockIndex &dbindex) const {
     return Read(make_pair(DB_BLOCK_INDEX, blockhash), dbindex);
 }
 
-bool CBlockTreeDB::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) {
+bool CBlockTreeDB::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) const {
     return Read(make_pair(DB_TXINDEX, txid), pos);
 }
 
@@ -514,7 +514,7 @@ bool CBlockTreeDB::ReadAddressIndex(
     return true;
 }
 
-bool CBlockTreeDB::ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) {
+bool CBlockTreeDB::ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) const {
     return Read(make_pair(DB_SPENTINDEX, key), value);
 }
 
@@ -570,7 +570,7 @@ bool CBlockTreeDB::WriteTimestampBlockIndex(const CTimestampBlockIndexKey &block
     return WriteBatch(batch);
 }
 
-bool CBlockTreeDB::ReadTimestampBlockIndex(const uint256 &hash, unsigned int &ltimestamp)
+bool CBlockTreeDB::ReadTimestampBlockIndex(const uint256 &hash, unsigned int &ltimestamp) const
 {
     CTimestampBlockIndexValue(lts);
     if (!Read(std::make_pair(DB_BLOCKHASHINDEX, hash), lts))
@@ -585,7 +585,7 @@ bool CBlockTreeDB::WriteFlag(const std::string &name, bool fValue) {
     return Write(std::make_pair(DB_FLAG, name), fValue ? '1' : '0');
 }
 
-bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue) {
+bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue) const {
     char ch;
     if (!Read(std::make_pair(DB_FLAG, name), ch))
         return false;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -634,7 +634,12 @@ bool CBlockTreeDB::LoadBlockIndexGuts(
                 CBlockHeader header;
                 {
                     LOCK(cs_main);
-                    header = pindexNew->GetBlockHeader();
+                    try {
+                        header = pindexNew->GetBlockHeader();
+                    } catch (const runtime_error&) {
+                        return error("LoadBlockIndex(): failed to read index entry: diskindex hash = %s",
+                            diskindex.GetBlockHash().ToString());
+                    }
                 }
                 if (header.GetHash() != diskindex.GetBlockHash())
                     return error("LoadBlockIndex(): inconsistent header vs diskindex hash: header hash = %s, diskindex hash = %s",

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -613,9 +613,12 @@ bool CBlockTreeDB::LoadBlockIndexGuts(
 
                 // Consistency checks
                 auto header = pindexNew->GetBlockHeader();
+                if (header.GetHash() != diskindex.GetBlockHash())
+                    return error("LoadBlockIndex(): inconsistent header vs diskindex hash: header hash = %s, diskindex hash = %s",
+                        header.GetHash().ToString(), diskindex.GetBlockHash().ToString());
                 if (header.GetHash() != pindexNew->GetBlockHash())
                     return error("LoadBlockIndex(): block header inconsistency detected: on-disk = %s, in-memory = %s",
-                       diskindex.ToString(),  pindexNew->ToString());
+                        diskindex.ToString(), pindexNew->ToString());
                 if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params().GetConsensus()))
                     return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -17,6 +17,8 @@
 
 #include <boost/thread.hpp>
 
+#include <rust/metrics.h>
+
 using namespace std;
 
 // NOTE: Per issue #3277, do not use the prefix 'X' or 'x' as they were
@@ -383,6 +385,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
 }
 
 bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<CBlockIndex*>& blockinfo) {
+    MetricsIncrementCounter("zcashd.debug.blocktree.write_batch");
     CDBBatch batch(*this);
     for (std::vector<std::pair<int, const CBlockFileInfo*> >::const_iterator it=fileInfo.begin(); it != fileInfo.end(); it++) {
         batch.Write(make_pair(DB_BLOCK_FILES, it->first), *it->second);
@@ -392,6 +395,7 @@ bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockF
         std::pair<char, uint256> key = make_pair(DB_BLOCK_INDEX, (*it)->GetBlockHash());
         try {
             CDiskBlockIndex dbindex {*it, [this, &key]() {
+                MetricsIncrementCounter("zcashd.debug.blocktree.write_batch_read_dbindex");
                 // It can happen that the index entry is written, then the Equihash solution is cleared from memory,
                 // then the index entry is rewritten. In that case we must read the solution from the old entry.
                 CDiskBlockIndex dbindex_old;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -117,12 +117,13 @@ private:
     CBlockTreeDB(const CBlockTreeDB&);
     void operator=(const CBlockTreeDB&);
 public:
-    bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo);
+    bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<CBlockIndex*>& blockinfo);
     bool EraseBatchSync(const std::vector<const CBlockIndex*>& blockinfo);
     bool ReadBlockFileInfo(int nFile, CBlockFileInfo &info);
     bool ReadLastBlockFile(int &nFile);
     bool WriteReindexing(bool fReindexing);
     bool ReadReindexing(bool &fReindexing);
+    bool ReadDiskBlockIndex(const uint256 &blockhash, CDiskBlockIndex &dbindex);
     bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &vect);
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -119,12 +119,12 @@ private:
 public:
     bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<CBlockIndex*>& blockinfo);
     bool EraseBatchSync(const std::vector<const CBlockIndex*>& blockinfo);
-    bool ReadBlockFileInfo(int nFile, CBlockFileInfo &info);
-    bool ReadLastBlockFile(int &nFile);
+    bool ReadBlockFileInfo(int nFile, CBlockFileInfo &info) const;
+    bool ReadLastBlockFile(int &nFile) const;
     bool WriteReindexing(bool fReindexing);
-    bool ReadReindexing(bool &fReindexing);
-    bool ReadDiskBlockIndex(const uint256 &blockhash, CDiskBlockIndex &dbindex);
-    bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
+    bool ReadReindexing(bool &fReindexing) const;
+    bool ReadDiskBlockIndex(const uint256 &blockhash, CDiskBlockIndex &dbindex) const;
+    bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) const;
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &vect);
 
     // START insightexplorer
@@ -133,18 +133,18 @@ public:
     bool WriteAddressIndex(const std::vector<CAddressIndexDbEntry> &vect);
     bool EraseAddressIndex(const std::vector<CAddressIndexDbEntry> &vect);
     bool ReadAddressIndex(uint160 addressHash, int type, std::vector<CAddressIndexDbEntry> &addressIndex, int start = 0, int end = 0);
-    bool ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value);
+    bool ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) const;
     bool UpdateSpentIndex(const std::vector<CSpentIndexDbEntry> &vect);
     bool WriteTimestampIndex(const CTimestampIndexKey &timestampIndex);
     bool ReadTimestampIndex(unsigned int high, unsigned int low,
             const bool fActiveOnly, std::vector<std::pair<uint256, unsigned int> > &vect);
     bool WriteTimestampBlockIndex(const CTimestampBlockIndexKey &blockhashIndex,
             const CTimestampBlockIndexValue &logicalts);
-    bool ReadTimestampBlockIndex(const uint256 &hash, unsigned int &logicalTS);
+    bool ReadTimestampBlockIndex(const uint256 &hash, unsigned int &logicalTS) const;
     // END insightexplorer
 
     bool WriteFlag(const std::string &name, bool fValue);
-    bool ReadFlag(const std::string &name, bool &fValue);
+    bool ReadFlag(const std::string &name, bool &fValue) const;
     bool LoadBlockIndexGuts(
         std::function<CBlockIndex*(const uint256&)> insertBlockIndex,
         const CChainParams& chainParams);


### PR DESCRIPTION
The `nSolution` field of `CBlockIndex` holds a `std::vector<unsigned char>` containing a 1344-byte Equihash solution. In normal operation the node holds a linked tree of `CBlockIndex` nodes for the whole chain. Therefore, the total memory required for these `nSolution` fields for the current mainnet height 1834642, is at least $1834642 \cdot 1344$ bytes $\approx 2.3$ GiB.

It has to be possible to retrieve the `nSolution` field for any stored block in order to answer peer `getheaders` queries, for example. But once a block index entry has been flushed to leveldb (which happens asynchronously), it is no longer necessary to keep this field in memory, because it can be read back if needed. The cost of this should be small because of the caching done by leveldb.

This PR also adds the following Prometheus metrics:
* (counter) `zcashd.debug.memory.allocated_equihash_solutions` - the number of Equihash solutions that have ever been allocated;
* (counter) `zcashd.debug.memory.trimmed_equihash_solutions` - the number of Equihash solutions that were trimmed;
* (counter) `zcashd.debug.blocktree.trimmed_equihash_read_dbindex` - the number of times a block index entry needed to be reread to construct a block header because a solution had been trimmed;
* (counter) `zcashd.debug.blocktree.write_batch` - the number of block tree batch write operations (calls to `CBlockTreeDB::WriteBatchSync`);
* (counter) `zcashd.debug.blocktree.write_batch_read_dbindex` - the number of times a block index entry needed to be reread before being written during a block tree batch write operation.

These metrics are specific to zcashd; they are primarily intended for performance debugging of this feature and should not be considered stable. Note that in #6259 these metrics will be put behind the `-debugmetrics` flag.

fixes #5936