### PR TITLE
Load `-allowdeprecated` settings after reading the config file

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -94,14 +94,6 @@ bool AppInit(int argc, char* argv[])
         return true;
     }
 
-    // Handle setting of allowed-deprecated features as early as possible
-    // so that it's possible for other initialization steps to respect them.
-    auto deprecationError = SetAllowedDeprecatedFeaturesFromCLIArgs();
-    if (deprecationError.has_value()) {
-        fprintf(stderr, "%s", deprecationError.value().c_str());
-        return false;
-    }
-
     try
     {
         if (!fs::is_directory(GetDataDir(false)))
@@ -140,6 +132,14 @@ bool AppInit(int argc, char* argv[])
             SelectParams(ChainNameFromCommandLine());
         } catch(std::exception &e) {
             fprintf(stderr, "Error: %s\n", e.what());
+            return false;
+        }
+
+        // Handle setting of allowed-deprecated features as early as possible
+        // so that it's possible for other initialization steps to respect them.
+        auto deprecationError = LoadAllowedDeprecatedFeatures();
+        if (deprecationError.has_value()) {
+            fprintf(stderr, "%s", deprecationError.value().c_str());
             return false;
         }
 

--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -61,7 +61,7 @@ void EnforceNodeDeprecation(int nHeight, bool forceLogging, bool fThread) {
     }
 }
 
-std::optional<std::string> SetAllowedDeprecatedFeaturesFromCLIArgs() {
+std::optional<std::string> LoadAllowedDeprecatedFeatures() {
     auto args = GetMultiArg("-allowdeprecated");
     std::set<std::string> allowdeprecated(args.begin(), args.end());
 

--- a/src/deprecation.h
+++ b/src/deprecation.h
@@ -71,13 +71,13 @@ extern bool fEnableWalletTxVJoinSplit;
 void EnforceNodeDeprecation(int nHeight, bool forceLogging=false, bool fThread=true);
 
 /**
- * Checks command-line arguments for enabling and/or disabling of deprecated
+ * Checks config options for enabling and/or disabling of deprecated
  * features and sets flags that enable deprecated features accordingly.
  *
  * @return std::nullopt if successful, or an error message indicating what
  * values are permitted for `-allowdeprecated`.
  */
-std::optional<std::string> SetAllowedDeprecatedFeaturesFromCLIArgs();
+std::optional<std::string> LoadAllowedDeprecatedFeatures();
 
 /**
  * Returns a comma-separated list of the valid arguments to the -allowdeprecated


### PR DESCRIPTION
We need to load these early so that it's possible for other initialization steps to respect them. However, we were loading them slightly too early, before the config file had been read, which meant that only CLI arguments were being used.

We now load the `-allowdeprecated` settings just after the config file is parsed and the chain parameters are prepared; neither of these are features we would ever consider deprecating (at least while `zcashd` exists in its Bitcoin Core-derived form).

Closes zcash/zcash#6420.