### PR TITLE
Allow explicit “no memo” in z_mergetoaddress

### DIFF
--- a/qa/rpc-tests/mergetoaddress_helper.py
+++ b/qa/rpc-tests/mergetoaddress_helper.py
@@ -15,7 +15,6 @@ from test_framework.zip317 import conventional_fee
 
 from decimal import Decimal
 
-
 def assert_mergetoaddress_exception(expected_error_msg, merge_to_address_lambda):
     try:
         merge_to_address_lambda()
@@ -165,7 +164,7 @@ class MergeToAddressHelper:
             lambda: test.nodes[0].z_mergetoaddress(["ANY_SPROUT", "ANY_SAPLING"], mytaddr))
 
         # Merge UTXOs from node 0 of value 30, default fee
-        result = test.nodes[0].z_mergetoaddress([mytaddr, mytaddr2, mytaddr3], myzaddr)
+        result = test.nodes[0].z_mergetoaddress([mytaddr, mytaddr2, mytaddr3], myzaddr, None, None, None, None, 'AllowRevealedSenders')
         wait_and_assert_operationid_status(test.nodes[0], result['opid'])
         test.sync_all()
         generate_and_check(test.nodes[1], 2)
@@ -207,7 +206,7 @@ class MergeToAddressHelper:
         assert_equal(test.nodes[2].getbalance(), Decimal('0'))
 
         # Merge all notes from node 0 into a node 0 taddr, and set fee to 0
-        result = test.nodes[0].z_mergetoaddress(self.any_zaddr, mytaddr, 0)
+        result = test.nodes[0].z_mergetoaddress(self.any_zaddr, mytaddr, 0, None, None, None, 'AllowRevealedRecipients')
         wait_and_assert_operationid_status(test.nodes[0], result['opid'])
         test.sync_all()
         generate_and_check(test.nodes[1], 2)
@@ -224,7 +223,7 @@ class MergeToAddressHelper:
         # Merge all node 0 UTXOs together into a node 1 taddr, and set fee to 0
         test.nodes[1].getnewaddress()  # Ensure we have an empty address
         n1taddr = test.nodes[1].getnewaddress()
-        result = test.nodes[0].z_mergetoaddress(["ANY_TADDR"], n1taddr, 0)
+        result = test.nodes[0].z_mergetoaddress(["ANY_TADDR"], n1taddr, 0, None, None, None, 'AllowFullyTransparent')
         wait_and_assert_operationid_status(test.nodes[0], result['opid'])
         test.sync_all()
         generate_and_check(test.nodes[1], 2)
@@ -252,7 +251,7 @@ class MergeToAddressHelper:
         test.sync_all()
 
         # This z_mergetoaddress and the one below result in two notes in myzaddr.
-        result = test.nodes[0].z_mergetoaddress([mytaddr], myzaddr, DEFAULT_FEE)
+        result = test.nodes[0].z_mergetoaddress([mytaddr], myzaddr, DEFAULT_FEE, None, None, None, 'AllowRevealedSenders')
         assert_equal(result["mergingUTXOs"], 5)
         assert_equal(result["remainingUTXOs"], 0)
         assert_equal(result["mergingNotes"], 0)
@@ -260,7 +259,7 @@ class MergeToAddressHelper:
         wait_and_assert_operationid_status(test.nodes[0], result['opid'])
 
         # Verify maximum number of UTXOs is not limited when the limit parameter is set to 0.
-        result = test.nodes[2].z_mergetoaddress([n2taddr], myzaddr, DEFAULT_FEE, 0)
+        result = test.nodes[2].z_mergetoaddress([n2taddr], myzaddr, DEFAULT_FEE, 0, None, None, 'AllowRevealedSenders')
         assert_equal(result["mergingUTXOs"], 20)
         assert_equal(result["remainingUTXOs"], 0)
         assert_equal(result["mergingNotes"], 0)
@@ -277,7 +276,7 @@ class MergeToAddressHelper:
             test.nodes[1].sendtoaddress(mytaddr, 1)
         generate_and_check(test.nodes[1], 101)
         test.sync_all()
-        result = test.nodes[0].z_mergetoaddress([mytaddr], myzaddr, conventional_fee(52))
+        result = test.nodes[0].z_mergetoaddress([mytaddr], myzaddr, conventional_fee(52), None, None, None, 'AllowRevealedSenders')
         assert_equal(result["mergingUTXOs"], 50)
         assert_equal(result["remainingUTXOs"], 50)
         assert_equal(result["mergingNotes"], 0)
@@ -289,7 +288,7 @@ class MergeToAddressHelper:
         assert_equal(3, len(test.nodes[0].z_listunspent(0)))
 
         # Verify maximum number of UTXOs which node 0 can shield can be set by the limit parameter
-        result = test.nodes[0].z_mergetoaddress([mytaddr], myzaddr, conventional_fee(35), 33)
+        result = test.nodes[0].z_mergetoaddress([mytaddr], myzaddr, conventional_fee(35), 33, None, None, 'AllowRevealedSenders')
         assert_equal(result["mergingUTXOs"], 33)
         assert_equal(result["remainingUTXOs"], 17)
         assert_equal(result["mergingNotes"], 0)
@@ -325,7 +324,7 @@ class MergeToAddressHelper:
         test.sync_all()
 
         # Shield both UTXOs and notes to a z-addr
-        result = test.nodes[0].z_mergetoaddress(self.any_zaddr_or_utxo, myzaddr, DEFAULT_FEE, 10, 2)
+        result = test.nodes[0].z_mergetoaddress(self.any_zaddr_or_utxo, myzaddr, DEFAULT_FEE, 10, 2, None, 'AllowRevealedSenders')
         assert_equal(result["mergingUTXOs"], 10)
         assert_equal(result["remainingUTXOs"], 7)
         assert_equal(result["mergingNotes"], 2)

--- a/qa/rpc-tests/mergetoaddress_sapling.py
+++ b/qa/rpc-tests/mergetoaddress_sapling.py
@@ -16,7 +16,6 @@ class MergeToAddressSapling (BitcoinTestFramework):
     def setup_network(self, split=False):
         self.helper.setup_network(self, [
             '-anchorconfirmations=1',
-            '-allowdeprecated=legacy_privacy',
         ])
 
     def run_test(self):

--- a/src/wallet/test/rpc_wallet_tests.cpp
+++ b/src/wallet/test/rpc_wallet_tests.cpp
@@ -1625,7 +1625,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_parameters)
     std::fill(v.begin(),v.end(), 'A');
     std::string badmemo(v.begin(), v.end());
     CheckRPCThrows("z_mergetoaddress [\"" + taddr1 + "\"] " + aSproutAddr + " 0.00001 100 100 " + badmemo,
-        strprintf("Invalid parameter, memo is longer than the maximum allowed %d characters.", ZC_MEMO_SIZE));
+        strprintf("Invalid parameter, size of memo is larger than maximum allowed %d", ZC_MEMO_SIZE));
 
     // Mutable tx containing contextual information we need to build tx
     UniValue retValue = CallRPC("getblockcount");

--- a/src/wallet/wallet_tx_builder.cpp
+++ b/src/wallet/wallet_tx_builder.cpp
@@ -228,12 +228,16 @@ ResolveNetPayment(
     auto initialFee = fee.value_or(MINIMUM_FEE);
     return ValidateAmount(spendable, initialFee)
         .and_then([&](void) {
+            // Needed so that the initial call to `ResolvePayment` (which is just a placeholder used
+            // to help calculate the fee) doesn’t accidentally decrement funds.
+            CAmount tempMaxSapling = maxSaplingAvailable;
+            CAmount tempMaxOrchard = maxOrchardAvailable;
             return ResolvePayment(
                     Payment(netpay.first, spendable.Total() - initialFee, netpay.second),
                     canResolveOrchard,
                     strategy,
-                    maxSaplingAvailable,
-                    maxOrchardAvailable,
+                    tempMaxSapling,
+                    tempMaxOrchard,
                     orchardOutputs)
                 .map_error([](const auto& error) -> InputSelectionError { return error; })
                 .and_then([&](const auto& rpayment) {


### PR DESCRIPTION
Previously, there were no arguments after `memo`, so it could always just be
omitted. Now the `privacyPolicy` is there, so it’s necessary to be able to
explicitly omit the memo.

Using `"F6"` would work in some situations, but while it encodes the “no memo”
case, the internal checks that ensure we don’t try to send a memo to transparent
recipients fail on it. And as we can’t merge to a taddr without specifying
`"AllowRevealedRecipients"`, this prevents merging to taddrs (unless the
deprecated `legacy_privacy` feature is enabled).

This change makes it possible to send `null` as the `memo` argument, which
indicates “no memo” successfully. It does the same for `*_limit` parameters in
`z_mergetoaddress` and `z_shieldcoinbase` (even though those don’t have a
similar failure case), since those parameters also need to be specified when the
`privacyPolicy` is, and it’s consistent with #6599, rather than hardcoding some
particular value.

This also fixes a bug in `WalletTxBuilder` that could inadvertently require
`AllowRevealedAmounts` on a transaction from a shielded pool to itself (via
`NetAmountRecipient`).