### PR TITLE
Fix macOS build on CI

### DIFF
--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -9,6 +9,7 @@
 
 #include <tl/expected.hpp>
 #include <univalue.h>
+#include <variant>
 
 class UnknownRPCMethod {
  public:

--- a/src/util/match.h
+++ b/src/util/match.h
@@ -5,6 +5,8 @@
 #ifndef ZCASH_UTIL_MATCH_H
 #define ZCASH_UTIL_MATCH_H
 
+#include <variant>
+
 // Helper for using `std::visit` with Rust-style match syntax.
 //
 // This can be used in place of defining an explicit visitor. `std::visit` requires an


### PR DESCRIPTION
Not sure if it’s because of Clang 13 or something else, but the macOS build seems more sensitive to some missing includes.