### PR TITLE
Encapsulate UnifiedAccount

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -906,16 +906,16 @@ UniValue listaddresses(const UniValue& params, bool fHelp)
         UniValue unified_groups(UniValue::VARR);
         auto hdChain = pwalletMain->GetMnemonicHDChain();
         for (const auto& [ufvkid, addrmeta] : pwalletMain->mapUfvkAddressMetadata) {
-            auto account = pwalletMain->GetUnifiedAccountId(ufvkid);
+            auto account = pwalletMain->GetUnifiedAccount(ufvkid);
             if (account.has_value() && hdChain.has_value()) {
                 // double-check that the ufvkid we get from address metadata is actually
                 // associated with the mnemonic HD chain
                 auto ufvkCheck = pwalletMain->mapUnifiedAccountKeys.find(
-                    std::make_pair(hdChain.value().GetSeedFingerprint(), account.value())
+                    std::make_pair(hdChain.value().GetSeedFingerprint(), account.value().id)
                 );
                 if (ufvkCheck != pwalletMain->mapUnifiedAccountKeys.end() && ufvkCheck->second == ufvkid) {
                     UniValue unified_group(UniValue::VOBJ);
-                    unified_group.pushKV("account", uint64_t(account.value()));
+                    unified_group.pushKV("account", uint64_t(account.value().id));
                     unified_group.pushKV("seedfp", hdChain.value().GetSeedFingerprint().GetHex());
 
                     UniValue unified_addrs(UniValue::VARR);
@@ -2859,7 +2859,7 @@ UniValue z_listunspent(const UniValue& params, bool fHelp)
         obj.pushKV("spendable", hasSaplingSpendingKey);
         auto account = pwalletMain->FindUnifiedAccountByReceiver(entry.address);
         if (account.has_value()) {
-            obj.pushKV("account", (uint64_t) account.value());
+            obj.pushKV("account", (uint64_t) account.value().id);
         }
         auto addr = pwalletMain->GetPaymentAddressForRecipient(entry.op.hash, entry.address);
         if (addr.second != RecipientType::WalletInternalAddress) {
@@ -2885,14 +2885,14 @@ UniValue z_listunspent(const UniValue& params, bool fHelp)
         // TODO: add a better mechanism for checking whether we have the
         // spending key for an Orchard receiver.
         auto ufvkMeta = pwalletMain->GetUFVKMetadataForReceiver(entry.GetAddress());
-        auto account = pwalletMain->GetUnifiedAccountId(ufvkMeta.value().GetUFVKId());
+        auto account = pwalletMain->GetUnifiedAccount(ufvkMeta.value().GetUFVKId());
         bool haveSpendingKey = ufvkMeta.has_value() && account.has_value();
         bool isInternal = pwalletMain->IsInternalRecipient(entry.GetAddress());
 
         std::optional<std::string> addrStr;
         obj.pushKV("spendable", haveSpendingKey);
         if (account.has_value()) {
-            obj.pushKV("account", (uint64_t) account.value());
+            obj.pushKV("account", (uint64_t) account.value().id);
         }
         auto addr = pwalletMain->GetPaymentAddressForRecipient(entry.GetOutPoint().hash, entry.GetAddress());
         if (addr.second != RecipientType::WalletInternalAddress) {
@@ -3235,12 +3235,27 @@ UniValue z_getnewaccount(const UniValue& params, bool fHelp)
     EnsureWalletIsBackedUp(Params());
 
     // Generate the new account.
-    auto ufvkNew = pwalletMain->GenerateNewUnifiedSpendingKey();
-    const auto& account = ufvkNew.second;
+    auto account = pwalletMain->GenerateNewUnifiedSpendingKey();
 
     UniValue result(UniValue::VOBJ);
-    result.pushKV("account", (uint64_t)account);
+    result.pushKV("account", (uint64_t)account.id);
     return result;
+}
+
+static UnifiedAccount ParseAccount(const UniValue& accountValue) {
+    int64_t accountInt = accountValue.get_int64();
+    if (0 <= accountInt && accountInt < ZCASH_LEGACY_ACCOUNT) {
+        auto ufvk = pwalletMain->GetUnifiedFullViewingKeyByAccount(accountInt);
+        if (ufvk.has_value()) {
+            return UnifiedAccount(accountInt, ufvk.value().ToFullViewingKey());
+        } else {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "No such account.");
+        }
+    } else {
+        throw JSONRPCError(
+                RPC_INVALID_PARAMETER,
+                "Invalid account number, must be 0 <= account < (2^31)-1.");
+    }
 }
 
 UniValue z_getaddressforaccount(const UniValue& params, bool fHelp)
@@ -3282,11 +3297,7 @@ UniValue z_getaddressforaccount(const UniValue& params, bool fHelp)
     // CWallet::DefaultReceiverTypes
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
-    int64_t accountInt = params[0].get_int64();
-    if (accountInt < 0 || accountInt >= ZCASH_LEGACY_ACCOUNT) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid account number, must be 0 <= account <= (2^31)-2.");
-    }
-    libzcash::AccountId account = accountInt;
+    auto account = ParseAccount(params[0]);
 
     std::set<libzcash::ReceiverType> receiverTypes;
     if (params.size() >= 2) {
@@ -3335,7 +3346,7 @@ UniValue z_getaddressforaccount(const UniValue& params, bool fHelp)
     auto res = pwalletMain->GenerateUnifiedAddress(account, receiverTypes, j);
 
     UniValue result(UniValue::VOBJ);
-    result.pushKV("account", (uint64_t)account);
+    result.pushKV("account", (uint64_t)account.id);
 
     examine(res, match {
         [&](std::pair<libzcash::UnifiedAddress, libzcash::diversifier_index_t> addr) {
@@ -3347,9 +3358,6 @@ UniValue z_getaddressforaccount(const UniValue& params, bool fHelp)
         [&](WalletUAGenerationError err) {
             std::string strErr;
             switch (err) {
-                case WalletUAGenerationError::NoSuchAccount:
-                    strErr = tfm::format("Error: account %d has not been generated by z_getnewaccount.", account);
-                    break;
                 case WalletUAGenerationError::ExistingAddressMismatch:
                     strErr = tfm::format(
                         "Error: address at diversifier index %s was already generated with different receiver types.",
@@ -4152,11 +4160,7 @@ UniValue z_getbalanceforaccount(const UniValue& params, bool fHelp)
             + HelpExampleRpc("z_getbalanceforaccount", "4 5")
         );
 
-    int64_t accountInt = params[0].get_int64();
-    if (accountInt < 0 || accountInt >= ZCASH_LEGACY_ACCOUNT) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid account number, must be 0 <= account <= (2^31)-2.");
-    }
-    libzcash::AccountId account = accountInt;
+    auto account = ParseAccount(params[0]);
 
     auto asOfHeight = parseAsOfHeight(params, 2);
 
@@ -4166,13 +4170,8 @@ UniValue z_getbalanceforaccount(const UniValue& params, bool fHelp)
 
     // Get the receivers for this account.
     auto selector = pwalletMain->ZTXOSelectorForAccount(account, false, TransparentCoinbasePolicy::Allow);
-    if (!selector.has_value()) {
-        throw JSONRPCError(
-            RPC_INVALID_PARAMETER,
-            tfm::format("Error: account %d has not been generated by z_getnewaccount.", account));
-    }
 
-    auto spendableInputs = pwalletMain->FindSpendableInputs(selector.value(), minconf, asOfHeight);
+    auto spendableInputs = pwalletMain->FindSpendableInputs(selector, minconf, asOfHeight);
     // Accounts never contain Sprout notes.
     assert(spendableInputs.sproutNoteEntries.empty());
 
@@ -5001,17 +5000,16 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
             }
 
             auto selectorAccount = pwalletMain->FindAccountForSelector(ztxoSelectorOpt.value());
-            bool unknownOrLegacy = !selectorAccount.has_value() || selectorAccount.value() == ZCASH_LEGACY_ACCOUNT;
             examine(sender.value(), match {
                 [&](const libzcash::UnifiedAddress& ua) {
-                    if (unknownOrLegacy) {
+                    if (!selectorAccount.has_value()) {
                         throw JSONRPCError(
                                 RPC_INVALID_ADDRESS_OR_KEY,
                                 "Invalid from address, UA does not correspond to a known account.");
                     }
                 },
                 [&](const auto& other) {
-                    if (!unknownOrLegacy) {
+                    if (selectorAccount.has_value()) {
                         throw JSONRPCError(
                                 RPC_INVALID_ADDRESS_OR_KEY,
                                 "Invalid from address: is a bare receiver from a Unified Address in this wallet. Provide the UA as returned by z_getaddressforaccount instead.");
@@ -5296,14 +5294,14 @@ UniValue z_shieldcoinbase(const UniValue& params, bool fHelp)
             auto selectorAccount = pwalletMain->FindAccountForSelector(ztxoSelectorOpt.value());
             examine(decoded.value(), match {
                 [&](const libzcash::UnifiedAddress&) {
-                    if (!selectorAccount.has_value() || selectorAccount.value() == ZCASH_LEGACY_ACCOUNT) {
+                    if (!selectorAccount.has_value()) {
                         throw JSONRPCError(
                                 RPC_INVALID_ADDRESS_OR_KEY,
                                 "Invalid from address, UA does not correspond to a known account.");
                     }
                 },
                 [&](const auto&) {
-                    if (selectorAccount.has_value() && selectorAccount.value() != ZCASH_LEGACY_ACCOUNT) {
+                    if (selectorAccount.has_value()) {
                         throw JSONRPCError(
                                 RPC_INVALID_ADDRESS_OR_KEY,
                                 "Invalid from address: is a bare receiver from a Unified Address in this wallet. Provide the UA as returned by z_getaddressforaccount instead.");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -55,6 +55,44 @@ unsigned int nOrchardActionLimit = DEFAULT_ORCHARD_ACTION_LIMIT;
 
 const char * DEFAULT_WALLET_DAT = "wallet.dat";
 
+
+libzcash::UnifiedFullViewingKey
+UnifiedAccount::GetUnifiedFullViewingKey() const
+{
+    return ufvk;
+}
+
+std::optional<RecipientAddress>
+UnifiedAccount::GenerateChangeAddress(const CChainParams& params, const std::set<OutputPool>& changeOptions) const
+{
+    auto ufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(params, GetUnifiedFullViewingKey());
+    // changeOptions is sorted in preference order, so return
+    // the first (and therefore most preferred) change address that
+    // we're able to generate.
+    for (OutputPool t : changeOptions) {
+        std::optional<RecipientAddress> changeAddr;
+        switch (t) {
+            case OutputPool::Orchard:
+                changeAddr = ufvk.GetChangeAddress(OrchardChangeRequest());
+                break;
+            case OutputPool::Sapling:
+                changeAddr = ufvk.GetChangeAddress(SaplingChangeRequest());
+                break;
+            case OutputPool::Transparent:
+                // UFVKs must have a shielded component, so we would only
+                // reach this point if changeOptions contained no shielded
+                // options. But we prefer to opportunistically shield funds
+                // where possible, so we don't produce transparent change
+                // addresses for accounts.
+                break;
+        }
+        if (changeAddr.has_value()) {
+            return changeAddr.value();
+        }
+    }
+    return std::nullopt;
+}
+
 std::set<ReceiverType> CWallet::DefaultReceiverTypes(int nHeight) {
     // For now, just ignore the height information because the default
     // is always the same.
@@ -503,8 +541,7 @@ libzcash::transparent::AccountKey CWallet::GetLegacyAccountKey() const {
             ZCASH_LEGACY_ACCOUNT).value();
 }
 
-
-std::pair<UnifiedFullViewingKey, libzcash::AccountId> CWallet::GenerateNewUnifiedSpendingKey() {
+UnifiedAccount CWallet::GenerateNewUnifiedSpendingKey() {
     AssertLockHeld(cs_wallet);
 
     if (!mnemonicHDChain.has_value()) {
@@ -529,13 +566,14 @@ std::pair<UnifiedFullViewingKey, libzcash::AccountId> CWallet::GenerateNewUnifie
                         "CWallet::GenerateNewUnifiedSpendingKey(): Writing HD chain model failed");
             }
 
-            return std::make_pair(generated.value().ToFullViewingKey(), accountId);
+            auto ufvk = generated.value().ToFullViewingKey();
+            return UnifiedAccount(accountId, ufvk);
         }
     }
 }
 
 std::optional<libzcash::ZcashdUnifiedSpendingKey>
-        CWallet::GenerateUnifiedSpendingKeyForAccount(libzcash::AccountId accountId) {
+CWallet::GenerateUnifiedSpendingKeyForAccount(libzcash::AccountId accountId) {
     AssertLockHeld(cs_wallet); // mapUnifiedAccountKeys
 
     auto seed = GetMnemonicSeed();
@@ -684,7 +722,7 @@ WalletUAGenerationResult ToWalletUAGenerationResult(UnifiedAddressGenerationResu
 }
 
 WalletUAGenerationResult CWallet::GenerateUnifiedAddress(
-    const libzcash::AccountId& accountId,
+    const UnifiedAccount& account,
     const std::set<libzcash::ReceiverType>& receiverTypes,
     std::optional<libzcash::diversifier_index_t> j)
 {
@@ -712,124 +750,122 @@ WalletUAGenerationResult CWallet::GenerateUnifiedAddress(
         }
     }
 
-    auto ufvk = GetUnifiedFullViewingKeyByAccount(accountId);
-    if (ufvk.has_value()) {
-        auto ufvkid = ufvk.value().GetKeyID();
+    auto ufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(
+            Params(),
+            account.GetUnifiedFullViewingKey());
+    auto ufvkid = ufvk.GetKeyID();
 
-        // Check whether an address has already been generated for any provided
-        // diversifier index. Return that address, or set the diversifier index
-        // at which we'll begin searching for the next available diversified
-        // address.
-        auto metadata = mapUfvkAddressMetadata.find(ufvkid);
-        if (metadata != mapUfvkAddressMetadata.end()) {
-            if (j.has_value()) {
-                auto receivers = metadata->second.GetReceivers(j.value());
-                if (receivers.has_value()) {
-                    // Ensure that the set of receiver types being requested is
-                    // the same as the set of receiver types that was previously
-                    // generated. If they match, simply return that address.
-                    if (receivers.value() == receiverTypes) {
-                        return ToWalletUAGenerationResult(ufvk.value().Address(j.value(), receiverTypes));
-                    } else {
-                        return WalletUAGenerationError::ExistingAddressMismatch;
-                    }
-                }
-            } else {
-                // Set the diversifier index to one greater than the last used
-                // diversifier
-                j = metadata->second.GetNextDiversifierIndex();
-                if (!j.has_value()) {
-                    return UnifiedAddressGenerationError::DiversifierSpaceExhausted;
+    // Check whether an address has already been generated for any provided
+    // diversifier index. Return that address, or set the diversifier index
+    // at which we'll begin searching for the next available diversified
+    // address.
+    auto metadata = mapUfvkAddressMetadata.find(ufvkid);
+    if (metadata != mapUfvkAddressMetadata.end()) {
+        if (j.has_value()) {
+            auto receivers = metadata->second.GetReceivers(j.value());
+            if (receivers.has_value()) {
+                // Ensure that the set of receiver types being requested is
+                // the same as the set of receiver types that was previously
+                // generated. If they match, simply return that address.
+                if (receivers.value() == receiverTypes) {
+                    return ToWalletUAGenerationResult(ufvk.Address(j.value(), receiverTypes));
+                } else {
+                    return WalletUAGenerationError::ExistingAddressMismatch;
                 }
             }
         } else {
-            // Begin searching from the zero diversifier index if we haven't
-            // yet generated an address from the specified UFVK and no
-            // diversifier index has been specified.
+            // Set the diversifier index to one greater than the last used
+            // diversifier
+            j = metadata->second.GetNextDiversifierIndex();
             if (!j.has_value()) {
-                j = libzcash::diversifier_index_t(0);
+                return UnifiedAddressGenerationError::DiversifierSpaceExhausted;
             }
         }
-
-        // Find a working diversifier and construct the associated address.
-        // At this point, we know that `j` will contain a value.
-        auto addressGenerationResult = searchDiversifiers ?
-            ufvk.value().FindAddress(j.value(), receiverTypes) :
-            ufvk.value().Address(j.value(), receiverTypes);
-
-        if (std::holds_alternative<UnifiedAddressGenerationError>(addressGenerationResult)) {
-            return std::get<UnifiedAddressGenerationError>(addressGenerationResult);
-        }
-
-        auto address = std::get<std::pair<UnifiedAddress, diversifier_index_t>>(addressGenerationResult);
-
-        assert(mapUfvkAddressMetadata[ufvkid].SetReceivers(address.second, receiverTypes));
-        if (hasTransparent) {
-            // We must construct and add the transparent spending key associated
-            // with the external and internal transparent child addresses to the
-            // transparent keystore. This call to `value` will succeed because
-            // this key must have been previously generated.
-            auto usk = GenerateUnifiedSpendingKeyForAccount(accountId).value();
-            auto accountKey = usk.GetTransparentKey();
-            // this .value is known to be safe from the earlier check
-            auto childIndex = address.second.ToTransparentChildIndex().value();
-            auto externalKey = accountKey.DeriveExternalSpendingKey(childIndex);
-
-            if (!externalKey.has_value()) {
-                return UnifiedAddressGenerationError::NoAddressForDiversifier;
-            }
-
-            AddTransparentSecretKey(
-                mnemonicHDChain.value().GetSeedFingerprint(),
-                externalKey.value(),
-                transparent::AccountKey::KeyPath(BIP44CoinType(), accountId, true, childIndex)
-            );
-
-            // We do not add the change address for the transparent key, because
-            // we do not send transparent change when using unified accounts.
-
-            // Writing this data is handled by `CWalletDB::WriteUnifiedAddressMetadata` below.
-            assert(
-                CCryptoKeyStore::AddTransparentReceiverForUnifiedAddress(
-                    ufvkid, address.second, address.first
-                )
-            );
-        }
-
-        // If the address has a Sapling component, add an association between
-        // that address and the Sapling IVK corresponding to the ufvk
-        auto hasSapling = receiverTypes.find(ReceiverType::Sapling) != receiverTypes.end();
-        if (hasSapling) {
-            auto dfvk = ufvk.value().GetSaplingKey();
-            auto saplingAddress = address.first.GetSaplingReceiver();
-            assert (dfvk.has_value() && saplingAddress.has_value());
-
-            AddSaplingPaymentAddress(dfvk.value().ToIncomingViewingKey(), saplingAddress.value());
-        }
-
-        // If the address has an Orchard component, add an association between
-        // that address and the Orchard IVK corresponding to the ufvk
-        auto hasOrchard = receiverTypes.find(ReceiverType::Orchard) != receiverTypes.end();
-        if (hasOrchard) {
-            auto fvk = ufvk.value().GetOrchardKey();
-            auto orchardReceiver = address.first.GetOrchardReceiver();
-            assert (fvk.has_value() && orchardReceiver.has_value());
-
-            AddOrchardRawAddress(fvk.value().ToIncomingViewingKey(), orchardReceiver.value());
-        }
-
-        // Save the metadata for the generated address so that we can re-derive
-        // it in the future.
-        ZcashdUnifiedAddressMetadata addrmeta(ufvkid, address.second, receiverTypes);
-        if (fFileBacked && !CWalletDB(strWalletFile).WriteUnifiedAddressMetadata(addrmeta)) {
-            throw std::runtime_error(
-                    "CWallet::AddUnifiedAddress(): Writing unified address metadata failed");
-        }
-
-        return address;
     } else {
-        return WalletUAGenerationError::NoSuchAccount;
+        // Begin searching from the zero diversifier index if we haven't
+        // yet generated an address from the specified UFVK and no
+        // diversifier index has been specified.
+        if (!j.has_value()) {
+            j = libzcash::diversifier_index_t(0);
+        }
     }
+
+    // Find a working diversifier and construct the associated address.
+    // At this point, we know that `j` will contain a value.
+    auto addressGenerationResult = searchDiversifiers ?
+        ufvk.FindAddress(j.value(), receiverTypes) :
+        ufvk.Address(j.value(), receiverTypes);
+
+    if (std::holds_alternative<UnifiedAddressGenerationError>(addressGenerationResult)) {
+        return std::get<UnifiedAddressGenerationError>(addressGenerationResult);
+    }
+
+    auto address = std::get<std::pair<UnifiedAddress, diversifier_index_t>>(addressGenerationResult);
+
+    assert(mapUfvkAddressMetadata[ufvkid].SetReceivers(address.second, receiverTypes));
+    if (hasTransparent) {
+        // We must construct and add the transparent spending key associated
+        // with the external and internal transparent child addresses to the
+        // transparent keystore. This call to `value` will succeed because
+        // this key must have been previously generated.
+        auto usk = GenerateUnifiedSpendingKeyForAccount(account.id).value();
+        auto accountKey = usk.GetTransparentKey();
+        // this .value is known to be safe from the earlier check
+        auto childIndex = address.second.ToTransparentChildIndex().value();
+        auto externalKey = accountKey.DeriveExternalSpendingKey(childIndex);
+
+        if (!externalKey.has_value()) {
+            return UnifiedAddressGenerationError::NoAddressForDiversifier;
+        }
+
+        AddTransparentSecretKey(
+            mnemonicHDChain.value().GetSeedFingerprint(),
+            externalKey.value(),
+            transparent::AccountKey::KeyPath(BIP44CoinType(), account.id, true, childIndex)
+        );
+
+        // We do not add the change address for the transparent key, because
+        // we do not send transparent change when using unified accounts.
+
+        // Writing this data is handled by `CWalletDB::WriteUnifiedAddressMetadata` below.
+        assert(
+            CCryptoKeyStore::AddTransparentReceiverForUnifiedAddress(
+                ufvkid, address.second, address.first
+            )
+        );
+    }
+
+    // If the address has a Sapling component, add an association between
+    // that address and the Sapling IVK corresponding to the ufvk
+    auto hasSapling = receiverTypes.find(ReceiverType::Sapling) != receiverTypes.end();
+    if (hasSapling) {
+        auto dfvk = ufvk.GetSaplingKey();
+        auto saplingAddress = address.first.GetSaplingReceiver();
+        assert (dfvk.has_value() && saplingAddress.has_value());
+
+        AddSaplingPaymentAddress(dfvk.value().ToIncomingViewingKey(), saplingAddress.value());
+    }
+
+    // If the address has an Orchard component, add an association between
+    // that address and the Orchard IVK corresponding to the ufvk
+    auto hasOrchard = receiverTypes.find(ReceiverType::Orchard) != receiverTypes.end();
+    if (hasOrchard) {
+        auto fvk = ufvk.GetOrchardKey();
+        auto orchardReceiver = address.first.GetOrchardReceiver();
+        assert (fvk.has_value() && orchardReceiver.has_value());
+
+        AddOrchardRawAddress(fvk.value().ToIncomingViewingKey(), orchardReceiver.value());
+    }
+
+    // Save the metadata for the generated address so that we can re-derive
+    // it in the future.
+    ZcashdUnifiedAddressMetadata addrmeta(ufvkid, address.second, receiverTypes);
+    if (fFileBacked && !CWalletDB(strWalletFile).WriteUnifiedAddressMetadata(addrmeta)) {
+        throw std::runtime_error(
+                "CWallet::AddUnifiedAddress(): Writing unified address metadata failed");
+    }
+
+    return address;
 }
 
 bool CWallet::LoadUnifiedFullViewingKey(const libzcash::UnifiedFullViewingKey &key)
@@ -1861,24 +1897,16 @@ void CWallet::SyncMetaData(pair<typename TxSpendMap<T>::iterator, typename TxSpe
 // Zcash transaction output selectors
 //
 
-std::optional<ZTXOSelector> CWallet::ZTXOSelectorForAccount(
-    libzcash::AccountId account,
+ZTXOSelector CWallet::ZTXOSelectorForAccount(
+    const UnifiedAccount& account,
     bool requireSpendingKey,
     TransparentCoinbasePolicy transparentCoinbasePolicy,
     std::set<libzcash::ReceiverType> receiverTypes) const
 {
-    if (mnemonicHDChain.has_value() &&
-        mapUnifiedAccountKeys.count(
-            std::make_pair(mnemonicHDChain.value().GetSeedFingerprint(), account)
-        ) > 0)
-    {
-        return ZTXOSelector(
-                AccountZTXOPattern(account, receiverTypes),
-                requireSpendingKey,
-                transparentCoinbasePolicy);
-    } else {
-        return std::nullopt;
-    }
+    return ZTXOSelector(
+            AccountZTXOPattern(account, receiverTypes),
+            requireSpendingKey,
+            transparentCoinbasePolicy);
 }
 
 std::optional<ZTXOSelector> CWallet::ZTXOSelectorForAddress(
@@ -1911,17 +1939,17 @@ std::optional<ZTXOSelector> CWallet::ZTXOSelectorForAddress(
             }
         },
         [&](const libzcash::UnifiedAddress& ua) {
-            auto ufvkId = GetUFVKIdForAddress(ua);
-            if (ufvkId.has_value()) {
+            auto ufvk = GetUFVKForAddress(ua);
+            if (ufvk.has_value()) {
                 // TODO: at present, the `false` value for the `requireSpendingKey` argument
                 // is not respected for unified addresses, because we have no notion of
                 // an account for which we do not control the spending key. An alternate
                 // approach would be to use the UFVK directly in the case that we cannot
                 // determine a local account.
-                auto accountId = this->GetUnifiedAccountId(ufvkId.value());
-                if (accountId.has_value()) {
+                auto account = this->GetUnifiedAccount(ufvk.value().GetKeyID());
+                if (account.has_value()) {
                     if (allowAddressLinkability) {
-                        pattern = AccountZTXOPattern(accountId.value(), ua.GetKnownReceiverTypes());
+                        pattern = AccountZTXOPattern(account.value(), ua.GetKnownReceiverTypes());
                     } else {
                         pattern = ua;
                     }
@@ -1957,9 +1985,11 @@ std::optional<ZTXOSelector> CWallet::ZTXOSelectorForViewingKey(
         },
         [&](const libzcash::UnifiedFullViewingKey& ufvk) {
             auto ufvkId = ufvk.GetKeyID(Params());
-            auto accountId = this->GetUnifiedAccountId(ufvkId);
+            auto accountId = this->GetUnifiedAccount(ufvkId);
             if (accountId.has_value()) {
-                pattern = AccountZTXOPattern(accountId.value(), ufvk.GetKnownReceiverTypes());
+                pattern = AccountZTXOPattern(
+                        UnifiedAccount(accountId.value()),
+                        ufvk.GetKnownReceiverTypes());
             } else {
                 pattern = ufvk;
             }
@@ -1974,58 +2004,51 @@ std::optional<ZTXOSelector> CWallet::ZTXOSelectorForViewingKey(
 }
 
 ZTXOSelector CWallet::LegacyTransparentZTXOSelector(bool requireSpendingKey, TransparentCoinbasePolicy transparentCoinbasePolicy) {
-    return ZTXOSelector(
-            AccountZTXOPattern(ZCASH_LEGACY_ACCOUNT, {ReceiverType::P2PKH, ReceiverType::P2SH}),
-            requireSpendingKey,
-            transparentCoinbasePolicy);
+    return ZTXOSelector(LegacyAccount(), requireSpendingKey, transparentCoinbasePolicy);
 }
 
-std::optional<libzcash::AccountId> CWallet::FindAccountForSelector(const ZTXOSelector& selector) const {
+std::optional<UnifiedAccount> CWallet::FindAccountForSelector(const ZTXOSelector& selector) const {
     auto self = this;
-    std::optional<libzcash::AccountId> result{};
+    std::optional<UnifiedAccount> result{};
     examine(selector.GetPattern(), match {
         [&](const CKeyID& addr) {
             auto meta = self->GetUFVKMetadataForReceiver(addr);
             if (meta.has_value()) {
-                result = self->GetUnifiedAccountId(meta.value().GetUFVKId());
+                result = self->GetUnifiedAccount(meta.value().GetUFVKId());
             }
         },
         [&](const CScriptID& addr) {
             auto meta = self->GetUFVKMetadataForReceiver(addr);
             if (meta.has_value()) {
-                result = self->GetUnifiedAccountId(meta.value().GetUFVKId());
+                result = self->GetUnifiedAccount(meta.value().GetUFVKId());
             }
         },
-        [&](const libzcash::SproutPaymentAddress& addr) { },
-        [&](const libzcash::SproutViewingKey& vk) { },
+        [](const LegacyAccount&) { },
+        [](const libzcash::SproutPaymentAddress&) { },
+        [](const libzcash::SproutViewingKey&) { },
         [&](const libzcash::SaplingPaymentAddress& addr) {
             auto meta = GetUFVKMetadataForReceiver(addr);
             if (meta.has_value()) {
-                result = self->GetUnifiedAccountId(meta.value().GetUFVKId());
+                result = self->GetUnifiedAccount(meta.value().GetUFVKId());
             }
         },
         [&](const libzcash::SaplingExtendedFullViewingKey& vk) {
             auto ufvkid = GetUFVKIdForViewingKey(vk);
             if (ufvkid.has_value()) {
-                result = self->GetUnifiedAccountId(ufvkid.value());
+                result = self->GetUnifiedAccount(ufvkid.value());
             }
         },
         [&](const libzcash::UnifiedAddress& addr) {
             auto ufvkId = GetUFVKIdForAddress(addr);
             if (ufvkId.has_value()) {
-                result = self->GetUnifiedAccountId(ufvkId.value());
+                result = self->GetUnifiedAccount(ufvkId.value());
             }
         },
         [&](const libzcash::UnifiedFullViewingKey& vk) {
-            result = self->GetUnifiedAccountId(vk.GetKeyID(Params()));
+            result = self->GetUnifiedAccount(vk.GetKeyID(Params()));
         },
         [&](const AccountZTXOPattern& acct) {
-            if (self->mnemonicHDChain.has_value() &&
-                self->mapUnifiedAccountKeys.count(
-                    std::make_pair(self->mnemonicHDChain.value().GetSeedFingerprint(), acct.GetAccountId())
-                ) > 0) {
-                result = acct.GetAccountId();
-            }
+            result = acct.GetAccount();
         }
     });
     return result;
@@ -2046,6 +2069,10 @@ bool CWallet::SelectorMatchesAddress(
             CTxDestination scriptIdDest = scriptId;
             return address == scriptIdDest;
         },
+        // FIXME: What if it’s a UA taddr?!
+        // The legacy account is treated as a single pool of transparent funds, reproducing wallet
+        // behavior prior to the advent of unified addresses.
+        [](const LegacyAccount&) { return true; },
         [&](const libzcash::SproutPaymentAddress& addr) { return false; },
         [&](const libzcash::SproutViewingKey& vk) { return false; },
         [&](const libzcash::SaplingPaymentAddress& addr) { return false; },
@@ -2077,19 +2104,14 @@ bool CWallet::SelectorMatchesAddress(
         },
         [&](const AccountZTXOPattern& acct) {
             if (acct.IncludesP2PKH() || acct.IncludesP2SH()) {
-                auto meta = self->GetUFVKMetadataForAddress(address);
-                if (meta.has_value()) {
-                    // use the coin if the account id corresponding to the UFVK is
-                    // the payment source account.
-                    return self->GetUnifiedAccountId(meta.value().GetUFVKId()) == std::optional(acct.GetAccountId());
-                } else {
-                    // The legacy account is treated as a single pool of
-                    // transparent funds, reproducing wallet behavior prior to
-                    // the advent of unified addresses.
-                    return acct.GetAccountId() == ZCASH_LEGACY_ACCOUNT;
-                }
+                auto account = acct.GetAccount();
+                auto ufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(
+                        Params(),
+                        account.GetUnifiedFullViewingKey());
+                return self->GetUnifiedAccount(ufvk.GetKeyID()) == std::optional(account);
+            } else {
+                return false;
             }
-            return false;
         }
     });
 }
@@ -2109,10 +2131,11 @@ bool CWallet::SelectorMatchesAddress(
         const libzcash::SaplingPaymentAddress& a0) const {
     auto self = this;
     return examine(selector.GetPattern(), match {
-        [&](const CKeyID& keyId) { return false; },
-        [&](const CScriptID& scriptId) { return false; },
-        [&](const libzcash::SproutPaymentAddress& addr) { return false; },
-        [&](const libzcash::SproutViewingKey& vk) { return false; },
+        [](const CKeyID&) { return false; },
+        [](const CScriptID&) { return false; },
+        [](const LegacyAccount&) { return false; },
+        [](const libzcash::SproutPaymentAddress&) { return false; },
+        [](const libzcash::SproutViewingKey&) { return false; },
         [&](const libzcash::SaplingPaymentAddress& a1) {
             return a0 == a1;
         },
@@ -2144,67 +2167,18 @@ bool CWallet::SelectorMatchesAddress(
         },
         [&](const AccountZTXOPattern& acct) {
             if (acct.IncludesSapling()) {
-                const auto meta = self->GetUFVKMetadataForReceiver(a0);
-                if (meta.has_value()) {
-                    // use the coin if the account id corresponding to the UFVK is
-                    // the payment source account.
-                    return self->GetUnifiedAccountId(meta.value().GetUFVKId()) == std::optional(acct.GetAccountId());
-                } else {
-                    return false;
-                }
+                auto account = acct.GetAccount();
+                auto ufvk = ZcashdUnifiedFullViewingKey::FromUnifiedFullViewingKey(
+                        Params(),
+                        account.GetUnifiedFullViewingKey());
+                // use the coin if the account id corresponding to the UFVK is the payment source
+                // account.
+                return self->GetUnifiedAccount(ufvk.GetKeyID()) == std::optional(account);
+            } else {
+                return false;
             }
-            return false;
         }
     });
-}
-
-tl::expected<RecipientAddress, AccountChangeAddressFailure>
-CWallet::GenerateChangeAddressForAccount(
-        libzcash::AccountId accountId,
-        std::set<OutputPool> changeOptions)
-{
-    AssertLockHeld(cs_wallet);
-
-    if (accountId == ZCASH_LEGACY_ACCOUNT) {
-        // We only call this method with this account ID for legacy transparent addresses.
-        for (OutputPool t : changeOptions) {
-            if (t == OutputPool::Transparent) {
-                return GenerateNewKey(false).GetID();
-            }
-        }
-        return tl::make_unexpected(AccountChangeAddressFailure::TransparentChangeNotPermitted);
-    } else {
-        auto ufvk = this->GetUnifiedFullViewingKeyByAccount(accountId);
-        if (ufvk.has_value()) {
-            // changeOptions is sorted in preference order, so return
-            // the first (and therefore most preferred) change address that
-            // we're able to generate.
-            for (OutputPool t : changeOptions) {
-                std::optional<RecipientAddress> changeAddr;
-                switch (t) {
-                case OutputPool::Orchard:
-                    changeAddr = ufvk.value().GetChangeAddress(OrchardChangeRequest());
-                    break;
-                case OutputPool::Sapling:
-                    changeAddr = ufvk.value().GetChangeAddress(SaplingChangeRequest());
-                    break;
-                case OutputPool::Transparent:
-                    // UFVKs must have a shielded component, so we would only
-                    // reach this point if changeOptions contained no shielded
-                    // options. But we prefer to opportunistically shield funds
-                    // where possible, so we don't produce transparent change
-                    // addresses for accounts.
-                    break;
-                }
-                if (changeAddr.has_value()) {
-                    return changeAddr.value();
-                }
-            }
-            return tl::make_unexpected(AccountChangeAddressFailure::DisjointReceivers);
-        } else {
-            return tl::make_unexpected(AccountChangeAddressFailure::NoSuchAccount);
-        }
-    }
 }
 
 SpendableInputs CWallet::FindSpendableInputs(
@@ -2371,24 +2345,23 @@ SpendableInputs CWallet::FindSpendableInputs(
                 }
                 return {};
             },
-            [&](const libzcash::UnifiedFullViewingKey& ufvk) -> std::vector<OrchardIncomingViewingKey> {
+            [](const libzcash::UnifiedFullViewingKey& ufvk) -> std::vector<OrchardIncomingViewingKey> {
                 auto fvk = ufvk.GetOrchardKey();
                 if (fvk.has_value()) {
                     return {fvk->ToIncomingViewingKey(), fvk->ToInternalIncomingViewingKey()};
+                } else {
+                    return {};
                 }
-                return {};
             },
-            [&](const AccountZTXOPattern& acct) -> std::vector<OrchardIncomingViewingKey> {
-                auto ufvk = GetUnifiedFullViewingKeyByAccount(acct.GetAccountId());
-                if (ufvk.has_value()) {
-                    auto fvk = ufvk->GetOrchardKey();
-                    if (fvk.has_value()) {
-                        return {fvk->ToIncomingViewingKey(), fvk->ToInternalIncomingViewingKey()};
-                    }
+            [](const AccountZTXOPattern& acct) -> std::vector<OrchardIncomingViewingKey> {
+                auto fvk = acct.GetAccount().GetUnifiedFullViewingKey().GetOrchardKey();
+                if (fvk.has_value()) {
+                    return {fvk->ToIncomingViewingKey(), fvk->ToInternalIncomingViewingKey()};
+                } else {
+                    return {};
                 }
-                return {};
             },
-            [&](const auto& addr) -> std::vector<OrchardIncomingViewingKey> { return {}; }
+            [](const auto&) -> std::vector<OrchardIncomingViewingKey> { return {}; }
         });
 
         for (const auto& ivk : orchardIvks) {
@@ -7105,11 +7078,21 @@ void CWallet::GetFilteredNotes(
     }
 }
 
-std::optional<libzcash::AccountId> CWallet::GetUnifiedAccountId(const libzcash::UFVKId& ufvkId) const {
+std::optional<UnifiedAccount> CWallet::GetUnifiedAccount(const libzcash::UFVKId& ufvkId) const {
     auto addrMetaIt = mapUfvkAddressMetadata.find(ufvkId);
     if (addrMetaIt != mapUfvkAddressMetadata.end()) {
-        return addrMetaIt->second.GetAccountId();
+        auto id = addrMetaIt->second.GetAccountId();
+        if (id.has_value()) {
+            auto zufvk = CCryptoKeyStore::GetUnifiedFullViewingKey(ufvkId);
+            assert(zufvk.has_value()); // we found metadata associated with this id, so the UFVK should exist
+            return UnifiedAccount(id.value(), zufvk.value().ToFullViewingKey());
+
+        } else {
+            // TODO: report “imported UFVK or wallet load in progress”
+            return std::nullopt;
+        }
     } else {
+        // TODO: report “no known UFVK”
         return std::nullopt;
     }
 }
@@ -7118,10 +7101,10 @@ std::optional<UnifiedAddress> CWallet::FindUnifiedAddressByReceiver(const Receiv
     return std::visit(UnifiedAddressForReceiver(*this), receiver);
 }
 
-std::optional<libzcash::AccountId> CWallet::FindUnifiedAccountByReceiver(const Receiver& receiver) const {
+std::optional<UnifiedAccount> CWallet::FindUnifiedAccountByReceiver(const Receiver& receiver) const {
     auto ufvkMeta = GetUFVKMetadataForReceiver(receiver);
     if (ufvkMeta.has_value()) {
-        return GetUnifiedAccountId(ufvkMeta.value().GetUFVKId());
+        return GetUnifiedAccount(ufvkMeta.value().GetUFVKId());
     } else {
         return std::nullopt;
     }
@@ -7700,12 +7683,13 @@ bool TransactionStrategy::IsCompatibleWith(PrivacyPolicy policy) const {
 
 bool ZTXOSelector::SelectsTransparent() const {
     return examine(this->pattern, match {
-        [](const CKeyID& keyId) { return true; },
-        [](const CScriptID& scriptId) { return true; },
-        [](const libzcash::SproutPaymentAddress& addr) { return false; },
-        [](const libzcash::SproutViewingKey& vk) { return false; },
-        [](const libzcash::SaplingPaymentAddress& addr) { return false; },
-        [](const libzcash::SaplingExtendedFullViewingKey& vk) { return false; },
+        [](const CKeyID&) { return true; },
+        [](const CScriptID&) { return true; },
+        [](const LegacyAccount&) { return true; },
+        [](const libzcash::SproutPaymentAddress&) { return false; },
+        [](const libzcash::SproutViewingKey&) { return false; },
+        [](const libzcash::SaplingPaymentAddress&) { return false; },
+        [](const libzcash::SaplingExtendedFullViewingKey&) { return false; },
         [](const libzcash::UnifiedAddress& ua) {
             return ua.GetP2PKHReceiver().has_value() || ua.GetP2SHReceiver().has_value();
         },

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -447,7 +447,6 @@ public:
 };
 
 enum class WalletUAGenerationError {
-    NoSuchAccount,
     ExistingAddressMismatch,
     WalletEncrypted
 };
@@ -827,16 +826,55 @@ public:
     bool IsCompatibleWith(PrivacyPolicy policy) const;
 };
 
+class UnifiedAccount
+{
+public:
+    libzcash::AccountId id;
+    libzcash::UnifiedFullViewingKey ufvk;
+
+    UnifiedAccount(libzcash::AccountId id, libzcash::UnifiedFullViewingKey ufvk)
+        : id(id), ufvk(ufvk) {}
+
+    friend bool operator==(const UnifiedAccount &a, const UnifiedAccount &b) {
+        return a.id == b.id;
+    }
+
+    libzcash::UnifiedFullViewingKey GetUnifiedFullViewingKey() const;
+
+    /**
+     * Generate a change address for the specified account.
+     *
+     * If a shielded change address is requested, this will return the default
+     * unified address for the internal unified full viewing key.
+     *
+     * If a transparent change address is requested, this will generate a fresh
+     * diversified unified address from the internal unified full viewing key,
+     * and return the associated transparent change address.
+     *
+     * Returns `std::nullopt` if the account does not have an internal spending
+     * key matching the requested `OutputPool`.
+     */
+    std::optional<libzcash::RecipientAddress>
+    GenerateChangeAddress(
+            const CChainParams& params,
+            const std::set<libzcash::OutputPool>& changeOptions) const;
+};
+
+/**
+ * A class representing the collective spend authorities of all legacy transparent addresses
+ * generated via the `getnewaddress` RPC method.
+ */
+class LegacyAccount
+{
+public:
+    LegacyAccount() {}
+};
+
 /**
  * A class representing the ZIP 316 unified spending authority associated with
  * a ZIP 32 account and this wallet's mnemonic seed. This is intended to be
  * used as a ZTXOPattern value to choose prior Zcash transaction outputs,
  * including both transparent UTXOs and shielded notes.
- *
- * If the account ID is set to `ZCASH_LEGACY_ACCOUNT`, the instance instead
- * represents the collective spend authorities of all legacy transparent addresses
- * generated via the `getnewaddress` RPC method. Shielded notes will never be
- * selected for this account ID.
  *
  * If the set of receiver types provided is non-empty, only outputs for
  * protocols corresponding to the provided set of receiver types may be used.
@@ -844,14 +882,14 @@ public:
  * protocols outputs are selected for.
  */
 class AccountZTXOPattern {
-    libzcash::AccountId accountId;
+    UnifiedAccount account;
     std::set<libzcash::ReceiverType> receiverTypes;
 public:
-    AccountZTXOPattern(libzcash::AccountId accountIdIn, std::set<libzcash::ReceiverType> receiverTypesIn):
-        accountId(accountIdIn), receiverTypes(receiverTypesIn) {}
+    AccountZTXOPattern(UnifiedAccount account, std::set<libzcash::ReceiverType> receiverTypesIn):
+        account(account), receiverTypes(receiverTypesIn) {}
 
-    libzcash::AccountId GetAccountId() const {
-        return accountId;
+    const UnifiedAccount& GetAccount() const {
+        return account;
     }
 
     const std::set<libzcash::ReceiverType>& GetReceiverTypes() const {
@@ -875,7 +913,7 @@ public:
     }
 
     friend bool operator==(const AccountZTXOPattern &a, const AccountZTXOPattern &b) {
-        return a.accountId == b.accountId && a.receiverTypes == b.receiverTypes;
+        return a.account == b.account && a.receiverTypes == b.receiverTypes;
     }
 };
 
@@ -886,6 +924,7 @@ public:
 typedef std::variant<
     CKeyID,
     CScriptID,
+    LegacyAccount,
     libzcash::SproutPaymentAddress,
     libzcash::SproutViewingKey,
     libzcash::SaplingPaymentAddress,
@@ -1556,8 +1595,8 @@ public:
      * If the `requireSpendingKey` flag is set, this will only return a selector
      * that will choose outputs for which this wallet holds the spending keys.
      */
-    std::optional<ZTXOSelector> ZTXOSelectorForAccount(
-            libzcash::AccountId account,
+    ZTXOSelector ZTXOSelectorForAccount(
+            const UnifiedAccount& account,
             bool requireSpendingKey,
             TransparentCoinbasePolicy transparentCoinbasePolicy,
             std::set<libzcash::ReceiverType> receiverTypes={}) const;
@@ -1598,25 +1637,7 @@ public:
      * used in z_sendmany to ensure that we always correctly determine change
      * addresses and OVKs on the basis of account UFVKs when possible.
      */
-    std::optional<libzcash::AccountId> FindAccountForSelector(const ZTXOSelector& paymentSource) const;
-
-    /**
-     * Generate a change address for the specified account.
-     *
-     * If a shielded change address is requested, this will return the default
-     * unified address for the internal unified full viewing key.
-     *
-     * If a transparent change address is requested, this will generate a fresh
-     * diversified unified address from the internal unified full viewing key,
-     * and return the associated transparent change address.
-     *
-     * Returns `std::nullopt` if the account does not have an internal spending
-     * key matching the requested `OutputPool`.
-     */
-    tl::expected<libzcash::RecipientAddress, AccountChangeAddressFailure>
-    GenerateChangeAddressForAccount(
-            libzcash::AccountId accountId,
-            std::set<libzcash::OutputPool> changeOptions);
+    std::optional<UnifiedAccount> FindAccountForSelector(const ZTXOSelector& paymentSource) const;
 
     SpendableInputs FindSpendableInputs(
             ZTXOSelector paymentSource,
@@ -1796,8 +1817,7 @@ public:
 
     //! Generate the unified spending key from the wallet's mnemonic seed
     //! for the next unused account identifier.
-    std::pair<libzcash::UnifiedFullViewingKey, libzcash::AccountId>
-        GenerateNewUnifiedSpendingKey();
+    UnifiedAccount GenerateNewUnifiedSpendingKey();
 
     //! Generate the unified spending key for the specified ZIP-32/BIP-44
     //! account identifier from the wallet's mnemonic seed, or returns
@@ -1816,7 +1836,7 @@ public:
     //! If no diversifier index is provided, the next unused diversifier index
     //! will be selected.
     WalletUAGenerationResult GenerateUnifiedAddress(
-        const libzcash::AccountId& accountId,
+        const UnifiedAccount& account,
         const std::set<libzcash::ReceiverType>& receivers,
         std::optional<libzcash::diversifier_index_t> j = std::nullopt);
 
@@ -1843,7 +1863,7 @@ public:
     //! failures in reconstructing the cache.
     bool LoadCaches();
 
-    std::optional<libzcash::AccountId> GetUnifiedAccountId(const libzcash::UFVKId& ufvkId) const;
+    std::optional<UnifiedAccount> GetUnifiedAccount(const libzcash::UFVKId& ufvkId) const;
 
     /**
      * Reconstructs a unified address by determining the UFVK that the receiver
@@ -1857,7 +1877,7 @@ public:
     /**
      * Finds a unified account ID for a given receiver.
      */
-    std::optional<libzcash::AccountId> FindUnifiedAccountByReceiver(
+    std::optional<UnifiedAccount> FindUnifiedAccountByReceiver(
             const libzcash::Receiver& receiver) const;
 
     /**


### PR DESCRIPTION
Make some invalid states unrepresentable. Have an account carry around its UFVK, which pushes lookup failures to the interface layer rather than deep in wallet logic. This also partitions the legacy account from unified accounts, making it clearer which parts of the code are aware of the legacy account.