### PR TITLE
Fix `show_help` and `receivedby` RPC tests

### DIFF
--- a/qa/rpc-tests/show_help.py
+++ b/qa/rpc-tests/show_help.py
@@ -13,7 +13,7 @@ from test_framework.util import assert_equal, assert_true, zcashd_binary
 import subprocess
 import tempfile
 
-help_message = """
+help_message_1 = """
 In order to ensure you are adequately protecting your privacy when using Zcash,
 please see <https://z.cash/support/security/>.
 
@@ -85,7 +85,8 @@ Options:
        Keep at most <n> unconnectable transactions in memory (default: 100)
 
   -par=<n>
-       Set the number of script verification threads (-8 to 16, 0 = auto, <0 =
+       Set the number of script verification threads (""" # nondeterministic part here
+help_message_2 = """, 0 = auto, <0 =
        leave that many cores free, default: 0)
 
   -pid=<file>
@@ -492,7 +493,8 @@ class ShowHelpTest(BitcoinTestFramework):
             assert_equal(process.returncode, 0)
             log_stdout.seek(0)
             stdout = log_stdout.read().decode('utf-8')
-            assert_true(help_message in stdout)
+            assert_true(help_message_1 in stdout)
+            assert_true(help_message_2 in stdout)
 
     def run_test(self):
         self.show_help()

--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -107,7 +107,7 @@ def all_interfaces():
             max_possible *= 2
         else:
             break
-    namestr = names.tostring()
+    namestr = names.tobytes()
     return [(namestr[i:i+16].split(b'\0', 1)[0],
              socket.inet_ntoa(namestr[i+20:i+24]))
             for i in range(0, outbytes, struct_size)]


### PR DESCRIPTION
This fixes #6239 which is a dependency of the `show_help` RPC test on the number of cores, and also an incompatibility with Python 3.9 in the test framework that affected the `receivedby` extended RPC test.