### PR TITLE
Remove the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,0 @@
-Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.
-* [ ] Relevant documentation for this PR has to be completed and reviewed by @mdr0id before the PR can be merged
-* [ ] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release
-
-As a note, all buildbot tests need to be passing and all appropriate code reviews need to be done before this PR can be merged


### PR DESCRIPTION
Parts of it are automated (successful test, code review) and while the other
parts are useful, I haven’t seen this checklist be used as such.