### PR TITLE
Automatically migrate old coins database to account for complete subtrees for Sapling and Orchard

### DIFF
--- a/qa/rpc-tests/finalorchardroot.py
+++ b/qa/rpc-tests/finalorchardroot.py
@@ -41,6 +41,8 @@ class FinalOrchardRootTest(BitcoinTestFramework):
             '-allowdeprecated=getnewaddress',
             '-allowdeprecated=z_getnewaddress',
             '-allowdeprecated=z_getbalance',
+            '-experimentalfeatures',
+            '-lightwalletd'
             ]] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         self.is_network_split=False

--- a/qa/rpc-tests/finalsaplingroot.py
+++ b/qa/rpc-tests/finalsaplingroot.py
@@ -41,6 +41,8 @@ class FinalSaplingRootTest(BitcoinTestFramework):
             '-allowdeprecated=getnewaddress',
             '-allowdeprecated=z_getnewaddress',
             '-allowdeprecated=z_getbalance',
+            '-experimentalfeatures',
+            '-lightwalletd'
             ]] * self.num_nodes)
         connect_nodes_bi(self.nodes,0,1)
         self.is_network_split=False

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -662,6 +662,18 @@ void CCoinsViewCache::PopSubtree(ShieldedType type)
     }
 }
 
+void CCoinsViewCache::ResetSubtrees(ShieldedType type)
+{
+    switch(type) {
+        case SAPLING:
+            return cacheSaplingSubtrees.ResetSubtrees();
+        case ORCHARD:
+            return cacheOrchardSubtrees.ResetSubtrees();
+        default:
+            throw std::runtime_error("ResetSubtrees: unsupported shielded type");
+    }
+}
+
 template<typename Tree, typename Cache, typename CacheEntry>
 void CCoinsViewCache::AbstractPopAnchor(
     const uint256 &newrt,
@@ -1275,6 +1287,14 @@ void SubtreeCache::PopSubtree(CCoinsView *parentView) {
     } else {
         newSubtrees.pop_back();
     }
+}
+
+void SubtreeCache::ResetSubtrees() {
+    // This ensures that all subtrees will be popped from the parent view
+    initialized = true;
+
+    parentLatestSubtree = std::nullopt;
+    newSubtrees.clear();
 }
 
 void SubtreeCache::BatchWrite(CCoinsView *parentView, SubtreeCache &childMap) {

--- a/src/coins.h
+++ b/src/coins.h
@@ -487,6 +487,9 @@ class SubtreeCache {
     //! exception if the view has no subtrees.
     void PopSubtree(CCoinsView *parentView);
 
+    //! Effectively pops all subtrees from the view
+    void ResetSubtrees();
+
     //! Writes a child map to this cache; this clears the child map.
     void BatchWrite(CCoinsView *parentView, SubtreeCache &childMap);
 };
@@ -702,6 +705,9 @@ public:
     // supported. Throws an exception if there isn't a subtree present
     // in the database.
     void PopSubtree(ShieldedType type);
+
+    //! Effectively pops all subtrees from the view
+    void ResetSubtrees(ShieldedType type);
 
     /**
      * Return a pointer to CCoins in the cache, or NULL if not found. This is

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1818,6 +1818,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                     assert(pcoinsdbview->GetOrchardAnchorAt(pcoinsdbview->GetBestAnchor(ORCHARD), orchard_tree));
 
                     if (pcoinsdbview->CurrentSubtreeIndex(SAPLING) != sapling_tree.current_subtree_index()) {
+                        uiInterface.InitMessage(_("Regenerating subtrees for Sapling..."));
                         LogPrintf("init: the complete subtree database for Sapling needs to be migrated. Starting RegenerateSubtrees...\n");
                         struct timeval tv_start, tv_end;
                         float elapsed;
@@ -1832,6 +1833,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                     }
 
                     if (pcoinsdbview->CurrentSubtreeIndex(ORCHARD) != orchard_tree.current_subtree_index()) {
+                        uiInterface.InitMessage(_("Regenerating subtrees for Orchard..."));
                         LogPrintf("init: the complete subtree database for Orchard needs to be migrated. Starting RegenerateSubtrees...\n");
                         struct timeval tv_start, tv_end;
                         float elapsed;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1809,7 +1809,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                     break;
                 }
 
-                {
+                if (fExperimentalLightWalletd) {
                     LOCK(cs_main);
 
                     SaplingMerkleTree sapling_tree;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,8 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/math/distributions/poisson.hpp>
+#include <boost/range/algorithm/lower_bound.hpp>
+#include <boost/range/irange.hpp>
 #include <boost/thread.hpp>
 
 #include <rust/ed25519.h>
@@ -5802,6 +5804,218 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     }
 
     LogPrintf("No coin database inconsistencies in last %i blocks (%i transactions)\n", chainActive.Height() - pindexState->nHeight, nGoodTransactions);
+
+    return true;
+}
+
+bool RegenerateSubtrees(ShieldedType type, const Consensus::Params& consensusParams)
+{
+    AssertLockHeld(cs_main);
+
+    if (chainActive.Tip() == NULL || chainActive.Tip()->pprev == NULL) {
+        LogPrintf("RegenerateSubtrees: chain is at genesis currently; migration complete\n");
+        return true;
+    }
+
+    // Delete all subtrees in pcoinsTip.
+    pcoinsTip->ResetSubtrees(type);
+
+    Consensus::UpgradeIndex upgrade;
+    if (type == SAPLING) {
+        upgrade = Consensus::UPGRADE_SAPLING;
+    } else if (type == ORCHARD) {
+        upgrade = Consensus::UPGRADE_NU5;
+    } else {
+        throw std::runtime_error("RegenerateSubtrees: bad shielded pool type");
+    }
+
+    // The search space starts at the activation height of the shielded pool
+    auto currentHeightMaybe = consensusParams.GetActivationHeight(upgrade);
+    int currentHeight;
+    if (currentHeightMaybe.has_value()) {
+        currentHeight = *currentHeightMaybe;
+    } else {
+        LogPrintf("RegenerateSubtrees: shielded pool is not active; migration complete\n");
+        return true;
+    }
+
+    // The search space ends at the active chain tip.
+    int chainHeight = chainActive.Tip()->nHeight;
+
+    LogPrintf("RegenerateSubtrees: current chain height is %d, activation height is %d\n", chainHeight, currentHeight);
+
+    if (currentHeight > chainHeight) {
+        // We don't have any blocks to search through.
+        // The subtrees will be added naturally as the
+        // chain progresses.
+        LogPrintf("RegenerateSubtrees: activation takes place in the future; migration complete\n");
+        return true;
+    }
+
+    // Vector to accumulate the heights of discovered blocks
+    // that complete subtrees.
+    std::vector<int> vHeights;
+
+    libzcash::SubtreeIndex chainSubtreeIndex;
+    libzcash::SubtreeIndex loggingModulus;
+    size_t percentage = 0;
+
+    {
+        auto lookupCurrentSubtreeIndex = [&] (int nHeight) {
+            auto blockIndex = chainActive[nHeight];
+            assert(blockIndex != nullptr);
+
+            // Because these blocks are connected to the active chain
+            // tip, and because we are inspecting blocks where Sapling/Orchard
+            // are activated, hashFinalSaplingRoot and hashFinalOrchardRoot
+            // are guaranteed to be non-null.
+            if (type == SAPLING) {
+                SaplingMerkleTree latest_frontier;
+                assert(pcoinsTip->GetSaplingAnchorAt(blockIndex->hashFinalSaplingRoot, latest_frontier));
+                return latest_frontier.current_subtree_index();
+            } else if (type == ORCHARD) {
+                OrchardMerkleFrontier latest_frontier;
+                assert(pcoinsTip->GetOrchardAnchorAt(blockIndex->hashFinalOrchardRoot, latest_frontier));
+                return latest_frontier.current_subtree_index();
+            } else {
+                assert(false);
+            }
+        };
+
+        chainSubtreeIndex = lookupCurrentSubtreeIndex(chainHeight);
+
+        if (chainSubtreeIndex == 0) {
+            // There's nothing to do, because no complete subtrees
+            // exist on chain yet.
+            LogPrintf("RegenerateSubtrees: current subtree is index 0, nothing to do; migration complete\n");
+            return true;
+        }
+
+        // We'll report every ~10% of progress made.
+        loggingModulus = chainSubtreeIndex / 10;
+
+        if (loggingModulus == 0) {
+            loggingModulus = 1;
+        }
+
+        libzcash::SubtreeIndex subtreeIndex = 0;
+        while (currentHeight <= chainHeight) {
+            if ((subtreeIndex % loggingModulus) == 0) {
+                LogPrintf(
+                    "RegenerateSubtrees: Searching for complete subtrees... %d percent complete (%d / %d)\n",
+                    percentage,
+                    subtreeIndex,
+                    chainSubtreeIndex
+                );
+                percentage += 10;
+            }
+            // In this loop we're looking for the completed subtree
+            // with index subtreeIndex (if it exists) somewhere
+            // between currentHeight and chainHeight (inclusive).
+            // We'll first need to find the first block in this
+            // range that has a "current" subtree index one larger,
+            // which implies that block completed the subtree.
+
+            auto searchRange = boost::irange(currentHeight, chainHeight + 1);
+
+            auto result = boost::lower_bound(
+                searchRange,
+                subtreeIndex + 1,
+                [&](int a, libzcash::SubtreeIndex b) {
+                    return lookupCurrentSubtreeIndex(a) < b;
+                }
+            );
+
+            if (result != boost::end(searchRange)) {
+                vHeights.push_back(*result);
+
+                // Search for the next subtree, starting with the
+                // next block.
+                currentHeight = *result + 1;
+                subtreeIndex += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    LogPrintf("RegenerateSubtrees: Found all complete subtrees.\n");
+
+    percentage = 0;
+
+    for (size_t subtreeIndex = 0; subtreeIndex < vHeights.size(); subtreeIndex++) {
+        if ((subtreeIndex % loggingModulus) == 0) {
+            LogPrintf(
+                "RegenerateSubtrees: Rebuilding complete subtrees... %d percent complete (%d / %d)\n",
+                percentage,
+                subtreeIndex,
+                chainSubtreeIndex
+            );
+            percentage += 10;
+        }
+
+        int nHeight = vHeights[subtreeIndex];
+
+        auto pindex = chainActive[nHeight];
+        CBlock block;
+        if (!ReadBlockFromDisk(block, pindex, consensusParams)) {
+            LogPrintf("Failed to read block\n");
+            return false;
+        }
+
+        // We'll grab the final frontier from the previous block (which
+        // should have a hashFinalSaplingRoot/hashFinalOrchardRoot
+        // because this block completed a 2^16 size subtree!) and append
+        // to it until we complete the subtree.
+        if (type == SAPLING) {
+            SaplingMerkleTree sapling_tree;
+            assert(pcoinsTip->GetSaplingAnchorAt(pindex->pprev->hashFinalSaplingRoot, sapling_tree));
+            for (const CTransaction &tx : block.vtx) {
+                for (const auto &outputDescription : tx.GetSaplingOutputs()) {
+                    sapling_tree.append(uint256::FromRawBytes(outputDescription.cmu()));
+
+                    auto completeSubtreeRoot = sapling_tree.complete_subtree_root();
+                    if (completeSubtreeRoot.has_value()) {
+                        libzcash::SubtreeData subtree(completeSubtreeRoot->ToRawBytes(), nHeight);
+                        pcoinsTip->PushSubtree(SAPLING, subtree);
+                        goto nextsubtree; // sorry
+                    }
+                }
+            }
+
+            // We should not get here; this block should have completed the subtree
+            // and the goto statement above should have executed.
+            assert(false);
+        } else if (type == ORCHARD) {
+            OrchardMerkleFrontier orchard_tree;
+            assert(pcoinsTip->GetOrchardAnchorAt(pindex->pprev->hashFinalOrchardRoot, orchard_tree));
+            for (const CTransaction &tx : block.vtx) {
+                if (tx.GetOrchardBundle().IsPresent()) {
+                    try {
+                        auto appendResult = orchard_tree.AppendBundle(tx.GetOrchardBundle());
+                        if (appendResult.has_subtree_boundary) {
+                            libzcash::SubtreeData subtree(appendResult.completed_subtree_root, nHeight);
+
+                            pcoinsTip->PushSubtree(ORCHARD, subtree);
+                            goto nextsubtree; // sorry
+                        }
+                    } catch (const rust::Error& e) {
+                        return false;
+                    }
+                }
+            }
+
+            // Similarly, we should not get here.
+            assert(false);
+        } else {
+            assert(false);
+        }
+
+        nextsubtree:
+            // needed because statements need to exist
+            // after a label is defined or it won't parse
+            continue;
+    }
 
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5988,7 +5988,7 @@ bool RegenerateSubtrees(ShieldedType type, const Consensus::Params& consensusPar
             }
 
             // We should not get here; this block should have completed the subtree
-            // and the goto statement above should have executed.
+            // and the return statement above should have executed.
             assert(false);
         };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2938,7 +2938,9 @@ static DisconnectResult DisconnectBlock(const CBlock& block, CValidationState& s
     // (It is not possible for a block to complete more than one
     // subtree, due to the maximum number of outputs/actions in
     // a block being less than 2^16.)
-    {
+    //
+    // We do not store subtrees unless lightwalletd is enabled.
+    if (fExperimentalLightWalletd) {
         auto maybeDisconnectSubtree = [&] (ShieldedType type) {
             auto latestSubtree = view.GetLatestSubtree(type);
             if (latestSubtree.has_value()) {
@@ -3247,8 +3249,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // the node had not been writing the latest subtrees to the
     // view in the past and so later in this function we will
     // not bother to add new subtrees.
-    bool fUpdateSaplingSubtrees = view.CurrentSubtreeIndex(SAPLING) == sapling_tree.current_subtree_index();
-    bool fUpdateOrchardSubtrees = view.CurrentSubtreeIndex(ORCHARD) == orchard_tree.current_subtree_index();
+    //
+    // We do not store subtrees unless lightwalletd is enabled.
+    bool fUpdateSaplingSubtrees = fExperimentalLightWalletd && (view.CurrentSubtreeIndex(SAPLING) == sapling_tree.current_subtree_index());
+    bool fUpdateOrchardSubtrees = fExperimentalLightWalletd && (view.CurrentSubtreeIndex(ORCHARD) == orchard_tree.current_subtree_index());
 
     // Grab the consensus branch ID for this block and its parent
     auto consensusBranchId = CurrentEpochBranchId(pindex->nHeight, chainparams.GetConsensus());

--- a/src/main.h
+++ b/src/main.h
@@ -603,7 +603,7 @@ bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams,
 
 /**
  * This will clear the subtree database for a given shielded type from the
- * current CCoins view and regenerate the subtree database based on the current
+ * current CCoinsView and regenerate the subtree database based on the current
  * active chain.
  *
  * Only supports Sapling and Orchard. This does nothing in the event the chain

--- a/src/main.h
+++ b/src/main.h
@@ -601,6 +601,15 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
  */
 bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fIsBlockTemplate);
 
+/**
+ * This will clear the subtree database for a given shielded type from the
+ * current CCoins view and regenerate the subtree database based on the current
+ * active chain.
+ *
+ * Only supports Sapling and Orchard. This does nothing in the event the chain
+ * is fresh or if the shielded protocol has not activated yet on chain.
+ */
+bool RegenerateSubtrees(ShieldedType type, const Consensus::Params& consensusParams);
 
 /**
  * When there are blocks in the active chain with missing data (e.g. if the

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1461,7 +1461,7 @@ UniValue z_getsubtreesbyindex(const UniValue& params, bool fHelp)
         auto strHeight = strprintf("%d", libzcash::TRACKED_SUBTREE_HEIGHT);
         throw runtime_error(
             "z_getsubtreesbyindex \"pool\" start_index ( limit )\n"
-            "Returns roots of subtrees of the the given pool's note commitment tree. Each value returned\n"
+            "Returns roots of subtrees of the given pool's note commitment tree. Each value returned\n"
             "in the `subtrees` field is the Merkle root of a subtree containing 2^"+strHeight+" leaves.\n"
             + disabledMsg +
             "\nArguments:\n"

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1453,12 +1453,17 @@ UniValue z_gettreestate(const UniValue& params, bool fHelp)
 
 UniValue z_getsubtreesbyindex(const UniValue& params, bool fHelp)
 {
+    std::string disabledMsg = "";
+    if (!fExperimentalLightWalletd) {
+        disabledMsg = experimentalDisabledHelpMsg("z_getsubtreesbyindex", {"lightwalletd"});
+    }
     if (fHelp || params.size() < 2 || params.size() > 3) {
         auto strHeight = strprintf("%d", libzcash::TRACKED_SUBTREE_HEIGHT);
         throw runtime_error(
             "z_getsubtreesbyindex \"pool\" start_index ( limit )\n"
             "Returns roots of subtrees of the the given pool's note commitment tree. Each value returned\n"
             "in the `subtrees` field is the Merkle root of a subtree containing 2^"+strHeight+" leaves.\n"
+            + disabledMsg +
             "\nArguments:\n"
             "1. \"pool\"        (string, required) The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".\n"
             "2. start_index   (numeric, required) The index of the first 2^"+strHeight+"-leaf subtree to return.\n"
@@ -1478,6 +1483,11 @@ UniValue z_getsubtreesbyindex(const UniValue& params, bool fHelp)
             + HelpExampleCli("z_getsubtreesbyindex", "\"sapling\", 0")
             + HelpExampleRpc("z_getsubtreesbyindex", "\"orchard\", 3, 7")
         );
+    }
+
+    if (!fExperimentalLightWalletd) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Error: z_getsubtreesbyindex is disabled. "
+            "Run './zcash-cli help z_getsubtreesbyindex' for instructions on how to enable this feature.");
     }
 
     auto strPool = params[0].get_str();

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -77,6 +77,7 @@ EXPECTED_BOOST_INCLUDES=(
     boost/program_options/parsers.hpp
     boost/random/mersenne_twister.hpp
     boost/random/uniform_int_distribution.hpp
+    boost/range/algorithm/lower_bound.hpp
     boost/range/irange.hpp
     boost/scope_exit.hpp
     boost/scoped_ptr.hpp


### PR DESCRIPTION
This will completely reset and regenerate the complete subtreee database by sifting through blocks looking for complete subtrees and reconstructing them during initialization.

Tested on testnet and it worked, but testnet has only one sapling subtree so testing on mainnet is important.

Update: tested on mainnet and it produces the same results for Sapling.