### PR TITLE
Eliminate Memo::FromHexOrThrow duplication

### DIFF
--- a/src/wallet/gtest/test_rpc_wallet.cpp
+++ b/src/wallet/gtest/test_rpc_wallet.cpp
@@ -295,7 +295,7 @@ TEST(WalletRPCTests, RPCZsendmanyTaddrToSapling)
             true,
             TransparentCoinbasePolicy::Disallow,
             false).value();
-    std::vector<Payment> recipients = { Payment(pa, 1*COIN, Memo::FromHexOrThrow("ABCD")) };
+    std::vector<Payment> recipients = { Payment(pa, 1*COIN, Memo::FromHex("ABCD").value()) };
     std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 0, 0, strategy));
     std::shared_ptr<AsyncRPCOperation_sendmany> ptr = std::dynamic_pointer_cast<AsyncRPCOperation_sendmany> (operation);
 

--- a/src/wallet/memo.h
+++ b/src/wallet/memo.h
@@ -29,7 +29,7 @@ public:
         return Memo();
     }
 
-    static std::variant<MemoError, Memo> FromHex(const std::string& memoHex) {
+    static tl::expected<Memo, MemoError> FromHex(const std::string& memoHex) {
         Memo result;
         std::vector<unsigned char> rawMemo = ParseHex(memoHex.c_str());
 
@@ -49,31 +49,7 @@ public:
         return result;
     }
 
-    static Memo FromHexOrThrow(const std::string& memoHex) {
-        return std::visit(match {
-            [](Memo memo) {
-                return memo;
-            },
-            [&](MemoError err) -> Memo {
-                switch (err) {
-                    case MemoError::HexDecodeError:
-                        throw JSONRPCError(
-                                RPC_INVALID_PARAMETER,
-                                "Invalid parameter, expected memo data in hexadecimal format.");
-                    case MemoError::MemoTooLong:
-                        throw JSONRPCError(
-                                RPC_INVALID_PARAMETER,
-                                strprintf(
-                                        "Invalid parameter, memo is longer than the maximum allowed %d characters.",
-                                        ZC_MEMO_SIZE));
-                }
-            }
-        }, Memo::FromHex(memoHex));
-    }
-
     // This copies, because if it returns a reference to the underlying value,
-    // using an idiom like `Memo::FromHexOrThrow("abcd").ToBytes()` is unsafe
-    // and can result in pointing to memory that has been deallocated.
     MemoBytes ToBytes() const {
         return value;
     }

--- a/src/wallet/memo.h
+++ b/src/wallet/memo.h
@@ -51,23 +51,22 @@ public:
 
     static Memo FromHexOrThrow(const std::string& memoHex) {
         return std::visit(match {
-            [&](Memo memo) {
+            [](Memo memo) {
                 return memo;
             },
-            [&](MemoError err) {
+            [&](MemoError err) -> Memo {
                 switch (err) {
                     case MemoError::HexDecodeError:
-                        throw std::runtime_error(
+                        throw JSONRPCError(
+                                RPC_INVALID_PARAMETER,
                                 "Invalid parameter, expected memo data in hexadecimal format.");
                     case MemoError::MemoTooLong:
-                        throw std::runtime_error(strprintf(
-                                "Invalid parameter, memo is longer than the maximum allowed %d characters.",
-                                ZC_MEMO_SIZE));
-                    default:
-                        assert(false);
+                        throw JSONRPCError(
+                                RPC_INVALID_PARAMETER,
+                                strprintf(
+                                        "Invalid parameter, memo is longer than the maximum allowed %d characters.",
+                                        ZC_MEMO_SIZE));
                 }
-                // unreachable, but the compiler can't tell
-                return Memo::NoMemo();
             }
         }, Memo::FromHex(memoHex));
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4904,26 +4904,7 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
         UniValue memoValue = find_value(o, "memo");
         std::optional<Memo> memo;
         if (!memoValue.isNull()) {
-            auto memoHex = memoValue.get_str();
-            std::visit(match {
-                [&](MemoError err) {
-                    switch (err) {
-                        case MemoError::HexDecodeError:
-                            throw JSONRPCError(
-                                    RPC_INVALID_PARAMETER,
-                                    "Invalid parameter, expected memo data in hexadecimal format.");
-                        case MemoError::MemoTooLong:
-                            throw JSONRPCError(
-                                    RPC_INVALID_PARAMETER,
-                                    strprintf("Invalid parameter, size of memo is larger than maximum allowed %d", ZC_MEMO_SIZE ));
-                        default:
-                            assert(false);
-                    }
-                },
-                [&](Memo result) {
-                    memo = result;
-                }
-            }, Memo::FromHex(memoHex));
+            memo = Memo::FromHexOrThrow(memoValue.get_str());
         }
 
         UniValue av = find_value(o, "amount");

--- a/src/wallet/test/rpc_wallet_tests.cpp
+++ b/src/wallet/test/rpc_wallet_tests.cpp
@@ -1249,7 +1249,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
                 TransparentCoinbasePolicy::Allow,
                 false).value();
         WalletTxBuilder builder(Params(), minRelayTxFee);
-        std::vector<Payment> recipients = { Payment(zaddr1, 100*COIN, Memo::FromHexOrThrow("DEADBEEF")) };
+        std::vector<Payment> recipients = { Payment(zaddr1, 100*COIN, Memo::FromHex("DEADBEEF").value()) };
         TransactionStrategy strategy(PrivacyPolicy::AllowRevealedSenders);
         std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 1, 1, strategy));
         operation->main();
@@ -1266,7 +1266,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
                 TransparentCoinbasePolicy::Disallow,
                 false).value();
         WalletTxBuilder builder(Params(), minRelayTxFee);
-        std::vector<Payment> recipients = { Payment(taddr1, 100*COIN, Memo::FromHexOrThrow("DEADBEEF")) };
+        std::vector<Payment> recipients = { Payment(taddr1, 100*COIN, Memo::FromHex("DEADBEEF").value()) };
         TransactionStrategy strategy(PrivacyPolicy::AllowRevealedRecipients);
         std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 1, 1, strategy));
         operation->main();
@@ -1278,7 +1278,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
 
 BOOST_AUTO_TEST_CASE(memo_hex_parsing) {
     std::string memo = "DEADBEEF";
-    MemoBytes memoBytes = Memo::FromHexOrThrow(memo).ToBytes();
+    MemoBytes memoBytes = Memo::FromHex(memo).value().ToBytes();
     BOOST_CHECK_EQUAL(memoBytes[0], 0xDE);
     BOOST_CHECK_EQUAL(memoBytes[1], 0xAD);
     BOOST_CHECK_EQUAL(memoBytes[2], 0xBE);
@@ -1291,19 +1291,19 @@ BOOST_AUTO_TEST_CASE(memo_hex_parsing) {
     std::vector<char> v (2 * (ZC_MEMO_SIZE+1));
     std::fill(v.begin(),v.end(), 'A');
     std::string bigmemo(v.begin(), v.end());
-    BOOST_CHECK(std::get<MemoError>(Memo::FromHex(bigmemo)) == MemoError::MemoTooLong);
+    BOOST_CHECK(Memo::FromHex(bigmemo).error() == MemoError::MemoTooLong);
 
     // invalid hexadecimal string
     std::fill(v.begin(),v.end(), '@'); // not a hex character
     std::string badmemo(v.begin(), v.end());
-    BOOST_CHECK(std::get<MemoError>(Memo::FromHex(badmemo)) == MemoError::HexDecodeError);
+    BOOST_CHECK(Memo::FromHex(badmemo).error() == MemoError::HexDecodeError);
 
     // odd length hexadecimal string
     std::fill(v.begin(),v.end(), 'A');
     v.resize(v.size() - 1);
     assert(v.size() %2 == 1); // odd length
     std::string oddmemo(v.begin(), v.end());
-    BOOST_CHECK(std::get<MemoError>(Memo::FromHex(oddmemo)) == MemoError::HexDecodeError);
+    BOOST_CHECK(Memo::FromHex(oddmemo).error() == MemoError::HexDecodeError);
 }
 
 /*


### PR DESCRIPTION
The only non-test use of the logic had reimplemented it inline. This has it use the provided function.