### PR TITLE
Don't mine a transaction until it has had a chance to propagate

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,3 +4,23 @@ release-notes at release time)
 Notable changes
 ===============
 
+Changes
+-------
+
+This release includes a change to the behaviour of the ``getblocktemplate``
+RPC, motivated by reducing orphan rates for miners. When preparing a block
+template, the previous behaviour was to immediately consider a transaction
+accepted into the mempool as eligible to be included in the template.
+This release, by default, waits 10 seconds before considering each
+transaction eligible. This allows time for other nodes to have received
+and validated each transaction, which tends to reduce the latency for a
+block containing it to be accepted and propagated. As a result, blocks
+mined by the node are less likely to be orphaned.
+
+The old behaviour (of immediately considering mempool transactions to be
+eligible for inclusion in a block template) can be restored with the
+config option `enabletxminingdelay=0`.
+
+If a transaction is positively prioritised by the `prioritisetransaction`
+RPC (i.e. with either priority or fee delta > 0), it is not subject to
+this delay, regardless of the value of the `enabletxminingdelay` option.

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -50,7 +50,7 @@ class AddressIndexTest(BitcoinTestFramework):
 
     def setup_network(self):
         # -insightexplorer causes addressindex to be enabled (fAddressIndex = true)
-        args_insight = ('-debug', '-txindex', '-experimentalfeatures', '-insightexplorer')
+        args_insight = ('-debug', '-txindex', '-experimentalfeatures', '-insightexplorer', '-enabletxminingdelay=0')
         # -lightwallet also causes addressindex to be enabled
         args_lightwallet = ('-debug', '-txindex', '-experimentalfeatures', '-lightwalletd')
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [args_insight] * 3 + [args_lightwallet])

--- a/qa/rpc-tests/disablewallet.py
+++ b/qa/rpc-tests/disablewallet.py
@@ -20,7 +20,7 @@ class DisableWalletTest (BitcoinTestFramework):
         self.num_nodes = 1
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-disablewallet']])
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-disablewallet']] * self.num_nodes)
         self.is_network_split = False
         self.sync_all()
 

--- a/qa/rpc-tests/finalorchardroot.py
+++ b/qa/rpc-tests/finalorchardroot.py
@@ -32,12 +32,13 @@ class FinalOrchardRootTest(BitcoinTestFramework):
         self.cache_behavior = 'sprout'
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
             '-txindex', # Avoid JSONRPC error: No information available about transaction
             '-reindex', # Required due to enabling -txindex
             nuparams(NU5_BRANCH_ID, 200),
             '-debug',
-            ]] * self.num_nodes)
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         self.is_network_split=False
         self.sync_all()

--- a/qa/rpc-tests/finalsaplingroot.py
+++ b/qa/rpc-tests/finalsaplingroot.py
@@ -32,12 +32,13 @@ class FinalSaplingRootTest(BitcoinTestFramework):
         self.cache_behavior = 'sprout'
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
             '-txindex', # Avoid JSONRPC error: No information available about transaction
             '-reindex', # Required due to enabling -txindex
             nuparams(NU5_BRANCH_ID, 210),
             '-debug',
-            ]] * self.num_nodes)
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         self.is_network_split=False
         self.sync_all()

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -21,8 +21,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.num_nodes = 4
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                           extra_args=[['-experimentalfeatures', '-developerencryptwallet']] * 4)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-experimentalfeatures',
+            '-developerencryptwallet',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
 
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
@@ -450,7 +453,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         stop_nodes(self.nodes)
         wait_bitcoinds()
 
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
 
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)

--- a/qa/rpc-tests/getblocktemplate.py
+++ b/qa/rpc-tests/getblocktemplate.py
@@ -37,11 +37,11 @@ class GetBlockTemplateTest(BitcoinTestFramework):
         self.cache_behavior = 'sprout'
 
     def setup_network(self, split=False):
-        args = [
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(CANOPY_BRANCH_ID, 215),
             nuparams(NU5_BRANCH_ID, 230),
-        ]
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [args] * self.num_nodes)
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         self.is_network_split = False
         self.node = self.nodes[0]
 

--- a/qa/rpc-tests/getrawtransaction_insight.py
+++ b/qa/rpc-tests/getrawtransaction_insight.py
@@ -27,8 +27,13 @@ class GetrawtransactionTest(BitcoinTestFramework):
     def setup_network(self):
         # -insightexplorer causes spentindex to be enabled (fSpentIndex = true)
 
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-            [['-debug', '-txindex', '-experimentalfeatures', '-insightexplorer']] * self.num_nodes)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-debug',
+            '-txindex',
+            '-experimentalfeatures',
+            '-insightexplorer',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[0], 2)
 

--- a/qa/rpc-tests/key_import_export.py
+++ b/qa/rpc-tests/key_import_export.py
@@ -22,7 +22,7 @@ class KeyImportExportTest (BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir )
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -7,6 +7,7 @@
 # Exercise the listtransactions API
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import start_nodes
 
 from decimal import Decimal
 
@@ -32,6 +33,8 @@ def check_array_result(object_array, to_match, expected):
         raise AssertionError("No objects matched %s"%(str(to_match)))
 
 class ListTransactionsTest(BitcoinTestFramework):
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
 
     def run_test(self):
         # Simple send, 0 to 1:

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -130,10 +130,12 @@ class MaxUploadTest(BitcoinTestFramework):
         # Start a node with maxuploadtarget of 200 MB (/24h)
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, [
-            "-debug",
+            '-debug',
             '-nuparams=2bb40e60:1', # Blossom
-            "-maxuploadtarget=2200",
-            "-mocktime=%d" % old_time ]))
+            '-maxuploadtarget=2200',
+            '-mocktime=%d' % old_time,
+            '-enabletxminingdelay=0',
+        ]))
 
     def mine_full_block(self, node, address):
         # Want to create a full block

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -21,11 +21,11 @@ from time import sleep
 class MempoolLimit(BitcoinTestFramework):
     def setup_nodes(self):
         extra_args = [
-            ["-debug=mempool", '-mempooltxcostlimit=8000'], # 2 transactions at min cost
-            ["-debug=mempool", '-mempooltxcostlimit=8000'], # 2 transactions at min cost
-            ["-debug=mempool", '-mempooltxcostlimit=8000'], # 2 transactions at min cost
+            ["-debug=mempool", '-mempooltxcostlimit=8000', '-enabletxminingdelay=0'], # 2 transactions at min cost
+            ["-debug=mempool", '-mempooltxcostlimit=8000', '-enabletxminingdelay=0'], # 2 transactions at min cost
+            ["-debug=mempool", '-mempooltxcostlimit=8000', '-enabletxminingdelay=0'], # 2 transactions at min cost
             # Let node 3 hold one more transaction
-            ["-debug=mempool", '-mempooltxcostlimit=12000'], # 3 transactions at min cost
+            ["-debug=mempool", '-mempooltxcostlimit=12000', '-enabletxminingdelay=0'], # 3 transactions at min cost
         ]
         return start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
 

--- a/qa/rpc-tests/mempool_nu_activation.py
+++ b/qa/rpc-tests/mempool_nu_activation.py
@@ -29,7 +29,11 @@ class MempoolUpgradeActivationTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self):
-        args = ["-checkmempool", "-debug=mempool", "-blockmaxsize=4000",
+        args = [
+            '-checkmempool',
+            '-debug=mempool',
+            '-blockmaxsize=4000',
+            '-enabletxminingdelay=0',
             nuparams(BLOSSOM_BRANCH_ID, 200),
             nuparams(HEARTWOOD_BRANCH_ID, 210),
             nuparams(CANOPY_BRANCH_ID, 220),

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -23,7 +23,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
     alert_filename = None  # Set by setup_network
 
     def setup_network(self):
-        args = ["-checkmempool", "-debug=mempool"]
+        args = ['-checkmempool', '-debug=mempool', '-enabletxminingdelay=0']
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, args))
         self.nodes.append(start_node(1, self.options.tmpdir, args))

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -24,7 +24,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Just need one node for this test
-        args = ["-checkmempool", "-debug=mempool"]
+        args = ['-checkmempool', '-debug=mempool', '-enabletxminingdelay=0']
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, args))
         self.is_network_split = False

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -29,7 +29,7 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Just need one node for this test
-        args = ["-checkmempool", "-debug=mempool"]
+        args = ['-checkmempool', '-debug=mempool', '-enabletxminingdelay=0']
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, args))
         self.is_network_split = False

--- a/qa/rpc-tests/mempool_tx_expiry.py
+++ b/qa/rpc-tests/mempool_tx_expiry.py
@@ -21,11 +21,11 @@ TX_EXPIRY_DELTA = 10
 class MempoolTxExpiryTest(BitcoinTestFramework):
 
     def setup_nodes(self):
-        return start_nodes(self.num_nodes, self.options.tmpdir,
-            [[
-                "-txexpirydelta=%d" % TX_EXPIRY_DELTA,
-                "-debug=mempool"
-            ]] * self.num_nodes)
+        return start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-txexpirydelta=%d' % TX_EXPIRY_DELTA,
+            '-debug=mempool',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
 
     # Test before, at, and after expiry block
     # chain is at block height 199 when run_test executes

--- a/qa/rpc-tests/mergetoaddress_helper.py
+++ b/qa/rpc-tests/mergetoaddress_helper.py
@@ -42,14 +42,12 @@ class MergeToAddressHelper:
         initialize_chain_clean(test.options.tmpdir, 4)
 
     def setup_network(self, test, additional_args=[]):
-        args = ['-debug=zrpcunsafe']
+        args = ['-debug=zrpcunsafe', '-enabletxminingdelay=0']
         args += additional_args
         test.nodes = []
         test.nodes.append(start_node(0, test.options.tmpdir, args))
         test.nodes.append(start_node(1, test.options.tmpdir, args))
-        args2 = ['-debug=zrpcunsafe']
-        args2 += additional_args
-        test.nodes.append(start_node(2, test.options.tmpdir, args2))
+        test.nodes.append(start_node(2, test.options.tmpdir, args))
         connect_nodes_bi(test.nodes, 0, 1)
         connect_nodes_bi(test.nodes, 1, 2)
         connect_nodes_bi(test.nodes, 0, 2)

--- a/qa/rpc-tests/mergetoaddress_mixednotes.py
+++ b/qa/rpc-tests/mergetoaddress_mixednotes.py
@@ -12,12 +12,14 @@ from mergetoaddress_helper import assert_mergetoaddress_exception
 
 class MergeToAddressMixedNotes(BitcoinTestFramework):
     def setup_nodes(self):
-        self.num_nodes = 4
-        return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[['-anchorconfirmations=1']] * self.num_nodes)
+        return start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-anchorconfirmations=1',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
 
     def setup_chain(self):
         print("Initializing test directory " + self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 4)
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     def run_test(self):
         print("Mining blocks...")

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -25,11 +25,11 @@ class MerkleBlockTest(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
         # Nodes 0/1 are "wallet" nodes
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ['-debug', '-enabletxminingdelay=0']))
+        self.nodes.append(start_node(1, self.options.tmpdir, ['-debug']))
         # Nodes 2/3 are used for testing
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
-        self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-txindex"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ['-debug']))
+        self.nodes.append(start_node(3, self.options.tmpdir, ['-debug', '-txindex']))
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[0], 2)
         connect_nodes(self.nodes[0], 3)

--- a/qa/rpc-tests/mining_shielded_coinbase.py
+++ b/qa/rpc-tests/mining_shielded_coinbase.py
@@ -34,7 +34,8 @@ class ShieldCoinbaseTest (BitcoinTestFramework):
             nuparams(HEARTWOOD_BRANCH_ID, 10),
             nuparams(CANOPY_BRANCH_ID, 20),
             nuparams(NU5_BRANCH_ID, 20),
-            "-nurejectoldversions=false",
+            '-nurejectoldversions=false',
+            '-enabletxminingdelay=0',
         ]
         return start_node(index, self.options.tmpdir, args + extra_args)
 

--- a/qa/rpc-tests/nuparams.py
+++ b/qa/rpc-tests/nuparams.py
@@ -30,11 +30,10 @@ class NuparamsTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self, split=False):
-        args = [[
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(HEARTWOOD_BRANCH_ID, 3),
             nuparams(NU5_BRANCH_ID, 5),
-        ] * self.num_nodes]
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, args)
+        ]] * self.num_nodes)
         self.is_network_split = False
         self.sync_all()
 

--- a/qa/rpc-tests/orchard_reorg.py
+++ b/qa/rpc-tests/orchard_reorg.py
@@ -31,12 +31,13 @@ class OrchardReorgTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_nodes(self):
-        return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[
+        return start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(BLOSSOM_BRANCH_ID, 1),
             nuparams(HEARTWOOD_BRANCH_ID, 5),
             nuparams(CANOPY_BRANCH_ID, 5),
             nuparams(NU5_BRANCH_ID, 10),
             '-nurejectoldversions=false',
+            '-enabletxminingdelay=0',
         ]] * self.num_nodes)
 
     def run_test(self):

--- a/qa/rpc-tests/prioritisetransaction.py
+++ b/qa/rpc-tests/prioritisetransaction.py
@@ -26,8 +26,9 @@ class PrioritiseTransactionTest (BitcoinTestFramework):
     def setup_network(self, split=False):
         self.nodes = []
         # Start nodes with tiny block size of 11kb
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-blockprioritysize=7000", "-blockmaxsize=11000", "-maxorphantx=1000", "-relaypriority=true", "-printpriority=1"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockprioritysize=7000", "-blockmaxsize=11000", "-maxorphantx=1000", "-relaypriority=true", "-printpriority=1"]))
+        args = ['-blockprioritysize=7000', '-blockmaxsize=11000', '-maxorphantx=1000', '-relaypriority=true', '-printpriority=1', '-enabletxminingdelay=0']
+        self.nodes.append(start_node(0, self.options.tmpdir, args))
+        self.nodes.append(start_node(1, self.options.tmpdir, args))
         connect_nodes(self.nodes[1], 0)
         self.is_network_split=False
         self.sync_all()

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -25,7 +25,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
 
         #connect to a local machine for debugging
         #url = "http://bitcoinrpc:DP6DvqZtqXarpeNWyN3LZTFchCCyCUuHwNF7E8pX99x1@%s:%d" % ('127.0.0.1', 18232)

--- a/qa/rpc-tests/receivedby.py
+++ b/qa/rpc-tests/receivedby.py
@@ -7,7 +7,7 @@
 # Exercise the listreceivedbyaddress API
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import assert_equal, start_nodes
 
 from decimal import Decimal
 
@@ -53,6 +53,8 @@ def check_array_result(object_array, to_match, expected, should_not_find = False
         raise AssertionError("Objects was matched %s"%(str(to_match)))
 
 class ReceivedByTest(BitcoinTestFramework):
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
 
     def run_test(self):
         '''

--- a/qa/rpc-tests/regtest_signrawtransaction.py
+++ b/qa/rpc-tests/regtest_signrawtransaction.py
@@ -4,9 +4,11 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import wait_and_assert_operationid_status
+from test_framework.util import start_nodes, wait_and_assert_operationid_status
 
 class RegtestSignrawtransactionTest (BitcoinTestFramework):
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
 
     def run_test(self):
         self.nodes[0].generate(1)

--- a/qa/rpc-tests/remove_sprout_shielding.py
+++ b/qa/rpc-tests/remove_sprout_shielding.py
@@ -23,6 +23,7 @@ import logging
 HAS_CANOPY = [
     '-nurejectoldversions=false', 
     '-anchorconfirmations=1',
+    '-enabletxminingdelay=0',
     nuparams(BLOSSOM_BRANCH_ID, 205),
     nuparams(HEARTWOOD_BRANCH_ID, 210),
     nuparams(CANOPY_BRANCH_ID, 220),

--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -57,7 +57,7 @@ class RESTTest (BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/qa/rpc-tests/shorter_block_times.py
+++ b/qa/rpc-tests/shorter_block_times.py
@@ -22,6 +22,7 @@ class ShorterBlockTimes(BitcoinTestFramework):
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, [[
             '-nuparams=2bb40e60:106', # Blossom
+            '-enabletxminingdelay=0',
         ]] * self.num_nodes)
 
     def run_test(self):

--- a/qa/rpc-tests/show_help.py
+++ b/qa/rpc-tests/show_help.py
@@ -14,7 +14,7 @@ import subprocess
 import tempfile
 import time
 
-help_message = """
+help_message_1 = """
 In order to ensure you are adequately protecting your privacy when using Zcash,
 please see <https://z.cash/support/security/>.
 
@@ -86,7 +86,8 @@ Options:
        Keep at most <n> unconnectable transactions in memory (default: 100)
 
   -par=<n>
-       Set the number of script verification threads (-8 to 16, 0 = auto, <0 =
+       Set the number of script verification threads (""" # nondeterministic part here
+help_message_2 = """, 0 = auto, <0 =
        leave that many cores free, default: 0)
 
   -pid=<file>
@@ -495,7 +496,8 @@ class ShowHelpTest(BitcoinTestFramework):
             assert_equal(process.returncode, 0)
             log_stdout.seek(0)
             stdout = log_stdout.read().decode('utf-8')
-            assert_true(help_message in stdout)
+            assert_true(help_message_1 in stdout)
+            assert_true(help_message_2 in stdout)
 
     def run_test(self):
         self.show_help()

--- a/qa/rpc-tests/show_help.py
+++ b/qa/rpc-tests/show_help.py
@@ -405,6 +405,10 @@ Block creation options:
        Set maximum size of high-priority/low-fee transactions in bytes
        (default: 1000000)
 
+  -enabletxminingdelay
+       Improve orphan rate by not mining a transaction until it has had a
+       chance to propagate and be verified by other nodes (default: 1)
+
 Mining options:
 
   -gen

--- a/qa/rpc-tests/spentindex.py
+++ b/qa/rpc-tests/spentindex.py
@@ -22,17 +22,24 @@ from test_framework.mininode import COIN
 
 
 class SpentIndexTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 3)
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     def setup_network(self):
         # -insightexplorer causes spentindex to be enabled (fSpentIndex = true)
 
-        self.nodes = start_nodes(
-            3, self.options.tmpdir,
-            [['-debug', '-txindex', '-experimentalfeatures', '-insightexplorer']]*3)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-debug',
+            '-txindex',
+            '-experimentalfeatures',
+            '-insightexplorer',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[0], 2)
 

--- a/qa/rpc-tests/sprout_sapling_migration.py
+++ b/qa/rpc-tests/sprout_sapling_migration.py
@@ -55,17 +55,13 @@ class SproutSaplingMigration(BitcoinTestFramework):
         self.cache_behavior = 'sprout'
 
     def setup_nodes(self):
-        extra_args = [[
-        ]] * self.num_nodes
-        # Add migration parameters to nodes[0]
-        extra_args[0] = extra_args[0] + [
+        # Use migration parameters for nodes[0]
+        return start_nodes(self.num_nodes, self.options.tmpdir, [[
             '-migration',
             '-migrationdestaddress=' + SAPLING_ADDR,
-            '-debug=zrpcunsafe'
-        ]
-        assert_equal(3, len(extra_args[0]))
-        assert_equal(0, len(extra_args[1]))
-        return start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+            '-debug=zrpcunsafe',
+            '-enabletxminingdelay=0',
+        ]] + [['-enabletxminingdelay=0']] * (self.num_nodes-1))
 
     def run_migration_test(self, node, sproutAddr, saplingAddr, target_height, sprout_initial_balance):
         # Make sure we are in a good state to run the test

--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -107,7 +107,7 @@ def all_interfaces():
             max_possible *= 2
         else:
             break
-    namestr = names.tostring()
+    namestr = names.tobytes()
     return [(namestr[i:i+16].split(b'\0', 1)[0],
              socket.inet_ntoa(namestr[i+20:i+24]))
             for i in range(0, outbytes, struct_size)]

--- a/qa/rpc-tests/threeofthreerestore.py
+++ b/qa/rpc-tests/threeofthreerestore.py
@@ -14,8 +14,10 @@ class ThreeOfThreeRestoreTest(BitcoinTestFramework):
         self.num_nodes = 4
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                           extra_args=[['-experimentalfeatures', '-developerencryptwallet']] * 4)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-experimentalfeatures',
+            '-developerencryptwallet',
+        ]] * self.num_nodes)
 
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)

--- a/qa/rpc-tests/timestampindex.py
+++ b/qa/rpc-tests/timestampindex.py
@@ -20,17 +20,23 @@ from test_framework.util import (
 
 
 class TimestampIndexTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 3)
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     def setup_network(self):
         # -insightexplorer causes spentindex to be enabled (fSpentIndex = true)
 
-        self.nodes = start_nodes(
-            3, self.options.tmpdir,
-            [['-debug', '-txindex', '-experimentalfeatures', '-insightexplorer']]*3)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-debug',
+            '-txindex',
+            '-experimentalfeatures',
+            '-insightexplorer',
+        ]] * self.num_nodes)
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[0], 2)
 

--- a/qa/rpc-tests/turnstile.py
+++ b/qa/rpc-tests/turnstile.py
@@ -41,7 +41,8 @@ from test_framework.util import (
 from decimal import Decimal
 
 TURNSTILE_ARGS = ['-experimentalfeatures',
-                  '-developersetpoolsizezero']
+                  '-developersetpoolsizezero',
+                  '-enabletxminingdelay=0']
 
 class TurnstileTest (BitcoinTestFramework):
 
@@ -51,7 +52,7 @@ class TurnstileTest (BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         self.is_network_split=False
@@ -67,7 +68,7 @@ class TurnstileTest (BitcoinTestFramework):
         assert False, "pool named %r not found" % (name,)
 
     # Helper method to start a single node with extra args and sync to the network
-    def start_and_sync_node(self, index, args=[]):
+    def start_and_sync_node(self, index, args):
         self.nodes[index] = start_node(index, self.options.tmpdir, extra_args=args)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
@@ -75,7 +76,7 @@ class TurnstileTest (BitcoinTestFramework):
         self.sync_all()
 
     # Helper method to stop and restart a single node with extra args and sync to the network
-    def restart_and_sync_node(self, index, args=[]):
+    def restart_and_sync_node(self, index, args):
         self.nodes[index].stop()
         bitcoind_processes[index].wait()
         self.start_and_sync_node(index, args)
@@ -176,7 +177,7 @@ class TurnstileTest (BitcoinTestFramework):
         check_node_log(self, 0, string_to_find1, True)
         check_node_log(self, 0, string_to_find2, False)
         check_node_log(self, 0, string_to_find3, False)
-        self.start_and_sync_node(0)
+        self.start_and_sync_node(0, ['-enabletxminingdelay=0'])
 
         assert_equal(newhash, self.nodes[0].getbestblockhash())
 

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -9,7 +9,7 @@
 #
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, connect_nodes, \
+from test_framework.util import assert_equal, connect_nodes, start_nodes, \
     sync_blocks, gather_inputs
 
 
@@ -22,6 +22,9 @@ class TxnMallTest(BitcoinTestFramework):
     def setup_network(self):
         # Start with split network:
         return super(TxnMallTest, self).setup_network(True)
+
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
 
     def run_test(self):
         mining_reward = 10

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -19,7 +19,7 @@ class WalletTest (BitcoinTestFramework):
         self.num_nodes = 4
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir)
+        self.nodes = start_nodes(3, self.options.tmpdir, [['-enabletxminingdelay=0']] * 3)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/qa/rpc-tests/wallet_accounts.py
+++ b/qa/rpc-tests/wallet_accounts.py
@@ -24,6 +24,7 @@ class WalletAccountsTest(BitcoinTestFramework):
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(NU5_BRANCH_ID, 210),
+            '-enabletxminingdelay=0',
         ]] * self.num_nodes)
 
     def check_receiver_types(self, ua, expected):

--- a/qa/rpc-tests/wallet_addresses.py
+++ b/qa/rpc-tests/wallet_addresses.py
@@ -23,9 +23,9 @@ class WalletAddressesTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self):
-        self.nodes = start_nodes(
-            self.num_nodes, self.options.tmpdir,
-            extra_args=[[nuparams(NU5_BRANCH_ID, 2),]] * self.num_nodes)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            nuparams(NU5_BRANCH_ID, 2),
+        ]] * self.num_nodes)
         connect_nodes_bi(self.nodes, 0, 1)
         self.is_network_split = False
         self.sync_all()

--- a/qa/rpc-tests/wallet_anchorfork.py
+++ b/qa/rpc-tests/wallet_anchorfork.py
@@ -11,14 +11,21 @@ from test_framework.util import assert_equal, initialize_chain_clean, \
 from decimal import Decimal
 
 class WalletAnchorForkTest (BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 4)
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     # Start nodes with -regtestshieldcoinbase to set fCoinbaseMustBeShielded to true.
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir, extra_args=[['-regtestshieldcoinbase', '-debug=zrpc']] * 3 )
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-regtestshieldcoinbase',
+            '-debug=zrpc',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
@@ -64,7 +71,11 @@ class WalletAnchorForkTest (BitcoinTestFramework):
         # Relaunch nodes and partition network into two:
         # A: node 0
         # B: node 1, 2
-        self.nodes = start_nodes(3, self.options.tmpdir, extra_args=[['-regtestshieldcoinbase', '-debug=zrpc']] * 3 )
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-regtestshieldcoinbase',
+            '-debug=zrpc',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         connect_nodes_bi(self.nodes,1,2)
 
         # Partition B, node 1 mines an empty block
@@ -100,7 +111,11 @@ class WalletAnchorForkTest (BitcoinTestFramework):
         wait_bitcoinds()
 
         # Relaunch nodes and reconnect the entire network
-        self.nodes = start_nodes(3, self.options.tmpdir, extra_args=[['-regtestshieldcoinbase', '-debug=zrpc']] * 3 )
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-regtestshieldcoinbase',
+            '-debug=zrpc',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         connect_nodes_bi(self.nodes,0, 1)
         connect_nodes_bi(self.nodes,1, 2)
         connect_nodes_bi(self.nodes,0, 2)

--- a/qa/rpc-tests/wallet_broadcast.py
+++ b/qa/rpc-tests/wallet_broadcast.py
@@ -13,7 +13,10 @@ class WalletBroadcastTest(BitcoinTestFramework):
         #do some -walletbroadcast tests
         stop_nodes(self.nodes)
         wait_bitcoinds()
-        self.nodes = start_nodes(3, self.options.tmpdir, [["-walletbroadcast=0"]] * 3)
+        self.nodes = start_nodes(3, self.options.tmpdir, [[
+            '-walletbroadcast=0',
+            '-enabletxminingdelay=0',
+        ]] * 3)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
@@ -42,7 +45,7 @@ class WalletBroadcastTest(BitcoinTestFramework):
         #restart the nodes with -walletbroadcast=1
         stop_nodes(self.nodes)
         wait_bitcoinds()
-        self.nodes = start_nodes(3, self.options.tmpdir)
+        self.nodes = start_nodes(3, self.options.tmpdir, [['-enabletxminingdelay=0']] * 3)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/qa/rpc-tests/wallet_changeaddresses.py
+++ b/qa/rpc-tests/wallet_changeaddresses.py
@@ -25,7 +25,8 @@ class WalletChangeAddressesTest(BitcoinTestFramework):
         args = [
             '-nuparams=5ba81b19:1', # Overwinter
             '-nuparams=76b809bb:1', # Sapling
-            '-txindex'              # Avoid JSONRPC error: No information available about transaction
+            '-txindex',             # Avoid JSONRPC error: No information available about transaction
+            '-enabletxminingdelay=0',
         ]
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, args))

--- a/qa/rpc-tests/wallet_changeindicator.py
+++ b/qa/rpc-tests/wallet_changeindicator.py
@@ -4,11 +4,14 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_true, assert_false, wait_and_assert_operationid_status
+from test_framework.util import assert_equal, assert_true, assert_false, start_nodes, wait_and_assert_operationid_status
 
 from decimal import Decimal
 
 class WalletChangeIndicatorTest (BitcoinTestFramework):
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
+
     # Helper Methods
     def generate_and_sync(self):
         self.sync_all()

--- a/qa/rpc-tests/wallet_doublespend.py
+++ b/qa/rpc-tests/wallet_doublespend.py
@@ -27,6 +27,7 @@ class WalletDoubleSpendTest(BitcoinTestFramework):
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(NU5_BRANCH_ID, 201),
+            '-enabletxminingdelay=0',
         ]] * self.num_nodes)
 
     def run_test_for_recipient_type(self, recipient_type):

--- a/qa/rpc-tests/wallet_isfromme.py
+++ b/qa/rpc-tests/wallet_isfromme.py
@@ -21,17 +21,22 @@ from test_framework.util import (
 from decimal import Decimal
 
 class WalletIsFromMe(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 1
+
     def setup_chain(self):
-        initialize_chain_clean(self.options.tmpdir, 1)
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(1, self.options.tmpdir, extra_args=[[
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(OVERWINTER_BRANCH_ID, 1),
             nuparams(SAPLING_BRANCH_ID, 1),
             nuparams(BLOSSOM_BRANCH_ID, 1),
             nuparams(HEARTWOOD_BRANCH_ID, 1),
             nuparams(CANOPY_BRANCH_ID, 1),
-        ]])
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         self.is_network_split=False
 
     def run_test (self):

--- a/qa/rpc-tests/wallet_listnotes.py
+++ b/qa/rpc-tests/wallet_listnotes.py
@@ -20,9 +20,10 @@ from decimal import Decimal
 # Test wallet z_listunspent behaviour across network upgrades
 class WalletListNotes(BitcoinTestFramework):
     def setup_nodes(self):
-        return start_nodes(4, self.options.tmpdir, [[
+        return start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(NU5_BRANCH_ID, 215),
-        ]] * 4)
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
 
     def run_test(self):
         # Current height = 200 -> Sapling

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -33,12 +33,10 @@ class ListReceivedTest (BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self):
-        self.nodes = start_nodes(
-            self.num_nodes, self.options.tmpdir,
-            extra_args=[[
-                nuparams(NU5_BRANCH_ID, 225),
-            ]] * self.num_nodes
-            )
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            nuparams(NU5_BRANCH_ID, 225),
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 1, 2)
         connect_nodes_bi(self.nodes, 0, 2)

--- a/qa/rpc-tests/wallet_nullifiers.py
+++ b/qa/rpc-tests/wallet_nullifiers.py
@@ -13,8 +13,11 @@ from decimal import Decimal
 class WalletNullifiersTest (BitcoinTestFramework):
 
     def setup_nodes(self):
-        return start_nodes(self.num_nodes, self.options.tmpdir,
-                           extra_args=[['-experimentalfeatures', '-developerencryptwallet']] * self.num_nodes)
+        return start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-experimentalfeatures',
+            '-developerencryptwallet',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
 
     def run_test (self):
         # add zaddr to node 0
@@ -44,7 +47,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
         bitcoind_processes[1].wait()
 
         # restart node 1
-        self.nodes[1] = start_node(1, self.options.tmpdir)
+        self.nodes[1] = start_node(1, self.options.tmpdir, extra_args=['-enabletxminingdelay=0'])
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 1, 2)
         self.sync_all()

--- a/qa/rpc-tests/wallet_orchard.py
+++ b/qa/rpc-tests/wallet_orchard.py
@@ -24,6 +24,7 @@ class WalletOrchardTest(BitcoinTestFramework):
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(NU5_BRANCH_ID, 210),
+            '-enabletxminingdelay=0',
         ]] * self.num_nodes)
 
     def run_test(self):

--- a/qa/rpc-tests/wallet_orchard_change.py
+++ b/qa/rpc-tests/wallet_orchard_change.py
@@ -25,6 +25,7 @@ class WalletOrchardChangeTest(BitcoinTestFramework):
         return start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(NU5_BRANCH_ID, 205),
             '-regtestwalletsetbestchaineveryblock',
+            '-enabletxminingdelay=0',
         ]] * self.num_nodes)
 
     def check_has_output(self, node, tx, expected):

--- a/qa/rpc-tests/wallet_orchard_init.py
+++ b/qa/rpc-tests/wallet_orchard_init.py
@@ -29,7 +29,8 @@ class OrchardWalletInitTest(BitcoinTestFramework):
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(NU5_BRANCH_ID, 205),
-            '-regtestwalletsetbestchaineveryblock'
+            '-regtestwalletsetbestchaineveryblock',
+            '-enabletxminingdelay=0',
         ]] * self.num_nodes)
 
     def run_test(self):

--- a/qa/rpc-tests/wallet_orchard_persistence.py
+++ b/qa/rpc-tests/wallet_orchard_persistence.py
@@ -26,6 +26,7 @@ class WalletOrchardPersistenceTest(BitcoinTestFramework):
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(NU5_BRANCH_ID, 201),
+            '-enabletxminingdelay=0',
         ]] * self.num_nodes)
 
     def run_test(self):

--- a/qa/rpc-tests/wallet_overwintertx.py
+++ b/qa/rpc-tests/wallet_overwintertx.py
@@ -25,10 +25,11 @@ class WalletOverwinterTxTest (BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[
-            "-nuparams=2bb40e60:200",
-            "-debug=zrpcunsafe",
-            "-txindex",
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-nuparams=2bb40e60:200',
+            '-debug=zrpcunsafe',
+            '-txindex',
+            '-enabletxminingdelay=0',
         ]] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)

--- a/qa/rpc-tests/wallet_parsing_amounts.py
+++ b/qa/rpc-tests/wallet_parsing_amounts.py
@@ -10,8 +10,12 @@ from decimal import Decimal
 
 # Test wallet address behaviour across network upgrades
 class WalletAmountParsingTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
+
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/qa/rpc-tests/wallet_persistence.py
+++ b/qa/rpc-tests/wallet_persistence.py
@@ -17,10 +17,10 @@ class WalletPersistenceTest (BitcoinTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory " + self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 4)
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(4, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,2,3)

--- a/qa/rpc-tests/wallet_sapling.py
+++ b/qa/rpc-tests/wallet_sapling.py
@@ -8,6 +8,7 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.util import (
     assert_equal,
     get_coinbase_address,
+    start_nodes,
     wait_and_assert_operationid_status,
     DEFAULT_FEE
 )
@@ -16,6 +17,8 @@ from decimal import Decimal
 
 # Test wallet behaviour with Sapling addresses
 class WalletSaplingTest(BitcoinTestFramework):
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
 
     def run_test(self):
         # Sanity-check the test harness

--- a/qa/rpc-tests/wallet_sendmany_any_taddr.py
+++ b/qa/rpc-tests/wallet_sendmany_any_taddr.py
@@ -18,10 +18,10 @@ TX_EXPIRING_SOON_THRESHOLD = 3
 # Test ANY_TADDR special string in z_sendmany
 class WalletSendManyAnyTaddr(BitcoinTestFramework):
     def setup_nodes(self):
-        return start_nodes(self.num_nodes, self.options.tmpdir,
-            [[
-                "-txexpirydelta=%d" % TX_EXPIRY_DELTA,
-            ]] * self.num_nodes)
+        return start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-txexpirydelta=%d' % TX_EXPIRY_DELTA,
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
 
     def run_test(self):
         # Sanity-check the test harness

--- a/qa/rpc-tests/wallet_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldcoinbase.py
@@ -21,6 +21,7 @@ class WalletShieldCoinbaseTest (BitcoinTestFramework):
         args = [
             '-regtestprotectcoinbase',
             '-debug=zrpcunsafe',
+            '-enabletxminingdelay=0',
             nuparams(NU5_BRANCH_ID, self.nu5_activation),
         ]
         self.nodes = []

--- a/qa/rpc-tests/wallet_shieldingcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldingcoinbase.py
@@ -30,11 +30,15 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 4)
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     # Start nodes with -regtestshieldcoinbase to set fCoinbaseMustBeShielded to true.
     def setup_network(self, split=False):
-        self.nodes = start_nodes(4, self.options.tmpdir, extra_args=[['-regtestshieldcoinbase', '-debug=zrpcunsafe']] * 4 )
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-regtestshieldcoinbase',
+            '-debug=zrpcunsafe',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/qa/rpc-tests/wallet_treestate.py
+++ b/qa/rpc-tests/wallet_treestate.py
@@ -12,14 +12,21 @@ import time
 from decimal import Decimal
 
 class WalletTreeStateTest (BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 4)
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     # Start nodes with -regtestshieldcoinbase to set fCoinbaseMustBeShielded to true.
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir, extra_args=[['-regtestshieldcoinbase','-debug=zrpc']] * 3 )
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-regtestshieldcoinbase',
+            '-debug=zrpc',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/qa/rpc-tests/wallet_unified_change.py
+++ b/qa/rpc-tests/wallet_unified_change.py
@@ -24,6 +24,7 @@ class WalletUnifiedChangeTest(BitcoinTestFramework):
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(NU5_BRANCH_ID, 201),
+            '-enabletxminingdelay=0',
         ]] * self.num_nodes)
 
     def run_test(self):

--- a/qa/rpc-tests/wallet_z_sendmany.py
+++ b/qa/rpc-tests/wallet_z_sendmany.py
@@ -21,9 +21,14 @@ from decimal import Decimal
 
 # Test wallet address behaviour across network upgrades
 class WalletZSendmanyTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
+
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir, [[
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
             nuparams(NU5_BRANCH_ID, 238),
+            '-enabletxminingdelay=0',
         ]] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)

--- a/qa/rpc-tests/wallet_zero_value.py
+++ b/qa/rpc-tests/wallet_zero_value.py
@@ -9,8 +9,12 @@ from decimal import Decimal
 
 # Test wallet address behaviour across network upgrades
 class WalletZeroValueTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 2
+
     def setup_network(self, split=False):
-        self.nodes = start_nodes(2, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         self.is_network_split=False
         self.sync_all()

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -65,10 +65,10 @@ class WalletBackupTest(BitcoinTestFramework):
 
         # nodes 1, 2,3 are spenders, let's give them a keypool=100
         extra_args = [
-            ["-keypool=100", ed0, "-allowdeprecated=dumpwallet"], 
-            ["-keypool=100", ed1, "-allowdeprecated=dumpwallet"], 
-            ["-keypool=100", ed2, "-allowdeprecated=dumpwallet"], 
-            []
+            ['-keypool=100', ed0, '-allowdeprecated=dumpwallet', '-enabletxminingdelay=0'],
+            ['-keypool=100', ed1, '-allowdeprecated=dumpwallet', '-enabletxminingdelay=0'],
+            ['-keypool=100', ed2, '-allowdeprecated=dumpwallet', '-enabletxminingdelay=0'],
+            ['-enabletxminingdelay=0']
         ]
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
         connect_nodes(self.nodes[0], 3)

--- a/qa/rpc-tests/zapwallettxes.py
+++ b/qa/rpc-tests/zapwallettxes.py
@@ -18,7 +18,7 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/qa/rpc-tests/zcjoinsplit.py
+++ b/qa/rpc-tests/zcjoinsplit.py
@@ -18,7 +18,7 @@ class JoinSplitTest(BitcoinTestFramework):
         self.nodes = []
         self.is_network_split = False
         self.nodes.append(start_node(0, self.options.tmpdir, 
-            ["-allowdeprecated=zcrawkeygen", "-allowdeprecated=zcrawjoinsplit", "-allowdeprecated=zcrawreceive"]
+            ['-allowdeprecated=zcrawkeygen', '-allowdeprecated=zcrawjoinsplit', '-allowdeprecated=zcrawreceive', '-enabletxminingdelay=0']
             ))
 
     def run_test(self):

--- a/qa/rpc-tests/zcjoinsplitdoublespend.py
+++ b/qa/rpc-tests/zcjoinsplitdoublespend.py
@@ -17,8 +17,12 @@ class JoinSplitTest(BitcoinTestFramework):
         return super(JoinSplitTest, self).setup_network(True)
 
     def setup_nodes(self):
-        return start_nodes(self.num_nodes, self.options.tmpdir,
-                extra_args = [["-allowdeprecated=zcrawjoinsplit", "-allowdeprecated=zcrawkeygen", "-allowdeprecated=zcrawreceive"]] * self.num_nodes)
+        return start_nodes(self.num_nodes, self.options.tmpdir, [[
+            '-allowdeprecated=zcrawjoinsplit',
+            '-allowdeprecated=zcrawkeygen',
+            '-allowdeprecated=zcrawreceive',
+            '-enabletxminingdelay=0',
+        ]] * self.num_nodes)
 
     def txid_in_mempool(self, node, txid):
         exception_triggered = False

--- a/qa/rpc-tests/zkey_import_export.py
+++ b/qa/rpc-tests/zkey_import_export.py
@@ -17,13 +17,16 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO, str
 fee = DEFAULT_FEE # constant (but can be changed within reason)
 
 class ZkeyImportExportTest (BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 5
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 5)
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(5, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-enabletxminingdelay=0']] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -493,6 +493,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-blockprioritysize=<n>", strprintf(_("Set maximum size of high-priority/low-fee transactions in bytes (default: %d)"), DEFAULT_BLOCK_PRIORITY_SIZE));
     if (GetBoolArg("-help-debug", false))
         strUsage += HelpMessageOpt("-blockversion=<n>", strprintf("Override block version to test forking scenarios (default: %d)", (int)CBlock::CURRENT_VERSION));
+    strUsage += HelpMessageOpt("-enabletxminingdelay", strprintf(_("Improve orphan rate by not mining a transaction until it has had a chance to propagate and be verified by other nodes (default: %u)"), DEFAULT_ENABLETXMININGDELAY));
 
 #ifdef ENABLE_MINING
     strUsage += HelpMessageGroup(_("Mining options:"));

--- a/src/miner.h
+++ b/src/miner.h
@@ -24,6 +24,8 @@ static const int DEFAULT_GENERATE_THREADS = 1;
 
 static const bool DEFAULT_PRINTPRIORITY = false;
 
+static const bool DEFAULT_ENABLETXMININGDELAY = true;
+
 typedef std::variant<
     libzcash::OrchardRawAddress,
     libzcash::SaplingPaymentAddress,

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -992,6 +992,10 @@ public:
         return a.wtxid.hash != b.wtxid.hash;
     }
 
+    int64_t EstimatePropagationLatencyInSeconds() const {
+        return 10;
+    }
+
     std::string ToString() const;
 };
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -993,7 +993,7 @@ public:
     }
 
     int64_t EstimatePropagationLatencyInSeconds() const {
-        return 10;
+        return 30;
     }
 
     std::string ToString() const;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -377,7 +377,9 @@ UniValue prioritisetransaction(const UniValue& params, bool fHelp)
     if (fHelp || params.size() != 3)
         throw runtime_error(
             "prioritisetransaction <txid> <priority delta> <fee delta>\n"
-            "Accepts the transaction into mined blocks at a higher (or lower) priority\n"
+            "Accepts the transaction into mined blocks at a higher (or lower) priority.\n"
+            "If either the priority or fee delta of a transaction is positive, it is also not subject "
+            "to the mining delay controlled by the `enabletxminingdelay` configuration option."
             "\nArguments:\n"
             "1. \"txid\"       (string, required) The transaction id.\n"
             "2. priority delta (numeric, required) The priority to add or subtract.\n"

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -419,7 +419,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // ... or if EstimatePropagationLatencyInSeconds() seconds have passed.
     mempool.ClearPrioritisation(hash);
     auto latency = tx3_entry.GetSharedTx()->EstimatePropagationLatencyInSeconds();
-    BOOST_CHECK_EQUAL(latency, 10);
+    BOOST_CHECK_EQUAL(latency, 30);
     FixedClock::Instance()->Set(std::chrono::seconds(SaturatingAddTime(GetTime(), latency)));
     BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 2);

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -303,6 +303,16 @@ BOOST_AUTO_TEST_CASE(gettime)
     BOOST_CHECK((GetTime() & ~0xFFFFFFFFLL) == 0);
 }
 
+BOOST_AUTO_TEST_CASE(test_SaturatingAddTime)
+{
+    BOOST_CHECK_EQUAL(SaturatingAddTime(1, 2), 3);
+    BOOST_CHECK_EQUAL(SaturatingAddTime(1, -2), -1);
+    BOOST_CHECK_EQUAL(SaturatingAddTime(INT64_MAX, 1), INT64_MAX);
+    BOOST_CHECK_EQUAL(SaturatingAddTime(INT64_MIN, -1), INT64_MIN);
+    BOOST_CHECK_EQUAL(SaturatingAddTime(INT64_MIN, 1), INT64_MIN + 1);
+    BOOST_CHECK_EQUAL(SaturatingAddTime(INT64_MAX, -1), INT64_MAX - 1);
+}
+
 BOOST_AUTO_TEST_CASE(test_ParseInt32)
 {
     int32_t n;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -823,6 +823,16 @@ void CTxMemPool::ClearPrioritisation(const uint256 hash)
     mapDeltas.erase(hash);
 }
 
+bool CTxMemPool::IsPositivelyPrioritised(const uint256 hash) const
+{
+    LOCK(cs);
+    std::map<uint256, std::pair<double, CAmount> >::const_iterator pos = mapDeltas.find(hash);
+    if (pos == mapDeltas.end())
+        return false;
+    const std::pair<double, CAmount> &deltas = pos->second;
+    return deltas.first > 0.0 || deltas.second > 0;
+}
+
 bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 {
     for (unsigned int i = 0; i < tx.vin.size(); i++)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -344,6 +344,7 @@ public:
     void PrioritiseTransaction(const uint256 hash, const std::string strHash, double dPriorityDelta, const CAmount& nFeeDelta);
     void ApplyDeltas(const uint256 hash, double &dPriorityDelta, CAmount &nFeeDelta) const;
     void ClearPrioritisation(const uint256 hash);
+    bool IsPositivelyPrioritised(const uint256 hash) const;
 
     bool nullifierExists(const uint256& nullifier, ShieldedType type) const;
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -187,6 +187,12 @@ bool SoftSetBoolArg(const std::string& strArg, bool fValue)
         return SoftSetArg(strArg, std::string("0"));
 }
 
+void SetBoolArg(const std::string& strArg, bool fValue)
+{
+    LOCK(cs_args);
+    mapArgs[strArg] = fValue ? std::string("1") : std::string("0");
+}
+
 static const int screenWidth = 79;
 static const int optIndent = 2;
 static const int msgIndent = 7;

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -162,6 +162,14 @@ bool SoftSetArg(const std::string& strArg, const std::string& strValue);
 bool SoftSetBoolArg(const std::string& strArg, bool fValue);
 
 /**
+ * Set a boolean argument unconditionally
+ *
+ * @param strArg Argument to set (e.g. "-foo")
+ * @param fValue Value (e.g. false)
+ */
+void SetBoolArg(const std::string& strArg, bool fValue);
+
+/**
  * Format a string to be used as group of options in help messages
  *
  * @param message Group name (e.g. "RPC server options:")

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -172,3 +172,9 @@ std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)
     ss << boost::posix_time::from_time_t(nTime);
     return ss.str();
 }
+
+int64_t SaturatingAddTime(int64_t a, int64_t b) {
+    if (b > 0 && a > INT64_MAX - b) return INT64_MAX;
+    if (b < 0 && a < INT64_MIN - b) return INT64_MIN;
+    return a + b;
+}

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -105,4 +105,6 @@ std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);
 /** Sanity check epoch match normal Unix epoch */
 bool ChronoSanityCheck();
 
+int64_t SaturatingAddTime(int64_t a, int64_t b);
+
 #endif // BITCOIN_UTIL_TIME_H


### PR DESCRIPTION
This increases the likelihood that the transaction verification will have been cached by other nodes, potentially improving orphan rates. It is controlled by a new option `-enabletxminingdelay` which defaults to true.