### PR TITLE
Fix missing includes on macOS build

### DIFF
--- a/src/zcash/memo.h
+++ b/src/zcash/memo.h
@@ -7,6 +7,12 @@
 
 #include <tl/expected.hpp>
 
+#include <array>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
 namespace libzcash
 {
 


### PR DESCRIPTION
This is presumably a transitive `include` discrepancy. I.e., there is some other `std` header that
has `#include <variant>` etc. in Clang 15 (our usual compiler) but doesn’t have it in Clang 13 (our
macOS compiler).