### PR TITLE
Allow rescan to exit in the case that Ctrl-C is pressed.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4679,13 +4679,13 @@ void CWallet::WitnessNoteCommitment(std::vector<uint256> commitments,
  * from or to us. If fUpdate is true, found transactions that already
  * exist in the wallet will be updated.
  */
-int CWallet::ScanForWalletTransactions(
+std::optional<int> CWallet::ScanForWalletTransactions(
         CBlockIndex* pindexStart,
         bool fUpdate,
         bool isInitScan)
 {
     assert(pindexStart != nullptr);
-    int ret = 0;
+    int myTransactionsFound = 0;
     int64_t nNow = GetTime();
     const CChainParams& chainParams = Params();
     const auto& consensus = chainParams.GetConsensus();
@@ -4756,6 +4756,9 @@ int CWallet::ScanForWalletTransactions(
         double dProgressTip = Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip(), false);
         while (pindex)
         {
+            // Allow the rescan to be interrupted on a block boundary.
+            if (ShutdownRequested()) return std::nullopt;
+
             if (pindex->nHeight % 100 == 0 && dProgressTip - dProgressStart > 0.0)
                 ShowProgress(_("Rescanning..."), std::max(1, std::min(99, (int)((Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), pindex, false) - dProgressStart) / (dProgressTip - dProgressStart) * 100))));
 
@@ -4775,7 +4778,7 @@ int CWallet::ScanForWalletTransactions(
             {
                 if (batchScanner.AddToWalletIfInvolvingMe(consensus, tx, &block, pindex->nHeight, fUpdate)) {
                     myTxHashes.push_back(tx.GetHash());
-                    ret++;
+                    myTransactionsFound++;
                 }
             }
 
@@ -4820,7 +4823,7 @@ int CWallet::ScanForWalletTransactions(
 
         ShowProgress(_("Rescanning..."), 100); // hide progress dialog in GUI
     }
-    return ret;
+    return myTransactionsFound;
 }
 
 void CWallet::ReacceptWalletTransactions()
@@ -6810,7 +6813,10 @@ bool CWallet::InitLoadWallet(const CChainParams& params, bool clearWitnessCaches
                 chainActive.Height() - pindexRescan->nHeight,
                 pindexRescan->nHeight);
         nStart = GetTimeMillis();
-        walletInstance->ScanForWalletTransactions(pindexRescan, true, true);
+        if (!walletInstance->ScanForWalletTransactions(pindexRescan, true, true).has_value()) {
+            return UIError(_("CWallet::InitLoadWallet: rescan interrupted due to shutdown request."));
+        }
+
         LogPrintf(" rescan      %15dms\n", GetTimeMillis() - nStart);
         walletInstance->SetBestChain(chainActive.GetLocator());
         CWalletDB::IncrementUpdateCounter();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1859,7 +1859,7 @@ public:
          std::vector<uint256> commitments,
          std::vector<std::optional<SproutWitness>>& witnesses,
          uint256 &final_anchor);
-    int ScanForWalletTransactions(
+    std::optional<int> ScanForWalletTransactions(
         CBlockIndex* pindexStart,
         bool fUpdate,
         bool isInitScan);


### PR DESCRIPTION
Wallet rescanning that happens on node startup was previously not respecting Ctrl-C. We use an explicit check of `ShutdownRequested()` instead of a `boost::interruption_point` because wallet startup does not run in a separate thread.

Co-authored-by: Jack Grigg <jack@z.cash>