### PR TITLE
Increase the time that the wallet will wait for the block index to load

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,6 +4,13 @@ release-notes at release time)
 Notable changes
 ===============
 
+Fixes
+-----
+
+This release fixes an issue that could potentially cause a node to crash with the
+log message "The wallet's best block hash `<hash>` was not detected in restored
+chain state. Giving up; please restart with `-rescan`."
+
 RPC Changes
 -----------
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -87,7 +87,7 @@ static const bool DEFAULT_STOPAFTERBLOCKIMPORT = false;
 
 // The time that the wallet will wait for the block index to load
 // during startup before timing out.
-static const int64_t WALLET_INITIAL_SYNC_TIMEOUT = 1000 * 60 * 5;
+static const int64_t WALLET_INITIAL_SYNC_TIMEOUT = 1000 * 60 * 60 * 2;
 
 #if ENABLE_ZMQ
 static CZMQNotificationInterface* pzmqNotificationInterface = NULL;


### PR DESCRIPTION
This timeout is increased from 5 minutes to 2 hours. closes #6103 (see discussion on that issue for the choice of timeout).