### PR TITLE
Add `doc/book/src/user/installation.md` and remove `readthedocs.io` references.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please read [our Development Guidelines](https://zcash.readthedocs.io/en/latest/rtd_pages/development_guidelines.html).
+Please read [our Development Guidelines](doc/book/src/dev.md).

--- a/INSTALL
+++ b/INSTALL
@@ -1,5 +1,3 @@
 Building Zcash
 
-See the Zcash documentation wiki (https://zcash.readthedocs.io/en/latest/rtd_pages/zcashd.html) for instructions on building zcashd,
-the intended-for-services, no-graphical-interface, reference
-implementation of Zcash.
+See [the Zcashd book](doc/book/src/) for installation, build, and operation instructions.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ is an automatic deprecation shutdown feature which will halt the node some
 time after this 16-week period. The automatic feature is based on block
 height.
 
+#### Installation
+
+See [Debian / Ubuntu installation](user/installation.md#debian-ubuntu).
+
 ## Other Zcash Implementations
 
 The [Zebra](https://github.com/ZcashFoundation/zebra) project offers a
@@ -50,14 +54,12 @@ ground up.
 
 ## Getting Started
 
-Please see our [user
-guide](https://zcash.readthedocs.io/en/latest/rtd_pages/rtd_docs/user_guide.html)
-for instructions on joining the main Zcash network.
+Please see our [user documentation](user.md) for instructions on joining the main Zcash network.
+
+<!-- Relative link destinations like `user.md` live under `./doc/book/src`. -->
 
 ### Need Help?
 
-* :blue_book: See the documentation at the [ReadTheDocs](https://zcash.readthedocs.io)
-  for help and more information.
 * :incoming_envelope: Ask for help on the [Zcash](https://forum.z.cash/) forum.
 * :speech_balloon: Join our community on [Discord](https://discordapp.com/invite/PhJY6Pm)
 * 🧑‍🎓: Learn at [ZecHub](https://wiki.zechub.xyz/)
@@ -73,9 +75,9 @@ Build Zcash along with most dependencies from source by running the following co
 ./zcutil/build.sh -j$(nproc)
 ```
 
-Currently, Zcash is only officially supported on Debian and Ubuntu. See the
-[Debian / Ubuntu build](https://zcash.readthedocs.io/en/latest/rtd_pages/Debian-Ubuntu-build.html)
-for detailed instructions.
+### Development
+
+See [Developer Documentation](dev.md).
 
 License
 -------

--- a/doc/book/src/SUMMARY.md
+++ b/doc/book/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 [zcashd](README.md)
 - [User Documentation](user.md)
+  - [Installation](user/installation.md)
   - [Release Support](user/release-support.md)
   - [Platform Support](user/platform-support.md)
   - [Wallet Backup](user/wallet-backup.md)

--- a/doc/book/src/user.md
+++ b/doc/book/src/user.md
@@ -1,6 +1,3 @@
 # User Documentation
 
 This section contains user documentation specific to `zcashd`.
-
-See [here](https://zcash.readthedocs.io/) for more general Zcash documentation, as well as
-installation instructions for `zcashd`.

--- a/doc/book/src/user/installation.md
+++ b/doc/book/src/user/installation.md
@@ -1,0 +1,84 @@
+# Installation
+
+## Debian / Ubuntu
+
+The Electric Coin Company operates a package repository for 64-bit Debian-based distributions.
+
+### Fetching a New Signing Key
+
+First install the following dependency so you can talk to our repository using HTTPS:
+
+```
+sudo apt-get update && sudo apt-get install apt-transport-https wget gnupg2
+```
+
+Next add the Zcash master signing key to apt’s trusted keyring:
+
+```
+wget -qO - https://apt.z.cash/zcash.asc | gpg --import
+gpg --export B1C9095EAA1848DBB54D9DDA1D05FDC66B372CFE | sudo apt-key add -
+```
+
+### Adding and Installing from apt.z.cash
+
+Add the repository to your Bullseye sources:
+
+```
+echo "deb [arch=amd64] https://apt.z.cash/ bullseye main" | sudo tee /etc/apt/sources.list.d/zcash.list
+```
+
+Update the cache of sources and install Zcash:
+
+```
+sudo apt-get update && sudo apt-get install zcash
+```
+
+# Troubleshooting
+
+## Different Instruction Sets
+
+Only x86-64 processors are supported.
+
+## Missing sudo
+
+If you’re starting from a new virtual machine, sudo may not come installed. See this issue for instructions to get up and running: https://github.com/zcash/zcash/issues/1844
+
+## libgomp1 or libstdc++6 version problems
+
+These libraries are provided with gcc/g++. If you see errors related to updating them, you may need to upgrade your gcc/g++ packages to version 4.9 or later. First check which version you have using g++ --version; if it is before 4.9 then you will need to upgrade.
+
+On Ubuntu Trusty, you can install gcc/g++ 4.9 as follows:
+
+```
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo apt-get update
+sudo apt-get install g++-4.9
+```
+
+## Tor
+
+The repository is also accessible via Tor, after installing the apt-transport-tor package, at the address zcaptnv5ljsxpnjt.onion. Use the following pattern in your sources.list file:
+
+```
+deb [arch=amd64] tor+http://zcaptnv5ljsxpnjt.onion/ stretch main
+```
+
+## Updating Signing Keys
+
+If your Debian binary package isn’t updating due to an error with the public key, you can resolve the problem by updating to the new key.
+
+## Revoked Key error
+
+If you see:
+
+```
+The following signatures were invalid: REVKEYSIG AEFD26F966E279CD
+```
+
+Remove the key marked as revoked:
+
+```
+sudo apt-key del AEFD26F966E279CD
+```
+
+Then [retrieve the latest key](#fetching-a-new-signing-key), then rerun `sudo apt update`.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -243,7 +243,7 @@ ACK -  A loose ACK can be confusing. It's best to avoid them unless it's a docum
 
 NACK - Disagree with the code changes/concept. Should be accompanied by an explanation.
 
-See the [Development Guidelines](https://zcash.readthedocs.io/en/latest/rtd_pages/development_guidelines.html) documentation for preferred workflows, information on continuous integration and release versioning.
+See the [Development Documentation](book/src/dev.md) documentation for preferred workflows, information on continuous integration and release versioning.
 
 Strings and formatting
 ------------------------

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -18,6 +18,8 @@ is a common reason.)
 
 Check that dependencies are properly hosted.
 
+Check that `./doc/book/src/user/installation.md` has the latest apt signing key fingerprint.
+
 Check that there are no surprising performance regressions.
 
 Update `src/chainparams.cpp` nMinimumChainWork with information from the getblockchaininfo rpc.
@@ -257,9 +259,6 @@ some variables in the company's automation code and then run an Ansible playbook
   restarting DNS seeder.
 
 Verify that nodes can connect to the mainnet and testnet servers.
-
-Update the [Zcashd Full Node and CLI](https://zcash.readthedocs.io/en/latest/rtd_pages/zcashd.html)
-documentation on ReadTheDocs to give the new version number.
 
 ### Publish the release announcement (blog, github, zcash-dev, slack)
 


### PR DESCRIPTION
This adds an installation page to the book, which (currently) only contains Debian instructions.

Important details:

- I got the instructions from [zcash.readthedocs.io in the wayback machine](https://web.archive.org/web/20230608142101/https://zcash.readthedocs.io/en/latest/rtd_pages/install_debian_bin_packages.html), then dusted them off a bit, including updating the apt signing key fingerprint and removing `zcash-fetch-params` step. I also followed those instructions on a Debian Bullseye vm.
- I updated `doc/release-process.md` to check that apt fingerprint in the pre-release process.
- I tweaked the top-level `README.md` to replace readthedocs links with internal `mdbook` links. The issue here is that this works/makes sense in an `mdbook` rendering, but may be confusing in the top-level `README.md` context (such as github repo homepage). I added an html comment in order to help local file readers make the connection.