### PR TITLE
Retroactively enable ZIP 216 before NU5 activation

### DIFF
--- a/src/rust/include/librustzcash.h
+++ b/src/rust/include/librustzcash.h
@@ -97,7 +97,6 @@ extern "C" {
     /// The result is also of length 32 and placed in `result`.
     /// Returns false if the diversifier or pk_d is not valid
     bool librustzcash_sapling_compute_cmu(
-        bool zip216_enabled,
         const unsigned char *diversifier,
         const unsigned char *pk_d,
         const uint64_t value,
@@ -111,7 +110,6 @@ extern "C" {
     /// the result is written to the 32-byte
     /// `result` buffer.
     bool librustzcash_sapling_ka_agree(
-        bool zip216_enabled,
         const unsigned char *p,
         const unsigned char *sk,
         unsigned char *result

--- a/src/rust/src/tests/key_agreement.rs
+++ b/src/rust/src/tests/key_agreement.rs
@@ -43,7 +43,6 @@ fn test_key_agreement() {
     let addr_pk_d = addr.pk_d().to_bytes();
 
     assert!(librustzcash_sapling_ka_agree(
-        true,
         &addr_pk_d,
         &esk,
         &mut shared_secret_sender
@@ -61,7 +60,6 @@ fn test_key_agreement() {
     // Create sharedSecret with ephemeral key
     let mut shared_secret_recipient = [0u8; 32];
     assert!(librustzcash_sapling_ka_agree(
-        true,
         &epk,
         &ivk_serialized,
         &mut shared_secret_recipient

--- a/src/rust/src/tests/notes.rs
+++ b/src/rust/src/tests/notes.rs
@@ -649,7 +649,6 @@ fn notes() {
         // Compute commitment and compare with test vector
         let mut result = [0u8; 32];
         assert!(librustzcash_sapling_compute_cmu(
-            true,
             &tv.default_d,
             &tv.default_pk_d,
             tv.note_v,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4415,8 +4415,6 @@ std::optional<std::pair<
     SaplingPaymentAddress>> CWalletTx::RecoverSaplingNoteWithoutLeadByteCheck(SaplingOutPoint op, std::set<uint256>& ovks) const
 {
     auto output = this->vShieldedOutput[op.n];
-    // ZIP 216: This wallet method is not called from consensus rules.
-    bool zip216Enabled = true;
 
     for (auto ovk : ovks) {
         auto outPt = SaplingOutgoingPlaintext::decrypt(
@@ -4431,14 +4429,13 @@ std::optional<std::pair<
         }
 
         auto optDeserialized = SaplingNotePlaintext::attempt_sapling_enc_decryption_deserialization(
-            zip216Enabled, output.encCiphertext, output.ephemeralKey, outPt->esk, outPt->pk_d);
+            output.encCiphertext, output.ephemeralKey, outPt->esk, outPt->pk_d);
 
         // The transaction would not have entered the wallet unless
         // its plaintext had been successfully decrypted previously.
         assert(optDeserialized != std::nullopt);
 
         auto maybe_pt = SaplingNotePlaintext::plaintext_checks_without_height(
-            zip216Enabled,
             *optDeserialized,
             output.ephemeralKey,
             outPt->esk,

--- a/src/zcash/Note.hpp
+++ b/src/zcash/Note.hpp
@@ -193,7 +193,6 @@ public:
     );
 
     static std::optional<SaplingNotePlaintext> plaintext_checks_without_height(
-        bool zip216Enabled,
         const SaplingNotePlaintext &plaintext,
         const uint256 &epk,
         const uint256 &esk,
@@ -202,7 +201,6 @@ public:
     );
 
     static std::optional<SaplingNotePlaintext> attempt_sapling_enc_decryption_deserialization(
-        bool zip216Enabled,
         const SaplingEncCiphertext &ciphertext,
         const uint256 &epk,
         const uint256 &esk,

--- a/src/zcash/NoteEncryption.cpp
+++ b/src/zcash/NoteEncryption.cpp
@@ -115,9 +115,9 @@ std::optional<SaplingEncCiphertext> SaplingNoteEncryption::encrypt_to_recipient(
     uint256 dhsecret;
 
     // The new consensus rules from ZIP 216 (https://zips.z.cash/zip-0216#specification)
-    // on pk_d are enabled unconditionally, as they MAY be enforced in advance of NU5
-    // activation.
-    if (!librustzcash_sapling_ka_agree(true, pk_d.begin(), esk.begin(), dhsecret.begin())) {
+    // on pk_d were enabled unconditionally, even before we started to apply them
+    // retroactively.
+    if (!librustzcash_sapling_ka_agree(pk_d.begin(), esk.begin(), dhsecret.begin())) {
         return std::nullopt;
     }
 
@@ -150,9 +150,10 @@ std::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
 {
     uint256 dhsecret;
 
-    // ZIP 216: We can enable the rules unconditionally, because ephemeralKey has always
-    // been required to not be small-order (https://zips.z.cash/zip-0216#specification).
-    if (!librustzcash_sapling_ka_agree(true, epk.begin(), ivk.begin(), dhsecret.begin())) {
+    // We consider ZIP 216 active all of the time because blocks prior to NU5
+    // activation (on mainnet and testnet) did not contain Sapling transactions
+    // that violated its canonicity rule.
+    if (!librustzcash_sapling_ka_agree(epk.begin(), ivk.begin(), dhsecret.begin())) {
         return std::nullopt;
     }
 
@@ -180,7 +181,6 @@ std::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
 }
 
 std::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
-    bool zip216Enabled,
     const SaplingEncCiphertext &ciphertext,
     const uint256 &epk,
     const uint256 &esk,
@@ -189,7 +189,10 @@ std::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
 {
     uint256 dhsecret;
 
-    if (!librustzcash_sapling_ka_agree(zip216Enabled, pk_d.begin(), esk.begin(), dhsecret.begin())) {
+    // We consider ZIP 216 active all of the time because blocks prior to NU5
+    // activation (on mainnet and testnet) did not contain Sapling transactions
+    // that violated its canonicity rule.
+    if (!librustzcash_sapling_ka_agree(pk_d.begin(), esk.begin(), dhsecret.begin())) {
         return std::nullopt;
     }
 

--- a/src/zcash/NoteEncryption.hpp
+++ b/src/zcash/NoteEncryption.hpp
@@ -77,7 +77,6 @@ std::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
 // Attempts to decrypt a Sapling note using outgoing plaintext.
 // This will not check that the contents of the ciphertext are correct.
 std::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
-    bool zip216Enabled,
     const SaplingEncCiphertext &ciphertext,
     const uint256 &epk,
     const uint256 &esk,


### PR DESCRIPTION
This completes the work started in zcash/zcash#6000.

Closes zcash/zcash#6396.