### PR TITLE
Add Ubuntu 22.04 as a Tier 3 platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,11 @@ jobs:
             platform: Ubuntu 20.04
             os: ubuntu-20.04
 
+          - name: ubuntu-22.04
+            tier: 3
+            platform: Ubuntu 22.04
+            os: ubuntu-22.04
+
           - name: macos-11
             tier: 3
             platform: macOS Big Sur 11

--- a/doc/book/src/user/platform-support.md
+++ b/doc/book/src/user/platform-support.md
@@ -44,6 +44,7 @@ available.
 | target                  | OS           | notes |
 | ----------------------- | ------------ | ----- |
 | `x86_64-pc-linux-gnu`   | Arch         |
+|                         | Ubuntu 22.04 |
 | `x86_64-unknown-freebsd`| FreeBSD      |
 | `x86_64-w64-mingw32`    | Windows      | 64-bit MinGW |
 | `x86_64-apple-darwin16` | macOS 10.14+ |


### PR DESCRIPTION
Technically it is already close to Tier 1, as we are testing it in prod CI and require tests to pass. But I want to use this as a test run for going through the full Platform Tier promotion process.