### PR TITLE
Don't attempt to rewind the Orchard wallet to a height after its current checkpoint

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,3 +4,8 @@ release-notes at release time)
 Notable changes
 ===============
 
+Fixed
+-----
+
+This release fixes an error "Assertion `uResultHeight == rewindHeight' failed" (#5958)
+that could sometimes happen when restarting a node.

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -7,5 +7,5 @@ Notable changes
 Fixed
 -----
 
-This release fixes an error "Assertion `uResultHeight == rewindHeight' failed" (#5958)
+This release fixes an error "Assertion `uResultHeight == rewindHeight` failed" (#5958)
 that could sometimes happen when restarting a node.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4693,8 +4693,10 @@ int CWallet::ScanForWalletTransactions(
     {
         LOCK2(cs_main, cs_wallet);
 
-        // no need to read and scan block, if block was created before
-        // our wallet birthday (as adjusted for block time variability)
+        // There is no need to read and scan blocks that were created before
+        // our wallet birthday (as adjusted for block time variability).
+        // If there is an Orchard wallet checkpoint, the rewind point must not
+        // be advanced past the last Orchard wallet checkpoint height.
         auto optOrchardCheckpointHeight = orchardWallet.GetLastCheckpointHeight();
         while (chainActive.Next(pindex) != NULL && nTimeFirstKey && pindex->GetBlockTime() < nTimeFirstKey - TIMESTAMP_WINDOW &&
                (!optOrchardCheckpointHeight.has_value() || pindex->nHeight < optOrchardCheckpointHeight.value())) {


### PR DESCRIPTION
This fixes #5958.