### PR TITLE
Remove CentOS 8 as a supported platform

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -33,11 +33,6 @@ import os
 # - g++ version 8.0.1 (https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/g/ search for gcc-)
 # - libc6 version 2.27 (https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/g/ search for glibc)
 #
-# CentOS 8 (Full update EOL May 2024, Maintenance EOL 2029-05-31) has:
-#
-# - g++ version 8.3.1 (https://centos.pkgs.org/8/centos-baseos-x86_64/ search for libgcc)
-# - libc6 version 2.28 (https://centos.pkgs.org/8/centos-baseos-x86_64/ search for glibc)
-#
 # Fedora 31 (EOL ~November 2020) has:
 #
 # - g++ version 9.2.1 (https://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/ search for gcc-)

--- a/doc/book/src/user/platform-support.md
+++ b/doc/book/src/user/platform-support.md
@@ -15,8 +15,7 @@ be removed from tier 1. These dates are subject to change.
 
 | target                  | OS           | End of Support |
 | ----------------------- | ------------ | -------------- |
-| `x86_64-pc-linux-gnu`   | CentOS 8     | TBD            |
-|                         | Debian 10    | June 2024      |
+| `x86_64-pc-linux-gnu`   | Debian 10    | June 2024      |
 |                         | Debian 11    | June 2026      |
 |                         | Ubuntu 18.04 | April 2023     |
 |                         | Ubuntu 20.04 | April 2025     |

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -45,3 +45,9 @@ The following previously-deprecated features have been removed:
 - `zcrawreceive`
 - `zcrawjoinsplit`
 - `zcrawkeygen`
+
+Platform Support
+----------------
+
+- CentOS 8 has been removed from the list of supported platforms. It reached EoL
+  on December 31st 2021, and does not satisfy our Tier 2 policy requirements.


### PR DESCRIPTION
CentOS 8 reached EoL on December 31st 2021, and no longer satisfies our Tier 2 platform requirements.

Part of zcash/zcash#6340.