### PR TITLE
Defer z_getbalance and z_gettotalbalance disablement.

### DIFF
--- a/doc/book/src/user/deprecation.md
+++ b/doc/book/src/user/deprecation.md
@@ -37,6 +37,8 @@ the node, or if an `allowdeprecated=none` line is added to `zcash.conf`.
 
 | `feature`             | Deprecated | Feature details
 |-----------------------|------------|----------------
+| `z_getbalance`        | 5.0.0      | The `z_getbalance` RPC method.
+| `z_gettotalbalance`   | 5.0.0      | The `z_gettotalbalance` RPC method.
 | `gbt_oldhashes`       | 5.4.0      | The `finalsaplingroothash`, `lightclientroothash`, and `blockcommitmentshash` fields in the output of `getblocktemplate`, which are replaced by the `defaultroots` field.
 
 Stage 2
@@ -51,8 +53,6 @@ line to `zcash.conf`.
 | `legacy_privacy`      | 5.0.0      | The default "legacy" privacy policy for `z_sendmany` has been replaced by the `FullPrivacy` directive.
 | `getnewaddress`       | 5.0.0      | The `getnewaddress` RPC method.
 | `getrawchangeaddress` | 5.0.0      | The `getrawchangeaddress` RPC method.
-| `z_getbalance`        | 5.0.0      | The `z_getbalance` RPC method.
-| `z_gettotalbalance`   | 5.0.0      | The `z_gettotalbalance` RPC method.
 | `z_getnewaddress`     | 5.0.0      | The `z_getnewaddress` RPC method.
 | `z_listaddresses`     | 5.0.0      | The `z_listaddresses` RPC method.
 | `addrtype`            | 5.0.0      | The `type` attribute is deprecated in the results of RPC methods that return address metadata. It is recommended that applications using this metadata be updated to use the `pool` or `address_type` attributes, which have replaced the `type` attribute, as appropriate.

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -94,8 +94,6 @@ will be removed in 18 weeks:
 - `legacy_privacy`
 - `getnewaddress`
 - `getrawchangeaddress`
-- `z_getbalance`
-- `z_gettotalbalance`
 - `z_getnewaddress`
 - `z_listaddresses`
 - `addrtype`

--- a/src/deprecation.h
+++ b/src/deprecation.h
@@ -23,10 +23,12 @@ static const int DEPRECATION_WARN_LIMIT = 14 * 24 * EXPECTED_BLOCKS_PER_HOUR;
 //! Defaults for -allowdeprecated
 static const std::set<std::string> DEFAULT_ALLOW_DEPRECATED{{
     // Node-level features
-    "gbt_oldhashes"
+    "gbt_oldhashes",
 
     // Wallet-level features
 #ifdef ENABLE_WALLET
+    "z_getbalance",
+    "z_gettotalbalance",
 #endif
 }};
 static const std::set<std::string> DEFAULT_DENY_DEPRECATED{{
@@ -38,11 +40,9 @@ static const std::set<std::string> DEFAULT_DENY_DEPRECATED{{
     "getnewaddress",
     "getrawchangeaddress",
     "z_getnewaddress",
-    "z_getbalance",
-    "z_gettotalbalance",
     "z_listaddresses",
     "addrtype",
-    "wallettxvjoinsplit"
+    "wallettxvjoinsplit",
 #endif
 }};
 


### PR DESCRIPTION
These disable-by-default changes need to be deferred until we have a better replacement that provides a single source for summary balance information.