### PR TITLE
Lock notes (except Orchard) in wallet_tx_builder

### DIFF
--- a/src/wallet/asyncrpcoperation_sendmany.h
+++ b/src/wallet/asyncrpcoperation_sendmany.h
@@ -64,7 +64,7 @@ private:
     CAmount fee_;
     UniValue contextinfo_;     // optional data to include in return value from getStatus()
 
-    uint256 main_impl();
+    uint256 main_impl(CWallet& wallet);
 };
 
 // To test private methods, a friend class can act as a proxy
@@ -74,8 +74,8 @@ public:
 
     TEST_FRIEND_AsyncRPCOperation_sendmany(std::shared_ptr<AsyncRPCOperation_sendmany> ptr) : delegate(ptr) {}
 
-    uint256 main_impl() {
-        return delegate->main_impl();
+    uint256 main_impl(CWallet& wallet) {
+        return delegate->main_impl(wallet);
     }
 
     void set_state(OperationStatus state) {

--- a/src/wallet/wallet_tx_builder.h
+++ b/src/wallet/wallet_tx_builder.h
@@ -160,10 +160,6 @@ private:
     int anchorHeight;
 
 public:
-    /**
-     * This class locks the `SpendableInputs` provided to it. `UnlockSpendable` must be called to
-     * release them before the instance goes out of scope.
-     */
     TransactionEffects(
         uint32_t anchorConfirmations,
         SpendableInputs spendable,
@@ -192,13 +188,18 @@ public:
     }
 
     /**
-     * This is automatically called by the constructor, so it’s not generally necessary to call this
-     * otherwise.
+     * This should be called upon creating `TransactionEffects`, it locks exactly the notes that
+     * will be spent in the built transaction.
      */
     void LockSpendable(CWallet& wallet) const;
 
     /**
-     * This should be called just before the `TransactionEffects` goes out of scope.
+     * This should be called when we are finished with the transaction (whether it succeeds or
+     * fails).
+     *
+     * TODO: This currently needs to be called while the `TransactionEffects` exists. In future, it
+     *       would be useful to keep these notes locked until we have confirmation that the tx is on
+     *       the chain or not.
      */
     void UnlockSpendable(CWallet& wallet) const;
 

--- a/src/wallet/wallet_tx_builder.h
+++ b/src/wallet/wallet_tx_builder.h
@@ -48,7 +48,9 @@ public:
             PaymentAddress address,
             CAmount amount,
             std::optional<Memo> memo) :
-        address(address), amount(amount), memo(memo) {}
+        address(address), amount(amount), memo(memo) {
+        assert(amount >= 0);
+    }
 
     const PaymentAddress& GetAddress() const {
         return address;
@@ -158,6 +160,10 @@ private:
     int anchorHeight;
 
 public:
+    /**
+     * This class locks the `SpendableInputs` provided to it. `UnlockSpendable` must be called to
+     * release them before the instance goes out of scope.
+     */
     TransactionEffects(
         uint32_t anchorConfirmations,
         SpendableInputs spendable,
@@ -184,6 +190,17 @@ public:
     const SpendableInputs& GetSpendable() const {
         return spendable;
     }
+
+    /**
+     * This is automatically called by the constructor, so it’s not generally necessary to call this
+     * otherwise.
+     */
+    void LockSpendable(CWallet& wallet) const;
+
+    /**
+     * This should be called just before the `TransactionEffects` goes out of scope.
+     */
+    void UnlockSpendable(CWallet& wallet) const;
 
     const Payments& GetPayments() const {
         return payments;


### PR DESCRIPTION
This fixes an RPC test failure that tests specifically for this with z_shieldcoinbase. This also exposed an issue where an overly-high fee resulted in a negative Payment causing an exception too deep. Added an assert when creating a Payment and guarded against it for z_shieldcoinbase.

Fixes https://github.com/zcash/zcash/issues/2621 and https://github.com/zcash/zcash/issues/5654 (but does not handle Orchard locking, which is tracked in a separate issue).