### PR TITLE
[Experiment] Flush block database more frequently

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3670,6 +3670,7 @@ bool static FlushStateToDisk(
     LOCK2(cs_main, cs_LastBlockFile);
     static int64_t nLastWrite = 0;
     static int64_t nLastFlush = 0;
+    static int64_t nCallCount = 0;
     std::set<int> setFilesToPrune;
     bool fFlushForPrune = false;
     try {
@@ -3699,6 +3700,10 @@ bool static FlushStateToDisk(
     bool fCacheCritical = mode == FLUSH_STATE_IF_NEEDED && cacheSize > nCoinCacheUsage;
     // It's been a while since we wrote the block index to disk. Do this frequently, so we don't need to redownload after a crash.
     bool fPeriodicWrite = mode == FLUSH_STATE_PERIODIC && nNow > nLastWrite + (int64_t)DATABASE_WRITE_INTERVAL * 1000000;
+    if (mode == FLUSH_STATE_PERIODIC && ++nCallCount >= DATABASE_WRITE_CALL_COUNT) {
+        fPeriodicWrite = true;
+        nCallCount = 0;
+    }
     // It's been very long since we flushed the cache. Do this infrequently, to optimize cache usage.
     bool fPeriodicFlush = mode == FLUSH_STATE_PERIODIC && nNow > nLastFlush + (int64_t)DATABASE_FLUSH_INTERVAL * 1000000;
     // Combine all conditions that result in a full cache flush.

--- a/src/main.h
+++ b/src/main.h
@@ -112,6 +112,8 @@ static const unsigned int MAX_HEADERS_RESULTS = 160;
 static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
 /** Time to wait (in seconds) between writing blocks/block index to disk. */
 static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
+/** Maximum number of calls to FlushStateToDisk with mode == FLUSH_STATE_PERIODIC between database writes. */
+static const unsigned int DATABASE_WRITE_CALL_COUNT = 100;
 /** Time to wait (in seconds) between flushing chainstate to disk. */
 static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;
 /** Time to wait (in seconds) between writing wallet witness data to disk. */


### PR DESCRIPTION
This enforces a maximum number of calls to `FlushStateToDisk` with `mode == FLUSH_STATE_PERIODIC` between database writes.
