### PR TITLE
Fetch recently conflicted transactions incrementally in ThreadNotifyWallet

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -42,6 +42,18 @@ heights prior to this will not have any information recorded. To track changes
 from genesis, and thus monitor the total transparent pool size and chain supply,
 you would need to restart your node with the `-reindex` option.
 
+Wallet Performance Fixes
+------------------------
+
+The 100MiB memory limit for the batch scanner has been replaced by a 1000-block
+limit. This eliminates an expensive call to determine the current memory usage 
+of the batch scanner. 
+
+The following associated metric has been removed from the set of metrics
+reported when `-prometheusport` is set:
+
+- (gauge) `zcashd.wallet.batchscanner.usage.bytes`
+
 RPC Changes
 -----------
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4132,7 +4132,13 @@ std::pair<std::list<CTransaction>, std::optional<uint64_t>> TakeRecentlyConflict
 {
     AssertLockHeld(cs_main);
 
-    std::list<CTransaction> conflictedTxs = recentlyConflictedTxs.at(pindex);
+    // We use bracket notation for retrieving conflict data from recentlyConflictedTxs
+    // here because when a node restarts, the wallet may be behind the node's view of
+    // the current chain tip. The node may continue reindexing from the chain tip, but
+    // no entries will exist in `recentlyConflictedTxs` until the next block after the
+    // node's chain tip at the point of shutdown. In these cases, the wallet cannot learn
+    // about conflicts in those blocks (which should be fine).
+    std::list<CTransaction> conflictedTxs = recentlyConflictedTxs[pindex];
     recentlyConflictedTxs.erase(pindex);
     if (recentlyConflictedTxs.empty()) {
         return std::make_pair(conflictedTxs, nConnectedSequence);

--- a/src/main.h
+++ b/src/main.h
@@ -668,7 +668,8 @@ CMutableTransaction CreateNewContextualCMutableTransaction(
     int nHeight,
     bool requireV4);
 
-std::pair<std::map<CBlockIndex*, std::list<CTransaction>>, uint64_t> DrainRecentlyConflicted();
+std::pair<std::list<CTransaction>, std::optional<uint64_t>> TakeRecentlyConflicted(const CBlockIndex* pindex);
+uint64_t GetChainConnectedSequence();
 void SetChainNotifiedSequence(const CChainParams& chainparams, uint64_t recentlyConflictedSequence);
 bool ChainIsFullyNotified(const CChainParams& chainparams);
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -118,8 +118,6 @@ struct CachedBlockData {
 
 void ThreadNotifyWallets(CBlockIndex *pindexLastTip)
 {
-    size_t nBatchScannerMemLimit = DEFAULT_BATCHSCANNERMEMLIMIT * 1024 * 1024;
-
     // If pindexLastTip == nullptr, the wallet is at genesis.
     // However, the genesis block is not loaded synchronously.
     // We need to wait for ThreadImport to finish.

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -17,6 +17,8 @@
 
 /** Default limit on batch scanner memory usage in MiB. */
 static const size_t DEFAULT_BATCHSCANNERMEMLIMIT = 100;
+/** Limit on batch scanner memory usage in MiB. */
+static const size_t WALLET_NOTIFY_MAX_BLOCKS = 1000;
 
 class CBlock;
 class CBlockIndex;
@@ -29,11 +31,6 @@ class uint256;
 
 class BatchScanner {
 public:
-    /**
-     * Returns the current dynamic memory usage of this batch scanner.
-     */
-    virtual size_t RecursiveDynamicUsage() = 0;
-
     /**
      * Adds a transaction to the batch scanner.
      *

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -15,9 +15,10 @@
 #include "miner.h"
 #include "zcash/IncrementalMerkleTree.hpp"
 
-/** Default limit on batch scanner memory usage in MiB. */
-static const size_t DEFAULT_BATCHSCANNERMEMLIMIT = 100;
-/** Limit on batch scanner memory usage in MiB. */
+/**
+ * Limit on the maximum number of blocks that will be staged for
+ * scanning before an interrupt will be handled.
+ */
 static const size_t WALLET_NOTIFY_MAX_BLOCKS = 1000;
 
 class CBlock;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1455,6 +1455,15 @@ void CWallet::ChainTip(const CBlockIndex *pindex,
         DecrementNoteWitnesses(consensus, pindex);
         UpdateSaplingNullifierNoteMapForBlock(pblock);
     }
+
+    auto hash = tfm::format("%s", pindex->GetBlockHash().ToString());
+    auto height = tfm::format("%d", pindex->nHeight);
+    auto kind = tfm::format("%s", added.has_value() ? "connect" : "disconnect");
+
+    TracingInfo("wallet", "CWallet::ChainTip: processed block",
+        "hash", hash.c_str(),
+        "height", height.c_str(),
+        "kind", kind.c_str());
 }
 
 void CWallet::RunSaplingMigration(int blockHeight) {
@@ -3596,11 +3605,6 @@ bool WalletBatchScanner::AddToWalletIfInvolvingMe(
 //
 // BatchScanner APIs
 //
-
-size_t WalletBatchScanner::RecursiveDynamicUsage()
-{
-    return inner->get_dynamic_usage();
-}
 
 void WalletBatchScanner::AddTransaction(
     const CTransaction &tx,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1148,8 +1148,6 @@ public:
     // BatchScanner APIs
     //
 
-    size_t RecursiveDynamicUsage();
-
     void AddTransaction(
         const CTransaction &tx,
         const std::vector<unsigned char> &txBytes,


### PR DESCRIPTION
We no longer fetch updates from the mempool unless we have fetched all updates from the chain, as we would otherwise notify the wallet of mempool changes for which they have not observed parent transactions in the chain.