### PR TITLE
Simplify diversifier_index_t handling

### DIFF
--- a/src/gtest/test_keystore.cpp
+++ b/src/gtest/test_keystore.cpp
@@ -564,7 +564,7 @@ TEST(KeystoreTests, StoreAndRetrieveUFVK) {
     auto ufvkmetaUnadded = keyStore.GetUFVKMetadataForReceiver(saplingReceiver);
     EXPECT_TRUE(ufvkmetaUnadded.has_value());
     EXPECT_EQ(ufvkmetaUnadded.value().GetUFVKId(), ufvkid);
-    EXPECT_EQ(ufvkmetaUnadded.value().GetDiversifierIndex().value(), addrPair.second);
+    EXPECT_EQ(ufvkmetaUnadded.value().GetDiversifierIndex(), addrPair.second);
 
     // Adding the Sapling addr -> ivk map entry causes us to find the same UFVK,
     // and since we trial-decrypt with both external and internal IVKs to
@@ -575,7 +575,7 @@ TEST(KeystoreTests, StoreAndRetrieveUFVK) {
     auto ufvkmeta = keyStore.GetUFVKMetadataForReceiver(saplingReceiver);
     EXPECT_TRUE(ufvkmeta.has_value());
     EXPECT_EQ(ufvkmeta.value().GetUFVKId(), ufvkid);
-    EXPECT_TRUE(ufvkmeta.value().GetDiversifierIndex().has_value());
+    EXPECT_EQ(ufvkmeta.value().GetDiversifierIndex(), addrPair.second);
 }
 
 TEST(KeystoreTests, StoreAndRetrieveUFVKByOrchard) {
@@ -604,7 +604,7 @@ TEST(KeystoreTests, StoreAndRetrieveUFVKByOrchard) {
     auto ufvkmetaUnadded = keyStore.GetUFVKMetadataForReceiver(orchardReceiver);
     EXPECT_TRUE(ufvkmetaUnadded.has_value());
     EXPECT_EQ(ufvkmetaUnadded.value().GetUFVKId(), ufvkid);
-    EXPECT_EQ(ufvkmetaUnadded.value().GetDiversifierIndex().value(), addrPair.second);
+    EXPECT_EQ(ufvkmetaUnadded.value().GetDiversifierIndex(), addrPair.second);
 }
 
 TEST(KeystoreTests, AddTransparentReceiverForUnifiedAddress) {

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -22,14 +22,14 @@
 class AddressUFVKMetadata {
 private:
     libzcash::UFVKId ufvkId;
-    std::optional<libzcash::diversifier_index_t> j;
+    libzcash::diversifier_index_t j;
     bool externalAddress;
 public:
-    AddressUFVKMetadata(libzcash::UFVKId ufvkId, std::optional<libzcash::diversifier_index_t> j, bool externalAddress)
+    AddressUFVKMetadata(libzcash::UFVKId ufvkId, libzcash::diversifier_index_t j, bool externalAddress)
         : ufvkId(ufvkId), j(j), externalAddress(externalAddress) {}
 
     libzcash::UFVKId GetUFVKId() const { return ufvkId; }
-    std::optional<libzcash::diversifier_index_t> GetDiversifierIndex() const { return j; }
+    libzcash::diversifier_index_t GetDiversifierIndex() const { return j; }
     bool IsExternalAddress() const { return externalAddress; }
 };
 
@@ -145,12 +145,14 @@ public:
     virtual std::optional<AddressUFVKMetadata> GetUFVKMetadataForReceiver(
             const libzcash::Receiver& receiver) const = 0;
 
+    std::optional<AddressUFVKMetadata> GetUFVKMetadataForAddress(
+            const CTxDestination& address) const;
+
     /**
      * If all the receivers of the specified address correspond to a single
-     * UFVK, return that key's metadata. If all the receivers correspond to
-     * the same diversifier index, that diversifier index is also returned.
+     * UFVK, return that key's metadata.
      */
-    virtual std::optional<AddressUFVKMetadata> GetUFVKMetadataForAddress(
+    virtual std::optional<libzcash::UFVKId> GetUFVKIdForAddress(
             const libzcash::UnifiedAddress& addr) const = 0;
 
     virtual std::optional<libzcash::UFVKId> GetUFVKIdForViewingKey(
@@ -405,14 +407,14 @@ public:
         }
     }
 
-    virtual std::optional<AddressUFVKMetadata> GetUFVKMetadataForAddress(
+    virtual std::optional<libzcash::UFVKId> GetUFVKIdForAddress(
             const libzcash::UnifiedAddress& addr) const;
 
     std::optional<libzcash::ZcashdUnifiedFullViewingKey> GetUFVKForAddress(
             const libzcash::UnifiedAddress& addr) const {
-        auto ufvkMeta = GetUFVKMetadataForAddress(addr);
-        if (ufvkMeta.has_value()) {
-            return GetUnifiedFullViewingKey(ufvkMeta.value().GetUFVKId());
+        auto ufvkId = GetUFVKIdForAddress(addr);
+        if (ufvkId.has_value()) {
+            return GetUnifiedFullViewingKey(ufvkId.value());
         } else {
             return std::nullopt;
         }


### PR DESCRIPTION
- Remove `std::optional` from a number of uses,
- simplify `GetUFVKMetadataForAddress` to `GetUFVKIdForAddress`, and
- add a new `GetUFVKMetadataForAddress` as a wrapper around
  `GetUFVKMetadataForReceiver`.