### PR TITLE
Repair the show_help RPC test

### DIFF
--- a/qa/rpc-tests/show_help.py
+++ b/qa/rpc-tests/show_help.py
@@ -40,10 +40,10 @@ Options:
   -allowdeprecated=<feature>
        Explicitly allow the use of the specified deprecated feature. Multiple
        instances of this parameter are permitted; values for <feature> must be
-       selected from among {"none", "gbt_oldhashes", "addrtype",
+       selected from among {"none", "deprecationinfo_deprecationheight",
+       "gbt_oldhashes", "z_getbalance", "z_gettotalbalance", "addrtype",
        "getnewaddress", "getrawchangeaddress", "legacy_privacy",
-       "wallettxvjoinsplit", "z_getbalance", "z_getnewaddress",
-       "z_gettotalbalance", "z_listaddresses"}
+       "wallettxvjoinsplit", "z_getnewaddress", "z_listaddresses"}
 
   -blocknotify=<cmd>
        Execute command when the best block changes (%s in cmd is replaced by


### PR DESCRIPTION
This was broken by a combination of several PRs that were apparently merged with tests not passing (at least #6425 and #6479), due to a CI fault.

Part of #6509.