### PR TITLE
Improve taddr no-memo check.

### DIFF
--- a/qa/rpc-tests/wallet_z_sendmany.py
+++ b/qa/rpc-tests/wallet_z_sendmany.py
@@ -152,6 +152,11 @@ class WalletZSendmanyTest(BitcoinTestFramework):
         # The following assertion might fail nondeterministically
         # assert_equal(node2balance, Decimal('16.99799000'))
 
+        # try sending with a memo to a taddr, which should fail
+        recipients = [{"address":self.nodes[0].getnewaddress(), "amount":1, "memo":"DEADBEEF"}]
+        opid = self.nodes[2].z_sendmany(myzaddr, recipients, 1, DEFAULT_FEE, 'AllowRevealedRecipients')
+        wait_and_assert_operationid_status(self.nodes[2], opid, 'failed', 'Failed to build transaction: Memos cannot be sent to transparent addresses.')
+
         recipients = []
         recipients.append({"address":self.nodes[0].getnewaddress(), "amount":1})
         recipients.append({"address":self.nodes[2].getnewaddress(), "amount":1.0})

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4736,7 +4736,8 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
             "    [{\n"
             "      \"address\":address  (string, required) The address is a taddr, zaddr, or Unified Address\n"
             "      \"amount\":amount    (numeric, required) The numeric amount in " + CURRENCY_UNIT + " is the value\n"
-            "      \"memo\":memo        (string, optional) If the address is a zaddr, raw data represented in hexadecimal string format\n"
+            "      \"memo\":memo        (string, optional) If the address is a zaddr, raw data represented in hexadecimal string format. If\n"
+            "                           it’s a taddr, it’s an error to include this field.\n"
             "    }, ... ]\n"
             "3. minconf               (numeric, optional, default=" + strprintf("%u", DEFAULT_NOTE_CONFIRMATIONS) + ") Only use funds confirmed at least this many times.\n"
             "4. fee                   (numeric, optional, default=" + strprintf("%s", FormatMoney(DEFAULT_FEE)) + ") The fee amount to attach to this transaction.\n"
@@ -4841,12 +4842,6 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
         std::optional<Memo> memo;
         if (!memoValue.isNull()) {
             auto memoHex = memoValue.get_str();
-            if (!std::visit(libzcash::HasShieldedRecipient(), addr.value())) {
-                throw JSONRPCError(
-                        RPC_INVALID_PARAMETER,
-                        "Invalid parameter, memos cannot be sent to transparent addresses.");
-            }
-
             std::visit(match {
                 [&](MemoError err) {
                     switch (err) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4737,7 +4737,7 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
             "      \"address\":address  (string, required) The address is a taddr, zaddr, or Unified Address\n"
             "      \"amount\":amount    (numeric, required) The numeric amount in " + CURRENCY_UNIT + " is the value\n"
             "      \"memo\":memo        (string, optional) If the address is a zaddr, raw data represented in hexadecimal string format. If\n"
-            "                           it’s a taddr, it’s an error to include this field.\n"
+            "                           the output is being sent to a transparent address, it’s an error to include this field.\n"
             "    }, ... ]\n"
             "3. minconf               (numeric, optional, default=" + strprintf("%u", DEFAULT_NOTE_CONFIRMATIONS) + ") Only use funds confirmed at least this many times.\n"
             "4. fee                   (numeric, optional, default=" + strprintf("%s", FormatMoney(DEFAULT_FEE)) + ") The fee amount to attach to this transaction.\n"


### PR DESCRIPTION
Do the check deeper, preventing test_bitcoin from being able to bypass it. This
also moves it out of z_sendmany-specific code, which will be helpful when we add
other operations, like sendfromaccount.