### PR TITLE
Require `AllowRevealedRecipients` for transparent change

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -25,9 +25,10 @@ RPC Changes
   while you should already be checking the async operation status, there are now
   more cases that may trigger failure at that stage.
 - The `AllowRevealedRecipients` privacy policy is now required in order to choose a
-  transparent change address for a transaction (and thus `AllowFullyTransparent`
-  is required for the transaction, since transparent change implies a
-  transparent sender).
+  transparent change address for a transaction. This will only occur when the wallet 
+  is unable to construct the transaction without selecting funds from the transparent 
+  pool, so the impact of this change is that for such transactions, the user must specify
+  `AllowFullyTransparent`.
 
 [Deprecations](https://zcash.github.io/zcash/user/deprecation.html)
 --------------

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -24,6 +24,10 @@ RPC Changes
 - Several `z_sendmany` failures have moved from synchronous to asynchronous, so
   while you should already be checking the async operation status, there are now
   more cases that may trigger failure at that stage.
+- The `AllowRevealedRecipients` privacy policy is now required in order to choose a
+  transparent change address for a transaction (and thus `AllowFullyTransparent`
+  is required for the transaction, since transparent change implies a
+  transparent sender).
 
 [Deprecations](https://zcash.github.io/zcash/user/deprecation.html)
 --------------

--- a/qa/rpc-tests/mempool_nu_activation.py
+++ b/qa/rpc-tests/mempool_nu_activation.py
@@ -62,7 +62,7 @@ class MempoolUpgradeActivationTest(BitcoinTestFramework):
         node1_taddr = get_coinbase_address(self.nodes[1])
         node0_zaddr = self.nodes[0].z_getnewaddress('sapling')
         recipients = [{'address': node0_zaddr, 'amount': Decimal('10')}]
-        myopid = self.nodes[1].z_sendmany(node1_taddr, recipients, 1, 0)
+        myopid = self.nodes[1].z_sendmany(node1_taddr, recipients, 1, 0, 'AllowRevealedSenders')
         print(wait_and_assert_operationid_status(self.nodes[1], myopid))
         self.sync_all()
         self.nodes[0].generate(1)

--- a/qa/rpc-tests/mempool_nu_activation.py
+++ b/qa/rpc-tests/mempool_nu_activation.py
@@ -62,7 +62,7 @@ class MempoolUpgradeActivationTest(BitcoinTestFramework):
         node1_taddr = get_coinbase_address(self.nodes[1])
         node0_zaddr = self.nodes[0].z_getnewaddress('sapling')
         recipients = [{'address': node0_zaddr, 'amount': Decimal('10')}]
-        myopid = self.nodes[1].z_sendmany(node1_taddr, recipients, 1, 0, 'AllowRevealedSenders')
+        myopid = self.nodes[1].z_sendmany(node1_taddr, recipients, 1, 0)
         print(wait_and_assert_operationid_status(self.nodes[1], myopid))
         self.sync_all()
         self.nodes[0].generate(1)

--- a/qa/rpc-tests/regtest_signrawtransaction.py
+++ b/qa/rpc-tests/regtest_signrawtransaction.py
@@ -29,11 +29,11 @@ class RegtestSignrawtransactionTest (BitcoinTestFramework):
         self.sync_all()
 
         # Create and sign Sapling transaction.
-        # If the incorrect consensus branch id is selected, there will be a signing error. 
+        # If the incorrect consensus branch id is selected, there will be a signing error.
         opid = self.nodes[1].z_sendmany(
             taddr,
             [{'address': zaddr1, 'amount': 1}],
-            1, DEFAULT_FEE, 'AllowRevealedSenders')
+            1, DEFAULT_FEE, 'AllowFullyTransparent')
         wait_and_assert_operationid_status(self.nodes[1], opid)
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/wallet_changeaddresses.py
+++ b/qa/rpc-tests/wallet_changeaddresses.py
@@ -44,7 +44,7 @@ class WalletChangeAddressesTest(BitcoinTestFramework):
         midAddr = self.nodes[0].z_getnewaddress('sapling')
         myopid = self.nodes[0].z_shieldcoinbase(get_coinbase_address(self.nodes[0]), midAddr, 0)['opid']
         wait_and_assert_operationid_status(self.nodes[0], myopid)
-        
+
         self.sync_all()
         self.nodes[1].generate(1)
         self.sync_all()
@@ -87,7 +87,7 @@ class WalletChangeAddressesTest(BitcoinTestFramework):
 
         print()
         print('Checking z_sendmany(taddr->Sapling)')
-        check_change_taddr_reuse(saplingAddr, 'AllowRevealedSenders')
+        check_change_taddr_reuse(saplingAddr, 'AllowFullyTransparent')
         print()
         print('Checking z_sendmany(taddr->taddr)')
         check_change_taddr_reuse(taddr, 'AllowFullyTransparent')

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -67,7 +67,7 @@ class ListReceivedTest (BitcoinTestFramework):
         opid = self.nodes[1].z_sendmany(taddr, [
             {'address': zaddr1, 'amount': 1, 'memo': my_memo},
             {'address': zaddrExt, 'amount': 2},
-        ], 1, DEFAULT_FEE, 'AllowRevealedSenders')
+        ], 1, DEFAULT_FEE, 'AllowFullyTransparent')
         txid = wait_and_assert_operationid_status(self.nodes[1], opid)
         self.sync_all()
 
@@ -309,7 +309,7 @@ class ListReceivedTest (BitcoinTestFramework):
         opid = self.nodes[1].z_sendmany(taddr, [
             {'address': uao, 'amount': 1, 'memo': my_memo},
             {'address': uaso, 'amount': 2},
-        ], 1, 0, 'AllowRevealedSenders')
+        ], 1, 0, 'AllowFullyTransparent')
         txid0 = wait_and_assert_operationid_status(self.nodes[1], opid)
         self.sync_all()
 

--- a/qa/rpc-tests/wallet_listunspent.py
+++ b/qa/rpc-tests/wallet_listunspent.py
@@ -82,7 +82,7 @@ class WalletListUnspent(BitcoinTestFramework):
         opid = self.nodes[0].z_sendmany(
                 'ANY_TADDR',
                 [{'address': n1uaddr, 'amount': 2}],
-                1, 0, 'AllowRevealedSenders')
+                1, 0, 'AllowFullyTransparent')
         wait_and_assert_operationid_status(self.nodes[0], opid)
 
         self.nodes[0].generate(2)
@@ -92,7 +92,7 @@ class WalletListUnspent(BitcoinTestFramework):
         opid = self.nodes[0].z_sendmany(
                 'ANY_TADDR',
                 [{'address': n1uaddr, 'amount': 3}],
-                1, 0, 'AllowRevealedSenders')
+                1, 0, 'AllowFullyTransparent')
         wait_and_assert_operationid_status(self.nodes[0], opid)
 
         self.nodes[0].generate(2)

--- a/qa/rpc-tests/wallet_sendmany_any_taddr.py
+++ b/qa/rpc-tests/wallet_sendmany_any_taddr.py
@@ -77,7 +77,7 @@ class WalletSendManyAnyTaddr(BitcoinTestFramework):
             self.nodes[3].z_sendmany(
                 'ANY_TADDR',
                 [{'address': recipient, 'amount': 100}],
-                1, DEFAULT_FEE, 'AllowRevealedSenders'),
+                1, DEFAULT_FEE, 'AllowFullyTransparent'),
         )
 
         self.sync_all()
@@ -97,7 +97,7 @@ class WalletSendManyAnyTaddr(BitcoinTestFramework):
             self.nodes[3].z_sendmany(
                 'ANY_TADDR',
                 [{'address': recipient, 'amount': 20}],
-                1, DEFAULT_FEE, 'AllowRevealedSenders'),
+                1, DEFAULT_FEE, 'AllowFullyTransparent'),
         )
 
         self.sync_all()

--- a/qa/rpc-tests/wallet_z_sendmany.py
+++ b/qa/rpc-tests/wallet_z_sendmany.py
@@ -102,7 +102,7 @@ class WalletZSendmanyTest(BitcoinTestFramework):
         # send node 2 taddr to zaddr
         recipients = []
         recipients.append({"address":myzaddr, "amount":7})
-        opid = self.nodes[2].z_sendmany(mytaddr, recipients, 1, DEFAULT_FEE, 'AllowRevealedSenders')
+        opid = self.nodes[2].z_sendmany(mytaddr, recipients, 1, DEFAULT_FEE, 'AllowFullyTransparent')
         mytxid = wait_and_assert_operationid_status(self.nodes[2], opid)
 
         self.sync_all()

--- a/src/wallet/wallet_tx_builder.cpp
+++ b/src/wallet/wallet_tx_builder.cpp
@@ -50,10 +50,7 @@ PrepareTransactionResult WalletTxBuilder::PrepareTransaction(
                 switch (rtype) {
                     case ReceiverType::P2PKH:
                     case ReceiverType::P2SH:
-                        // TODO: This is the correct policy, but it’s a breaking change from
-                        //       previous behavior, so enable it separately. (#6409)
-                        // if (strategy.AllowRevealedRecipients()) {
-                        if (!spendable.utxos.empty() || strategy.AllowRevealedRecipients()) {
+                        if (strategy.AllowRevealedRecipients()) {
                             result.insert(OutputPool::Transparent);
                         }
                         break;
@@ -428,10 +425,7 @@ PrivacyPolicy TransactionEffects::GetRequiredPrivacyPolicy() const
     if (!spendable.utxos.empty()) {
         // TODO: Add a check for whether we need AllowLinkingAccountAddresses here. (#6467)
         if (payments.HasTransparentRecipient()) {
-            // TODO: AllowFullyTransparent is the correct policy, but it’s a breaking change from
-            //       previous behavior, so enable it separately. (#6409)
-            // maxPrivacy = PrivacyPolicy::AllowFullyTransparent;
-            return PrivacyPolicy::AllowRevealedSenders;
+            return PrivacyPolicy::AllowFullyTransparent;
         } else {
             return PrivacyPolicy::AllowRevealedSenders;
         }


### PR DESCRIPTION
There was a bug when selecting transparent change, where it wouldn’t require `AllowRevealedRecipients` if there was a transparent sender. The initial move to WalletTxBuilder preserved this bug, so this PR is to correct the behavior.