### PR TITLE
Correct the documentation of `-rpcconnect` in the example `zcash.conf`

### DIFF
--- a/contrib/debian/examples/zcash.conf
+++ b/contrib/debian/examples/zcash.conf
@@ -91,8 +91,8 @@
 # Listen for RPC connections on this TCP port:
 #rpcport=8232
 
-# You can use Zcash or zcashd to send commands to Zcash/zcashd
-# running on another host using this option:
+# You can use zcash-cli to send commands to zcashd running on another host using
+# this option:
 #rpcconnect=127.0.0.1
 
 # Transaction Fee

--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-# Test for -rpcbind, as well as -rpcallowip and -rpcconnect
+# Test for -rpcbind and -rpcallowip
 
 # Dependency: python-bitcoinrpc
 


### PR DESCRIPTION
`-rpcconnect` is only used by `zcash-cli`.