### PR TITLE
Appease ShellCheck

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -55,4 +55,5 @@ fi
 zcash-fetch-params
 touch .zcash/zcash.conf
 echo "Starting: ${ZCASHD_CMD}"
-exec "${ZCASHD_CMD}" "${@}"
+# shellcheck disable=SC2294 # see #6297
+eval exec "${ZCASHD_CMD}" "${@}"

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -55,4 +55,4 @@ fi
 zcash-fetch-params
 touch .zcash/zcash.conf
 echo "Starting: ${ZCASHD_CMD}"
-eval exec "${ZCASHD_CMD}" "${@}"
+exec "${ZCASHD_CMD}" "${@}"

--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -13,14 +13,14 @@
 # one. Any remaining diff signals an error.
 
 export LC_ALL=C
-if test "x$1" = "x"; then
+if test -z "$1"; then
     echo "Usage: $0 <commit>..."
     exit 1
 fi
 
 # Check that the working tree is clean (as this script performs hard resets).
 TREE_CHANGES=$(git diff HEAD | wc -l)
-if test "x$TREE_CHANGES" != "x0"; then
+if test "$TREE_CHANGES" != "0"; then
     echo "The working tree is not clean."
     exit 1
 fi
@@ -32,7 +32,7 @@ for commit in $(git rev-list --reverse $1); do
     if git rev-list -n 1 --pretty="%s" $commit | grep -q "^scripted-diff:"; then
         git checkout --quiet $commit^ || exit
         SCRIPT="$(git rev-list --format=%b -n1 $commit | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d')"
-        if test "x$SCRIPT" = "x"; then
+        if test -z "$SCRIPT"; then
             echo "Error: missing script for: $commit"
             echo "Failed"
             RET=1

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -40,7 +40,7 @@ if ! command -v shellcheck > /dev/null; then
 fi
 
 EXCLUDE="--exclude=$(IFS=','; echo "${disabled[*]}")"
-if ! shellcheck "$EXCLUDE" $(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|univalue)/'); then
+if ! shellcheck "$EXCLUDE" $(git ls-files -- '*.sh' | grep -vE '(qa/zcash/checksec\.sh|src/(|leveldb|secp256k1|univalue)/)'); then
     EXIT_CODE=1
 fi
 

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -40,7 +40,7 @@ if [ -z "${CONFIGURE_FLAGS-}" ]; then
     CONFIGURE_FLAGS=""
 fi
 
-if [ "x$*" = 'x--help' ]
+if [ "$*" = '--help' ]
 then
     cat <<EOF
 Usage:

--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -199,10 +199,10 @@ EOF
         # This may be the first time the user's run this script, so give
         # them some info, especially about bandwidth usage:
         cat <<EOF
-The complete parameters are currently just under 1.7GB in size, so plan 
+The complete parameters are currently just under 1.7GB in size, so plan
 accordingly for your bandwidth constraints. If the Sprout parameters are
-already present the additional Sapling parameters required are just under 
-800MB in size. If the files are already present and have the correct 
+already present the additional Sapling parameters required are just under
+800MB in size. If the files are already present and have the correct
 sha256sum, no networking is used.
 
 Creating params directory. For details about this directory, see:
@@ -225,7 +225,7 @@ EOF
     fetch_params "$SAPLING_SPROUT_GROTH16_NAME" "$PARAMS_DIR/$SAPLING_SPROUT_GROTH16_NAME" "b685d700c60328498fbde589c8c7c484c722b788b265b72af448a5bf0ee55b50"
 }
 
-if [ "x${1:-}" = 'x--testnet' ]
+if [ "${1:-}" = '--testnet' ]
 then
     echo "NOTE: testnet now uses the mainnet parameters, so the --testnet argument"
     echo "is no longer needed (ignored)"


### PR DESCRIPTION
ShellCheck has started failing in CI. My guess is that the ubuntu-latest runner
now uses a `/bin/sh` that is actually Bash.

- excludes checksec.sh, as it’s not our code
- fixes lints in other files