### PR TITLE
Explicitly set Cargo’s target-dir

### DIFF
--- a/.cargo/config.offline
+++ b/.cargo/config.offline
@@ -1,3 +1,6 @@
+[build]
+target-dir = "target"
+
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 


### PR DESCRIPTION
We rely on it being `target` (see src/Makefile.am:31), so ensure user configs
don’t trample the value.

I would prefer to have our code use the configured value instead of setting it,
but that seems convoluted to get right, as there are independent config and env
var settings and no way to ask cargo what the current setting is (e.g.,
`cargo config --get build.target-dir`[^1]). So setting it seems the most
reasonable option.

[^1]: There is a `cargo config get`, but it dumps the entire config and does not
take into account env vars.