### PR TITLE
Make `./configure` quieter by default

### DIFF
--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -40,6 +40,14 @@ if [ -z "${CONFIGURE_FLAGS-}" ]; then
     CONFIGURE_FLAGS=""
 fi
 
+case "$@" in
+    *"V=1"*)
+        ;;
+    *)
+        CONFIGURE_FLAGS="--quiet $CONFIGURE_FLAGS"
+        ;;
+esac
+
 if [ "$*" = '--help' ]
 then
     cat <<EOF

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -37,16 +37,15 @@ fi
 
 # Allow users to set arbitrary compile flags. Most users will not need this.
 if [ -z "${CONFIGURE_FLAGS-}" ]; then
-    CONFIGURE_FLAGS=""
+    # If the user did not set CONFIGURE_FLAGS, then use "--quiet" unless V=1 was given.
+    CONFIGURE_FLAGS="--quiet"
+    for arg in "$@"
+    do
+        if [ "$arg" = "V=1" ]; then
+            CONFIGURE_FLAGS=""
+        fi
+    done
 fi
-
-case "$@" in
-    *"V=1"*)
-        ;;
-    *)
-        CONFIGURE_FLAGS="--quiet $CONFIGURE_FLAGS"
-        ;;
-esac
 
 if [ "$*" = '--help' ]
 then


### PR DESCRIPTION
This ties the verbosity of `./configure` to that of `make` when run via
build.sh. I.e., if `V=1` isn’t passed, don’t print all the “checking …” lines,
only print the “Build Options” at the end.