### PR TITLE
Support ZIP 317 fees in the zcashd wallet

### DIFF
--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -13,6 +13,7 @@ from test_framework.util import (
     wait_and_assert_operationid_status,
     DEFAULT_FEE
 )
+from test_framework.zip317 import compute_conventional_fee
 
 from decimal import Decimal
 from time import sleep
@@ -105,9 +106,9 @@ class MempoolLimit(BitcoinTestFramework):
         print("Checking mempool size reset after block mined...")
         self.check_mempool_sizes(0)
         zaddr4 = self.nodes[0].z_getnewaddress('sapling')
-        opid4 = self.nodes[0].z_sendmany(zaddr1, [{"address": zaddr4, "amount": Decimal('10.0') - 2*DEFAULT_FEE}], 1)
+        opid4 = self.nodes[0].z_sendmany(zaddr1, [{"address": zaddr4, "amount": Decimal('10.0') - 2*compute_conventional_fee(2)}], 1)
         wait_and_assert_operationid_status(self.nodes[0], opid4)
-        opid5 = self.nodes[0].z_sendmany(zaddr2, [{"address": zaddr4, "amount": Decimal('10.0') - 2*DEFAULT_FEE}], 1)
+        opid5 = self.nodes[0].z_sendmany(zaddr2, [{"address": zaddr4, "amount": Decimal('10.0') - 2*compute_conventional_fee(2)}], 1)
         wait_and_assert_operationid_status(self.nodes[0], opid5)
         self.sync_all()
 

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -13,7 +13,7 @@ from test_framework.util import (
     wait_and_assert_operationid_status,
     DEFAULT_FEE
 )
-from test_framework.zip317 import compute_conventional_fee
+from test_framework.zip317 import conventional_fee
 
 from decimal import Decimal
 from time import sleep
@@ -106,9 +106,9 @@ class MempoolLimit(BitcoinTestFramework):
         print("Checking mempool size reset after block mined...")
         self.check_mempool_sizes(0)
         zaddr4 = self.nodes[0].z_getnewaddress('sapling')
-        opid4 = self.nodes[0].z_sendmany(zaddr1, [{"address": zaddr4, "amount": Decimal('10.0') - 2*compute_conventional_fee(2)}], 1)
+        opid4 = self.nodes[0].z_sendmany(zaddr1, [{"address": zaddr4, "amount": Decimal('10.0') - 2*conventional_fee(2)}], 1)
         wait_and_assert_operationid_status(self.nodes[0], opid4)
-        opid5 = self.nodes[0].z_sendmany(zaddr2, [{"address": zaddr4, "amount": Decimal('10.0') - 2*compute_conventional_fee(2)}], 1)
+        opid5 = self.nodes[0].z_sendmany(zaddr2, [{"address": zaddr4, "amount": Decimal('10.0') - 2*conventional_fee(2)}], 1)
         wait_and_assert_operationid_status(self.nodes[0], opid5)
         self.sync_all()
 

--- a/qa/rpc-tests/mempool_tx_expiry.py
+++ b/qa/rpc-tests/mempool_tx_expiry.py
@@ -12,6 +12,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, \
     connect_nodes_bi, sync_blocks, start_nodes, \
     wait_and_assert_operationid_status, DEFAULT_FEE
+from test_framework.zip317 import compute_conventional_fee
 
 from decimal import Decimal
 
@@ -219,7 +220,7 @@ class MempoolTxExpiryTest(BitcoinTestFramework):
         print("Ensure balance of node 0 is correct")
         bal = self.nodes[0].z_gettotalbalance()
         print("Balance after expire_shielded has expired: ", bal)
-        assert_equal(Decimal(bal["private"]), Decimal('8.0') - DEFAULT_FEE)
+        assert_equal(Decimal(bal["private"]), Decimal('8.0') - compute_conventional_fee(2))
 
         print("Splitting network...")
         self.split_network()

--- a/qa/rpc-tests/mempool_tx_expiry.py
+++ b/qa/rpc-tests/mempool_tx_expiry.py
@@ -12,7 +12,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, \
     connect_nodes_bi, sync_blocks, start_nodes, \
     wait_and_assert_operationid_status, DEFAULT_FEE
-from test_framework.zip317 import compute_conventional_fee
+from test_framework.zip317 import conventional_fee
 
 from decimal import Decimal
 
@@ -94,7 +94,7 @@ class MempoolTxExpiryTest(BitcoinTestFramework):
 
         # Create transactions
         blockheight = self.nodes[0].getblockchaininfo()['blocks']
-        zsendamount = Decimal('1.0') - compute_conventional_fee(2)
+        zsendamount = Decimal('1.0') - conventional_fee(2)
         recipients = []
         recipients.append({"address": z_bob, "amount": zsendamount})
         myopid = self.nodes[0].z_sendmany(z_alice, recipients, 1)

--- a/qa/rpc-tests/mempool_tx_expiry.py
+++ b/qa/rpc-tests/mempool_tx_expiry.py
@@ -94,7 +94,7 @@ class MempoolTxExpiryTest(BitcoinTestFramework):
 
         # Create transactions
         blockheight = self.nodes[0].getblockchaininfo()['blocks']
-        zsendamount = Decimal('1.0') - DEFAULT_FEE
+        zsendamount = Decimal('1.0') - compute_conventional_fee(2)
         recipients = []
         recipients.append({"address": z_bob, "amount": zsendamount})
         myopid = self.nodes[0].z_sendmany(z_alice, recipients, 1)
@@ -220,7 +220,7 @@ class MempoolTxExpiryTest(BitcoinTestFramework):
         print("Ensure balance of node 0 is correct")
         bal = self.nodes[0].z_gettotalbalance()
         print("Balance after expire_shielded has expired: ", bal)
-        assert_equal(Decimal(bal["private"]), Decimal('8.0') - compute_conventional_fee(2))
+        assert_equal(Decimal(bal["private"]), Decimal('8.0') - DEFAULT_FEE)
 
         print("Splitting network...")
         self.split_network()

--- a/qa/rpc-tests/test_framework/zip317.py
+++ b/qa/rpc-tests/test_framework/zip317.py
@@ -6,14 +6,25 @@
 #
 # zip317.py
 #
-# Utilities for ZIP 317 conventional fee specification.
+# Utilities for ZIP 317 conventional fee specification, as defined in https://zips.z.cash/zip-0317.
 #
 
 from test_framework.mininode import COIN
 from decimal import Decimal
 
-MARGINAL_FEE = Decimal(5000)/COIN
+# The fee per logical action, in ZAT. See https://zips.z.cash/zip-0317#fee-calculation.
+MARGINAL_FEE = 5000
+
+# The lower bound on the number of logical actions in a tx, for purposes of fee calculation. See
+# https://zips.z.cash/zip-0317#fee-calculation.
 GRACE_ACTIONS = 2
 
-def compute_conventional_fee(logical_actions):
+# The Zcashd RPC sentinel value to indicate the conventional_fee when a positional argument is
+# required.
+ZIP_317_FEE = -1
+
+def conventional_fee_zats(logical_actions):
     return MARGINAL_FEE * max(GRACE_ACTIONS, logical_actions)
+
+def conventional_fee(logical_actions):
+    return Decimal(conventional_fee_zats(logical_actions)) / COIN

--- a/qa/rpc-tests/test_framework/zip317.py
+++ b/qa/rpc-tests/test_framework/zip317.py
@@ -12,7 +12,7 @@
 from test_framework.mininode import COIN
 from decimal import Decimal
 
-# The fee per logical action, in ZAT. See https://zips.z.cash/zip-0317#fee-calculation.
+# The fee per logical action, in zatoshis. See https://zips.z.cash/zip-0317#fee-calculation.
 MARGINAL_FEE = 5000
 
 # The lower bound on the number of logical actions in a tx, for purposes of fee calculation. See
@@ -24,7 +24,7 @@ GRACE_ACTIONS = 2
 # https://zips.z.cash/zip-0317#recommended-algorithm-for-block-template-construction
 WEIGHT_RATIO_CAP = 4
 
-# The Zcashd RPC sentinel value to indicate the conventional_fee when a positional argument is
+# The zcashd RPC sentinel value to indicate the conventional_fee when a positional argument is
 # required.
 ZIP_317_FEE = -1
 

--- a/qa/rpc-tests/test_framework/zip317.py
+++ b/qa/rpc-tests/test_framework/zip317.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#
+# zip317.py
+#
+# Utilities for ZIP 317 conventional fee specification.
+#
+
+from test_framework.mininode import COIN
+from decimal import Decimal
+
+MARGINAL_FEE = Decimal(5000)/COIN
+GRACE_ACTIONS = 2
+
+def compute_conventional_fee(logical_actions):
+    return MARGINAL_FEE * max(GRACE_ACTIONS, logical_actions)

--- a/qa/rpc-tests/test_framework/zip317.py
+++ b/qa/rpc-tests/test_framework/zip317.py
@@ -19,6 +19,11 @@ MARGINAL_FEE = 5000
 # https://zips.z.cash/zip-0317#fee-calculation.
 GRACE_ACTIONS = 2
 
+# Limits the relative probability of picking a given transaction to be at most `WEIGHT_RATIO_CAP`
+# times greater than a transaction that pays exactly the conventional fee. See
+# https://zips.z.cash/zip-0317#recommended-algorithm-for-block-template-construction
+WEIGHT_RATIO_CAP = 4
+
 # The Zcashd RPC sentinel value to indicate the conventional_fee when a positional argument is
 # required.
 ZIP_317_FEE = -1

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -13,10 +13,11 @@ from test_framework.util import (
     connect_nodes_bi,
     nuparams,
     DEFAULT_FEE,
-    DEFAULT_FEE_ZATS,
     NU5_BRANCH_ID,
 )
 from test_framework.util import wait_and_assert_operationid_status, start_nodes
+from test_framework.mininode import COIN
+from test_framework.zip317 import compute_conventional_fee
 from decimal import Decimal
 
 my_memo_str = 'c0ffee' # stay awake
@@ -157,8 +158,8 @@ class ListReceivedTest (BitcoinTestFramework):
         outputs = sorted(pt['outputs'], key=lambda x: x['valueZat'])
         assert_equal(outputs[0]['pool'], 'sapling')
         assert_equal(outputs[0]['address'], zaddr1)
-        assert_equal(outputs[0]['value'], Decimal('0.4') - DEFAULT_FEE)
-        assert_equal(outputs[0]['valueZat'], 40000000 - DEFAULT_FEE_ZATS)
+        assert_equal(outputs[0]['value'], Decimal('0.4') - compute_conventional_fee(2))
+        assert_equal(outputs[0]['valueZat'], 40000000 - compute_conventional_fee(2)*COIN)
         assert_equal(outputs[0]['output'], 1)
         assert_equal(outputs[0]['outgoing'], False)
         assert_equal(outputs[0]['memo'], no_memo)
@@ -178,8 +179,8 @@ class ListReceivedTest (BitcoinTestFramework):
         assert_equal(2, len(r), "zaddr1 Should have received 2 notes")
         r = sorted(r, key = lambda received: received['amount'])
         assert_equal(txid, r[0]['txid'])
-        assert_equal(Decimal('0.4')-DEFAULT_FEE, r[0]['amount'])
-        assert_equal(40000000-DEFAULT_FEE_ZATS, r[0]['amountZat'])
+        assert_equal(Decimal('0.4')-compute_conventional_fee(2), r[0]['amount'])
+        assert_equal(40000000-compute_conventional_fee(2)*COIN, r[0]['amountZat'])
         assert_equal(r[0]['change'], True, "Note valued at (0.4-"+str(DEFAULT_FEE)+") should be change")
         assert_equal(no_memo, r[0]['memo'])
 
@@ -382,8 +383,8 @@ class ListReceivedTest (BitcoinTestFramework):
 
         # Verify that we observe the change output
         assert_equal(outputs[2]['pool'], 'orchard')
-        assert_equal(outputs[2]['value'], Decimal('0.49999'))
-        assert_equal(outputs[2]['valueZat'], 49999000)
+        assert_equal(outputs[2]['value'], Decimal('0.5') - compute_conventional_fee(3))
+        assert_equal(outputs[2]['valueZat'], 50000000 - compute_conventional_fee(3)*COIN)
         assert_equal(outputs[2]['outgoing'], False)
         assert_equal(outputs[2]['walletInternal'], True)
         assert_equal(outputs[2]['memo'], no_memo)

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -16,8 +16,7 @@ from test_framework.util import (
     NU5_BRANCH_ID,
 )
 from test_framework.util import wait_and_assert_operationid_status, start_nodes
-from test_framework.mininode import COIN
-from test_framework.zip317 import compute_conventional_fee
+from test_framework.zip317 import conventional_fee, conventional_fee_zats
 from decimal import Decimal
 
 my_memo_str = 'c0ffee' # stay awake
@@ -158,8 +157,8 @@ class ListReceivedTest (BitcoinTestFramework):
         outputs = sorted(pt['outputs'], key=lambda x: x['valueZat'])
         assert_equal(outputs[0]['pool'], 'sapling')
         assert_equal(outputs[0]['address'], zaddr1)
-        assert_equal(outputs[0]['value'], Decimal('0.4') - compute_conventional_fee(2))
-        assert_equal(outputs[0]['valueZat'], 40000000 - compute_conventional_fee(2)*COIN)
+        assert_equal(outputs[0]['value'], Decimal('0.4') - conventional_fee(2))
+        assert_equal(outputs[0]['valueZat'], 40000000 - conventional_fee_zats(2))
         assert_equal(outputs[0]['output'], 1)
         assert_equal(outputs[0]['outgoing'], False)
         assert_equal(outputs[0]['memo'], no_memo)
@@ -179,8 +178,8 @@ class ListReceivedTest (BitcoinTestFramework):
         assert_equal(2, len(r), "zaddr1 Should have received 2 notes")
         r = sorted(r, key = lambda received: received['amount'])
         assert_equal(txid, r[0]['txid'])
-        assert_equal(Decimal('0.4')-compute_conventional_fee(2), r[0]['amount'])
-        assert_equal(40000000-compute_conventional_fee(2)*COIN, r[0]['amountZat'])
+        assert_equal(Decimal('0.4')-conventional_fee(2), r[0]['amount'])
+        assert_equal(40000000-conventional_fee_zats(2), r[0]['amountZat'])
         assert_equal(r[0]['change'], True, "Note valued at (0.4-"+str(DEFAULT_FEE)+") should be change")
         assert_equal(no_memo, r[0]['memo'])
 
@@ -383,8 +382,8 @@ class ListReceivedTest (BitcoinTestFramework):
 
         # Verify that we observe the change output
         assert_equal(outputs[2]['pool'], 'orchard')
-        assert_equal(outputs[2]['value'], Decimal('0.5') - compute_conventional_fee(3))
-        assert_equal(outputs[2]['valueZat'], 50000000 - compute_conventional_fee(3)*COIN)
+        assert_equal(outputs[2]['value'], Decimal('0.5') - conventional_fee(3))
+        assert_equal(outputs[2]['valueZat'], 50000000 - conventional_fee_zats(3))
         assert_equal(outputs[2]['outgoing'], False)
         assert_equal(outputs[2]['walletInternal'], True)
         assert_equal(outputs[2]['memo'], no_memo)

--- a/qa/rpc-tests/wallet_nullifiers.py
+++ b/qa/rpc-tests/wallet_nullifiers.py
@@ -7,7 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_true, bitcoind_processes, \
     connect_nodes_bi, start_node, start_nodes, wait_and_assert_operationid_status, \
     get_coinbase_address, DEFAULT_FEE
-from test_framework.zip317 import compute_conventional_fee
+from test_framework.zip317 import conventional_fee
 
 from decimal import Decimal
 
@@ -93,7 +93,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
 
         # check zaddr balance
         zsendmany2notevalue = Decimal('2.0')
-        zsendmanyfee = compute_conventional_fee(2)
+        zsendmanyfee = conventional_fee(2)
         zaddrremaining = zsendmanynotevalue - zsendmany2notevalue - zsendmanyfee
         assert_equal(self.nodes[3].z_getbalance(myzaddr3), zsendmany2notevalue)
         assert_equal(self.nodes[2].z_getbalance(myzaddr), zaddrremaining)

--- a/qa/rpc-tests/wallet_nullifiers.py
+++ b/qa/rpc-tests/wallet_nullifiers.py
@@ -7,6 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_true, bitcoind_processes, \
     connect_nodes_bi, start_node, start_nodes, wait_and_assert_operationid_status, \
     get_coinbase_address, DEFAULT_FEE
+from test_framework.zip317 import compute_conventional_fee
 
 from decimal import Decimal
 
@@ -92,7 +93,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
 
         # check zaddr balance
         zsendmany2notevalue = Decimal('2.0')
-        zsendmanyfee = DEFAULT_FEE
+        zsendmanyfee = compute_conventional_fee(2)
         zaddrremaining = zsendmanynotevalue - zsendmany2notevalue - zsendmanyfee
         assert_equal(self.nodes[3].z_getbalance(myzaddr3), zsendmany2notevalue)
         assert_equal(self.nodes[2].z_getbalance(myzaddr), zaddrremaining)
@@ -117,7 +118,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
 
         # check zaddr balance
         zsendmany3notevalue = Decimal('1.0')
-        zaddrremaining2 = zaddrremaining - zsendmany3notevalue - zsendmanyfee
+        zaddrremaining2 = zaddrremaining - zsendmany3notevalue - DEFAULT_FEE
         assert_equal(self.nodes[1].z_getbalance(myzaddr), zaddrremaining2)
         assert_equal(self.nodes[2].z_getbalance(myzaddr), zaddrremaining2)
 

--- a/qa/rpc-tests/wallet_parsing_amounts.py
+++ b/qa/rpc-tests/wallet_parsing_amounts.py
@@ -70,19 +70,6 @@ class WalletAmountParsingTest(BitcoinTestFramework):
             print(errorString)
             assert(False)
 
-        # This fee is larger than the default fee and since amount=0
-        # it should trigger error
-        fee         = Decimal('0.1')
-        recipients  = [ {"address": myzaddr, "amount": Decimal('0.0') } ]
-        minconf     = 1
-        errorString = ''
-
-        try:
-            myopid = self.nodes[0].z_sendmany(myzaddr, recipients, minconf, fee)
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert('Small transaction amount' in errorString)
-
         # This fee is less than default and greater than amount, but still valid
         fee         = Decimal('0.0000001')
         recipients  = [ {"address": myzaddr, "amount": Decimal('0.00000001') } ]

--- a/qa/rpc-tests/wallet_shieldingcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldingcoinbase.py
@@ -105,7 +105,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         recipients = []
         recipients.append({"address":myzaddr, "amount":Decimal('1.23456789')})
 
-        myopid = self.nodes[0].z_sendmany(mytaddr, recipients, 10, DEFAULT_FEE, 'AllowRevealedSenders')
+        myopid = self.nodes[0].z_sendmany(mytaddr, recipients, 10, DEFAULT_FEE, 'AllowFullyTransparent')
         error_result = wait_and_assert_operationid_status_result(
                 self.nodes[0],
                 myopid, "failed",

--- a/qa/rpc-tests/wallet_shieldingcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldingcoinbase.py
@@ -324,7 +324,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
 
         # Send will fail because fee is more than `WEIGHT_RATIO_CAP * conventional_fee`
         myopid = self.nodes[0].z_sendmany(myzaddr, recipients, 1, (WEIGHT_RATIO_CAP * many_recipient_fee) + Decimal('0.00000001'))
-        wait_and_assert_operationid_status(self.nodes[0], myopid, 'failed', 'Fee 0.40000001 is greater than 4 times the conventional fee for this tx (which is 0.10). There is no prioritization benefit to a fee this large (see https://zips.z.cash/zip-0317#recommended-algorithm-for-block-template-construction) and likely indicates a mistake in setting the fee.')
+        wait_and_assert_operationid_status(self.nodes[0], myopid, 'failed', 'Fee 0.40000001 is greater than 4 times the conventional fee for this tx (which is 0.10). There is no prioritisation benefit to a fee this large (see https://zips.z.cash/zip-0317#recommended-algorithm-for-block-template-construction), and it likely indicates a mistake in setting the fee.')
 
         # Send will succeed because the balance of non-coinbase utxos is 10.0
         try:

--- a/qa/rpc-tests/wallet_shieldingcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldingcoinbase.py
@@ -10,7 +10,7 @@ from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, wait_and_assert_operationid_status, \
     wait_and_assert_operationid_status_result, get_coinbase_address, \
     check_node_log, DEFAULT_FEE
-from test_framework.zip317 import compute_conventional_fee
+from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 
 import sys
 import timeit
@@ -189,7 +189,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
 
         # A custom fee of 0 is okay.  Here the node will send the note value back to itself.
         recipients = []
-        recipients.append({"address":myzaddr, "amount": Decimal('20.0') - compute_conventional_fee(2)})
+        recipients.append({"address":myzaddr, "amount": Decimal('20.0') - conventional_fee(2)})
         myopid = self.nodes[0].z_sendmany(myzaddr, recipients, 1, Decimal('0.0'))
         mytxid = wait_and_assert_operationid_status(self.nodes[0], myopid)
         self.sync_all()
@@ -231,7 +231,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         # UTXO selection in z_sendmany sorts in ascending order, so smallest utxos are consumed first.
         # At this point in time, unspent notes all have a value of 10.0.
         recipients = []
-        amount = Decimal('10.0') - compute_conventional_fee(2) - Decimal('0.00000001')    # this leaves change at 1 zatoshi less than dust threshold
+        amount = Decimal('10.0') - conventional_fee(2) - Decimal('0.00000001')    # this leaves change at 1 zatoshi less than dust threshold
         recipients.append({"address":self.nodes[0].getnewaddress(), "amount":amount })
         myopid = self.nodes[0].z_sendmany(mytaddr, recipients, 1)
         wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "Insufficient funds: have 10.00, need 0.00000053 more to avoid creating invalid change output 0.00000001 (dust threshold is 0.00000054); note that coinbase outputs will not be selected if you specify ANY_TADDR, any transparent recipients are included, or if the `privacyPolicy` parameter is not set to `AllowRevealedSenders` or weaker.")
@@ -285,7 +285,7 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         self.nodes[0].getinfo()
         # Issue #2263 Workaround END
 
-        myopid = self.nodes[0].z_sendmany(myzaddr, recipients, 1, -1, 'AllowRevealedRecipients')
+        myopid = self.nodes[0].z_sendmany(myzaddr, recipients, 1, ZIP_317_FEE, 'AllowRevealedRecipients')
         try:
             wait_and_assert_operationid_status(self.nodes[0], myopid)
         except JSONRPCException as e:
@@ -301,9 +301,17 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
 
         # check balance
         node2balance = amount_per_recipient * num_t_recipients
-        saplingvalue -= node2balance + compute_conventional_fee(2+num_t_recipients) # 2+ for padded Sapling input/change
+        saplingvalue -= node2balance + conventional_fee(2+num_t_recipients) # 2+ for padded Sapling input/change
         assert_equal(self.nodes[2].getbalance(), node2balance)
         check_value_pool(self.nodes[0], 'sapling', saplingvalue)
+
+        # Send will fail because fee is negative
+        try:
+            # NB: Using -2 as the fee because -1 is the sentinel for using the conventional fee.
+            self.nodes[0].z_sendmany(myzaddr, recipients, 1, -2)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert_equal("Amount out of range" in errorString, True)
 
         # Send will fail because fee is larger than MAX_MONEY
         try:

--- a/qa/rpc-tests/wallet_treestate.py
+++ b/qa/rpc-tests/wallet_treestate.py
@@ -7,6 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, wait_and_assert_operationid_status, \
     get_coinbase_address, DEFAULT_FEE
+from test_framework.zip317 import compute_conventional_fee
 
 import time
 from decimal import Decimal
@@ -79,7 +80,7 @@ class WalletTreeStateTest (BitcoinTestFramework):
         # the z_sendmany implementation because there are only two inputs per joinsplit.
         recipients = []
         recipients.append({"address": self.nodes[2].z_getnewaddress(), "amount": Decimal('18.0')})
-        recipients.append({"address": self.nodes[2].z_getnewaddress(), "amount": Decimal('12.0') - 4*DEFAULT_FEE})
+        recipients.append({"address": self.nodes[2].z_getnewaddress(), "amount": Decimal('12.0') - 4 * compute_conventional_fee(3)})
         myopid = self.nodes[0].z_sendmany(myzaddr, recipients, 1)
 
         # Wait for Tx 2 to begin executing...

--- a/qa/rpc-tests/wallet_treestate.py
+++ b/qa/rpc-tests/wallet_treestate.py
@@ -7,7 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, wait_and_assert_operationid_status, \
     get_coinbase_address, DEFAULT_FEE
-from test_framework.zip317 import compute_conventional_fee
+from test_framework.zip317 import conventional_fee
 
 import time
 from decimal import Decimal
@@ -80,7 +80,7 @@ class WalletTreeStateTest (BitcoinTestFramework):
         # the z_sendmany implementation because there are only two inputs per joinsplit.
         recipients = []
         recipients.append({"address": self.nodes[2].z_getnewaddress(), "amount": Decimal('18.0')})
-        recipients.append({"address": self.nodes[2].z_getnewaddress(), "amount": Decimal('12.0') - 4 * compute_conventional_fee(3)})
+        recipients.append({"address": self.nodes[2].z_getnewaddress(), "amount": Decimal('12.0') - 4 * conventional_fee(3)})
         myopid = self.nodes[0].z_sendmany(myzaddr, recipients, 1)
 
         # Wait for Tx 2 to begin executing...

--- a/qa/rpc-tests/wallet_z_sendmany.py
+++ b/qa/rpc-tests/wallet_z_sendmany.py
@@ -22,6 +22,10 @@ from decimal import Decimal
 
 # Test wallet address behaviour across network upgrades
 class WalletZSendmanyTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.cache_behavior = 'sprout'
+
     def setup_network(self, split=False):
         self.nodes = start_nodes(3, self.options.tmpdir, [[
             nuparams(NU5_BRANCH_ID, 238),
@@ -110,12 +114,13 @@ class WalletZSendmanyTest(BitcoinTestFramework):
         # check balances
         zsendmanynotevalue = Decimal('7.0')
         zsendmanyfee = DEFAULT_FEE
-        node2utxobalance = Decimal('260.00000000') - zsendmanynotevalue - zsendmanyfee
+        node2sproutbalance = Decimal('50.00000000')
+        node2utxobalance = Decimal('210.00000000') - zsendmanynotevalue - zsendmanyfee
 
         # check shielded balance status with getwalletinfo
         wallet_info = self.nodes[2].getwalletinfo()
         assert_equal(Decimal(wallet_info["shielded_unconfirmed_balance"]), zsendmanynotevalue)
-        assert_equal(Decimal(wallet_info["shielded_balance"]), Decimal('0.0'))
+        assert_equal(Decimal(wallet_info["shielded_balance"]), node2sproutbalance)
 
         self.nodes[2].generate(10)
         self.sync_all()
@@ -130,13 +135,13 @@ class WalletZSendmanyTest(BitcoinTestFramework):
         # check via z_gettotalbalance
         resp = self.nodes[2].z_gettotalbalance()
         assert_equal(Decimal(resp["transparent"]), node2utxobalance)
-        assert_equal(Decimal(resp["private"]), zbalance)
-        assert_equal(Decimal(resp["total"]), node2utxobalance + zbalance)
+        assert_equal(Decimal(resp["private"]), node2sproutbalance + zbalance)
+        assert_equal(Decimal(resp["total"]), node2utxobalance + node2sproutbalance + zbalance)
 
         # check confirmed shielded balance with getwalletinfo
         wallet_info = self.nodes[2].getwalletinfo()
         assert_equal(Decimal(wallet_info["shielded_unconfirmed_balance"]), Decimal('0.0'))
-        assert_equal(Decimal(wallet_info["shielded_balance"]), zsendmanynotevalue)
+        assert_equal(Decimal(wallet_info["shielded_balance"]), node2sproutbalance + zsendmanynotevalue)
 
         # there should be at least one Sapling output
         mytxdetails = self.nodes[2].getrawtransaction(mytxid, 1)
@@ -377,7 +382,7 @@ class WalletZSendmanyTest(BitcoinTestFramework):
         for (policy, msg) in [
             ('FullPrivacy', 'Could not send to a shielded receiver of a unified address without spending funds from a different pool, which would reveal transaction amounts. THIS MAY AFFECT YOUR PRIVACY. Resubmit with the `privacyPolicy` parameter set to `AllowRevealedAmounts` or weaker if you wish to allow this transaction to proceed anyway.'),
             ('AllowRevealedAmounts', 'This transaction would send to a transparent receiver of a unified address, which is not enabled by default because it will publicly reveal transaction recipients and amounts. THIS MAY AFFECT YOUR PRIVACY. Resubmit with the `privacyPolicy` parameter set to `AllowRevealedRecipients` or weaker if you wish to allow this transaction to proceed anyway.'),
-            ('AllowRevealedRecipients', 'Could not send to an Orchard-only receiver, despite a lax privacy policy. Either there are insufficient non-Sprout funds (there is no transaction version that supports both Sprout and Orchard), or NU5 has not been activated yet.'),
+            ('AllowRevealedRecipients', 'Could not send to an Orchard-only receiver despite a lax privacy policy, because NU5 has not been activated yet.'),
         ]:
             opid = self.nodes[1].z_sendmany(n1ua0, recipients, 1, 0, policy)
             wait_and_assert_operationid_status(self.nodes[1], opid, 'failed', msg)
@@ -416,16 +421,17 @@ class WalletZSendmanyTest(BitcoinTestFramework):
         self.sync_all()
 
         #
-        # Test Orchard-only UA with insufficient non-Sprout funds
+        # Test sending Sprout funds to Orchard-only UA
         #
 
+        sproutAddr = self.nodes[0].listaddresses()[0]['sprout']['addresses'][0]
         recipients = [{"address":n0orchard_only, "amount":100}]
         for (policy, msg) in [
             ('FullPrivacy', 'Could not send to a shielded receiver of a unified address without spending funds from a different pool, which would reveal transaction amounts. THIS MAY AFFECT YOUR PRIVACY. Resubmit with the `privacyPolicy` parameter set to `AllowRevealedAmounts` or weaker if you wish to allow this transaction to proceed anyway.'),
             ('AllowRevealedAmounts', 'This transaction would send to a transparent receiver of a unified address, which is not enabled by default because it will publicly reveal transaction recipients and amounts. THIS MAY AFFECT YOUR PRIVACY. Resubmit with the `privacyPolicy` parameter set to `AllowRevealedRecipients` or weaker if you wish to allow this transaction to proceed anyway.'),
             ('AllowRevealedRecipients', 'Could not send to an Orchard-only receiver, despite a lax privacy policy. Either there are insufficient non-Sprout funds (there is no transaction version that supports both Sprout and Orchard), or NU5 has not been activated yet.'),
         ]:
-            opid = self.nodes[1].z_sendmany(n1ua0, recipients, 1, 0, policy)
+            opid = self.nodes[0].z_sendmany(sproutAddr, recipients, 1, 0, policy)
             wait_and_assert_operationid_status(self.nodes[1], opid, 'failed', msg)
 
         #

--- a/qa/rpc-tests/wallet_z_sendmany.py
+++ b/qa/rpc-tests/wallet_z_sendmany.py
@@ -494,5 +494,24 @@ class WalletZSendmanyTest(BitcoinTestFramework):
                 {'pools': {'orchard': {'valueZat': 200000000}}, 'minimum_confirmations': 1},
                 self.nodes[0].z_getbalanceforaccount(n0account0))
 
+
+        self.sync_all()
+        self.nodes[1].generate(1)
+        self.sync_all()
+
+        #
+        # Test transparent change
+        #
+
+        recipients = [{"address":n0ua1, "amount": 4}]
+        # Should fail because this generates transparent change, but we don’t have
+        # `AllowRevealedRecipients`
+        opid = self.nodes[2].z_sendmany(mytaddr, recipients, 1, 0, 'AllowRevealedSenders')
+        wait_and_assert_operationid_status(self.nodes[2], opid, 'failed', "This transaction would have transparent change, which is not enabled by default because it will publicly reveal the change address and amounts. THIS MAY AFFECT YOUR PRIVACY. Resubmit with the `privacyPolicy` parameter set to `AllowRevealedRecipients` or weaker if you wish to allow this transaction to proceed anyway.")
+
+        # Should succeed once we include `AllowRevealedRecipients`
+        opid = self.nodes[2].z_sendmany(mytaddr, recipients, 1, 0, 'AllowFullyTransparent')
+        wait_and_assert_operationid_status(self.nodes[2], opid)
+
 if __name__ == '__main__':
     WalletZSendmanyTest().main()

--- a/qa/rpc-tests/wallet_z_sendmany.py
+++ b/qa/rpc-tests/wallet_z_sendmany.py
@@ -424,15 +424,15 @@ class WalletZSendmanyTest(BitcoinTestFramework):
         # Test sending Sprout funds to Orchard-only UA
         #
 
-        sproutAddr = self.nodes[0].listaddresses()[0]['sprout']['addresses'][0]
+        sproutAddr = self.nodes[2].listaddresses()[0]['sprout']['addresses'][0]
         recipients = [{"address":n0orchard_only, "amount":100}]
         for (policy, msg) in [
             ('FullPrivacy', 'Could not send to a shielded receiver of a unified address without spending funds from a different pool, which would reveal transaction amounts. THIS MAY AFFECT YOUR PRIVACY. Resubmit with the `privacyPolicy` parameter set to `AllowRevealedAmounts` or weaker if you wish to allow this transaction to proceed anyway.'),
             ('AllowRevealedAmounts', 'This transaction would send to a transparent receiver of a unified address, which is not enabled by default because it will publicly reveal transaction recipients and amounts. THIS MAY AFFECT YOUR PRIVACY. Resubmit with the `privacyPolicy` parameter set to `AllowRevealedRecipients` or weaker if you wish to allow this transaction to proceed anyway.'),
-            ('AllowRevealedRecipients', 'Could not send to an Orchard-only receiver, despite a lax privacy policy. Either there are insufficient non-Sprout funds (there is no transaction version that supports both Sprout and Orchard), or NU5 has not been activated yet.'),
+            ('AllowRevealedRecipients', 'Could not send to an Orchard-only receiver despite a lax privacy policy, because you are sending from the Sprout pool and there is no transaction version that supports both Sprout and Orchard.'),
         ]:
-            opid = self.nodes[0].z_sendmany(sproutAddr, recipients, 1, 0, policy)
-            wait_and_assert_operationid_status(self.nodes[1], opid, 'failed', msg)
+            opid = self.nodes[2].z_sendmany(sproutAddr, recipients, 1, 0, policy)
+            wait_and_assert_operationid_status(self.nodes[2], opid, 'failed', msg)
 
         #
         # Test AllowRevealedAmounts policy

--- a/src/wallet/asyncrpcoperation_common.cpp
+++ b/src/wallet/asyncrpcoperation_common.cpp
@@ -124,7 +124,7 @@ void ThrowInputSelectionError(
                     "Insufficient funds: have %s, %s",
                     FormatMoney(err.available),
                     examine(err.reason, match {
-                        [](const QuasiChangeError& qce) {
+                        [](const PhantomChangeError& qce) {
                             return strprintf(
                                     "need %s more to surpass the dust threshold and avoid being "
                                     "forced to over-pay the fee. Alternatively, you could specify "
@@ -137,7 +137,7 @@ void ThrowInputSelectionError(
                             return strprintf("need %s", FormatMoney(ife.required));
                         },
                         // TODO: Add the fee here, so we can suggest specifying an explicit fee (see
-                        //       `QuasiChangeError`).
+                        //       `PhantomChangeError`).
                         [](const DustThresholdError& dte) {
                             return strprintf(
                                     "need %s more to avoid creating invalid change output %s (dust threshold is %s)",

--- a/src/wallet/asyncrpcoperation_common.cpp
+++ b/src/wallet/asyncrpcoperation_common.cpp
@@ -172,9 +172,9 @@ void ThrowInputSelectionError(
                 RPC_INVALID_PARAMETER,
                 strprintf(
                     "Fee %s is greater than %d times the conventional fee for this tx (which is "
-                    "%s). There is no prioritization benefit to a fee this large (see "
-                    "https://zips.z.cash/zip-0317#recommended-algorithm-for-block-template-construction) "
-                    "and likely indicates a mistake in setting the fee.",
+                    "%s). There is no prioritisation benefit to a fee this large (see "
+                    "https://zips.z.cash/zip-0317#recommended-algorithm-for-block-template-construction), "
+                    "and it likely indicates a mistake in setting the fee.",
                     FormatMoney(err.fixedFee),
                     WEIGHT_RATIO_CAP,
                     FormatMoney(err.conventionalFee)));

--- a/src/wallet/asyncrpcoperation_common.cpp
+++ b/src/wallet/asyncrpcoperation_common.cpp
@@ -113,9 +113,20 @@ void ThrowInputSelectionError(
                     "Insufficient funds: have %s, %s",
                     FormatMoney(err.available),
                     examine(err.reason, match {
+                        [](const QuasiChangeError& qce) {
+                            return strprintf(
+                                    "need %s more to surpass the dust threshold and avoid being "
+                                    "forced to over-pay the fee. Alternatively, you could specify "
+                                    "a fee of %s to allow overpayment of the conventional fee and "
+                                    "have this transaction proceed.",
+                                    FormatMoney(qce.dustThreshold),
+                                    FormatMoney(qce.finalFee));
+                        },
                         [](const InsufficientFundsError& ife) {
                             return strprintf("need %s", FormatMoney(ife.required));
                         },
+                        // TODO: Add the fee here, so we can suggest specifying an explicit fee (see
+                        //       `QuasiChangeError`).
                         [](const DustThresholdError& dte) {
                             return strprintf(
                                     "need %s more to avoid creating invalid change output %s (dust threshold is %s)",

--- a/src/wallet/asyncrpcoperation_common.cpp
+++ b/src/wallet/asyncrpcoperation_common.cpp
@@ -62,6 +62,14 @@ void ThrowInputSelectionError(
                         "recipients and amounts. THIS MAY AFFECT YOUR PRIVACY. Resubmit "
                         "with the `privacyPolicy` parameter set to `AllowRevealedRecipients` "
                         "or weaker if you wish to allow this transaction to proceed anyway.");
+                case AddressResolutionError::TransparentChangeNotAllowed:
+                    throw JSONRPCError(
+                        RPC_INVALID_PARAMETER,
+                        "This transaction would have transparent change, which is not "
+                        "enabled by default because it will publicly reveal the change "
+                        "address and amounts. THIS MAY AFFECT YOUR PRIVACY. Resubmit "
+                        "with the `privacyPolicy` parameter set to `AllowRevealedRecipients` "
+                        "or weaker if you wish to allow this transaction to proceed anyway.");
                 case AddressResolutionError::RevealingSaplingAmountNotAllowed:
                     throw JSONRPCError(
                         RPC_INVALID_PARAMETER,

--- a/src/wallet/asyncrpcoperation_common.cpp
+++ b/src/wallet/asyncrpcoperation_common.cpp
@@ -77,7 +77,9 @@ void ThrowInputSelectionError(
                                   strategy.AllowRevealedAmounts()
                                   ? strprintf("despite a lax privacy policy, because %s",
                                               selector.SelectsSprout()
-                                              ? "you are sending from the Sprout pool"
+                                              ? "you are sending from the Sprout pool and there is "
+                                                "no transaction version that supports both Sprout "
+                                                "and Orchard"
                                               : "NU5 has not been activated yet")
                                   : "without spending non-Orchard funds, which would reveal "
                                     "transaction amounts. THIS MAY AFFECT YOUR PRIVACY. Resubmit "

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -49,13 +49,13 @@ AsyncRPCOperation_sendmany::AsyncRPCOperation_sendmany(
         int minDepth,
         unsigned int anchorDepth,
         TransactionStrategy strategy,
-        CAmount fee,
+        std::optional<CAmount> fee,
         UniValue contextInfo) :
         builder_(std::move(builder)), ztxoSelector_(ztxoSelector), recipients_(recipients),
         mindepth_(minDepth), anchordepth_(anchorDepth), strategy_(strategy), fee_(fee),
         contextinfo_(contextInfo)
 {
-    assert(fee_ >= 0);
+    assert(!fee_.has_value() || fee_.value() >= 0);
     assert(mindepth_ >= 0);
     assert(!recipients_.empty());
     assert(ztxoSelector.RequireSpendingKeys());

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -84,7 +84,11 @@ void AsyncRPCOperation_sendmany::main() {
 
     std::optional<uint256> txid;
     try {
-        txid = main_impl(*pwalletMain);
+        txid = main_impl(*pwalletMain)
+            .map_error([&](const InputSelectionError& err) {
+                ThrowInputSelectionError(err, ztxoSelector_, strategy_);
+            })
+            .value();
     } catch (const UniValue& objError) {
         int code = find_value(objError, "code").get_int();
         std::string message = find_value(objError, "message").get_str();
@@ -137,7 +141,8 @@ void AsyncRPCOperation_sendmany::main() {
 // 4. #3615 There is no padding of inputs or outputs, which may leak information.
 //
 // At least #4 differs from the Rust transaction builder.
-uint256 AsyncRPCOperation_sendmany::main_impl(CWallet& wallet) {
+tl::expected<uint256, InputSelectionError>
+AsyncRPCOperation_sendmany::main_impl(CWallet& wallet) {
     auto spendable = builder_.FindAllSpendableInputs(wallet, ztxoSelector_, mindepth_);
 
     auto preparedTx = builder_.PrepareTransaction(
@@ -150,12 +155,8 @@ uint256 AsyncRPCOperation_sendmany::main_impl(CWallet& wallet) {
             fee_,
             anchordepth_);
 
-    uint256 txid;
-    examine(preparedTx, match {
-        [&](const InputSelectionError& err) {
-            ThrowInputSelectionError(err, ztxoSelector_, strategy_);
-        },
-        [&](const TransactionEffects& effects) {
+    return preparedTx
+        .map([&](const TransactionEffects& effects) {
             try {
                 const auto& spendable = effects.GetSpendable();
                 const auto& payments = effects.GetPayments();
@@ -187,16 +188,13 @@ uint256 AsyncRPCOperation_sendmany::main_impl(CWallet& wallet) {
                 UniValue sendResult = SendTransaction(tx, payments.GetResolvedPayments(), std::nullopt, testmode);
                 set_result(sendResult);
 
-                txid = tx.GetHash();
                 effects.UnlockSpendable(wallet);
+                return tx.GetHash();
             } catch (...) {
                 effects.UnlockSpendable(wallet);
                 throw;
             }
-        }
-    });
-
-    return txid;
+        });
 }
 
 /**

--- a/src/wallet/asyncrpcoperation_sendmany.h
+++ b/src/wallet/asyncrpcoperation_sendmany.h
@@ -35,7 +35,7 @@ public:
         int minDepth,
         unsigned int anchorDepth,
         TransactionStrategy strategy,
-        CAmount fee = DEFAULT_FEE,
+        std::optional<CAmount> fee,
         UniValue contextInfo = NullUniValue);
 
     virtual ~AsyncRPCOperation_sendmany();
@@ -61,7 +61,7 @@ private:
     TransactionStrategy strategy_;
     int mindepth_{1};
     unsigned int anchordepth_{nAnchorConfirmations};
-    CAmount fee_;
+    std::optional<CAmount> fee_;
     UniValue contextinfo_;     // optional data to include in return value from getStatus()
 
     uint256 main_impl(CWallet& wallet);

--- a/src/wallet/asyncrpcoperation_sendmany.h
+++ b/src/wallet/asyncrpcoperation_sendmany.h
@@ -64,7 +64,7 @@ private:
     std::optional<CAmount> fee_;
     UniValue contextinfo_;     // optional data to include in return value from getStatus()
 
-    uint256 main_impl(CWallet& wallet);
+    tl::expected<uint256, InputSelectionError> main_impl(CWallet& wallet);
 };
 
 // To test private methods, a friend class can act as a proxy
@@ -74,7 +74,7 @@ public:
 
     TEST_FRIEND_AsyncRPCOperation_sendmany(std::shared_ptr<AsyncRPCOperation_sendmany> ptr) : delegate(ptr) {}
 
-    uint256 main_impl(CWallet& wallet) {
+    tl::expected<uint256, InputSelectionError> main_impl(CWallet& wallet) {
         return delegate->main_impl(wallet);
     }
 

--- a/src/wallet/gtest/test_rpc_wallet.cpp
+++ b/src/wallet/gtest/test_rpc_wallet.cpp
@@ -296,7 +296,7 @@ TEST(WalletRPCTests, RPCZsendmanyTaddrToSapling)
             TransparentCoinbasePolicy::Disallow,
             false).value();
     std::vector<Payment> recipients = { Payment(pa, 1*COIN, Memo::FromHexOrThrow("ABCD")) };
-    std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 0, 0, strategy));
+    std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 0, 0, strategy, std::nullopt));
     std::shared_ptr<AsyncRPCOperation_sendmany> ptr = std::dynamic_pointer_cast<AsyncRPCOperation_sendmany> (operation);
 
     // Enable test mode so tx is not sent

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4813,7 +4813,7 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
             "                           the output is being sent to a transparent address, it’s an error to include this field.\n"
             "    }, ... ]\n"
             "3. minconf               (numeric, optional, default=" + strprintf("%u", DEFAULT_NOTE_CONFIRMATIONS) + ") Only use funds confirmed at least this many times.\n"
-            "4. fee                   (numeric, optional, default=-1) The fee amount to attach to this transaction. The default behavior\n"
+            "4. fee                   (numeric, optional, default=-1) The fee amount in " + CURRENCY_UNIT + " to attach to this transaction. The default behavior\n"
             "                         is to use a fee calculated according to ZIP 317.\n"
             "5. privacyPolicy         (string, optional, default=\"LegacyCompat\") Policy for what information leakage is acceptable.\n"
             "                         One of the following strings:\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5028,7 +5028,6 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
     // Minimum confirmations
     int nMinDepth = parseMinconf(DEFAULT_NOTE_CONFIRMATIONS, params, 2, std::nullopt);
 
-    // Fee in Zatoshis, not currency format)
     std::optional<CAmount> nFee;
     if (params.size() > 3 && params[3].get_real() != -1.0) {
         nFee = AmountFromValue( params[3] );
@@ -5040,7 +5039,7 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
     o.pushKV("amounts", params[1]);
     o.pushKV("minconf", nMinDepth);
     if (nFee.has_value()) {
-        o.pushKV("fee", std::stod(FormatMoney(nFee.value())));
+        o.pushKV("fee", ValueFromAmount(nFee.value()));
     }
     UniValue contextInfo = o;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4813,7 +4813,8 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
             "                           the output is being sent to a transparent address, it’s an error to include this field.\n"
             "    }, ... ]\n"
             "3. minconf               (numeric, optional, default=" + strprintf("%u", DEFAULT_NOTE_CONFIRMATIONS) + ") Only use funds confirmed at least this many times.\n"
-            "4. fee                   (numeric, optional, default=" + strprintf("%s", FormatMoney(DEFAULT_FEE)) + ") The fee amount to attach to this transaction.\n"
+            "4. fee                   (numeric, optional, default=-1) The fee amount to attach to this transaction. The default behavior\n"
+            "                         is to use a fee calculated according to ZIP 317.\n"
             "5. privacyPolicy         (string, optional, default=\"LegacyCompat\") Policy for what information leakage is acceptable.\n"
             "                         One of the following strings:\n"
             "                               - \"FullPrivacy\": Only allow fully-shielded transactions (involving a single shielded value pool).\n"
@@ -5028,31 +5029,33 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
     int nMinDepth = parseMinconf(DEFAULT_NOTE_CONFIRMATIONS, params, 2, std::nullopt);
 
     // Fee in Zatoshis, not currency format)
-    CAmount nFee = DEFAULT_FEE;
-    if (params.size() > 3) {
+    std::optional<CAmount> nFee;
+    if (params.size() > 3 && params[3].get_real() >= 0.0) {
+        CAmount fixedFee;
         if (params[3].get_real() == 0.0) {
-            nFee = 0;
+            fixedFee = 0;
         } else {
-            nFee = AmountFromValue( params[3] );
+            fixedFee = AmountFromValue( params[3] );
         }
 
         // Check that the user specified fee is not absurd.
         // This allows amount=0 (and all amount < DEFAULT_FEE) transactions to use the default network fee
         // or anything less than DEFAULT_FEE instead of being forced to use a custom fee and leak metadata
         if (nTotalOut < DEFAULT_FEE) {
-            if (nFee > DEFAULT_FEE) {
+            if (fixedFee > DEFAULT_FEE) {
                 throw JSONRPCError(
                         RPC_INVALID_PARAMETER,
-                        strprintf("Small transaction amount %s has fee %s that is greater than the default fee %s", FormatMoney(nTotalOut), FormatMoney(nFee), FormatMoney(DEFAULT_FEE)));
+                        strprintf("Small transaction amount %s has fee %s that is greater than the default fee %s", FormatMoney(nTotalOut), FormatMoney(fixedFee), FormatMoney(DEFAULT_FEE)));
             }
         } else {
             // Check that the user specified fee is not absurd.
-            if (nFee > nTotalOut) {
+            if (fixedFee > nTotalOut) {
                 throw JSONRPCError(
                         RPC_INVALID_PARAMETER,
-                        strprintf("Fee %s is greater than the sum of outputs %s and also greater than the default fee", FormatMoney(nFee), FormatMoney(nTotalOut)));
+                        strprintf("Fee %s is greater than the sum of outputs %s and also greater than the default fee", FormatMoney(fixedFee), FormatMoney(nTotalOut)));
             }
         }
+        nFee = fixedFee;
     }
 
     // Use input parameters as the optional context info to be returned by z_getoperationstatus and z_getoperationresult.
@@ -5060,7 +5063,9 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
     o.pushKV("fromaddress", params[0]);
     o.pushKV("amounts", params[1]);
     o.pushKV("minconf", nMinDepth);
-    o.pushKV("fee", std::stod(FormatMoney(nFee)));
+    if (nFee.has_value()) {
+        o.pushKV("fee", std::stod(FormatMoney(nFee.value())));
+    }
     UniValue contextInfo = o;
 
     // Create operation and add to global queue

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5030,13 +5030,8 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
 
     // Fee in Zatoshis, not currency format)
     std::optional<CAmount> nFee;
-    if (params.size() > 3 && params[3].get_real() >= 0.0) {
-        CAmount fixedFee;
-        if (params[3].get_real() == 0.0) {
-            fixedFee = 0;
-        } else {
-            fixedFee = AmountFromValue( params[3] );
-        }
+    if (params.size() > 3 && params[3].get_real() != -1.0) {
+        CAmount fixedFee = AmountFromValue( params[3] );
 
         // Check that the user specified fee is not absurd.
         // This allows amount=0 (and all amount < DEFAULT_FEE) transactions to use the default network fee

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5031,26 +5031,7 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
     // Fee in Zatoshis, not currency format)
     std::optional<CAmount> nFee;
     if (params.size() > 3 && params[3].get_real() != -1.0) {
-        CAmount fixedFee = AmountFromValue( params[3] );
-
-        // Check that the user specified fee is not absurd.
-        // This allows amount=0 (and all amount < DEFAULT_FEE) transactions to use the default network fee
-        // or anything less than DEFAULT_FEE instead of being forced to use a custom fee and leak metadata
-        if (nTotalOut < DEFAULT_FEE) {
-            if (fixedFee > DEFAULT_FEE) {
-                throw JSONRPCError(
-                        RPC_INVALID_PARAMETER,
-                        strprintf("Small transaction amount %s has fee %s that is greater than the default fee %s", FormatMoney(nTotalOut), FormatMoney(fixedFee), FormatMoney(DEFAULT_FEE)));
-            }
-        } else {
-            // Check that the user specified fee is not absurd.
-            if (fixedFee > nTotalOut) {
-                throw JSONRPCError(
-                        RPC_INVALID_PARAMETER,
-                        strprintf("Fee %s is greater than the sum of outputs %s and also greater than the default fee", FormatMoney(fixedFee), FormatMoney(nTotalOut)));
-            }
-        }
-        nFee = fixedFee;
+        nFee = AmountFromValue( params[3] );
     }
 
     // Use input parameters as the optional context info to be returned by z_getoperationstatus and z_getoperationresult.

--- a/src/wallet/test/rpc_wallet_tests.cpp
+++ b/src/wallet/test/rpc_wallet_tests.cpp
@@ -1251,7 +1251,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         WalletTxBuilder builder(Params(), minRelayTxFee);
         std::vector<Payment> recipients = { Payment(zaddr1, 100*COIN, Memo::FromHexOrThrow("DEADBEEF")) };
         TransactionStrategy strategy(PrivacyPolicy::AllowRevealedSenders);
-        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 1, 1, strategy));
+        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 1, 1, strategy, std::nullopt));
         operation->main();
         BOOST_CHECK(operation->isFailed());
         std::string msg = operation->getErrorMessage();
@@ -1268,7 +1268,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         WalletTxBuilder builder(Params(), minRelayTxFee);
         std::vector<Payment> recipients = { Payment(taddr1, 100*COIN, Memo::FromHexOrThrow("DEADBEEF")) };
         TransactionStrategy strategy(PrivacyPolicy::AllowRevealedRecipients);
-        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 1, 1, strategy));
+        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::move(builder), selector, recipients, 1, 1, strategy, std::nullopt));
         operation->main();
         BOOST_CHECK(operation->isFailed());
         std::string msg = operation->getErrorMessage();

--- a/src/wallet/wallet_tx_builder.cpp
+++ b/src/wallet/wallet_tx_builder.cpp
@@ -212,8 +212,7 @@ CalcZIP317Fee(
         const std::optional<ChangeAddress>& changeAddr)
 {
     std::vector<CTxOut> vouts{};
-    size_t sproutOutputCount = 0;
-    size_t saplingOutputCount{}, orchardOutputCount{};
+    size_t sproutOutputCount{}, saplingOutputCount{}, orchardOutputCount{};
     for (const auto& payment : payments) {
         std::visit(match {
             [&](const CKeyID& addr) {
@@ -546,7 +545,7 @@ WalletTxBuilder::ResolveInputsAndPayments(
         // probably perform note selection at the same time as we're performing resolved payment
         // construction above.
         bool foundSufficientFunds = spendableMut.LimitToAmount(
-                sendAmount + finalFee,
+                targetAmount,
                 dustThreshold,
                 resolved.GetRecipientPools());
         CAmount changeAmount{spendableMut.Total() - targetAmount};
@@ -574,7 +573,7 @@ WalletTxBuilder::ResolveInputsAndPayments(
         auto limitResult = IterateLimit(wallet, selector, strategy, sendAmount, dustThreshold, spendableMut, resolved, afterNU5);
         if (limitResult.has_value()) {
             std::tie(spendableMut, finalFee, changeAddr) = limitResult.value();
-            targetAmount = sendAmount - finalFee;
+            targetAmount = sendAmount + finalFee;
         } else {
             return tl::make_unexpected(limitResult.error());
         }

--- a/src/wallet/wallet_tx_builder.cpp
+++ b/src/wallet/wallet_tx_builder.cpp
@@ -35,10 +35,7 @@ WalletTxBuilder::GetChangeAddress(
             switch (rtype) {
                 case ReceiverType::P2PKH:
                 case ReceiverType::P2SH:
-                    // TODO: This is the correct policy, but it’s a breaking change from
-                    //       previous behavior, so enable it separately. (#6409)
-                    // if (strategy.AllowRevealedRecipients()) {
-                    if (!spendable.utxos.empty() || strategy.AllowRevealedRecipients()) {
+                    if (strategy.AllowRevealedRecipients()) {
                         result.insert(OutputPool::Transparent);
                     }
                     break;

--- a/src/wallet/wallet_tx_builder.h
+++ b/src/wallet/wallet_tx_builder.h
@@ -290,6 +290,17 @@ public:
         available(available), required(required) { }
 };
 
+/// Error when a fee is higher than can be useful. This reduces the chance of accidentally
+/// overpaying with explicit fees.
+class AbsurdFeeError {
+public:
+    CAmount conventionalFee;
+    CAmount fixedFee;
+
+    AbsurdFeeError(CAmount conventionalFee, CAmount fixedFee):
+        conventionalFee(conventionalFee), fixedFee(fixedFee) { }
+};
+
 enum ActionSide {
     Input,
     Output,
@@ -310,6 +321,7 @@ typedef std::variant<
     AddressResolutionError,
     InvalidFundsError,
     ChangeNotAllowedError,
+    AbsurdFeeError,
     ExcessOrchardActionsError> InputSelectionError;
 
 class InputSelection {

--- a/src/wallet/wallet_tx_builder.h
+++ b/src/wallet/wallet_tx_builder.h
@@ -241,12 +241,16 @@ enum class AddressResolutionError {
     RevealingReceiverAmountsNotAllowed,
 };
 
-class QuasiChangeError {
+/// Phantom change is change that appears to exist until we add the output for it, at which point it
+/// is consumed by the increase to the conventional fee. When we are at the limit of selectable
+/// notes, this makes it impossible to create the transaction without either creating a 0-valued
+/// output or overpaying the fee.
+class PhantomChangeError {
 public:
     CAmount finalFee;
     CAmount dustThreshold;
 
-    QuasiChangeError(CAmount finalFee, CAmount dustThreshold):
+    PhantomChangeError(CAmount finalFee, CAmount dustThreshold):
         finalFee(finalFee), dustThreshold(dustThreshold) { }
 };
 
@@ -268,7 +272,7 @@ public:
 };
 
 typedef std::variant<
-    QuasiChangeError,
+    PhantomChangeError,
     InsufficientFundsError,
     DustThresholdError> InvalidFundsReason;
 

--- a/src/wallet/wallet_tx_builder.h
+++ b/src/wallet/wallet_tx_builder.h
@@ -225,6 +225,8 @@ enum class AddressResolutionError {
     SproutRecipientsNotSupported,
     //! Requested `PrivacyPolicy` doesn’t include `AllowRevealedRecipients`
     TransparentRecipientNotAllowed,
+    //! Requested `PrivacyPolicy` doesn’t include `AllowRevealedRecipients`
+    TransparentChangeNotAllowed,
     //! Requested `PrivacyPolicy` doesn’t include `AllowRevealedAmounts`, but we don’t have enough
     //! Sapling funds to avoid revealing amounts
     RevealingSaplingAmountNotAllowed,
@@ -338,7 +340,7 @@ private:
      */
     CAmount DefaultDustThreshold() const;
 
-    ChangeAddress
+    tl::expected<ChangeAddress, AddressResolutionError>
     GetChangeAddress(
             CWallet& wallet,
             const ZTXOSelector& selector,

--- a/src/zip317.cpp
+++ b/src/zip317.cpp
@@ -14,6 +14,13 @@ CAmount CalculateConventionalFee(size_t logicalActionCount) {
     return MARGINAL_FEE * std::max(GRACE_ACTIONS, logicalActionCount);
 }
 
+template<typename T>
+size_t GetUTXOFieldSize(const std::vector<T>& utxos) {
+    auto size = GetSerializeSize(utxos, SER_NETWORK, PROTOCOL_VERSION);
+    auto countSize = GetSizeOfCompactSize(utxos.size());
+    return size - countSize;
+}
+
 size_t CalculateLogicalActionCount(
         const std::vector<CTxIn>& vin,
         const std::vector<CTxOut>& vout,
@@ -21,8 +28,8 @@ size_t CalculateLogicalActionCount(
         unsigned int saplingSpendCount,
         unsigned int saplingOutputCount,
         unsigned int orchardActionCount) {
-    const size_t tx_in_total_size = GetSerializeSize(vin, SER_NETWORK, PROTOCOL_VERSION);
-    const size_t tx_out_total_size = GetSerializeSize(vout, SER_NETWORK, PROTOCOL_VERSION);
+    const size_t tx_in_total_size = GetUTXOFieldSize(vin);
+    const size_t tx_out_total_size = GetUTXOFieldSize(vout);
 
     return std::max(ceil_div(tx_in_total_size, P2PKH_STANDARD_INPUT_SIZE),
                     ceil_div(tx_out_total_size, P2PKH_STANDARD_OUTPUT_SIZE)) +

--- a/src/zip317.cpp
+++ b/src/zip317.cpp
@@ -15,9 +15,9 @@ CAmount CalculateConventionalFee(size_t logicalActionCount) {
 }
 
 template<typename T>
-size_t GetUTXOFieldSize(const std::vector<T>& utxos) {
-    auto size = GetSerializeSize(utxos, SER_NETWORK, PROTOCOL_VERSION);
-    auto countSize = GetSizeOfCompactSize(utxos.size());
+static size_t GetTxIOFieldSize(const std::vector<T>& txIOs) {
+    auto size = GetSerializeSize(txIOs, SER_NETWORK, PROTOCOL_VERSION);
+    auto countSize = GetSizeOfCompactSize(txIOs.size());
     return size - countSize;
 }
 
@@ -28,8 +28,8 @@ size_t CalculateLogicalActionCount(
         unsigned int saplingSpendCount,
         unsigned int saplingOutputCount,
         unsigned int orchardActionCount) {
-    const size_t tx_in_total_size = GetUTXOFieldSize(vin);
-    const size_t tx_out_total_size = GetUTXOFieldSize(vout);
+    const size_t tx_in_total_size = GetTxIOFieldSize(vin);
+    const size_t tx_out_total_size = GetTxIOFieldSize(vout);
 
     return std::max(ceil_div(tx_in_total_size, P2PKH_STANDARD_INPUT_SIZE),
                     ceil_div(tx_out_total_size, P2PKH_STANDARD_OUTPUT_SIZE)) +

--- a/src/zip317.h
+++ b/src/zip317.h
@@ -23,6 +23,9 @@ static const int64_t WEIGHT_RATIO_SCALE = INT64_C(10000000000000000);
 static const int64_t WEIGHT_RATIO_CAP = 4;
 static const size_t BLOCK_UNPAID_ACTION_LIMIT = 50;
 
+/// This is the lowest the conventional fee can be in ZIP 317.
+static const CAmount MINIMUM_FEE = MARGINAL_FEE * GRACE_ACTIONS;
+
 /// Return the conventional fee for the given `logicalActionCount` calculated according to
 /// <https://zips.z.cash/zip-0317#fee-calculation>.
 CAmount CalculateConventionalFee(size_t logicalActionCount);


### PR DESCRIPTION
- still support explicit fixed fees everywhere – if a caller provides a fee, we
  don’t adjust it
- treat a fee of -1 as a signifier for use of ZIP 317 fees when a fee needs to
  be provided because of additional positional arguments

Fixes #6345.