### PR TITLE
Update authors of librustzcash to include Greg Pfeil

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
     "Ying Tong Lai <yingtong@electriccoin.co>",
     "Simon Liu",
     "Kris Nuttycombe <kris@electriccoin.co>",
+    "Greg Pfeil <greg@electriccoin.co>",
     "Larry Ruane <larry@electriccoin.co>",
     "Steven Smith <steven@electriccoin.co>"
 ]


### PR DESCRIPTION
The authors are all current and former members of Core Team in alphabetical order (as established by #5295).