### PR TITLE
Fix issues in zcash-cli

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -160,8 +160,8 @@ static const CRPCConvertTable rpcCvtTable =
     { "z_sendmany",                  {{s, o}, {o, o, s}} },
     { "z_setmigration",              {{o}, {}} },
     { "z_getmigrationstatus",        {{}, {o}} },
-    { "z_shieldcoinbase",            {{s, s}, {o, o}} },
-    { "z_mergetoaddress",            {{o, s}, {o, o, o, s}} },
+    { "z_shieldcoinbase",            {{s, s}, {o, o, s, s}} },
+    { "z_mergetoaddress",            {{o, s}, {o, o, o, s, s}} },
     { "z_listoperationids",          {{}, {s}} },
     { "z_getnotescount",             {{}, {o, o}} },
     // server

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4779,7 +4779,7 @@ static std::optional<Memo> ParseMemo(const UniValue& memoValue)
         return std::nullopt;
     } else {
         return examine(Memo::FromHex(memoValue.get_str()), match {
-            [](MemoError err) -> Memo {
+            [](MemoError err) -> std::optional<Memo> {
                 switch (err) {
                     case MemoError::HexDecodeError:
                         throw JSONRPCError(
@@ -4793,7 +4793,13 @@ static std::optional<Memo> ParseMemo(const UniValue& memoValue)
                         assert(false);
                 }
             },
-            [](Memo result) { return result; }
+            [](Memo result) -> std::optional<Memo> {
+                if (result.ToBytes() == Memo::NoMemo().ToBytes()) {
+                    return std::nullopt;
+                } else {
+                    return result;
+                }
+            }
         });
     }
 }


### PR DESCRIPTION
1. `z_mergetoaddress` didn’t accept the new `privacyPolicy` parameter,
2. `z_shieldcoinbase` didn’t accept the new `memo` or `privacyPolicy` parameters, and
3. there was no way to provide a memo that’s interpreted as the empty memo (now `"F6"` does that).

1 and 3 each independently caused a regression where it’s no longer possible to merge to a taddr – `privacyPolicy` must be provided to send to taddrs, and that can only be provided if you also provide some value for `memo`, and the `memo` value must become `std::nullopt` to be read as “no memo provided”.