### PR TITLE
Experiment with using clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,77 @@
+---
+Checks: >-
+  'clang-diagnostic-*,
+   clang-analyzer-*,
+   boost-*,
+   bugprone-argument-comment, bugprone-assignment-in-if-condition, bugprone-bad-signal-to-kill-thread, bugprone-bool-pointer-implicit-conversion, bugprone-branch-clone,
+   bugprone-copy-constructor-init, bugprone-dangling-handle, bugprone-dynamic-static-initializers, bugprone-exception-escape, bugprone-fold-init-type,
+   bugprone-forward-declaration-namespace, bugprone-forwarding-reference-overload, bugprone-implicit-widening-of-multiplication-result, bugprone-inaccurate-erase,
+   bugprone-incorrect-roundings, bugprone-infinite-loop, bugprone-integer-division, bugprone-lambda-function-name, bugprone-macro-parentheses,
+   bugprone-macro-repeated-side-effects, bugprone-misplaced-widening-cast, bugprone-move-forwarding-reference, bugprone-multiple-statement-macro, bugprone-no-escape,
+   bugprone-not-null-terminated-result, bugprone-parent-virtual-call, bugprone-posix-return, bugprone-redundant-branch-condition, bugprone-reserved-identifier,
+   bugprone-shared-ptr-array-mismatch, bugprone-signal-handler, bugprone-signed-char-misuse, bugprone-sizeof-container, bugprone-sizeof-expression,
+   bugprone-spuriously-wake-up-functions, bugprone-standalone-empty, bugprone-string-constructor, bugprone-string-integer-assignment,
+   bugprone-string-literal-with-embedded-nul, bugprone-stringview-nullptr, bugprone-suspicious-enum-usage, bugprone-suspicious-include,
+   bugprone-suspicious-memory-comparison, bugprone-suspicious-memset-usage, bugprone-suspicious-missing-comma, bugprone-suspicious-realloc-usage,
+   bugprone-suspicious-semicolon, bugprone-suspicious-string-compare, bugprone-terminating-continue, bugprone-throw-keyword-missing, bugprone-too-small-loop-variable,
+   bugprone-unchecked-optional-access, bugprone-undefined-memory-manipulation, bugprone-undelegated-constructor, bugprone-unhandled-exception-at-new,
+   bugprone-unhandled-self-assignment, bugprone-unsafe-functions, bugprone-unused-raii, bugprone-unused-return-value, bugprone-use-after-move, bugprone-virtual-near-miss,
+   cert-dcl58-cpp, cert-err33-c, cert-err34-c, cert-err58-cpp, cert-err60-cpp, cert-flp30-c, cert-mem57-cpp, cert-oop57-cpp, cert-oop58-cpp,
+   concurrency-*,
+   cppcoreguidelines-avoid-capture-default-when-capturing-this, cppcoreguidelines-avoid-goto, cppcoreguidelines-interfaces-global-init,
+   cppcoreguidelines-narrowing-conversions, cppcoreguidelines-pro-type-cstyle-cast, cppcoreguidelines-pro-type-member-init, cppcoreguidelines-pro-type-static-cast-downcast,
+   cppcoreguidelines-rvalue-reference-param-not-moved, cppcoreguidelines-slicing, cppcoreguidelines-special-member-functions, cppcoreguidelines-virtual-class-destructor,
+   darwin-*,
+   google-default-arguments, google-explicit-constructor, google-global-names-in-headers, google-readability-avoid-underscore-in-googletest-name,
+   google-runtime-int, google-runtime-operator, google-upgrade-googletest-case,
+   hicpp-exception-baseclass, hicpp-multiway-paths-covered,
+   misc-confusable-identifiers, misc-const-correctness, misc-definitions-in-headers, misc-misleading-bidirectional, misc-misleading-identifier, misc-misplaced-const,
+   misc-new-delete-overloads, misc-non-copyable-objects, misc-redundant-expression, misc-static-assert, misc-throw-by-value-catch-by-reference,
+   misc-unconventional-assign-operator, misc-unused-alias-decls, misc-unused-parameters, misc-unused-using-decls,
+   modernize-avoid-bind, modernize-concat-nested-namespaces, modernize-deprecated-headers, modernize-deprecated-ios-base-aliases, modernize-loop-convert,
+   modernize-macro-to-enum, modernize-make-shared, modernize-make-unique, modernize-pass-by-value, modernize-redundant-void-arg, modernize-replace-auto-ptr,
+   modernize-return-braced-init-list, modernize-shrink-to-fit, modernize-unary-static-assert, modernize-use-auto, modernize-use-bool-literals,
+   modernize-use-default-member-init, modernize-use-emplace, modernize-use-equals-default, modernize-use-equals-delete, modernize-use-nodiscard,
+   modernize-use-noexcept, modernize-use-override, modernize-use-transparent-functors, modernize-use-uncaught-exceptions,
+   performance-faster-string-find, performance-for-range-copy, performance-implicit-conversion-in-loop, performance-inefficient-algorithm,
+   performance-inefficient-vector-operation, performance-move-const-arg, performance-move-constructor-init, performance-no-automatic-move, performance-no-int-to-ptr,
+   performance-noexcept-move-constructor, performance-trivially-destructible, performance-type-promotion-in-math-fn, performance-unnecessary-copy-initialization,
+   performance-unnecessary-value-param,
+   portability-std-allocator-const, readability-avoid-const-params-in-decls, readability-avoid-unconditional-preprocessor-if, readability-braces-around-statements,
+   readability-const-return-type, readability-container-contains, readability-container-data-pointer, readability-container-size-empty,
+   readability-convert-member-functions-to-static, readability-delete-null-pointer, readability-duplicate-include, readability-else-after-return,
+   readability-function-size, readability-implicit-bool-conversion, readability-inconsistent-declaration-parameter-name, readability-magic-numbers,
+   readability-make-member-function-const, readability-misleading-indentation, readability-misplaced-array-index, readability-named-parameter,
+   readability-non-const-parameter, readability-qualified-auto, readability-redundant-access-specifiers, readability-redundant-control-flow,
+   readability-redundant-declaration, readability-redundant-function-ptr-dereference, readability-redundant-member-init, readability-redundant-preprocessor,
+   readability-redundant-smartptr-get, readability-redundant-string-cstr, readability-simplify-boolean-expr, readability-simplify-subscript-expr,
+   readability-static-accessed-through-instance, readability-static-definition-in-anonymous-namespace, readability-string-compare, readability-suspicious-call-argument,
+   readability-uppercase-literal-suffix, readability-use-anyofallof'
+FormatStyle: none
+CheckOptions:
+  - key:   bugprone-suspicious-enum-usage.StrictMode
+    value: 1
+  - key:   cppcoreguidelines-narrowing-conversions.WarnWithinTemplateInstantiation
+    value: 'true'
+  - key:   modernize-loop-convert.MinConfidence
+    value: reasonable
+  - key:   modernize-use-auto.MinTypeNameLength
+    value: 12
+  - key:   readability-braces-around-statements.ShortStatementLines
+    value: 2
+  - key:   readability-else-after-return.WarnOnUnfixable
+    value: 'false'
+  - key:   readability-function-size.StatementThreshold
+    value: 2000
+  - key:   readability-function-size.BranchThreshold
+    value: 30
+  - key:   readability-function-size.NestingThreshold
+    value: 10
+  - key:   readability-function-size.VariableThreshold
+    value: 30
+  - key:   readability-simplify-boolean-expr.ChainedConditionalReturn
+    value: 'true'
+  - key:   readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value: 'true'
+  - key:   readability-simplify-boolean-expr.SimplifyDeMorgan
+    value: 'true'

--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -49,6 +49,7 @@ define $(package)_stage_cmds
   cp bin/llvm-objcopy $($(package)_staging_prefix_dir)/bin && \
   cp -P bin/clang $($(package)_staging_prefix_dir)/bin && \
   cp -P bin/clang++ $($(package)_staging_prefix_dir)/bin && \
+  (test ! -f bin/clang-tidy || cp -P bin/clang-tidy $($(package)_staging_prefix_dir)/bin) && \
   cp -P bin/ld.lld $($(package)_staging_prefix_dir)/bin && \
   cp -P bin/ld64.lld $($(package)_staging_prefix_dir)/bin && \
   cp -P bin/lld-link $($(package)_staging_prefix_dir)/bin && \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3945,31 +3945,32 @@ struct PoolMetrics {
     }
 };
 
+// This has to be a macro so that each use creates separate callsites in MetricsStaticGauge.
 #define RenderPoolMetrics(poolName, poolMetrics) \
     do {                                         \
-        if (poolMetrics.created) {               \
+        if ((poolMetrics).created) {             \
             MetricsStaticGauge(                  \
                 "zcash.pool.notes.created",      \
-                poolMetrics.created.value(),     \
-                "name", poolName);               \
+                (poolMetrics).created.value(),   \
+                "name", (poolName));             \
         }                                        \
-        if (poolMetrics.spent) {                 \
+        if ((poolMetrics).spent) {               \
             MetricsStaticGauge(                  \
                 "zcash.pool.notes.spent",        \
-                poolMetrics.spent.value(),       \
-                "name", poolName);               \
+                (poolMetrics).spent.value(),     \
+                "name", (poolName));             \
         }                                        \
-        if (poolMetrics.unspent) {               \
+        if ((poolMetrics).unspent) {             \
             MetricsStaticGauge(                  \
                 "zcash.pool.notes.unspent",      \
-                poolMetrics.unspent.value(),     \
-                "name", poolName);               \
+                (poolMetrics).unspent.value(),   \
+                "name", (poolName));             \
         }                                        \
-        if (poolMetrics.value) {                 \
+        if ((poolMetrics).value) {               \
             MetricsStaticGauge(                  \
                 "zcash.pool.value.zatoshis",     \
-                poolMetrics.value.value(),       \
-                "name", poolName);               \
+                (poolMetrics).value.value(),     \
+                "name", (poolName));             \
         }                                        \
     } while (0)
 

--- a/src/rust/include/rust/helpers.h
+++ b/src/rust/include/rust/helpers.h
@@ -29,6 +29,6 @@
 #define T_ESCAPEQUOTE(a) T_DOUBLEESCAPE(a)
 
 // Computes the length of the given array. This is COUNT_OF from Chromium.
-#define T_ARRLEN(x) ((sizeof(x) / sizeof(0 [x])) / ((size_t)(!(sizeof(x) % sizeof(0 [x])))))
+#define T_ARRLEN(x) ((sizeof(x) / sizeof(0 [x])) / ((size_t)(!(sizeof(x) % sizeof(0 [x]))))) /* NOLINT(readability-misplaced-array-index) */
 
 #endif // ZCASH_RUST_INCLUDE_RUST_HELPERS_H

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -40,6 +40,13 @@ if [ -z "${CONFIGURE_FLAGS-}" ]; then
     CONFIGURE_FLAGS=""
 fi
 
+# Adds a prefix to the make command. For example:
+#   MAKE_PREFIX='bear --' ./zcutil/build.sh
+# will use bear (https://github.com/rizsotto/Bear) to create a JSON compilation database.
+if [ -z "${MAKE_PREFIX-}" ]; then
+    MAKE_PREFIX=""
+fi
+
 if [ "$*" = '--help' ]
 then
     cat <<EOF
@@ -87,4 +94,4 @@ fi
 ./zcutil/clean.sh
 ./autogen.sh
 CONFIG_SITE="$PWD/depends/$HOST/share/config.site" ./configure $CONFIGURE_FLAGS
-"$MAKE" "$@"
+$MAKE_PREFIX "$MAKE" "$@"


### PR DESCRIPTION
This isn't integrated into the build system yet. For the time being, do:
```
sudo apt install bear
zcutil/build.sh -j$(nproc)
MAKE_PREFIX='bear --' zcutil/build.sh -j$(nproc)
depends/$TARGET/native/bin/clang-tidy $SOURCEFILES -p compile_commands.json
```