### PR TITLE
Remove CWallet member from WalletTxBuilder

### DIFF
--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -138,9 +138,10 @@ void AsyncRPCOperation_sendmany::main() {
 //
 // At least #4 differs from the Rust transaction builder.
 uint256 AsyncRPCOperation_sendmany::main_impl() {
-    auto spendable = builder_.FindAllSpendableInputs(ztxoSelector_, mindepth_);
+    auto spendable = builder_.FindAllSpendableInputs(*pwalletMain, ztxoSelector_, mindepth_);
 
     auto preparedTx = builder_.PrepareTransaction(
+            *pwalletMain,
             ztxoSelector_,
             spendable,
             recipients_,

--- a/src/wallet/gtest/test_rpc_wallet.cpp
+++ b/src/wallet/gtest/test_rpc_wallet.cpp
@@ -284,7 +284,7 @@ TEST(WalletRPCTests, RPCZsendmanyTaddrToSapling)
     pwalletMain->LoadWalletTx(wtx);
 
     // Context that z_sendmany requires
-    auto builder = WalletTxBuilder(Params(), *pwalletMain, minRelayTxFee);
+    auto builder = WalletTxBuilder(Params(), minRelayTxFee);
     mtx = CreateNewContextualCMutableTransaction(consensusParams, nextBlockHeight, false);
 
     // we need AllowFullyTransparent because the transaction will result

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5016,7 +5016,7 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
 
     // Create operation and add to global queue
     auto nAnchorDepth = std::min((unsigned int) nMinDepth, nAnchorConfirmations);
-    WalletTxBuilder builder(Params(), *pwalletMain, minRelayTxFee);
+    WalletTxBuilder builder(Params(), minRelayTxFee);
 
     std::shared_ptr<AsyncRPCQueue> q = getAsyncRPCQueue();
     std::shared_ptr<AsyncRPCOperation> operation(

--- a/src/wallet/test/rpc_wallet_tests.cpp
+++ b/src/wallet/test/rpc_wallet_tests.cpp
@@ -1248,7 +1248,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
                 // confirm this.
                 TransparentCoinbasePolicy::Allow,
                 false).value();
-        WalletTxBuilder builder(Params(), *pwalletMain, minRelayTxFee);
+        WalletTxBuilder builder(Params(), minRelayTxFee);
         std::vector<Payment> recipients = { Payment(zaddr1, 100*COIN, Memo::FromHexOrThrow("DEADBEEF")) };
         TransactionStrategy strategy(PrivacyPolicy::AllowRevealedSenders);
         std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 1, 1, strategy));
@@ -1265,7 +1265,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
                 true,
                 TransparentCoinbasePolicy::Disallow,
                 false).value();
-        WalletTxBuilder builder(Params(), *pwalletMain, minRelayTxFee);
+        WalletTxBuilder builder(Params(), minRelayTxFee);
         std::vector<Payment> recipients = { Payment(taddr1, 100*COIN, Memo::FromHexOrThrow("DEADBEEF")) };
         TransactionStrategy strategy(PrivacyPolicy::AllowRevealedRecipients);
         std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 1, 1, strategy));

--- a/src/wallet/wallet_tx_builder.h
+++ b/src/wallet/wallet_tx_builder.h
@@ -305,7 +305,6 @@ typedef std::variant<
 class WalletTxBuilder {
 private:
     const CChainParams& params;
-    const CWallet& wallet;
     CFeeRate minRelayFee;
     uint32_t maxOrchardActions;
 
@@ -320,6 +319,7 @@ private:
      * and the requested transaction strategy.
      */
     InputSelectionResult ResolveInputsAndPayments(
+            const CWallet& wallet,
             const ZTXOSelector& selector,
             SpendableInputs& spendable,
             const std::vector<Payment>& payments,
@@ -332,18 +332,21 @@ private:
      * the spendable inputs.
      */
     std::pair<uint256, uint256> SelectOVKs(
+            const CWallet& wallet,
             const ZTXOSelector& selector,
             const SpendableInputs& spendable) const;
 
 public:
-    WalletTxBuilder(const CChainParams& params, const CWallet& wallet, CFeeRate minRelayFee):
-        params(params), wallet(wallet), minRelayFee(minRelayFee), maxOrchardActions(nOrchardActionLimit) {}
+    WalletTxBuilder(const CChainParams& params, CFeeRate minRelayFee):
+        params(params), minRelayFee(minRelayFee), maxOrchardActions(nOrchardActionLimit) {}
 
     SpendableInputs FindAllSpendableInputs(
+            const CWallet& wallet,
             const ZTXOSelector& selector,
             int32_t minDepth) const;
 
     PrepareTransactionResult PrepareTransaction(
+            CWallet& wallet,
             const ZTXOSelector& selector,
             SpendableInputs& spendable,
             const std::vector<Payment>& payments,


### PR DESCRIPTION
This resolves a conflict where most usage is `const`, but some modifies the
wallet. Previously it held a const member and then used `pwalletMain` directly
for the mutating calls. This now passes `CWallet` explicitly where necessary,
using `const` when possible.

This also benefits a follow-up PR (#6408) that introduces locking, which also
mutates the wallet.