### PR TITLE
Fix a minor bug in an error message

### DIFF
--- a/src/wallet/asyncrpcoperation_common.cpp
+++ b/src/wallet/asyncrpcoperation_common.cpp
@@ -202,10 +202,13 @@ void ThrowInputSelectionError(
             switch (err.side) {
                 case ActionSide::Input:
                     side = "inputs";
+                    break;
                 case ActionSide::Output:
                     side = "outputs";
+                    break;
                 case ActionSide::Both:
                     side = "actions";
+                    break;
             };
             throw JSONRPCError(
                 RPC_INVALID_PARAMETER,


### PR DESCRIPTION
Excess Orchard actions would always report “Orchard actions” rather than the specific “Orchard
inputs” or “Orchard outputs” when creating a tx. “Actions” wasn’t incorrect per se, but it was only
a bug in a `switch` that prevented a more helpful message from being presented to the user.