### PR TITLE
txdb: Remove const annotation from blockinfo iterator type

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -387,14 +387,14 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
 bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<CBlockIndex*>& blockinfo) {
     MetricsIncrementCounter("zcashd.debug.blocktree.write_batch");
     CDBBatch batch(*this);
-    for (std::vector<std::pair<int, const CBlockFileInfo*> >::const_iterator it=fileInfo.begin(); it != fileInfo.end(); it++) {
-        batch.Write(make_pair(DB_BLOCK_FILES, it->first), *it->second);
+    for (const auto& it : fileInfo) {
+        batch.Write(make_pair(DB_BLOCK_FILES, it.first), *it.second);
     }
     batch.Write(DB_LAST_BLOCK, nLastFile);
-    for (std::vector<CBlockIndex*>::const_iterator it=blockinfo.begin(); it != blockinfo.end(); it++) {
-        std::pair<char, uint256> key = make_pair(DB_BLOCK_INDEX, (*it)->GetBlockHash());
+    for (const auto& it : blockinfo) {
+        std::pair<char, uint256> key = make_pair(DB_BLOCK_INDEX, it->GetBlockHash());
         try {
-            CDiskBlockIndex dbindex {*it, [this, &key]() {
+            CDiskBlockIndex dbindex {it, [this, &key]() {
                 MetricsIncrementCounter("zcashd.debug.blocktree.write_batch_read_dbindex");
                 // It can happen that the index entry is written, then the Equihash solution is cleared from memory,
                 // then the index entry is rewritten. In that case we must read the solution from the old entry.

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -391,7 +391,7 @@ bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockF
         batch.Write(make_pair(DB_BLOCK_FILES, it->first), *it->second);
     }
     batch.Write(DB_LAST_BLOCK, nLastFile);
-    for (std::vector<const CBlockIndex*>::const_iterator it=blockinfo.begin(); it != blockinfo.end(); it++) {
+    for (std::vector<CBlockIndex*>::const_iterator it=blockinfo.begin(); it != blockinfo.end(); it++) {
         std::pair<char, uint256> key = make_pair(DB_BLOCK_INDEX, (*it)->GetBlockHash());
         try {
             CDiskBlockIndex dbindex {*it, [this, &key]() {


### PR DESCRIPTION
The const annotation was removed from the blockinfo type in zcash/zcash#6192, but not from the type of its iterator. Recent Clang versions are able to handle this, but GCC 11 (and it appears older Clang versions) raise an error.

Closes zcash/zcash#6306.