### PR TITLE
Restore previous `-maxtxfee` bound

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -36,10 +36,11 @@ RPC Changes
 Changes to Transaction Fee Selection
 ------------------------------------
 
-- The `-sendfreetransactions` option has been removed. This option used to
-  instruct the wallet's legacy transaction creation APIs (`sendtoaddress`,
-  `sendmany`, and `fundrawtransaction`) to use a zero fee for "small" transactions
-  that spend "old" inputs. It will now cause a warning on node startup if used.
+- The `-mintxfee` and `-sendfreetransactions` options have been removed. These
+  options used to instruct the wallet's legacy transaction creation APIs
+  (`sendtoaddress`, `sendmany`, and `fundrawtransaction`) to increase fees to
+  this limit and to use a zero fee for "small" transactions that spend "old"
+  inputs, respectively. They will now cause a warning on node startup if used.
 
 Changes to Block Template Construction
 --------------------------------------
@@ -57,13 +58,9 @@ Removal of Priority Estimation
   number of blocks, and the associated `estimatepriority` RPC call, have been
   removed. The format for `fee_estimates.dat` has also changed to no longer save
   these priority estimates. It will automatically be converted to the new format
-  which is not readable by prior versions of the software.
-
-Removal of obsolete config options
-----------------------------------
-
-- The fee changes for ZIP 317 have made the `-mintxfee` and `-txconfirmtarget` config options
-  obsolete. They have been removed and will now cause a warning if used.
+  which is not readable by prior versions of the software. The `-txconfirmtarget`
+  config option is now obsolete and has also been removed. It will cause a
+  warning if used.
 
 [Deprecations](https://zcash.github.io/zcash/user/deprecation.html)
 --------------

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6713,15 +6713,23 @@ bool CWallet::ParameterInteraction(const CChainParams& params)
     if (mapArgs.count("-maxtxfee"))
     {
         CAmount nMaxFee = 0;
+        CAmount lowMaxTxFee = CalculateConventionalFee(LOW_LOGICAL_ACTIONS);
         if (!ParseMoney(mapArgs["-maxtxfee"], nMaxFee))
             return UIError(AmountErrMsg("maxtxfee", mapArgs["-maxtxfee"]));
         if (nMaxFee > HIGH_MAX_TX_FEE)
             UIWarning(_("-maxtxfee is set to a very high fee rate! Fee rates this large could be paid on a single transaction."));
         maxTxFee = nMaxFee;
-        if (maxTxFee < CalculateConventionalFee(LOW_LOGICAL_ACTIONS))
+        if (CFeeRate(maxTxFee, 1000) < ::minRelayTxFee)
         {
-            return UIError(strprintf(_("Invalid amount for -maxtxfee=<amount>: '%s' (must allow for at least %d logical actions at the conventional fee)"),
-                                       mapArgs["-maxtxfee"], LOW_LOGICAL_ACTIONS));
+            return UIError(strprintf(_("Invalid amount for -maxtxfee=<amount>: '%s' (must be at least the minimum relay fee rate of %s to prevent stuck transactions)"),
+                                       mapArgs["-maxtxfee"], ::minRelayTxFee.ToString()));
+        }
+        else if (maxTxFee < lowMaxTxFee)
+        {
+            UIWarning(strprintf(_("-maxtxfee is set to a very low fee rate (%s). The recommendation is to allow for at least %d logical actions at the conventional fee, which would be %s."),
+                                mapArgs["-maxtxfee"],
+                                LOW_LOGICAL_ACTIONS,
+                                DisplayMoney(lowMaxTxFee)));
         }
     }
     if (mapArgs.count("-txconfirmtarget")) {


### PR DESCRIPTION
And warn on the new bound.

Fixes #6577.