### PR TITLE
Give better error messages if proof parameters aren't loaded

### DIFF
--- a/src/rust/src/builder_ffi.rs
+++ b/src/rust/src/builder_ffi.rs
@@ -157,7 +157,8 @@ pub extern "C" fn orchard_unauthorized_bundle_prove_and_sign(
     let bundle = unsafe { Box::from_raw(bundle) };
     let keys = unsafe { slice::from_raw_parts(keys, keys_len) };
     let sighash = unsafe { sighash.as_ref() }.expect("sighash pointer may not be null.");
-    let pk = unsafe { ORCHARD_PK.as_ref() }.unwrap();
+    let pk = unsafe { ORCHARD_PK.as_ref() }
+        .expect("Parameters not loaded: ORCHARD_PK should have been initialized");
 
     let signing_keys = keys
         .iter()

--- a/src/rust/src/orchard_ffi.rs
+++ b/src/rust/src/orchard_ffi.rs
@@ -235,8 +235,8 @@ pub extern "C" fn orchard_batch_add_bundle(
 pub extern "C" fn orchard_batch_validate(batch: *mut BatchValidator) -> bool {
     if !batch.is_null() {
         let batch = unsafe { Box::from_raw(batch) };
-        let vk =
-            unsafe { crate::ORCHARD_VK.as_ref() }.expect("ORCHARD_VK should have been initialized");
+        let vk = unsafe { crate::ORCHARD_VK.as_ref() }
+            .expect("Parameters not loaded: ORCHARD_VK should have been initialized");
         if batch.validator.validate(vk, OsRng) {
             // `BatchValidator::validate()` is only called if every
             // `BatchValidator::check_bundle()` returned `true`, so at this point

--- a/src/rust/src/rustzcash.rs
+++ b/src/rust/src/rustzcash.rs
@@ -554,12 +554,11 @@ pub extern "C" fn librustzcash_sprout_prove(
     vpub_new: u64,
 ) {
     // Load parameters from disk
-    let sprout_fs = File::open(
-        unsafe { &SPROUT_GROTH16_PARAMS_PATH }
-            .as_ref()
-            .expect("parameters should have been initialized"),
-    )
-    .expect("couldn't load Sprout groth16 parameters file");
+    let sprout_fs =
+        File::open(unsafe { &SPROUT_GROTH16_PARAMS_PATH }.as_ref().expect(
+            "Parameters not loaded: SPROUT_GROTH16_PARAMS_PATH should have been initialized",
+        ))
+        .expect("couldn't load Sprout groth16 parameters file");
 
     let mut sprout_fs = BufReader::with_capacity(1024 * 1024, sprout_fs);
 
@@ -625,7 +624,8 @@ pub extern "C" fn librustzcash_sprout_verify(
         unsafe { &*cm2 },
         vpub_old,
         vpub_new,
-        unsafe { SPROUT_GROTH16_VK.as_ref() }.expect("parameters should have been initialized"),
+        unsafe { SPROUT_GROTH16_VK.as_ref() }
+            .expect("Parameters not loaded: SPROUT_GROTH16_VK should have been initialized"),
     )
 }
 

--- a/src/rust/src/sapling.rs
+++ b/src/rust/src/sapling.rs
@@ -335,8 +335,12 @@ impl Prover {
                 value,
                 anchor,
                 merkle_path,
-                unsafe { SAPLING_SPEND_PARAMS.as_ref() }.unwrap(),
-                &prepare_verifying_key(unsafe { SAPLING_SPEND_VK.as_ref() }.unwrap()),
+                unsafe { SAPLING_SPEND_PARAMS.as_ref() }.expect(
+                    "Parameters not loaded: SAPLING_SPEND_PARAMS should have been initialized",
+                ),
+                &prepare_verifying_key(unsafe { SAPLING_SPEND_VK.as_ref() }.expect(
+                    "Parameters not loaded: SAPLING_SPEND_VK should have been initialized",
+                )),
             )
             .expect("proving should not fail");
 
@@ -387,7 +391,9 @@ impl Prover {
             payment_address,
             rcm,
             value,
-            unsafe { SAPLING_OUTPUT_PARAMS.as_ref() }.unwrap(),
+            unsafe { SAPLING_OUTPUT_PARAMS.as_ref() }.expect(
+                "Parameters not loaded: SAPLING_OUTPUT_PARAMS should have been initialized",
+            ),
         );
 
         // Write the proof out to the caller
@@ -485,7 +491,10 @@ impl Verifier {
             sighash_value,
             spend_auth_sig,
             zkproof,
-            &prepare_verifying_key(unsafe { SAPLING_SPEND_VK.as_ref() }.unwrap()),
+            &prepare_verifying_key(
+                unsafe { SAPLING_SPEND_VK.as_ref() }
+                    .expect("Parameters not loaded: SAPLING_SPEND_VK should have been initialized"),
+            ),
         )
     }
     fn check_output(
@@ -525,7 +534,11 @@ impl Verifier {
             cm,
             epk,
             zkproof,
-            &prepare_verifying_key(unsafe { SAPLING_OUTPUT_VK.as_ref() }.unwrap()),
+            &prepare_verifying_key(
+                unsafe { SAPLING_OUTPUT_VK.as_ref() }.expect(
+                    "Parameters not loaded: SAPLING_OUTPUT_VK should have been initialized",
+                ),
+            ),
         )
     }
     fn final_check(
@@ -625,8 +638,11 @@ impl BatchValidator {
     fn validate(&mut self) -> bool {
         if let Some(inner) = self.0.take() {
             if inner.validator.validate(
-                unsafe { SAPLING_SPEND_VK.as_ref() }.unwrap(),
-                unsafe { SAPLING_OUTPUT_VK.as_ref() }.unwrap(),
+                unsafe { SAPLING_SPEND_VK.as_ref() }
+                    .expect("Parameters not loaded: SAPLING_SPEND_VK should have been initialized"),
+                unsafe { SAPLING_OUTPUT_VK.as_ref() }.expect(
+                    "Parameters not loaded: SAPLING_OUTPUT_VK should have been initialized",
+                ),
                 OsRng,
             ) {
                 // `Self::validate()` is only called if every `Self::check_bundle()`


### PR DESCRIPTION
Error messages like this don't give an obvious indication of what's going on:
```
nuttycom@sword:~/work/zcash/canon (master)λ ./src/zcash-gtest --gtest_filter=OrchardWalletTests.TxInvolvesMyNotes
Note: Google Test filter = OrchardWalletTests.TxInvolvesMyNotes
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from OrchardWalletTests
[ RUN      ] OrchardWalletTests.TxInvolvesMyNotes
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', src/rust/src/builder_ffi.rs:160:45
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted (core dumped)
```

We replace that flavor of `unwrap` with `expect` everywhere that the proof parameters are used. Tere were three instances of that being done already, and change those lines only harmonize the error message to a format of `"Parameters not loaded: [PARAMETER_NAME_HERE] should have been initialized"`