### PR TITLE
Update performance-measurements.sh

### DIFF
--- a/qa/zcash/performance-measurements.sh
+++ b/qa/zcash/performance-measurements.sh
@@ -106,7 +106,7 @@ function zcashd_heaptrack_start {
             mkdir -p "$DATADIR/regtest"
             touch "$DATADIR/zcash.conf"
     esac
-    heaptrack ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 -showmetrics=0 &
+    heaptrack -o "$1" ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 -showmetrics=0 &
     ZCASHD_PID=$!
     zcash_rpc_wait_for_start
 }


### PR DESCRIPTION
To properly allow tekton benchmark pipelines to clean data, explicitly output the name of the test. Also using heaptrack compiled from source, avoid issues from heaptrack gui and profile creation procedures.

Example:
```
./qa/zcash/performance-measurements.sh memory createsaplingspend | tail -n 7 | python ./mem_metrics.py
```
Cannot parse because the profile is ONLY setup after runtime

Fix:
```
./qa/zcash/performance-measurements.sh memory createsaplingspend 

(performance_measurements has -o to output createsaplingspend.gz)

heaptrack -a createsaplingspend.gz | tail -n 7 | python ./mem_metrics.py
```