### PR TITLE
Change to a more recent URL format for GitHub archives

### DIFF
--- a/depends/packages/googletest.mk
+++ b/depends/packages/googletest.mk
@@ -1,6 +1,6 @@
 package=googletest
 $(package)_version=1.12.1
-$(package)_download_path=https://github.com/google/$(package)/archive/
+$(package)_download_path=https://github.com/google/$(package)/archive/refs/tags
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_download_file=release-$($(package)_version).tar.gz
 $(package)_sha256_hash=81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,6 +1,6 @@
 package=libevent
 $(package)_version=2.1.12
-$(package)_download_path=https://github.com/libevent/libevent/archive/
+$(package)_download_path=https://github.com/libevent/libevent/archive/refs/tags
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_download_file=release-$($(package)_version)-stable.tar.gz
 $(package)_sha256_hash=7180a979aaa7000e1264da484f712d403fcf7679b1e9212c4e3d09f5c93efc24

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -1,6 +1,6 @@
 package=native_cctools
 $(package)_version=55562e4073dea0fbfd0b20e0bf69ffe6390c7f97
-$(package)_download_path=https://github.com/tpoechtrager/cctools-port/archive
+$(package)_download_path=https://github.com/tpoechtrager/cctools-port/archive/refs/tags
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=e51995a843533a3dac155dd0c71362dd471597a2d23f13dff194c6285362f875
 $(package)_build_subdir=cctools
@@ -8,7 +8,7 @@ $(package)_dependencies=native_clang
 $(package)_patches=ignore-otool.diff
 
 $(package)_libtapi_version=3efb201881e7a76a21e0554906cf306432539cef
-$(package)_libtapi_download_path=https://github.com/tpoechtrager/apple-libtapi/archive
+$(package)_libtapi_download_path=https://github.com/tpoechtrager/apple-libtapi/archive/refs/tags
 $(package)_libtapi_download_file=$($(package)_libtapi_version).tar.gz
 $(package)_libtapi_file_name=$($(package)_libtapi_version).tar.gz
 $(package)_libtapi_sha256_hash=380c1ca37cfa04a8699d0887a8d3ee1ad27f3d08baba78887c73b09485c0fbd3

--- a/depends/packages/tl_expected.mk
+++ b/depends/packages/tl_expected.mk
@@ -1,6 +1,6 @@
 package=tl_expected
 $(package)_version=1.0.1
-$(package)_download_path=https://github.com/TartanLlama/expected/archive
+$(package)_download_path=https://github.com/TartanLlama/expected/archive/refs/tags
 $(package)_download_file=96d547c03d2feab8db64c53c3744a9b4a7c8f2c5.tar.gz
 $(package)_file_name=tl-expected-1.0.1.tar.gz
 $(package)_sha256_hash=64901df1de9a5a3737b331d3e1de146fa6ffb997017368b322c08f45c51b90a7

--- a/depends/packages/utfcpp.mk
+++ b/depends/packages/utfcpp.mk
@@ -1,6 +1,6 @@
 package=utfcpp
 $(package)_version=3.2.3
-$(package)_download_path=https://github.com/nemtrif/$(package)/archive/
+$(package)_download_path=https://github.com/nemtrif/$(package)/archive/refs/tags
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_download_file=v$($(package)_version).tar.gz
 $(package)_sha256_hash=3ba9b0dbbff08767bdffe8f03b10e596ca351228862722e4c9d4d126d2865250


### PR DESCRIPTION
Use URLs with path ending `archive/refs/tags`.