### PR TITLE
CI: Use latest stable Rust for book deployment

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        id: toolchain
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1


### PR DESCRIPTION
We were inheriting the repo's pinned Rust version, which became insufficient to use `mdbook-katex` recently due to MSRV bumps.