### PR TITLE
Partially revert PR #6384 for URLs using a git commit hash, and make the `native_cctools` tarballs download to meaningful names

### DIFF
--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -1,7 +1,8 @@
 package=native_cctools
 $(package)_version=55562e4073dea0fbfd0b20e0bf69ffe6390c7f97
 $(package)_download_path=https://github.com/tpoechtrager/cctools-port/archive
-$(package)_file_name=$($(package)_version).tar.gz
+$(package)_download_file=$($(package)_version).tar.gz
+$(package)_file_name=$(package)_$($(package)_version).tar.gz
 $(package)_sha256_hash=e51995a843533a3dac155dd0c71362dd471597a2d23f13dff194c6285362f875
 $(package)_build_subdir=cctools
 $(package)_dependencies=native_clang
@@ -10,7 +11,7 @@ $(package)_patches=ignore-otool.diff
 $(package)_libtapi_version=3efb201881e7a76a21e0554906cf306432539cef
 $(package)_libtapi_download_path=https://github.com/tpoechtrager/apple-libtapi/archive
 $(package)_libtapi_download_file=$($(package)_libtapi_version).tar.gz
-$(package)_libtapi_file_name=$($(package)_libtapi_version).tar.gz
+$(package)_libtapi_file_name=$(package)_libtapi_$($(package)_libtapi_version).tar.gz
 $(package)_libtapi_sha256_hash=380c1ca37cfa04a8699d0887a8d3ee1ad27f3d08baba78887c73b09485c0fbd3
 
 $(package)_extra_sources += $($(package)_libtapi_file_name)

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -1,6 +1,6 @@
 package=native_cctools
 $(package)_version=55562e4073dea0fbfd0b20e0bf69ffe6390c7f97
-$(package)_download_path=https://github.com/tpoechtrager/cctools-port/archive/refs/tags
+$(package)_download_path=https://github.com/tpoechtrager/cctools-port/archive
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=e51995a843533a3dac155dd0c71362dd471597a2d23f13dff194c6285362f875
 $(package)_build_subdir=cctools
@@ -8,7 +8,7 @@ $(package)_dependencies=native_clang
 $(package)_patches=ignore-otool.diff
 
 $(package)_libtapi_version=3efb201881e7a76a21e0554906cf306432539cef
-$(package)_libtapi_download_path=https://github.com/tpoechtrager/apple-libtapi/archive/refs/tags
+$(package)_libtapi_download_path=https://github.com/tpoechtrager/apple-libtapi/archive
 $(package)_libtapi_download_file=$($(package)_libtapi_version).tar.gz
 $(package)_libtapi_file_name=$($(package)_libtapi_version).tar.gz
 $(package)_libtapi_sha256_hash=380c1ca37cfa04a8699d0887a8d3ee1ad27f3d08baba78887c73b09485c0fbd3

--- a/depends/packages/tl_expected.mk
+++ b/depends/packages/tl_expected.mk
@@ -1,8 +1,8 @@
 package=tl_expected
-$(package)_version=1.0.1
+$(package)_version=96d547c03d2feab8db64c53c3744a9b4a7c8f2c5
 $(package)_download_path=https://github.com/TartanLlama/expected/archive
-$(package)_download_file=96d547c03d2feab8db64c53c3744a9b4a7c8f2c5.tar.gz
-$(package)_file_name=tl-expected-1.0.1.tar.gz
+$(package)_download_file=$($(package)_version).tar.gz
+$(package)_file_name=$(package)_$($(package)_version).tar.gz
 $(package)_sha256_hash=64901df1de9a5a3737b331d3e1de146fa6ffb997017368b322c08f45c51b90a7
 $(package)_patches=remove-undefined-behaviour.diff
 

--- a/depends/packages/tl_expected.mk
+++ b/depends/packages/tl_expected.mk
@@ -1,6 +1,6 @@
 package=tl_expected
 $(package)_version=1.0.1
-$(package)_download_path=https://github.com/TartanLlama/expected/archive/refs/tags
+$(package)_download_path=https://github.com/TartanLlama/expected/archive
 $(package)_download_file=96d547c03d2feab8db64c53c3744a9b4a7c8f2c5.tar.gz
 $(package)_file_name=tl-expected-1.0.1.tar.gz
 $(package)_sha256_hash=64901df1de9a5a3737b331d3e1de146fa6ffb997017368b322c08f45c51b90a7


### PR DESCRIPTION
The new URLs (with `archive/ref/tags`) are good for tag-based references so we leave them alone, and only revert the hash-based URLs to GitHub URLs which doesn't 404 and give us files with the expected hashes today.

Currently, the three repos in question (`cctools-port`, `apple-libtapi`, and `expected`) do not have usable tags/releases we can use instead of the hashes.

We will also upload correct versions of those files to the download.z.cash server (with the correct filenames) so if there's another issue with hash stability (like there was on 30 January 2023 https://github.com/orgs/community/discussions/46034) it won't instantly break the build.

This should fix #6415.

@str4d suggested changing `native_cctools.mk` so that the saved filenames for `native_cctools[_libtapi]` aren't just long hash names. @daira also pointed out that we had used a non-existent version number in the saved filename for `tl_expected`. This PR fixes these issues, saving to `native_cctools_55562e4073dea0fbfd0b20e0bf69ffe6390c7f97.tar.gz`, `native_cctools_libtapi_3efb201881e7a76a21e0554906cf306432539cef.tar.gz`, and `tl_expected_96d547c03d2feab8db64c53c3744a9b4a7c8f2c5.tar.gz`. These download OK with both the github URLs and also (by breaking the github download URL to force it) download OK with the download.z.cash server.

Since the filename on the download.z.cash server needs to match the *saved* filename (and not the filename in the original URL, which happened to coincide with the saved filename for the two tarballs in `native_cctools.mk`), we needed to reupload copies to the download server with the right naming scheme.