### PR TITLE
CI: Use `github.head_ref` instead of `HEAD` for "recent base" check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Ensure branch contains necessary commits for Tekton CI
         id: tekton
         # https://github.com/zcash/zcash/pull/6358
-        run: git merge-base --is-ancestor 267ddf8efe36cc799c4c31772a8883ea332ef55b HEAD
+        run: git merge-base --is-ancestor 267ddf8efe36cc799c4c31772a8883ea332ef55b ${{ github.head_ref }}
 
       - name: Tell PR author if they need to rebase
         if: failure() && steps.tekton.outcome == 'failure'


### PR DESCRIPTION
The `pull_request_target` event causes `actions/checkout` to check out the target branch (e.g. the main repo's `master` branch) instead of the PR's branch. This meant that after zcash/zcash#6487 merged, the check would always pass (because the queried revision is always present in the history of `master`). `github.head_ref` correctly points to the tip of the PR's branch, ensuring that `git merge-base --is-ancestor` performs the expected comparison.