### PR TITLE
rust: Compile with ThinLTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ default-features = false
 features = ["ansi", "env-filter", "fmt", "time"]
 
 [profile.release]
-lto = true
+lto = 'thin'
 panic = 'abort'
 codegen-units = 1
 


### PR DESCRIPTION
This should achieve similar performance gains to "fat" LTO (which we were previously using) while taking substantially less time to run (over 20s saved on a Ryzen 9 5950X).

Part of zcash/zcash#6065.