### PR TITLE
Reduce MAX_INV_SZ so wtx invs fit within a network message

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -47,7 +47,7 @@ static const int PING_INTERVAL = 2 * 60;
 /** Time after which to disconnect, after waiting for a ping response (or inactivity). */
 static const int TIMEOUT_INTERVAL = 20 * 60;
 /** The maximum number of entries in an 'inv' protocol message */
-static const unsigned int MAX_INV_SZ = 50000;
+static const unsigned int MAX_INV_SZ = 25000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
 /** The maximum rate of address records we're willing to process on average. Can be bypassed using


### PR DESCRIPTION
MAX_INV_SZ is too large for a network message filled with wide transaction IDs:
```
50000 * 68 = 3400000 (3.4 MB)
```

But this is unlikely to happen with the default mempool config, because ZIP-401 limits the number of transactions in the mempool to 8,000.