### PR TITLE
Document the Sprout cache used for RPC tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ confdefs.h
 conftest.cpp
 conftest.err
 
-cache/
 venv-mnf/
 src/univalue/gen
 

--- a/qa/rpc-tests/.gitignore
+++ b/qa/rpc-tests/.gitignore
@@ -1,2 +1,1 @@
 *.pyc
-cache

--- a/qa/rpc-tests/cache/sprout/README.md
+++ b/qa/rpc-tests/cache/sprout/README.md
@@ -1,0 +1,10 @@
+# Sprout cache contents
+
+This Sprout cache was created in 5d44ce318eb1916340e680b944b78cb5175468f9 by
+`create_sprout_chains.py`, which was added in the same commit (and removed
+shortly after). If changes are needed, the script can be updated and run from
+that commit – it’s no longer possible to send funds to Sprout in the master
+branch.
+
+The cache contains one Sprout address per node on nodes [0..3]. Each address
+contains a single 50 ZEC note.


### PR DESCRIPTION
This also removes some entries from .gitignore that were hiding the cache
directory, and didn’t seem to be hiding any other artifacts.