### PR TITLE
Update gitian-linux-parallel.yml

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux-parallel.yml
+++ b/contrib/gitian-descriptors/gitian-linux-parallel.yml
@@ -1,5 +1,5 @@
 ---
-name: "zcash-5.3.0-rc1"
+name: "zcash-5.3.0"
 enable_cache: true
 distro: "debian"
 suites:


### PR DESCRIPTION
The release commit was built with a `make-release.py` that was before the parallel-gitian commit, causing the parallel gitian descriptor to not be updated.