### PR TITLE
Update performance-measurements.sh with Heaptrack

### DIFF
--- a/qa/zcash/performance-measurements.sh
+++ b/qa/zcash/performance-measurements.sh
@@ -86,7 +86,7 @@ function zcashd_stop {
     wait $ZCASHD_PID
 }
 
-function zcashd_massif_start {
+function zcashd_heaptrack_start {
     case "$1" in
         sendtoaddress|loadwallet|listunspent)
             case "$2" in
@@ -97,7 +97,7 @@ function zcashd_massif_start {
                     use_200k_benchmark 1
                     ;;
                 *)
-                    echo "Bad arguments to zcashd_massif_start."
+                    echo "Bad arguments to zcashd_heaptrack_start."
                     exit 1
             esac
             ;;
@@ -106,16 +106,14 @@ function zcashd_massif_start {
             mkdir -p "$DATADIR/regtest"
             touch "$DATADIR/zcash.conf"
     esac
-    rm -f massif.out
-    valgrind --tool=massif --time-unit=ms --massif-out-file=massif.out ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 -showmetrics=0 &
+    heaptrack ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 -showmetrics=0 &
     ZCASHD_PID=$!
     zcash_rpc_wait_for_start
 }
 
-function zcashd_massif_stop {
+function zcashd_heaptrack_stop {
     zcash_rpc stop > /dev/null
     wait $ZCASHD_PID
-    ms_print massif.out
 }
 
 function zcashd_valgrind_start {
@@ -258,7 +256,7 @@ case "$1" in
         zcashd_stop
         ;;
     memory)
-        zcashd_massif_start "${@:2}"
+        zcashd_heaptrack_start "${@:2}"
         case "$2" in
             sleep)
                 zcash_rpc zcbenchmark sleep 1
@@ -321,12 +319,11 @@ case "$1" in
                 zcash_rpc zcbenchmark listunspent 1
                 ;;
             *)
-                zcashd_massif_stop
+                zcashd_heaptrack_stop
                 echo "Bad arguments to memory."
                 exit 1
         esac
-        zcashd_massif_stop
-        rm -f massif.out
+        zcashd_heaptrack_stop
         ;;
     valgrind)
         zcashd_valgrind_start


### PR DESCRIPTION
Add heaptrack to benchmarking suite to better support current and future needs of CI/CD. 

On linux systems, install via apt:
```
apt install heaptrack
```
Or from source:
https://github.com/KDE/heaptrack

Heaptrack can be run with a debugger using `-d` with `heaptrack` invocation but please ensure the zcashd is built with debug enabled(note this pr does not use the `-d` param):
```
CONFIGURE_FLAGS='--enable-debug' zcutil/build.sh
```
Then ensure proper flags are set so the debugger can attach gracefully during a heaptrack session:
```
 echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
```

To run against a live zcashd node, simply get the `PID` of zcash and track using `heaptrack -p PID`

To run with existing performance-measurements.sh:
```
./qa/zcash/performance-measurements.sh memory connectblockslow
```
Please ensure the zcash directory contains the benchmark data needed for all of the suite:
1. block-1708048.tar.xz
2. block-107134.tar.xz
3. block-1723244.tar.xz
4. benchmark-200k-UTXOs.tar.xz