### PR TITLE
Improve token handling in the updatecheck script

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -28,9 +28,10 @@ Check that dependencies are up-to-date or have been postponed:
 $ ./qa/zcash/updatecheck.py
 ```
 
-You can optionally create an `$XDG_DATA_HOME/zcash/updatecheck/token` file to
-avoid running into GitHub rate limiting. Create an unprivileged personal access
-token on GitHub and copy the value into the file.
+You can optionally create a file `~/.local/share/zcash/updatecheck/token` (or
+`$XDG_DATA_HOME/zcash/updatecheck/token` if the `XDG_DATA_HOME` environment
+variable is set) to avoid running into GitHub rate limiting. Create an
+unprivileged personal access token on GitHub and copy the value into the file.
 
 If there are updates that have not been postponed, review their changelogs
 for urgent security fixes, and if there aren't any, postpone the update by

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -28,10 +28,9 @@ Check that dependencies are up-to-date or have been postponed:
 $ ./qa/zcash/updatecheck.py
 ```
 
-If you are missing the `.updatecheck-token` file required to run this script,
-please ask Taylor or another Zcash developer for a copy, or create an
-unprivileged personal access token for a github account and save it to the
-file in the format `username:hex-token`.
+You can optionally create an `.updatecheck-token` file in the root of the
+repository to avoid running into GitHub rate limiting. Create an unprivileged
+personal access token on GitHub and copy the value into the file.
 
 If there are updates that have not been postponed, review their changelogs
 for urgent security fixes, and if there aren't any, postpone the update by

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -28,9 +28,9 @@ Check that dependencies are up-to-date or have been postponed:
 $ ./qa/zcash/updatecheck.py
 ```
 
-You can optionally create an `.updatecheck-token` file in the root of the
-repository to avoid running into GitHub rate limiting. Create an unprivileged
-personal access token on GitHub and copy the value into the file.
+You can optionally create an `$XDG_DATA_HOME/zcash/updatecheck/token` file to
+avoid running into GitHub rate limiting. Create an unprivileged personal access
+token on GitHub and copy the value into the file.
 
 If there are updates that have not been postponed, review their changelogs
 for urgent security fixes, and if there aren't any, postpone the update by
@@ -58,9 +58,8 @@ The release script has the following dependencies:
 
 - `help2man`
 - `debchange` (part of the devscripts Debian package)
-
-You can optionally install the `progressbar2` Python module with pip to have a
-progress bar displayed during the build process.
+- the python modules `progressbar2` (optional - displays a progress bar),
+  `requests` and `xdg`
 
 ## Versioning
 

--- a/qa/zcash/updatecheck.py
+++ b/qa/zcash/updatecheck.py
@@ -3,8 +3,7 @@
 # This script checks for updates to zcashd's dependencies.
 #
 # The SOURCE_ROOT constant specifies the location of the zcashd codebase to
-# check, and the GITHUB_API_* constants specify a personal access token for the
-# GitHub API, which need not have any special privileges.
+# check.
 #
 # All dependencies must be specified inside the get_dependency_list() function
 # below. A dependency is specified by:
@@ -126,10 +125,10 @@ class GitHubToken:
             sys.exit(1)
 
     def user(self):
-        return self.user
+        return self._user
 
     def password(self):
-        return self.password
+        return self._password
 
 class Version(list):
     def __init__(self, version_tuple):

--- a/qa/zcash/updatecheck.py
+++ b/qa/zcash/updatecheck.py
@@ -35,6 +35,7 @@ import requests
 import os
 import re
 import sys
+import xdg
 import datetime
 
 SOURCE_ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..")
@@ -113,6 +114,8 @@ def get_dependency_list():
 
 def parse_token():
     token_path = os.path.realpath(os.path.join(SOURCE_ROOT, ".updatecheck-token"))
+    if not os.path.exists(token_path):
+        token_path = os.path.join(xdg.xdg_data_home(), "zcash/updatecheck/token")
     try:
         with open(token_path, encoding='utf8') as f:
             token = f.read().strip()

--- a/qa/zcash/updatecheck.py
+++ b/qa/zcash/updatecheck.py
@@ -203,7 +203,7 @@ class GithubTagReleaseLister:
 
     def all_tag_names(self):
         url = "https://api.github.com/repos/" + safe(self.org) + "/" + safe(self.repo) + "/git/refs/tags"
-        auth = ()
+        auth = {}
         if token:
             auth = { 'Authorization': 'Bearer ' + token }
         r = requests.get(url, headers=auth)


### PR DESCRIPTION
- make it actually use the token for auth (this was just broken)
- make the token optional (just will hit a rate limit after a few runs of the
  script – but again, it was previously required, but never actually got used)
- only load the token once, rather than once per request (this is necessary
  after the above change, so you don't get the warning printed repeatedly if
  you don’t have a token file)
- switch from BasicAuth to an Authorization header (this means we no longer need
  the GitHub username, just the token)
- support a token file that doesn't contain a username (it will still parse old
  versions of the file properly)
- add a user-wide XDG-based path to look for the token (to avoid having to copy
  to various clones or worktrees)