### PR TITLE
InsertBlockIndex: pass const reference on hash, instead of hash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5492,7 +5492,7 @@ fs::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix)
     return GetDataDir() / "blocks" / strprintf("%s%05u.dat", prefix, pos.nFile);
 }
 
-CBlockIndex * InsertBlockIndex(uint256 hash)
+CBlockIndex * InsertBlockIndex(const uint256& hash)
 {
     if (hash.IsNull())
         return NULL;

--- a/src/main.h
+++ b/src/main.h
@@ -332,7 +332,7 @@ void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfterHeight
 void UnlinkPrunedFiles(std::set<int>& setFilesToPrune);
 
 /** Create a new block index entry for a given block hash */
-CBlockIndex * InsertBlockIndex(uint256 hash);
+CBlockIndex * InsertBlockIndex(const uint256& hash);
 /** Get statistics from node state */
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 /** Increase a node's misbehavior score. */


### PR DESCRIPTION
`InsertBlockIndex` should take a const reference to a uint256 instead of just a uint256.

`LoadBlockIndexGuts` also assume `std::function<CBlockIndex*(const uint256&)> insertBlockIndex` as an argument:

https://github.com/zcash/zcash/blob/2d456afebef138abbea301a1d2c44b127548db21/src/txdb.h#L150