### PR TITLE
Add CCoinsView support for Orchard/Sapling subtrees.

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1219,22 +1219,23 @@ std::optional<libzcash::SubtreeData> SubtreeCache::GetSubtreeData(CCoinsView *pa
         return std::nullopt;
     }
 
-    if (parentLatestSubtree.has_value() && index <= parentLatestSubtree.value().index) {
-        // This subtree is complete, but it's not in the local cache
-        return parentView->GetSubtreeData(type, index);
-    } else {
-        if (parentLatestSubtree.has_value()) {
+    if (parentLatestSubtree.has_value()) {
+        if (index <= parentLatestSubtree.value().index) {
+            // This subtree in question must have previously been flushed to the parent cache layer,
+            // so we ask for it there.
+            return parentView->GetSubtreeData(type, index);
+        } else {
             // Get the index into our local `newSubtrees` where the subtree should
             // be located.
             auto localIndex = index - (parentLatestSubtree.value().index + 1);
             assert(newSubtrees.size() > localIndex);
-            return newSubtrees[localIndex];
-        } else {
-            // The index we've been given is the index into our local `newSubtrees`
-            // since the parent view has no subtrees.
-            assert(newSubtrees.size() > index);
-            return newSubtrees[index];
-        }
+            return newSubtrees[localIndex];            
+        } 
+    } else {
+        // The index we've been given is the index into our local `newSubtrees`
+        // since the parent view has no subtrees.
+        assert(newSubtrees.size() > index);
+        return newSubtrees[index];
     }
 }
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -666,6 +666,15 @@ public:
     // Pop MMR node history from the end of the history tree
     void PopHistoryNode(uint32_t epochId);
 
+    // Push a new subtree for a given shielded type. Only Sapling
+    // and Orchard supported.
+    void PushSubtree(ShieldedType type, libzcash::SubtreeData subtree);
+
+    // Pop a subtree out of the database. Only Sapling and Orchard
+    // supported. Throws an exception if there isn't a subtree present
+    // in the database.
+    void PopSubtree(ShieldedType type);
+
     /**
      * Return a pointer to CCoins in the cache, or NULL if not found. This is
      * more efficient than GetCoins. Modifications to other cache entries are

--- a/src/coins.h
+++ b/src/coins.h
@@ -435,16 +435,16 @@ public:
 };
 
 //! This class is used by `CCoinsViewCache` to internally store, for each
-//! shielded type, the complete subtrees that have not yet been flushed
+//! shielded type, the roots of complete subtrees that have not yet been flushed
 //! to the backing `CCoinsView`. This allows the cache to both store new
-//! subtrees and handle removing subtrees from the backing view when the
+//! subtree roots and handle removing subtree roots from the backing view when the
 //! cache is flushed.
 class SubtreeCache {
     public:
 
     bool initialized = false;
     //! We store in `parentLatestSubtree` our perspective of what the latest
-    //! subtree aught to be in the backing `CCoinsView`. If subtrees are
+    //! subtree ought to be in the backing `CCoinsView`. If subtrees are
     //! removed from this subtree cache but no new complete subtrees exist,
     //! they must be removed from the backing view later when it is flushed.
     std::optional<libzcash::LatestSubtree> parentLatestSubtree;

--- a/src/coins.h
+++ b/src/coins.h
@@ -434,7 +434,7 @@ public:
     virtual ~CCoinsView() {}
 };
 
-//! This class is used by `CCoinsViewCache` to interally store, for each
+//! This class is used by `CCoinsViewCache` to internally store, for each
 //! shielded type, the complete subtrees that have not yet been flushed
 //! to the backing `CCoinsView`. This allows the cache to both store new
 //! subtrees and handle removing subtrees from the backing view when the
@@ -454,11 +454,11 @@ class SubtreeCache {
 
     SubtreeCache(ShieldedType type) : type(type) { };
 
-    //! Initialize the subtree cache so that the `parentLatestSubtree`
+    //! Initializes the subtree cache so that the `parentLatestSubtree`
     //! stored internally is consistent with the parent view.
     void Initialize(CCoinsView *parentView);
 
-    //! Resets this cache to its original uninitialized state
+    //! Resets this cache to its original uninitialized state.
     void clear();
 
     //! Gets the latest subtree for this cache, using the parent view

--- a/src/gtest/test_coins.cpp
+++ b/src/gtest/test_coins.cpp
@@ -415,7 +415,7 @@ libzcash::SubtreeData RandomSubtree(libzcash::SubtreeIndex index) {
     }
 
     // We store the intended index in the nHeight field
-    // so that the mock database can exercise tests. (Indexes
+    // so that the mock database can exercise tests. (Indices
     // are not stored in the SubtreeData struct because they
     // are already known by the caller of GetSubtreeData)
     return libzcash::SubtreeData(root, index);

--- a/src/gtest/test_mempool.cpp
+++ b/src/gtest/test_mempool.cpp
@@ -72,6 +72,15 @@ public:
         return uint256();
     }
 
+    std::optional<libzcash::LatestSubtree> GetLatestSubtree(ShieldedType type) const {
+        return std::nullopt;
+    };
+    std::optional<libzcash::SubtreeData> GetSubtreeData(
+            ShieldedType type,
+            libzcash::SubtreeIndex index) const {
+            return std::nullopt;
+    };
+
     bool BatchWrite(CCoinsMap &mapCoins,
                     const uint256 &hashBlock,
                     const uint256 &hashSproutAnchor,
@@ -83,7 +92,9 @@ public:
                     CNullifiersMap &mapSproutNullifiers,
                     CNullifiersMap &mapSaplingNullifiers,
                     CNullifiersMap &mapOrchardNullifiers,
-                    CHistoryCacheMap &historyCacheMap) {
+                    CHistoryCacheMap &historyCacheMap,
+                    SubtreeCache &cacheSaplingSubtrees,
+                    SubtreeCache &cacheOrchardSubtrees) {
         return false;
     }
 

--- a/src/gtest/test_transaction_builder.h
+++ b/src/gtest/test_transaction_builder.h
@@ -60,6 +60,16 @@ public:
         throw std::runtime_error("`GetHistoryRoot` unimplemented for mock TransactionBuilderCoinsViewDB");
     }
 
+    std::optional<libzcash::LatestSubtree> GetLatestSubtree(ShieldedType type) const {
+        return std::nullopt;
+    };
+    std::optional<libzcash::SubtreeData> GetSubtreeData(
+            ShieldedType type,
+            libzcash::SubtreeIndex index) const
+    {
+        return std::nullopt;
+    };
+
     bool BatchWrite(CCoinsMap &mapCoins,
                     const uint256 &hashBlock,
                     const uint256 &hashSproutAnchor,
@@ -71,7 +81,9 @@ public:
                     CNullifiersMap &mapSproutNullifiers,
                     CNullifiersMap &mapSaplingNullifiers,
                     CNullifiersMap &mapOrchardNullifiers,
-                    CHistoryCacheMap &historyCacheMap) {
+                    CHistoryCacheMap &historyCacheMap,
+                    SubtreeCache &cacheSaplingSubtrees,
+                    SubtreeCache &cacheOrchardSubtrees) {
         return false;
     }
 

--- a/src/gtest/test_validation.cpp
+++ b/src/gtest/test_validation.cpp
@@ -97,6 +97,16 @@ public:
         return uint256();
     }
 
+    std::optional<libzcash::LatestSubtree> GetLatestSubtree(ShieldedType type) const {
+        return std::nullopt;
+    };
+    std::optional<libzcash::SubtreeData> GetSubtreeData(
+            ShieldedType type,
+            libzcash::SubtreeIndex index) const
+    {
+        return std::nullopt;
+    };
+
     bool BatchWrite(CCoinsMap &mapCoins,
                     const uint256 &hashBlock,
                     const uint256 &hashSproutAnchor,
@@ -108,7 +118,9 @@ public:
                     CNullifiersMap &mapSproutNullifiers,
                     CNullifiersMap &mapSaplingNullifiers,
                     CNullifiersMap &mapOrchardNullifiers,
-                    CHistoryCacheMap &historyCacheMap) {
+                    CHistoryCacheMap &historyCacheMap,
+                    SubtreeCache &cacheSaplingSubtrees,
+                    SubtreeCache &cacheOrchardSubtrees) {
         return false;
     }
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -198,6 +198,16 @@ public:
     HistoryNode GetHistoryAt(uint32_t epochId, HistoryIndex index) const { return HistoryNode(); }
     uint256 GetHistoryRoot(uint32_t epochId) const { return uint256(); }
 
+    std::optional<libzcash::LatestSubtree> GetLatestSubtree(ShieldedType type) const {
+        return std::nullopt;
+    };
+    std::optional<libzcash::SubtreeData> GetSubtreeData(
+            ShieldedType type,
+            libzcash::SubtreeIndex index) const
+    {
+        return std::nullopt;
+    };
+
     bool BatchWrite(CCoinsMap& mapCoins,
                     const uint256& hashBlock,
                     const uint256& hashSproutAnchor,
@@ -209,7 +219,9 @@ public:
                     CNullifiersMap& mapSproutNullifiers,
                     CNullifiersMap& mapSaplingNullifiers,
                     CNullifiersMap& mapOrchardNullifiers,
-                    CHistoryCacheMap &historyCacheMap)
+                    CHistoryCacheMap &historyCacheMap,
+                    SubtreeCache &cacheSaplingSubtrees,
+                    SubtreeCache &cacheOrchardSubtrees)
     {
         for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end(); ) {
             if (it->second.flags & CCoinsCacheEntry::DIRTY) {
@@ -261,7 +273,9 @@ public:
                      memusage::DynamicUsage(cacheSproutNullifiers) +
                      memusage::DynamicUsage(cacheSaplingNullifiers) +
                      memusage::DynamicUsage(cacheOrchardNullifiers) +
-                     memusage::DynamicUsage(historyCacheMap);
+                     memusage::DynamicUsage(historyCacheMap) +
+                     memusage::DynamicUsage(cacheSaplingSubtrees) +
+                     memusage::DynamicUsage(cacheOrchardSubtrees);
         for (CCoinsMap::iterator it = cacheCoins.begin(); it != cacheCoins.end(); it++) {
             ret += it->second.coins.DynamicMemoryUsage();
         }

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -94,6 +94,10 @@ public:
     HistoryIndex GetHistoryLength(uint32_t epochId) const;
     HistoryNode GetHistoryAt(uint32_t epochId, HistoryIndex index) const;
     uint256 GetHistoryRoot(uint32_t epochId) const;
+    std::optional<libzcash::LatestSubtree> GetLatestSubtree(ShieldedType type) const;
+    std::optional<libzcash::SubtreeData> GetSubtreeData(
+            ShieldedType type,
+            libzcash::SubtreeIndex index) const;
     bool BatchWrite(CCoinsMap &mapCoins,
                     const uint256 &hashBlock,
                     const uint256 &hashSproutAnchor,
@@ -105,7 +109,9 @@ public:
                     CNullifiersMap &mapSproutNullifiers,
                     CNullifiersMap &mapSaplingNullifiers,
                     CNullifiersMap &mapOrchardNullifiers,
-                    CHistoryCacheMap &historyCacheMap);
+                    CHistoryCacheMap &historyCacheMap,
+                    SubtreeCache &cacheSaplingSubtrees,
+                    SubtreeCache &cacheOrchardSubtrees);
     bool GetStats(CCoinsStats &stats) const;
 };
 

--- a/src/util/test.h
+++ b/src/util/test.h
@@ -50,6 +50,15 @@ public:
         throw std::runtime_error("`GetHistoryRoot` unimplemented for mock AssumeShieldedInputsExistAndAreSpendable");
     }
 
+    std::optional<libzcash::LatestSubtree> GetLatestSubtree(ShieldedType type) const {
+        throw std::runtime_error("`GetLatestSubtree` unimplemented for mock AssumeShieldedInputsExistAndAreSpendable");
+    };
+    std::optional<libzcash::SubtreeData> GetSubtreeData(
+            ShieldedType type,
+            libzcash::SubtreeIndex index) const {
+        throw std::runtime_error("`GetSubtreeData` unimplemented for mock AssumeShieldedInputsExistAndAreSpendable");
+    };
+
     bool BatchWrite(CCoinsMap &mapCoins,
                     const uint256 &hashBlock,
                     const uint256 &hashSproutAnchor,
@@ -61,7 +70,9 @@ public:
                     CNullifiersMap &mapSproutNullifiers,
                     CNullifiersMap &mapSaplingNullifiers,
                     CNullifiersMap &mapOrchardNullifiers,
-                    CHistoryCacheMap &historyCacheMap) {
+                    CHistoryCacheMap &historyCacheMap,
+                    SubtreeCache &cacheSaplingSubtrees,
+                    SubtreeCache &cacheOrchardSubtrees) {
         return false;
     }
     bool GetStats(CCoinsStats &stats) const { return false; }

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -31,7 +31,8 @@ class LatestSubtree {
     SubtreeIndex index;
     //! The latest complete subtree root at level TRACKED_SUBTREE_HEIGHT
     SubtreeRoot root;
-    //! The height of the block that completed the latest complete subtree
+    //! The height of the block that contains the note commitment that is
+    //! the rightmost leaf of the most recently completed subtree.
     int nHeight;
 
     LatestSubtree() { }
@@ -57,7 +58,8 @@ class SubtreeData {
     uint8_t leadbyte = 0x00;
     //! The root of the subtree at level TRACKED_SUBTREE_HEIGHT
     SubtreeRoot root;
-    //! The height of the block that completed this subtree
+    //! The height of the block that contains the note commitment
+    //! that completed this subtree.
     int nHeight;
 
     SubtreeData() { }

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -35,10 +35,10 @@ class LatestSubtree {
     //! the rightmost leaf of the most recently completed subtree.
     int nHeight;
 
-    LatestSubtree() { }
+    LatestSubtree() : nHeight(0) { }
 
     LatestSubtree(SubtreeIndex index, SubtreeRoot root, int nHeight)
-        : index(index), root(root), nHeight(nHeight){ }
+        : index(index), root(root), nHeight(nHeight) { }
 
     ADD_SERIALIZE_METHODS;
 
@@ -62,10 +62,10 @@ class SubtreeData {
     //! that completed this subtree.
     int nHeight;
 
-    SubtreeData() { }
+    SubtreeData() : nHeight(0) { }
 
     SubtreeData(SubtreeRoot root, int nHeight)
-        : root(root), nHeight(nHeight){ }
+        : root(root), nHeight(nHeight) { }
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -17,6 +17,64 @@
 
 namespace libzcash {
 
+
+typedef uint64_t SubtreeIndex;
+typedef std::array<uint8_t, 32> SubtreeRoot;
+static const uint8_t TRACKED_SUBTREE_HEIGHT = 16;
+
+class LatestSubtree {
+    public:
+
+    //! Version of this structure for extensibility purposes
+    uint8_t leadbyte = 0x00;
+    //! The index of the latest complete subtree
+    SubtreeIndex index;
+    //! The latest complete subtree root at level TRACKED_SUBTREE_HEIGHT
+    SubtreeRoot root;
+    //! The height of the block that completed the latest complete subtree
+    int nHeight;
+
+    LatestSubtree() { }
+
+    LatestSubtree(SubtreeIndex index, SubtreeRoot root, int nHeight)
+        : index(index), root(root), nHeight(nHeight){ }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(leadbyte);
+        READWRITE(index);
+        READWRITE(root);
+        READWRITE(nHeight);
+    }
+};
+
+class SubtreeData {
+    public:
+
+    //! Version of this structure for extensibility purposes
+    uint8_t leadbyte = 0x00;
+    //! The root of the subtree at level TRACKED_SUBTREE_HEIGHT
+    SubtreeRoot root;
+    //! The height of the block that completed this subtree
+    int nHeight;
+
+    SubtreeData() { }
+
+    SubtreeData(SubtreeRoot root, int nHeight)
+        : root(root), nHeight(nHeight){ }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(leadbyte);
+        READWRITE(root);
+        READWRITE(nHeight);
+    }
+};
+
 class MerklePath {
 public:
     std::vector<std::vector<bool>> authentication_path;

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -551,6 +551,11 @@ public:
     HistoryNode GetHistoryAt(uint32_t epochId, HistoryIndex index) const { return HistoryNode(); }
     uint256 GetHistoryRoot(uint32_t epochId) const { return uint256(); }
 
+    std::optional<libzcash::LatestSubtree> GetLatestSubtree(ShieldedType type) const { return std::nullopt; };
+    std::optional<libzcash::SubtreeData> GetSubtreeData(
+            ShieldedType type,
+            libzcash::SubtreeIndex index) const { return std::nullopt; };
+
     bool BatchWrite(CCoinsMap &mapCoins,
                     const uint256 &hashBlock,
                     const uint256 &hashSproutAnchor,
@@ -562,7 +567,9 @@ public:
                     CNullifiersMap &mapSproutNullifiers,
                     CNullifiersMap &mapSaplingNullifiers,
                     CNullifiersMap &mapOrchardNullifiers,
-                    CHistoryCacheMap &historyCacheMap) {
+                    CHistoryCacheMap &historyCacheMap,
+                    SubtreeCache &cacheSaplingSubtrees,
+                    SubtreeCache &cacheOrchardSubtrees) {
         return false;
     }
 


### PR DESCRIPTION
This PR adds `CCoinsView`/`CCoinsViewCache`/`CCoinsViewDB` support for storing (in leveldb) subtree roots for Sapling and Orchard.

`CCoinsViewCache` has new `PushSubtree` and `PopSubtree` methods for storing the "next" (or removing the last added) subtree for a given shielded type. This will be what we need to use in `ConnectBlock`/`DisconnectBlock` when the logic is actually added for storing the subtrees. You can also ask any `CCoinsView` for a particular subtree by index (`GetSubtreeData`) or for the latest subtree (`GetLatestSubtree`). This will be what we need for RPC support.