### PR TITLE
Avoid inconsistent Python lookup

### DIFF
--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -137,12 +137,8 @@ def ensure_no_dot_so_in_depends():
     return exit_code == 0
 
 def util_test():
-    python = []
-    if os.path.isfile('/usr/local/bin/python3'):
-        python = ['/usr/local/bin/python3']
-
     return subprocess.call(
-        python + [repofile('src/test/bitcoin-util-test.py')],
+        [sys.executable, repofile('src/test/bitcoin-util-test.py')],
         cwd=repofile('src'),
         env={'PYTHONPATH': repofile('src/test'), 'srcdir': repofile('src')}
     ) == 0


### PR DESCRIPTION
When executing a Python script from within Python, rather than looking for
`python3` in /usr/local/bin and falling back to the script’s shebang line,
_always_ use the same Python that is executing the caller.

I don’t know why this script doesn’t just run `bitcoin_util_test.py`
directly (always using the shebang line), but I assume that is
intentional (but that should be documented). Otherwise, I’d prefer that
approach.