### PR TITLE
Change module comment in bridge.rs to doc comment to fix errors in zcash_script build

### DIFF
--- a/src/rust/src/bridge.rs
+++ b/src/rust/src/bridge.rs
@@ -1,11 +1,12 @@
-//! FFI bridges between `zcashd`'s Rust and C++ code.
-//!
-//! These are all collected into a single file because we can't use the same Rust type
-//! across multiple bridges until https://github.com/dtolnay/cxx/issues/496 is closed.
-//!
-//! The bridges that we leave separate are either standalone Rust code, or exporting C++
-//! types to Rust (because we _can_ use the same C++ type across multiple bridges).
-
+/// FFI bridges between `zcashd`'s Rust and C++ code.
+///
+/// These are all collected into a single file because we can't use the same Rust type
+/// across multiple bridges until https://github.com/dtolnay/cxx/issues/496 is closed.
+///
+/// The bridges that we leave separate are either standalone Rust code, or exporting C++
+/// types to Rust (because we _can_ use the same C++ type across multiple bridges).
+//
+// This file can't use a module comment (`//! comment`) because it causes compilation issues in zcash_script.
 use crate::{
     bundlecache::init as bundlecache_init,
     merkle_frontier::{new_orchard, orchard_empty_root, parse_orchard, Orchard, OrchardWallet},


### PR DESCRIPTION
This allows zcash_script to include!() the file as part of its build process.

We don't need this fix immediately, but it will help to avoid symlinks on Windows.