### PR TITLE
Correct fee calculation for vin in tx creation

### DIFF
--- a/qa/rpc-tests/mergetoaddress_helper.py
+++ b/qa/rpc-tests/mergetoaddress_helper.py
@@ -173,7 +173,7 @@ class MergeToAddressHelper:
         # Confirm balances and that do_not_shield_taddr containing funds of 10 was left alone
         assert_equal(test.nodes[0].getbalance(), Decimal('10'))
         assert_equal(test.nodes[0].z_getbalance(do_not_shield_taddr), Decimal('10'))
-        assert_equal(test.nodes[0].z_getbalance(myzaddr), Decimal('40') - conventional_fee(4))
+        assert_equal(test.nodes[0].z_getbalance(myzaddr), Decimal('40') - conventional_fee(5))
         assert_equal(test.nodes[1].getbalance(), Decimal('40'))
         assert_equal(test.nodes[2].getbalance(), Decimal('30'))
 
@@ -190,7 +190,7 @@ class MergeToAddressHelper:
         test.sync_all()
 
         assert_equal(test.nodes[0].z_getbalance(myzaddr), Decimal('0'))
-        assert_equal(test.nodes[0].z_getbalance(myzaddr2), Decimal('40') - conventional_fee(4))
+        assert_equal(test.nodes[0].z_getbalance(myzaddr2), Decimal('40') - conventional_fee(5))
 
         # Shield coinbase UTXOs from any node 2 taddr, and set fee to 0
         result = test.nodes[2].z_shieldcoinbase("*", myzaddr, 0)
@@ -201,7 +201,7 @@ class MergeToAddressHelper:
 
         assert_equal(test.nodes[0].getbalance(), Decimal('10'))
         assert_equal(test.nodes[0].z_getbalance(myzaddr), Decimal('30'))
-        assert_equal(test.nodes[0].z_getbalance(myzaddr2), Decimal('40') - conventional_fee(4))
+        assert_equal(test.nodes[0].z_getbalance(myzaddr2), Decimal('40') - conventional_fee(5))
         assert_equal(test.nodes[1].getbalance(), Decimal('60'))
         assert_equal(test.nodes[2].getbalance(), Decimal('0'))
 
@@ -212,9 +212,9 @@ class MergeToAddressHelper:
         generate_and_check(test.nodes[1], 2)
         test.sync_all()
 
-        assert_equal(test.nodes[0].getbalance(), Decimal('80') - conventional_fee(4))
+        assert_equal(test.nodes[0].getbalance(), Decimal('80') - conventional_fee(5))
         assert_equal(test.nodes[0].z_getbalance(do_not_shield_taddr), Decimal('10'))
-        assert_equal(test.nodes[0].z_getbalance(mytaddr), Decimal('70') - conventional_fee(4))
+        assert_equal(test.nodes[0].z_getbalance(mytaddr), Decimal('70') - conventional_fee(5))
         assert_equal(test.nodes[0].z_getbalance(myzaddr), Decimal('0'))
         assert_equal(test.nodes[0].z_getbalance(myzaddr2), Decimal('0'))
         assert_equal(test.nodes[1].getbalance(), Decimal('70'))
@@ -234,8 +234,8 @@ class MergeToAddressHelper:
         assert_equal(test.nodes[0].z_getbalance(do_not_shield_taddr), Decimal('0'))
         assert_equal(test.nodes[0].z_getbalance(mytaddr), Decimal('0'))
         assert_equal(test.nodes[0].z_getbalance(myzaddr), Decimal('0'))
-        assert_equal(test.nodes[1].getbalance(), Decimal('160') - conventional_fee(4))
-        assert_equal(test.nodes[1].z_getbalance(n1taddr), Decimal('80') - conventional_fee(4))
+        assert_equal(test.nodes[1].getbalance(), Decimal('160') - conventional_fee(5))
+        assert_equal(test.nodes[1].z_getbalance(n1taddr), Decimal('80') - conventional_fee(5))
         assert_equal(test.nodes[2].getbalance(), Decimal('0'))
 
         # Generate 5 regular UTXOs on node 0, and 20 regular UTXOs on node 2.

--- a/qa/rpc-tests/wallet_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldcoinbase.py
@@ -111,7 +111,7 @@ class WalletShieldCoinbaseTest (BitcoinTestFramework):
         # Confirm balances and that do_not_shield_taddr containing funds of 10 was left alone
         assert_equal(self.nodes[0].getbalance(), 10)
         assert_equal(self.nodes[0].z_getbalance(do_not_shield_taddr), Decimal('10.0'))
-        self.test_check_balance_zaddr(self.nodes[0], Decimal('40.0') - conventional_fee(4))
+        self.test_check_balance_zaddr(self.nodes[0], Decimal('40.0') - conventional_fee(6))
         assert_equal(self.nodes[1].getbalance(), 20)
         assert_equal(self.nodes[2].getbalance(), 30)
 
@@ -123,7 +123,7 @@ class WalletShieldCoinbaseTest (BitcoinTestFramework):
         self.sync_all()
 
         assert_equal(self.nodes[0].getbalance(), 10)
-        self.test_check_balance_zaddr(self.nodes[0], Decimal('70.0') - conventional_fee(4))
+        self.test_check_balance_zaddr(self.nodes[0], Decimal('70.0') - conventional_fee(6))
         assert_equal(self.nodes[1].getbalance(), 30)
         assert_equal(self.nodes[2].getbalance(), 0)
 

--- a/src/wallet/gtest/test_rpc_wallet.cpp
+++ b/src/wallet/gtest/test_rpc_wallet.cpp
@@ -341,3 +341,163 @@ TEST(WalletRPCTests, RPCZsendmanyTaddrToSapling)
     RegtestDeactivateSapling();
     UnloadGlobalWallet();
 }
+
+TEST(WalletRPCTests, ZIP317Fee)
+{
+    LoadProofParameters();
+    SelectParams(CBaseChainParams::TESTNET);
+
+    LoadGlobalWallet();
+
+    RegtestActivateSapling();
+    {
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+
+        if (!pwalletMain->HaveMnemonicSeed()) {
+            pwalletMain->GenerateNewSeed();
+        }
+
+        UniValue retValue;
+
+        KeyIO keyIO(Params());
+        // add keys manually
+        auto taddr = pwalletMain->GenerateNewKey(true).GetID();
+        auto pa = pwalletMain->GenerateNewLegacySaplingZKey();
+
+        const Consensus::Params& consensusParams = Params().GetConsensus();
+
+        int nextBlockHeight = chainActive.Height() + 1;
+
+        // Add a fake transaction to the wallet
+        CMutableTransaction mtx = CreateNewContextualCMutableTransaction(consensusParams, nextBlockHeight, false);
+        CScript scriptPubKey = CScript() << OP_DUP << OP_HASH160 << ToByteVector(taddr) << OP_EQUALVERIFY << OP_CHECKSIG;
+        size_t utxoCount = 100;
+        for (size_t i = 0; i < utxoCount; i++) {
+            mtx.vout.push_back(CTxOut(5 * COIN, scriptPubKey));
+        }
+        CWalletTx wtx(pwalletMain, mtx);
+        pwalletMain->LoadWalletTx(wtx);
+
+        // Fake-mine the transaction
+        EXPECT_EQ(-1, chainActive.Height());
+        CBlock block;
+        block.vtx.push_back(wtx);
+        block.hashMerkleRoot = BlockMerkleRoot(block);
+        auto blockHash = block.GetHash();
+        CBlockIndex fakeIndex {block};
+        mapBlockIndex.insert(std::make_pair(blockHash, &fakeIndex));
+        chainActive.SetTip(&fakeIndex);
+        EXPECT_TRUE(chainActive.Contains(&fakeIndex));
+        EXPECT_EQ(0, chainActive.Height());
+        wtx.SetMerkleBranch(block);
+        pwalletMain->LoadWalletTx(wtx);
+
+        // Add keys manually
+        std::string taddr_string = keyIO.EncodeDestination(taddr);
+
+        WalletTxBuilder builder(Params(), minRelayTxFee);
+
+        auto selector = CWallet::LegacyTransparentZTXOSelector(
+                true,
+                TransparentCoinbasePolicy::Disallow);
+
+        { // test transparent inputs to NetAmountRecipient
+            auto saplingKey = pwalletMain->GenerateNewLegacySaplingZKey();
+            NetAmountRecipient zaddr2(saplingKey, std::nullopt);
+
+            TransactionStrategy strategy(PrivacyPolicy::AllowRevealedSenders);
+
+            SpendableInputs inputs;
+            for (size_t i = 0; i < utxoCount; i++) {
+                inputs.utxos.emplace_back(COutput(&wtx, i, 100, true));
+            }
+
+            auto effects = builder.PrepareTransaction(
+                    *pwalletMain,
+                    selector,
+                    inputs,
+                    zaddr2,
+                    chainActive,
+                    strategy,
+                    std::nullopt,
+                    1)
+            .map_error([&](const auto& err) {
+                try {
+                    ThrowInputSelectionError(err, selector, strategy);
+                } catch (const UniValue& value) {
+                    FAIL() << value.write();
+                }
+            })
+            .value();
+
+            auto buildResult = effects.ApproveAndBuild(
+                    Params().GetConsensus(),
+                    *pwalletMain,
+                    chainActive,
+                    strategy);
+            auto tx = buildResult.GetTxOrThrow();
+
+            auto expectedFee = tx.GetConventionalFee();
+            // Leave one incremental fee tick of buffer above the conventional fee.
+            EXPECT_TRUE(effects.GetFee() == expectedFee
+                        || effects.GetFee() == expectedFee + 5000)
+            << "effects.GetFee() = " << effects.GetFee() << std::endl
+            << "expectedFee = " << expectedFee;
+        }
+
+        { // test transparent inputs to Payment vector
+            auto saplingKey = pwalletMain->GenerateNewLegacySaplingZKey();
+            Payment saplingPayment(saplingKey, 200 * COIN, std::nullopt);
+            auto saplingKey2 = pwalletMain->GenerateNewLegacySaplingZKey();
+            Payment saplingPayment2(saplingKey2, 200 * COIN, std::nullopt);
+            std::vector<Payment> payments {saplingPayment, saplingPayment2};
+
+            TransactionStrategy strategy(PrivacyPolicy::AllowFullyTransparent);
+
+            SpendableInputs inputs;
+            for (size_t i = 0; i < utxoCount; i++) {
+                inputs.utxos.emplace_back(COutput(&wtx, i, 100, true));
+            }
+
+            auto effects = builder.PrepareTransaction(
+                    *pwalletMain,
+                    selector,
+                    inputs,
+                    payments,
+                    chainActive,
+                    strategy,
+                    std::nullopt,
+                    1)
+                .map_error([&](const auto& err) {
+                    try {
+                        ThrowInputSelectionError(err, selector, strategy);
+                    } catch (const UniValue& value) {
+                        FAIL() << value.write();
+                    }
+                })
+                .value();
+
+            auto buildResult = effects.ApproveAndBuild(
+                    Params().GetConsensus(),
+                    *pwalletMain,
+                    chainActive,
+                    strategy);
+            auto tx = buildResult.GetTxOrThrow();
+
+            auto expectedFee = tx.GetConventionalFee();
+            // Leave one incremental fee tick of buffer above the conventional fee.
+            EXPECT_TRUE(effects.GetFee() == expectedFee
+                        || effects.GetFee() == expectedFee + 5000)
+                << "effects.GetFee() = " << effects.GetFee() << std::endl
+                << "expectedFee = " << expectedFee;
+        }
+
+        // Tear down
+        chainActive.SetTip(NULL);
+        mapBlockIndex.erase(blockHash);
+
+    }
+    // Revert to default
+    RegtestDeactivateSapling();
+    UnloadGlobalWallet();
+}

--- a/src/wallet/wallet_tx_builder.h
+++ b/src/wallet/wallet_tx_builder.h
@@ -396,14 +396,14 @@ private:
         InputSelectionError>
     IterateLimit(
             CWallet& wallet,
-            const CChain& chain,
             const ZTXOSelector& selector,
             const TransactionStrategy& strategy,
             CAmount sendAmount,
             CAmount dustThreshold,
             const SpendableInputs& spendable,
             Payments& resolved,
-            bool afterNU5) const;
+            bool afterNU5,
+            uint32_t consensusBranchId) const;
 
     /**
      * Select inputs sufficient to fulfill the specified requested payments,
@@ -416,10 +416,10 @@ private:
             const ZTXOSelector& selector,
             const SpendableInputs& spendable,
             const std::vector<Payment>& payments,
-            const CChain& chain,
             const TransactionStrategy& strategy,
             const std::optional<CAmount>& fee,
-            bool afterNU5) const;
+            bool afterNU5,
+            uint32_t consensusBranchId) const;
     /**
      * Compute the internal and external OVKs to use in transaction construction, given
      * the spendable inputs.

--- a/src/wallet/wallet_tx_builder.h
+++ b/src/wallet/wallet_tx_builder.h
@@ -396,6 +396,7 @@ private:
         InputSelectionError>
     IterateLimit(
             CWallet& wallet,
+            const CChain& chain,
             const ZTXOSelector& selector,
             const TransactionStrategy& strategy,
             CAmount sendAmount,


### PR DESCRIPTION
Previously transparent inputs were under-counted because the `CTxIn`s were created without a
signature. This now adds a dummy signatures so sizes are correct.

Fixes #6658.