### PR TITLE
Fix `--disable-mining` build regression

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -21,7 +21,7 @@
 #include "httpserver.h"
 #include "httprpc.h"
 #include "key.h"
-#if defined(ENABLE_MINING) || defined(ENABLE_WALLET)
+#ifdef ENABLE_MINING
 #include "key_io.h"
 #endif
 #include "main.h"
@@ -1279,9 +1279,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
 
-    KeyIO keyIO(chainparams);
 #ifdef ENABLE_MINING
     if (mapArgs.count("-mineraddress")) {
+        KeyIO keyIO(chainparams);
         auto addr = keyIO.DecodePaymentAddress(mapArgs["-mineraddress"]);
         auto consensus = chainparams.GetConsensus();
         int height = consensus.HeightOfLatestSettledUpgrade();
@@ -1894,6 +1894,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
  #ifdef ENABLE_WALLET
         bool minerAddressInLocalWallet = false;
         if (pwalletMain) {
+            KeyIO keyIO(chainparams);
             auto zaddr = keyIO.DecodePaymentAddress(mapArgs["-mineraddress"]);
             if (!zaddr.has_value()) {
                 return InitError(_("-mineraddress is not a valid " PACKAGE_NAME " address."));

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -243,6 +243,7 @@ class MinerAddressScript : public CReserveScript
     void KeepScript() {}
 };
 
+#ifdef ENABLE_MINING
 // This is only useful if the test changes to require more blocks, but we keep it
 // compiling to avoid bitrot.
 void MineBlockForTest(const CChainParams& chainparams, CBlock* pblock) {
@@ -288,6 +289,7 @@ void MineBlockForTest(const CChainParams& chainparams, CBlock* pblock) {
         try_nonce += 1;
     }
 }
+#endif
 
 // NOTE: These tests rely on CreateNewBlock doing its own self-validation!
 BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
@@ -346,12 +348,16 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
             pblock->nNonce = uint256S(blockinfo[i].nonce_hex);
             pblock->nSolution = ParseHex(blockinfo[i].solution_hex);
         } else {
+#ifdef ENABLE_MINING
             // If you need to mine more blocks than are currently in blockinfo, increase
             // nblocks and then this code will do so.
             MineBlockForTest(chainparams, pblock);
             std::cout << "    {\"" << pblock->nNonce.GetHex() << "\", \"";
             std::cout << HexStr(pblock->nSolution.begin(), pblock->nSolution.end());
             std::cout << "\"}," << std::endl;
+#else
+            assert(false);
+#endif
         }
 
         // These tests assume null hashBlockCommitments (before Sapling)


### PR DESCRIPTION
This also fixes a separate build failure if both `--disable-mining` and `--disable-wallet` are selected.