### PR TITLE
Don’t select transparent coinbase with ANY_TADDR

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,3 +4,12 @@ release-notes at release time)
 Notable changes
 ===============
 
+RPC Changes
+-----------
+
+- `z_sendmany` will no longer select transparent coinbase when "ANY\_TADDR" is
+  used as the `fromaddress`. It was already documented to do this, but the
+  previous behavior didn’t match. When coinbase notes were selected in this
+  case, they would (properly) require that the transaction didn’t have any
+  change, but this could be confusing, as the documentation stated that these
+  two conditions (using "ANY\_TADDR" and disallowing change) wouldn’t coincide.

--- a/qa/rpc-tests/wallet_listunspent.py
+++ b/qa/rpc-tests/wallet_listunspent.py
@@ -80,51 +80,39 @@ class WalletListUnspent(BitcoinTestFramework):
 
         opid = self.nodes[0].z_sendmany(
                 'ANY_TADDR',
-                # FIXME: #6262 The amount here _should_ be 2, but because of a
-                #        bug in the selector for `ANY_TADDR`, it’s selecting
-                #        transparent coinbase, which also means we can’t have
-                #        change. When that bug is fixed, the test should fail
-                #        here, and we can switch it back to 2 (and cascade the
-                #        corrected amounts mentioned below.
-                [{'address': n1uaddr, 'amount': 10}],
+                [{'address': n1uaddr, 'amount': 2}],
                 1, 0, 'AllowRevealedSenders')
         wait_and_assert_operationid_status(self.nodes[0], opid)
 
         self.nodes[0].generate(2)
         self.sync_all() # height 207
-        # FIXME: #6262, should be `expected_matured_at_height(207) - 10 + 10 - 2`
-        assert_equal(self.nodes[0].getbalance(), expected_matured_at_height(207) - 10 + 10 - 10)
+        assert_equal(self.nodes[0].getbalance(), expected_matured_at_height(207) - 10 + 10 - 2)
 
         opid = self.nodes[0].z_sendmany(
                 'ANY_TADDR',
-                # FIXME: Should be 3 (see above)
-                [{'address': n1uaddr, 'amount': 10}],
+                [{'address': n1uaddr, 'amount': 3}],
                 1, 0, 'AllowRevealedSenders')
         wait_and_assert_operationid_status(self.nodes[0], opid)
 
         self.nodes[0].generate(2)
         self.sync_all() # height 209
-        # FIXME: #6262, should be `expected_matured_at_height(209) - 10 + 10 - 2 - 3`
-        assert_equal(self.nodes[0].getbalance(), expected_matured_at_height(209) - 10 + 10 - 10 - 10)
+        assert_equal(self.nodes[0].getbalance(), expected_matured_at_height(209) - 10 + 10 - 2 - 3)
 
         opid = self.nodes[0].z_sendmany(
                 'ANY_TADDR',
-                # FIXME: Should be 5 (see above)
-                [{'address': n1uaddr, 'amount': 10}],
+                [{'address': n1uaddr, 'amount': 5}],
                 1, 0, 'AllowRevealedSenders')
         wait_and_assert_operationid_status(self.nodes[0], opid)
 
         self.nodes[0].generate(2)
         self.sync_all() # height 211
-        # FIXME: #6262, should be `expected_matured_at_height(211) - 10 + 10 - 2 - 3 - 5`
-        assert_equal(self.nodes[0].getbalance(), expected_matured_at_height(211) - 10 + 10 - 10 - 10 - 10)
+        assert_equal(self.nodes[0].getbalance(), expected_matured_at_height(211) - 10 + 10 - 2 - 3 - 5)
 
         # check balances at various past points in the chain
-        # FIXME: #6262, change the comparison amounts when the above changes are made.
         assert_equal(self.matured_at_height(205), expected_matured_at_height(205) - 10 + 10)
-        assert_equal(self.matured_at_height(207), expected_matured_at_height(207) - 10 + 10 - 10)
-        assert_equal(self.matured_at_height(209), expected_matured_at_height(209) - 10 + 10 - 10 - 10)
-        assert_equal(self.matured_at_height(211), expected_matured_at_height(211) - 10 + 10 - 10 - 10 - 10)
+        assert_equal(self.matured_at_height(207), expected_matured_at_height(207) - 10 + 10 - 2)
+        assert_equal(self.matured_at_height(209), expected_matured_at_height(209) - 10 + 10 - 2 - 3)
+        assert_equal(self.matured_at_height(211), expected_matured_at_height(211) - 10 + 10 - 2 - 3 - 5)
 
 if __name__ == '__main__':
     WalletListUnspent().main()

--- a/qa/rpc-tests/wallet_sendmany_any_taddr.py
+++ b/qa/rpc-tests/wallet_sendmany_any_taddr.py
@@ -97,7 +97,7 @@ class WalletSendManyAnyTaddr(BitcoinTestFramework):
 
         # Check that ANY_TADDR note selection doesn't attempt a double-spend
         myopid = self.nodes[3].z_sendmany('ANY_TADDR', [{'address': recipient, 'amount': 20}], 1)
-        wait_and_assert_operationid_status(self.nodes[3], myopid, "failed", "Insufficient funds: have 14.99998, need 20.00001")
+        wait_and_assert_operationid_status(self.nodes[3], myopid, "failed", "Insufficient funds: have 14.99998, need 20.00001; note that coinbase outputs will not be selected if you specify ANY_TADDR or if any transparent recipients are included.")
 
         # Create an expired transaction on node 3.
         self.split_network()
@@ -123,7 +123,7 @@ class WalletSendManyAnyTaddr(BitcoinTestFramework):
         assert_equal(0, self.nodes[2].getbalance())
 
         # Check that ANY_TADDR doesn't select an expired output.
-        wait_and_assert_operationid_status(self.nodes[2], self.nodes[2].z_sendmany('ANY_TADDR', [{'address': recipient, 'amount': 13}]), "failed", "Insufficient funds: have 0.00, need 13.00001")
+        wait_and_assert_operationid_status(self.nodes[2], self.nodes[2].z_sendmany('ANY_TADDR', [{'address': recipient, 'amount': 13}]), "failed", "Insufficient funds: have 0.00, need 13.00001; note that coinbase outputs will not be selected if you specify ANY_TADDR or if any transparent recipients are included.")
 
 if __name__ == '__main__':
     WalletSendManyAnyTaddr().main()

--- a/qa/rpc-tests/wallet_shieldingcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldingcoinbase.py
@@ -88,8 +88,8 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
             errorString = e.error['message']
         assert_equal("Invalid from address, no payment source found for address.", errorString);
 
-        # This send will fail because our consensus does not allow transparent change when 
-        # shielding a coinbase utxo. 
+        # This send will fail because our consensus does not allow transparent change when
+        # shielding a coinbase utxo.
         # TODO: After upgrading to unified address support, change will be sent to the most
         # recent shielded spend authority corresponding to the account of the source address
         # and this send will succeed, causing this test to fail.
@@ -98,9 +98,9 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
 
         myopid = self.nodes[0].z_sendmany(mytaddr, recipients)
         error_result = wait_and_assert_operationid_status_result(
-                self.nodes[0], 
-                myopid, "failed", 
-                "When shielding coinbase funds, the wallet does not allow any change. The proposed transaction would result in 8.76542211 in change.", 
+                self.nodes[0],
+                myopid, "failed",
+                "When shielding coinbase funds, the wallet does not allow any change. The proposed transaction would result in 8.76542211 in change.",
                 10)
 
         # Test that the returned status object contains a params field with the operation's input parameters
@@ -225,7 +225,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         amount = Decimal('10.0') - DEFAULT_FEE - Decimal('0.00000001')    # this leaves change at 1 zatoshi less than dust threshold
         recipients.append({"address":self.nodes[0].getnewaddress(), "amount":amount })
         myopid = self.nodes[0].z_sendmany(mytaddr, recipients, 1)
-        wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "Insufficient funds: have 10.00, need 0.00000053 more to avoid creating invalid change output 0.00000001 (dust threshold is 0.00000054)")
+        wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "Insufficient funds: have 10.00, need 0.00000053 more to avoid creating invalid change output 0.00000001 (dust threshold is 0.00000054); note that coinbase outputs will not be selected if you specify ANY_TADDR or if any transparent recipients are included.")
 
         # Send will fail because send amount is too big, even when including coinbase utxos
         errorString = ""

--- a/qa/rpc-tests/wallet_z_sendmany.py
+++ b/qa/rpc-tests/wallet_z_sendmany.py
@@ -317,7 +317,7 @@ class WalletZSendmanyTest(BitcoinTestFramework):
 
         # If we try to send 3 ZEC from n1ua0, it will fail with too-few funds.
         recipients = [{"address":n0ua0, "amount":3}]
-        linked_addrs_msg = 'Insufficient funds: have 2.00, need 3.00 (This transaction may require selecting transparent coins that were sent to multiple Unified Addresses, which is not enabled by default because it would create a public link between the transparent receivers of these addresses. THIS MAY AFFECT YOUR PRIVACY. Resubmit with the `privacyPolicy` parameter set to `AllowLinkingAccountAddresses` or weaker if you wish to allow this transaction to proceed anyway.)'
+        linked_addrs_msg = 'Insufficient funds: have 2.00, need 3.00. (This transaction may require selecting transparent coins that were sent to multiple Unified Addresses, which is not enabled by default because it would create a public link between the transparent receivers of these addresses. THIS MAY AFFECT YOUR PRIVACY. Resubmit with the `privacyPolicy` parameter set to `AllowLinkingAccountAddresses` or weaker if you wish to allow this transaction to proceed anyway.)'
         opid = self.nodes[1].z_sendmany(n1ua0, recipients, 1, 0)
         wait_and_assert_operationid_status(self.nodes[1], opid, 'failed', linked_addrs_msg)
 

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -203,7 +203,7 @@ uint256 AsyncRPCOperation_sendmany::main_impl() {
             // creating dust change, rather than prohibit them from sending
             // entirely in this circumstance.
             // (Daira disagrees, as this could leak information to the recipient
-            // or to a viewing key holder.)
+            // or to an external viewing key holder.)
             insufficientFundsMessage +=
                 strprintf(
                     ", need %s more to avoid creating invalid change output %s (dust threshold is %s)",

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -202,7 +202,8 @@ uint256 AsyncRPCOperation_sendmany::main_impl() {
             // and send the extra to the recipient or the miner fee to avoid
             // creating dust change, rather than prohibit them from sending
             // entirely in this circumstance.
-            // (Daira disagrees, as this could leak information to the recipient)
+            // (Daira disagrees, as this could leak information to the recipient
+            // or to a viewing key holder.)
             insufficientFundsMessage +=
                 strprintf(
                     ", need %s more to avoid creating invalid change output %s (dust threshold is %s)",
@@ -216,7 +217,7 @@ uint256 AsyncRPCOperation_sendmany::main_impl() {
         throw JSONRPCError(
                 RPC_WALLET_INSUFFICIENT_FUNDS,
                 insufficientFundsMessage
-                + (allowTransparentCoinbase && ztxoSelector_.SelectsTransparentCoinbase() ? "" :
+                + (allowTransparentCoinbase && ztxoSelector_.SelectsTransparentCoinbase() ? "." :
                    "; note that coinbase outputs will not be selected if you specify "
                    "ANY_TADDR or if any transparent recipients are included.")
                 + ((!isFromUa || strategy_.AllowLinkingAccountAddresses()) ? "" :

--- a/src/wallet/asyncrpcoperation_sendmany.h
+++ b/src/wallet/asyncrpcoperation_sendmany.h
@@ -80,7 +80,6 @@ private:
     bool isfromsprout_{false};
     bool isfromsapling_{false};
     TransactionStrategy strategy_;
-    uint32_t transparentRecipients_{0};
     AccountId sendFromAccount_;
     std::set<OutputPool> recipientPools_;
     TxOutputAmounts txOutputAmounts_;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -872,6 +872,7 @@ public:
     }
 
     bool SelectsTransparent() const;
+    bool SelectsTransparentCoinbase() const;
     bool SelectsSprout() const;
     bool SelectsSapling() const;
     bool SelectsOrchard() const;


### PR DESCRIPTION
This also includes the “Insufficient funds” suffixes on dust threshold
failures.

Fixes #6262