### PR TITLE
Add reference in Makefile.am to zip317.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -334,6 +334,7 @@ BITCOIN_CORE_H = \
   wallet/wallet_tx_builder.h \
   warnings.h \
   weighted_map.h \
+  zip317.h \
   zmq/zmqabstractnotifier.h \
   zmq/zmqconfig.h\
   zmq/zmqnotificationinterface.h \


### PR DESCRIPTION
Testing as a possible fix for this build error seen with gitian:

```
/home/debian/build/zcash/depends/x86_64-linux-gnu/native/bin/clang++ -target x86_64-linux-gnu -B/home/debian/build/zcash/depends/x86_64-linux-gnu/native/bin -stdlib=libc++ -m64 -std=c++17 -DHAVE_CONFIG_H -I. -I../src/config   -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -I. -I./obj  -pthread -I/home/debian/build/zcash/depends/x86_64-linux-gnu/share/../include -I./leveldb/include -I./leveldb/helpers/memenv -I./rust/include -I./rust/gen/include -I./secp256k1/include -I./univalue/include -I/home/debian/build/zcash/depends/x86_64-linux-gnu/include -pthread -I/home/debian/build/zcash/depends/x86_64-linux-gnu/include -I/home/debian/build/zcash/depends/x86_64-linux-gnu/share/../include/  -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS -g -Wformat -Wformat-security -Wstack-protector -fstack-protector-all -Wthread-safety-analysis -Werror   -fPIE -pipe -O3  -fwrapv -fvisibility=hidden -fno-strict-aliasing -c -o libbitcoin_server_a-init.o `test -f 'init.cpp' || echo './'`init.cpp
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
init.cpp:49:10: fatal error: 'zip317.h' file not found
#include "zip317.h"
         ^~~~~~~~~~
1 error generated.
make[3]: *** [Makefile:5732: libbitcoin_server_a-init.o] Error 1
make[3]: Leaving directory '/home/debian/build/zcash/distsrc-x86_64-linux-gnu/src'
make[2]: *** [Makefile:8886: all-recursive] Error 1
make[2]: Leaving directory '/home/debian/build/zcash/distsrc-x86_64-linux-gnu/src'
make[1]: *** [Makefile:2814: all] Error 2
make[1]: Leaving directory '/home/debian/build/zcash/distsrc-x86_64-linux-gnu/src'
make: *** [Makefile:644: all-recursive] Error 1
```