### PR TITLE
Eliminate LegacyCompat–ZTXOSelector cycle

### DIFF
--- a/qa/rpc-tests/mempool_nu_activation.py
+++ b/qa/rpc-tests/mempool_nu_activation.py
@@ -62,7 +62,7 @@ class MempoolUpgradeActivationTest(BitcoinTestFramework):
         node1_taddr = get_coinbase_address(self.nodes[1])
         node0_zaddr = self.nodes[0].z_getnewaddress('sapling')
         recipients = [{'address': node0_zaddr, 'amount': Decimal('10')}]
-        myopid = self.nodes[1].z_sendmany(node1_taddr, recipients, 1, 0, 'AllowRevealedSenders')
+        myopid = self.nodes[1].z_sendmany(node1_taddr, recipients, 1, 0)
         print(wait_and_assert_operationid_status(self.nodes[1], myopid))
         self.sync_all()
         self.nodes[0].generate(1)

--- a/qa/rpc-tests/remove_sprout_shielding.py
+++ b/qa/rpc-tests/remove_sprout_shielding.py
@@ -89,7 +89,7 @@ class RemoveSproutShieldingTest (BitcoinTestFramework):
         # Create taddr -> Sprout z_sendmany transaction on node 0. Should fail
         sprout_addr = self.nodes[1].z_getnewaddress('sprout')
         recipients = [{"address": sprout_addr, "amount": Decimal('1')}]
-        myopid = self.nodes[0].z_sendmany(taddr_0, recipients, 1, 0, 'AllowRevealedSenders')
+        myopid = self.nodes[0].z_sendmany(taddr_0, recipients, 1, 0)
         wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "Sending funds into the Sprout pool is no longer supported.")
         print("taddr -> Sprout z_sendmany tx rejected at Canopy activation on node 0")
 


### PR DESCRIPTION
This now determines the meaning of “LegacyCompat” in advance, then always has a
known `TransactionStrategy` when we create the `ZTXOSelector`. With the addition
of `TransparentCoinbasePolicy`, there were two different ways that the selector
depended on the strategy, so it became more complicated to manage the cycle. And
the coinbase policy was overly conservative when there were no transparent
recipients or UAs in the tx. So this resolves that as well.

Fixes #6541.