### PR TITLE
rust: Unset "codegen-units = 1"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,5 +111,3 @@ features = ["ansi", "env-filter", "fmt", "time"]
 [profile.release]
 lto = 'thin'
 panic = 'abort'
-codegen-units = 1
-


### PR DESCRIPTION
This moves us back to using the default value of 16 for the release profile (which does not enable incremental builds).

Part of zcash/zcash#6065.