### PR TITLE
Fix gitian version string issue by reverting the GIT_DIR backport commit

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux-parallel.yml
+++ b/contrib/gitian-descriptors/gitian-linux-parallel.yml
@@ -97,7 +97,6 @@ script: |
   create_per-host_faketime_wrappers "${REFERENCE_DATETIME}"
 
   # Create the release tarball using (arbitrarily) the first host
-  export GIT_DIR="$PWD/.git"
   ./autogen.sh
   CONFIG_SITE=${BASEPREFIX}/$(echo "${HOSTS}" | awk '{print $1;}')/share/config.site ./configure --prefix=/
   make dist

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -97,7 +97,6 @@ script: |
   create_per-host_faketime_wrappers "${REFERENCE_DATETIME}"
 
   # Create the release tarball using (arbitrarily) the first host
-  export GIT_DIR="$PWD/.git"
   ./autogen.sh
   CONFIG_SITE=${BASEPREFIX}/$(echo "${HOSTS}" | awk '{print $1;}')/share/config.site ./configure --prefix=/
   make dist

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -92,7 +92,6 @@ script: |
   create_per-host_faketime_wrappers "${REFERENCE_DATETIME}"
 
   # Create the release tarball using (arbitrarily) the first host
-  export GIT_DIR="$PWD/.git"
   ./autogen.sh
   CONFIG_SITE=${BASEPREFIX}/$(echo "${HOSTS}" | awk '{print $1;}')/share/config.site ./configure --prefix=/
   make dist

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -113,7 +113,6 @@ script: |
   create_per-host_linker_wrapper "${REFERENCE_DATETIME}"
 
   # Create the release tarball using (arbitrarily) the first host
-  export GIT_DIR="$PWD/.git"
   ./autogen.sh
   CONFIG_SITE=${BASEPREFIX}/$(echo "${HOSTS}" | awk '{print $1;}')/share/config.site ./configure --prefix=/
   make dist

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -20,13 +20,9 @@ else
     exit 1
 fi
 
-git_check_in_repo() {
-    ! { git status --porcelain -uall --ignored "$@" 2>/dev/null || echo '??'; } | grep -q '?'
-}
-
 DESC=""
 SUFFIX=""
-if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] && git_check_in_repo share/genbuild.sh; then
+if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
     # clean 'dirty' status of touched files that haven't been modified
     git diff >/dev/null 2>/dev/null
 


### PR DESCRIPTION
We partially revert 8dbd2edd9855e0a95e481f3615d9549195c937ad by removing all instances of setting `GIT_DIR` in the gitian descriptors. Currently, gitian builds cause zcash to have version strings which look like `Zcash Daemon version v5.3.0-35186b009-dirty`, which is inaccurate.

Setting `GIT_DIR` with a current working directory of `/home/debian/build/zcash/distsrc-x86_64-linux-gnu` makes the git invocations in `genbuild.sh` see that directory as the top of the working tree, which causes git to believe that a bunch of tracked files were deleted (namely, those not included by the `make dist` step).

This causes `genbuild.sh` to believe that it is working with a dirty tree, and with the help of `src/clientversion.cpp`, zcash gets a version string that includes a hash ending in `-dirty`.


Also, we remove the `git_check_in_repo` condition from `genbuild.sh`.

This removes the git hash from `gitian`-built `zcashd` version strings (when the state of the working tree is clean and corresponds to an annotated tag) -- which was the behavior prior the backported commit that introduced this condition.