### PR TITLE
Update to released versions of patch dependencies.

### DIFF
--- a/.cargo/config.offline
+++ b/.cargo/config.offline
@@ -4,20 +4,5 @@ linker = "aarch64-linux-gnu-gcc"
 [source.crates-io]
 replace-with = "vendored-sources"
 
-[source."https://github.com/zcash/incrementalmerkletree.git"]
-git = "https://github.com/zcash/incrementalmerkletree.git"
-rev = "62f0c9039b0bee94c16c40c272e19c5922290664"
-replace-with = "vendored-sources"
-
-[source."https://github.com/zcash/librustzcash.git"]
-git = "https://github.com/zcash/librustzcash.git"
-rev = "36d7222685e65cd8b6335f67dfe619e1a8f13197"
-replace-with = "vendored-sources"
-
-[source."https://github.com/zcash/orchard.git"]
-git = "https://github.com/zcash/orchard.git"
-rev = "11b6858ac81a79675de205980155a49d6f92b71e"
-replace-with = "vendored-sources"
-
 [source.vendored-sources]
 # The directory for this source is set to RUST_VENDORED_SOURCES by src/Makefile.am

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +107,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -232,19 +249,21 @@ dependencies = [
 
 [[package]]
 name = "bridgetree"
-version = "0.2.0"
-source = "git+https://github.com/zcash/incrementalmerkletree.git?rev=62f0c9039b0bee94c16c40c272e19c5922290664#62f0c9039b0bee94c16c40c272e19c5922290664"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a813dadc684e4c78a4547757debd99666282545d90e4ccc3210913ed4337ad2"
 dependencies = [
  "incrementalmerkletree",
 ]
 
 [[package]]
 name = "bs58"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
- "sha2 0.9.9",
+ "sha2 0.10.6",
+ "tinyvec",
 ]
 
 [[package]]
@@ -252,6 +271,12 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
@@ -517,7 +542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek",
- "hashbrown",
+ "hashbrown 0.12.3",
  "hex",
  "rand_core 0.6.4",
  "serde",
@@ -534,7 +559,8 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=36d7222685e65cd8b6335f67dfe619e1a8f13197#36d7222685e65cd8b6335f67dfe619e1a8f13197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab579d7cf78477773b03e80bc2f89702ef02d7112c711d54ca93dcdce68533d5"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -564,7 +590,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=36d7222685e65cd8b6335f67dfe619e1a8f13197#36d7222685e65cd8b6335f67dfe619e1a8f13197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
 dependencies = [
  "blake2b_simd",
 ]
@@ -591,10 +618,13 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
  "static_assertions",
 ]
 
@@ -675,7 +705,7 @@ checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -762,7 +792,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -866,9 +905,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "incrementalmerkletree"
-version = "0.3.1"
-source = "git+https://github.com/zcash/incrementalmerkletree.git?rev=62f0c9039b0bee94c16c40c272e19c5922290664#62f0c9039b0bee94c16c40c272e19c5922290664"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb91780c91bfc79769006a55c49127b83e1c1a6cf2b3b149ce3f247cbe342f0"
 dependencies = [
  "either",
  "proptest",
@@ -881,7 +941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1044,16 +1104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
-name = "lock_api"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,10 +1113,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
+name = "mach2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
 dependencies = [
  "libc",
 ]
@@ -1116,28 +1166,27 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
+checksum = "aa8ebbd1a9e57bbab77b9facae7f5136aea44c356943bf9a198f647da64285d6"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "metrics-macros",
  "portable-atomic",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
+checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
 dependencies = [
+ "base64",
  "hyper",
  "indexmap",
  "ipnet",
  "metrics",
  "metrics-util",
- "parking_lot",
- "portable-atomic",
  "quanta",
  "thiserror",
  "tokio",
@@ -1146,29 +1195,27 @@ dependencies = [
 
 [[package]]
 name = "metrics-macros"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
+checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d24dc2dbae22bff6f1f9326ffce828c9f07ef9cc1e8002e5279f845432a30a"
+checksum = "111cb375987443c3de8d503580b536f77dc8416d32db62d9456db5d93bd7ac47"
 dependencies = [
  "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown",
+ "hashbrown 0.13.2",
  "metrics",
  "num_cpus",
- "parking_lot",
- "portable-atomic",
  "quanta",
  "sketches-ddsketch",
 ]
@@ -1196,7 +1243,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -1302,8 +1349,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "orchard"
-version = "0.4.0"
-source = "git+https://github.com/zcash/orchard.git?rev=11b6858ac81a79675de205980155a49d6f92b71e#11b6858ac81a79675de205980155a49d6f92b71e"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4e7a52f510cb8c39e639e662a353adbaf86025478af89ae54a0551f8ca35e2"
 dependencies = [
  "aes",
  "bitvec",
@@ -1344,26 +1392,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
+name = "parity-scale-codec"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.9.7"
+name = "parity-scale-codec-derive"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
 dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "windows-sys",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1465,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.19"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
 
 [[package]]
 name = "ppv-lite86"
@@ -1477,12 +1528,23 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primitive-types"
-version = "0.12.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
 dependencies = [
  "fixed-hash",
+ "impl-codec",
  "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1516,16 +1578,16 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
 dependencies = [
  "crossbeam-utils",
  "libc",
- "mach",
+ "mach2",
  "once_cell",
  "raw-cpuid",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
  "web-sys",
  "winapi",
 ]
@@ -1742,6 +1804,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "rustix"
 version = "0.37.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,12 +1949,6 @@ name = "sketches-ddsketch"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -2057,6 +2119,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,12 +2293,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"
@@ -2391,6 +2464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,8 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.2.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=36d7222685e65cd8b6335f67dfe619e1a8f13197#36d7222685e65cd8b6335f67dfe619e1a8f13197"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8944af5c206cf2e37020ad54618e1825501b98548d35a638b73e0ec5762df8d5"
 dependencies = [
  "bech32",
  "bs58",
@@ -2413,7 +2496,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=36d7222685e65cd8b6335f67dfe619e1a8f13197#36d7222685e65cd8b6335f67dfe619e1a8f13197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03391b81727875efa6ac0661a20883022b6fba92365dc121c48fa9b00c5aac0"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2422,7 +2506,8 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=36d7222685e65cd8b6335f67dfe619e1a8f13197#36d7222685e65cd8b6335f67dfe619e1a8f13197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb611a28a4e13ac715ee712f4344d6b279b767daf6345dafefb2c4bf582b6679"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -2431,8 +2516,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_note_encryption"
-version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=36d7222685e65cd8b6335f67dfe619e1a8f13197#36d7222685e65cd8b6335f67dfe619e1a8f13197"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b4580cd6cee12e44421dac43169be8d23791650816bdb34e6ddfa70ac89c1c5"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -2443,8 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.11.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=36d7222685e65cd8b6335f67dfe619e1a8f13197#36d7222685e65cd8b6335f67dfe619e1a8f13197"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1a231e6a58d3dcdd6e21d229db33d7c10f9b54d8c170e122b267f6826bb48f"
 dependencies = [
  "aes",
  "bip0039",
@@ -2479,8 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.11.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=36d7222685e65cd8b6335f67dfe619e1a8f13197#36d7222685e65cd8b6335f67dfe619e1a8f13197"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b209661425fa780ff4fd1b5d8ef2148f569536b5071051143eede32e291e1a65"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,29 +42,29 @@ bellman = "0.14"
 blake2b_simd = "1"
 blake2s_simd = "1"
 bls12_381 = "0.8"
-bridgetree = "0.2"
+bridgetree = "0.3"
 byteorder = "1"
 crossbeam-channel = "0.5"
 group = "0.13"
-incrementalmerkletree = "0.3"
+incrementalmerkletree = "0.4"
 libc = "0.2"
 jubjub = "0.10"
 memuse = "0.2"
 nonempty = "0.7"
-orchard = "0.4"
+orchard = "0.5"
 secp256k1 = "0.26"
 subtle = "2.2"
 rand_core = "0.6"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-appender = "0.2"
-zcash_address = "0.2"
+zcash_address = "0.3"
 zcash_encoding = "0.2"
 zcash_history = "0.3"
-zcash_note_encryption = "0.3"
-zcash_primitives = { version = "0.11", features = ["temporary-zcashd", "transparent-inputs"] }
-zcash_proofs = { version = "0.11", features = ["directories"] }
-ed25519-zebra = "3"
+zcash_note_encryption = "0.4"
+zcash_primitives = { version = "0.12", features = ["temporary-zcashd", "transparent-inputs"] }
+zcash_proofs = { version = "0.12", features = ["directories"] }
+ed25519-zebra = "3.1"
 zeroize = "1.4.2"
 
 # Rust/C++ interop
@@ -76,9 +76,9 @@ rayon = "1.5"
 
 # Metrics
 ipnet = "2"
-metrics = "0.20"
-metrics-exporter-prometheus = "0.11"
-metrics-util = { version = "0.14", default-features = false, features = ["layer-filter"] }
+metrics = "0.21"
+metrics-exporter-prometheus = "0.12"
+metrics-util = { version = "0.15", default-features = false, features = ["layer-filter"] }
 tokio = { version = "1", features = ["rt", "net", "time"] }
 
 # General tool dependencies
@@ -105,9 +105,9 @@ thiserror = "1"
 time = { version = "0.3", features = ["formatting", "macros"] }
 
 [dev-dependencies]
-incrementalmerkletree = { version = "0.3", features = ["test-dependencies"] }
+incrementalmerkletree = { version = "0.4", features = ["test-dependencies"] }
 proptest = "1.0.0"
-zcash_primitives = { version = "0.11", features = ["temporary-zcashd", "transparent-inputs", "test-dependencies"] }
+zcash_primitives = { version = "0.12", features = ["temporary-zcashd", "transparent-inputs", "test-dependencies"] }
 
 [dependencies.tracing-subscriber]
 version = "0.3"
@@ -118,17 +118,3 @@ features = ["ansi", "env-filter", "fmt", "time"]
 lto = 'thin'
 panic = 'abort'
 codegen-units = 1
-
-[patch.crates-io]
-bridgetree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "62f0c9039b0bee94c16c40c272e19c5922290664" }
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "62f0c9039b0bee94c16c40c272e19c5922290664" }
-
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "11b6858ac81a79675de205980155a49d6f92b71e" }
-
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "36d7222685e65cd8b6335f67dfe619e1a8f13197" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "36d7222685e65cd8b6335f67dfe619e1a8f13197" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "36d7222685e65cd8b6335f67dfe619e1a8f13197" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "36d7222685e65cd8b6335f67dfe619e1a8f13197" }
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "36d7222685e65cd8b6335f67dfe619e1a8f13197" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "36d7222685e65cd8b6335f67dfe619e1a8f13197" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "36d7222685e65cd8b6335f67dfe619e1a8f13197" }

--- a/qa/supply-chain/audits.toml
+++ b/qa/supply-chain/audits.toml
@@ -101,6 +101,12 @@ criteria = "safe-to-deploy"
 delta = "0.7.1 -> 0.8.0"
 notes = "I previously reviewed the crypto-sensitive portions of these changes as well."
 
+[[audits.bridgetree]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+notes = "The ECC core team maintains this crate, and we have reviewed every line."
+
 [[audits.bumpalo]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = "safe-to-deploy"
@@ -664,6 +670,12 @@ criteria = "safe-to-deploy"
 delta = "0.3.0 -> 0.3.1"
 notes = "Fixes bug in calculating altitudes from tree positions on 32-bit platforms."
 
+[[audits.incrementalmerkletree]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.4.0"
+notes = "Removes `bridgetree` to a separate crate & updates Frontier representation."
+
 [[audits.indexmap]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = "safe-to-deploy"
@@ -875,6 +887,12 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = ["safe-to-deploy", "crypto-reviewed"]
 delta = "0.3.0 -> 0.4.0"
 notes = "The ECC core team maintains this crate, and we have reviewed every line."
+
+[[audits.orchard]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = ["safe-to-deploy", "crypto-reviewed"]
+delta = "0.4.0 -> 0.5.0"
+notes = "Updated to use incrementalmerkletree version 0.4.0."
 
 [[audits.pairing]]
 who = "Sean Bowe <ewillbefull@gmail.com>"
@@ -1476,6 +1494,12 @@ criteria = "safe-to-deploy"
 delta = "0.2.0 -> 0.2.1"
 notes = "The ECC core team maintains this crate, and we have reviewed every line."
 
+[[audits.zcash_address]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.3.0"
+notes = "Updates the bs58 dependency to version 0.5."
+
 [[audits.zcash_encoding]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = "safe-to-deploy"
@@ -1509,6 +1533,12 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = ["safe-to-deploy", "crypto-reviewed"]
 delta = "0.2.0 -> 0.3.0"
 notes = "The ECC core team maintains this crate, and we have reviewed every line."
+
+[[audits.zcash_note_encryption]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = ["safe-to-deploy", "crypto-reviewed"]
+delta = "0.3.0 -> 0.4.0"
+notes = "A minor API change that removes some unused parameters."
 
 [[audits.zcash_primitives]]
 who = "Jack Grigg <jack@z.cash>"
@@ -1563,6 +1593,12 @@ criteria = ["safe-to-deploy", "crypto-reviewed"]
 delta = "0.10.2 -> 0.11.0"
 notes = "The ECC core team maintains this crate, and we have reviewed every line."
 
+[[audits.zcash_primitives]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = ["safe-to-deploy", "crypto-reviewed"]
+delta = "0.11.0 -> 0.12.0"
+notes = "The ECC core team maintains this crate, and we have reviewed every line."
+
 [[audits.zcash_proofs]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = ["crypto-reviewed", "safe-to-deploy"]
@@ -1602,6 +1638,12 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = ["safe-to-deploy", "crypto-reviewed"]
 delta = "0.10.0 -> 0.11.0"
 notes = "The ECC core team maintains this crate, and we have reviewed every line."
+
+[[audits.zcash_proofs]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = ["safe-to-deploy", "crypto-reviewed"]
+delta = "0.11.0 -> 0.12.0"
+notes = "The only change is that the zcash_primitives dependency has been updated to version 0.12."
 
 [[audits.zeroize]]
 who = "Daira Hopwood <daira@jacaranda.org>"

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -72,6 +72,10 @@ criteria = "safe-to-deploy"
 version = "0.7.6"
 criteria = "safe-to-deploy"
 
+[[exemptions.ahash]]
+version = "0.8.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.aho-corasick]]
 version = "0.7.18"
 criteria = "safe-to-deploy"
@@ -117,7 +121,11 @@ version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bs58]]
-version = "0.4.0"
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.byte-slice-cast]]
+version = "1.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.byteorder]]
@@ -213,7 +221,7 @@ version = "0.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.fixed-hash]]
-version = "0.8.0"
+version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.fpe]]
@@ -288,6 +296,18 @@ criteria = "safe-to-deploy"
 version = "0.14.25"
 criteria = "safe-to-deploy"
 
+[[exemptions.impl-codec]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.impl-trait-for-tuples]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.incrementalmerkletree]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.indexmap]]
 version = "1.8.1"
 criteria = "safe-to-deploy"
@@ -332,14 +352,6 @@ criteria = "safe-to-deploy"
 version = "0.3.8"
 criteria = "safe-to-deploy"
 
-[[exemptions.lock_api]]
-version = "0.4.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.mach]]
-version = "0.3.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.memchr]]
 version = "2.5.0"
 criteria = "safe-to-deploy"
@@ -353,19 +365,19 @@ version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.metrics]]
-version = "0.19.0"
+version = "0.21.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.metrics-exporter-prometheus]]
-version = "0.10.0"
+version = "0.12.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.metrics-macros]]
-version = "0.5.1"
+version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.metrics-util]]
-version = "0.13.0"
+version = "0.15.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.minimal-lexical]]
@@ -416,12 +428,12 @@ criteria = "safe-to-deploy"
 version = "0.22.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.parking_lot]]
-version = "0.11.2"
+[[exemptions.parity-scale-codec]]
+version = "3.5.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.parking_lot_core]]
-version = "0.9.5"
+[[exemptions.parity-scale-codec-derive]]
+version = "3.1.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.password-hash]]
@@ -461,7 +473,7 @@ version = "0.7.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.portable-atomic]]
-version = "0.3.19"
+version = "1.3.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.ppv-lite86]]
@@ -469,7 +481,11 @@ version = "0.2.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.primitive-types]]
-version = "0.12.1"
+version = "0.11.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro-crate]]
+version = "1.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.proptest]]
@@ -477,7 +493,7 @@ version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.quanta]]
-version = "0.9.3"
+version = "0.11.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.quick-error]]
@@ -544,6 +560,10 @@ criteria = "safe-to-deploy"
 version = "0.1.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.rustc-hex]]
+version = "2.1.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.rustix]]
 version = "0.37.7"
 criteria = "safe-to-deploy"
@@ -600,10 +620,6 @@ criteria = "safe-to-deploy"
 version = "0.1.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.smallvec]]
-version = "1.10.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.socket2]]
 version = "0.4.9"
 criteria = "safe-to-deploy"
@@ -652,6 +668,10 @@ criteria = "safe-to-deploy"
 version = "1.27.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.toml_edit]]
+version = "0.19.10"
+criteria = "safe-to-deploy"
+
 [[exemptions.tower-service]]
 version = "0.3.2"
 criteria = "safe-to-deploy"
@@ -693,10 +713,6 @@ version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasi]]
-version = "0.10.2+wasi-snapshot-preview1"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasi]]
 version = "0.11.0+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
 
@@ -734,6 +750,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.winnow]]
+version = "0.4.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.wyz]]

--- a/qa/supply-chain/imports.lock
+++ b/qa/supply-chain/imports.lock
@@ -19,6 +19,12 @@ Well documented invariants, good assertions for those invariants in unsafe code,
 and tested with MIRI to boot. LGTM.
 """
 
+[[audits.bytecode-alliance.audits.base64]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.21.0"
+notes = "This crate has no dependencies, no build.rs, and contains no unsafe code."
+
 [[audits.bytecode-alliance.audits.block-buffer]]
 who = "Benjamin Bouvier <public@benj.me>"
 criteria = "safe-to-deploy"
@@ -69,6 +75,18 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.3.27"
 notes = "Unsafe used to implement a concurrency primitive AtomicWaker. Well-commented and not obviously incorrect. Like my other audits of these concurrency primitives inside the futures family, I couldn't certify that it is correct without formal methods, but that is out of scope for this vetting."
+
+[[audits.bytecode-alliance.audits.hashbrown]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+delta = "0.12.3 -> 0.13.1"
+notes = "The diff looks plausible. Much of it is low-level memory-layout code and I can't be 100% certain without a deeper dive into the implementation logic, but nothing looks actively malicious."
+
+[[audits.bytecode-alliance.audits.hashbrown]]
+who = "Trevor Elliott <telliott@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.1 -> 0.13.2"
+notes = "I read through the diff between v0.13.1 and v0.13.2, and verified that the changes made matched up with the changelog entries. There were very few changes between these two releases, and it was easy to verify what they did."
 
 [[audits.bytecode-alliance.audits.httpdate]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -241,6 +259,12 @@ criteria = "safe-to-deploy"
 version = "1.0.40"
 notes = "Found no unsafe or ambient capabilities used"
 
+[[audits.embark-studios.audits.toml_datetime]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.1 -> 0.6.2"
+notes = "No notable changes"
+
 [[audits.embark-studios.audits.valuable]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -268,6 +292,16 @@ who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 version = "0.9.4"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.isrg.audits.base64]]
+who = "Tim Geoghegan <timg@letsencrypt.org>"
+criteria = "safe-to-deploy"
+delta = "0.21.0 -> 0.21.1"
+
+[[audits.isrg.audits.base64]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "0.21.1 -> 0.21.2"
 
 [[audits.isrg.audits.block-buffer]]
 who = "David Cook <dcook@divviup.org>"
@@ -565,6 +599,12 @@ aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supp
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 version = "0.4.17"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.mach2]]
+who = "Gabriele Svelto <gsvelto@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.4.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.memoffset]]


### PR DESCRIPTION
- bridgetree 0.3
- incrementalmerkletree 0.4
- orchard 0.5
- zcash_address 0.3
- zcash_note_encryption 0.4
- zcash_primitives 0.12
- zcash_proofs 0.12

Also, this updates the following dependencies to help eliminate duplicate transitive crate dependencies:
- ed25519-zebra 3.1
- metrics 0.21
- metrics-exporter-prometheus 0.12
- metrics-util 0.15