### PR TITLE
Add metrics for mempool composition

### DIFF
--- a/contrib/metrics/grafana/dashboards/zcashd-metrics.json
+++ b/contrib/metrics/grafana/dashboards/zcashd-metrics.json
@@ -338,7 +338,7 @@
             "uid": "T9XAoUn4k"
           },
           "editorMode": "builder",
-          "expr": "avg_over_time(zcashd_wallet_batchscanner_usage_byes[$__interval])",
+          "expr": "avg_over_time(zcashd_wallet_batchscanner_usage_bytes[$__interval])",
           "hide": false,
           "legendFormat": "Heap usage",
           "range": true,
@@ -618,7 +618,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 50,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -631,11 +631,11 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
+            "showPoints": "auto",
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -648,14 +648,10 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "ZEC"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -665,7 +661,7 @@
         "x": 12,
         "y": 16
       },
-      "id": 8,
+      "id": 18,
       "options": {
         "legend": {
           "calcs": [],
@@ -678,20 +674,21 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "T9XAoUn4k"
           },
-          "expr": "zcash_pool_value_zatoshis/100000000",
-          "interval": "",
-          "legendFormat": "{{name}}",
-          "refId": "A"
+          "editorMode": "code",
+          "expr": "zcash_mempool_size_weighted",
+          "hide": false,
+          "legendFormat": "{{bk}}",
+          "range": true,
+          "refId": "Size"
         }
       ],
-      "title": "Shielded pools",
+      "title": "Mempool composition by weight",
       "type": "timeseries"
     },
     {
@@ -814,6 +811,200 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "T9XAoUn4k"
+          },
+          "editorMode": "code",
+          "expr": "zcash_mempool_actions_unpaid",
+          "legendFormat": "{{bk}}",
+          "range": true,
+          "refId": "Unpaid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "T9XAoUn4k"
+          },
+          "editorMode": "code",
+          "expr": "zcash_mempool_actions_paid",
+          "hide": false,
+          "legendFormat": "Paid",
+          "range": true,
+          "refId": "Paid"
+        }
+      ],
+      "title": "Mempool unpaid actions by weight",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "T9XAoUn4k"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ZEC"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.1.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "T9XAoUn4k"
+          },
+          "expr": "zcash_pool_value_zatoshis/100000000",
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Shielded pools",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "T9XAoUn4k"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
@@ -859,7 +1050,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 32
       },
       "id": 14,
       "options": {
@@ -906,6 +1097,6 @@
   "timezone": "",
   "title": "zcashd metrics",
   "uid": "U4U58t-Gk",
-  "version": 1,
+  "version": 8,
   "weekStart": ""
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2019,10 +2019,7 @@ bool AcceptToMemoryPool(
             }
 
             pool.EnsureSizeLimit();
-
-            MetricsGauge("zcash.mempool.size.transactions", pool.size());
-            MetricsGauge("zcash.mempool.size.bytes", pool.GetTotalTxSize());
-            MetricsGauge("zcash.mempool.usage.bytes", pool.DynamicMemoryUsage());
+            pool.UpdateMetrics();
         }
     }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -19,6 +19,8 @@
 #include "mempool_limit.h"
 #include "zip317.h"
 
+#include <rust/metrics.h>
+
 #include <optional>
 
 using namespace std;
@@ -1229,6 +1231,14 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
     total += insight;
 
     return total;
+}
+
+void CTxMemPool::UpdateMetrics() const {
+    LOCK(cs);
+
+    MetricsGauge("zcash.mempool.size.transactions", size());
+    MetricsGauge("zcash.mempool.size.bytes", GetTotalTxSize());
+    MetricsGauge("zcash.mempool.usage.bytes", DynamicMemoryUsage());
 }
 
 void CTxMemPool::SetMempoolCostLimit(int64_t totalCostLimit, int64_t evictionMemorySeconds) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1236,7 +1236,72 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
 void CTxMemPool::UpdateMetrics() const {
     LOCK(cs);
 
+    static const int64_t WEIGHT_RATIO_20_PCT = WEIGHT_RATIO_SCALE / 5;
+
+    // Track the sum of unpaid actions within each transaction (as they are subject to the
+    // unpaid action limit). Transactions that have weight >= 1 have no unpaid actions by
+    // definition.
+    size_t unpaidActionsWithWeightLt20pct = 0;
+    size_t unpaidActionsWithWeightLt40pct = 0;
+    size_t unpaidActionsWithWeightLt60pct = 0;
+    size_t unpaidActionsWithWeightLt80pct = 0;
+    size_t unpaidActionsWithWeightLt1 = 0;
+
+    // Track the total number of paid actions across all transactions in the mempool. This
+    // added to the bucketed unpaid actions above is equal to the total number of
+    // conventional actions in the mempool.
+    size_t paidActions = 0;
+
+    // Track the sum of transaction sizes (the metric by which they are mainly
+    // limited) across several buckets.
+    size_t sizeWithWeightLt1 = 0;
+    size_t sizeWithWeightEq1 = 0;
+    size_t sizeWithWeightGt1 = 0;
+    size_t sizeWithWeightGt2 = 0;
+    size_t sizeWithWeightGt3 = 0;
+
+    for (auto entry : mapTx) {
+        size_t txSize = entry.GetTxSize();
+        size_t unpaidActions = entry.GetUnpaidActionCount();
+        paidActions += std::max(GRACE_ACTIONS, entry.GetTx().GetLogicalActionCount()) - unpaidActions;
+
+        int128_t weightRatio = entry.GetWeightRatio();
+        if (weightRatio > 3 * WEIGHT_RATIO_SCALE) {
+            sizeWithWeightGt3 += txSize;
+        } else if (weightRatio > 2 * WEIGHT_RATIO_SCALE) {
+            sizeWithWeightGt2 += txSize;
+        } else if (weightRatio > WEIGHT_RATIO_SCALE) {
+            sizeWithWeightGt1 += txSize;
+        } else if (weightRatio == WEIGHT_RATIO_SCALE) {
+            sizeWithWeightEq1 += txSize;
+        } else {
+            sizeWithWeightLt1 += txSize;
+            if (weightRatio < WEIGHT_RATIO_20_PCT) {
+                unpaidActionsWithWeightLt20pct += unpaidActions;
+            } else if (weightRatio < 2 * WEIGHT_RATIO_20_PCT) {
+                unpaidActionsWithWeightLt40pct += unpaidActions;
+            } else if (weightRatio < 3 * WEIGHT_RATIO_20_PCT) {
+                unpaidActionsWithWeightLt60pct += unpaidActions;
+            } else if (weightRatio < 4 * WEIGHT_RATIO_20_PCT) {
+                unpaidActionsWithWeightLt80pct += unpaidActions;
+            } else {
+                unpaidActionsWithWeightLt1 += unpaidActions;
+            }
+        }
+    }
+
+    MetricsGauge("zcash.mempool.actions.unpaid", unpaidActionsWithWeightLt20pct, "bk", "< 0.2");
+    MetricsGauge("zcash.mempool.actions.unpaid", unpaidActionsWithWeightLt40pct, "bk", "< 0.4");
+    MetricsGauge("zcash.mempool.actions.unpaid", unpaidActionsWithWeightLt60pct, "bk", "< 0.6");
+    MetricsGauge("zcash.mempool.actions.unpaid", unpaidActionsWithWeightLt80pct, "bk", "< 0.8");
+    MetricsGauge("zcash.mempool.actions.unpaid", unpaidActionsWithWeightLt1, "bk", "< 1");
+    MetricsGauge("zcash.mempool.actions.paid", paidActions);
     MetricsGauge("zcash.mempool.size.transactions", size());
+    MetricsGauge("zcash.mempool.size.weighted", sizeWithWeightLt1, "bk", "< 1");
+    MetricsGauge("zcash.mempool.size.weighted", sizeWithWeightEq1, "bk", "1");
+    MetricsGauge("zcash.mempool.size.weighted", sizeWithWeightGt1, "bk", "> 1");
+    MetricsGauge("zcash.mempool.size.weighted", sizeWithWeightGt2, "bk", "> 2");
+    MetricsGauge("zcash.mempool.size.weighted", sizeWithWeightGt3, "bk", "> 3");
     MetricsGauge("zcash.mempool.size.bytes", GetTotalTxSize());
     MetricsGauge("zcash.mempool.usage.bytes", DynamicMemoryUsage());
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -558,13 +558,13 @@ public:
     void SetNotifiedSequence(uint64_t recentlyAddedSequence);
     bool IsFullyNotified();
 
-    unsigned long size()
+    unsigned long size() const
     {
         LOCK(cs);
         return mapTx.size();
     }
 
-    uint64_t GetTotalTxSize()
+    uint64_t GetTotalTxSize() const
     {
         LOCK(cs);
         return totalTxSize;
@@ -581,6 +581,8 @@ public:
     std::vector<TxMempoolInfo> infoAll() const;
 
     size_t DynamicMemoryUsage() const;
+
+    void UpdateMetrics() const;
 
     /** Return nCheckFrequency */
     uint32_t GetCheckFrequency() const {


### PR DESCRIPTION
This PR adds the following new metrics:

- (gauge) `zcash.mempool.actions.unpaid { "bk" = ["< 0.2", "< 0.4", "< 0.6", "< 0.8", "< 1"] }`
- (gauge) `zcash.mempool.actions.paid`
- (gauge) `zcash.mempool.size.weighted { "bk" = ["< 1", "1", "> 1", "> 2", "> 3"] }`

These are proposed as common Zcash metrics (with a `zcash.` prefix). The corresponding `zcashd` PR is https://github.com/ZcashFoundation/zebra/pull/6972.