### PR TITLE
Fix `make distclean` to recursively remove `rust/gen`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -730,7 +730,7 @@ clean-local:
 	-$(MAKE) -C secp256k1 clean
 	-$(MAKE) -C univalue clean
 	rm -f leveldb/*/*.gcno leveldb/helpers/memenv/*.gcno
-	rm -f rust/gen
+	rm -rf rust/gen
 	rm -f fuzz.cpp
 	rm -rf fuzzing/*/output
 	-rm -f config.h


### PR DESCRIPTION
`make distclean` currently fails with:

```
rm -f rust/gen
rm: cannot remove 'rust/gen': Is a directory
make[2]: *** [Makefile:10025: clean-local] Error 1
```