### PR TITLE
Restore `height` parameter as being optional in `getblocksubsidy` RPC calls.

### DIFF
--- a/src/rpc/common.h
+++ b/src/rpc/common.h
@@ -76,7 +76,7 @@ static const CRPCConvertTable rpcCvtTable =
     // NB: The second argument _should_ be an object, but upstream treats it as a string, so we
     //     preserve that here.
     { "submitblock",                 {{s}, {s}} },
-    { "getblocksubsidy",             {{o}, {}} },
+    { "getblocksubsidy",             {{}, {o}} },
     // misc
     { "getinfo",                     {{}, {}} },
     { "validateaddress",             {{s}, {}} },


### PR DESCRIPTION
Closes #6727.