### PR TITLE
Stricter `version` message parsing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6994,26 +6994,6 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
     }
 
 
-    // Disconnect existing peer connection when:
-    // 1. The version message has been received
-    // 2. Peer version is below the minimum version for the current epoch
-    else if (pfrom->nVersion < chainparams.GetConsensus().vUpgrades[
-        CurrentEpoch(GetHeight(), chainparams.GetConsensus())].nProtocolVersion &&
-        !(
-            chainparams.NetworkIDString() == "regtest" &&
-            !GetBoolArg("-nurejectoldversions", DEFAULT_NU_REJECT_OLD_VERSIONS)
-        )
-    ) {
-        LogPrintf("peer=%d using obsolete version %i; disconnecting\n", pfrom->id, pfrom->nVersion);
-        pfrom->PushMessage("reject", strCommand, REJECT_OBSOLETE,
-                            strprintf("Version must be %d or greater",
-                            chainparams.GetConsensus().vUpgrades[
-                                CurrentEpoch(GetHeight(), chainparams.GetConsensus())].nProtocolVersion));
-        pfrom->fDisconnect = true;
-        return false;
-    }
-
-
     else if (strCommand == "addr")
     {
         vector<CAddress> vAddr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6816,12 +6816,13 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
 
         // Consume all available payload
         // This block might throw an IO exception. If that's the case then
-        // nothing in pfrom will be changed.
+        // nothing in pfrom's state will be changed.
         vRecv >> nVersion >> nServices >> nTime >> addrMe;
         if (nVersion >= 106) {
             if (vRecv.in_avail() < 39) {
                 // Be strict about size of addr_from + nonce + user_agent + start_height
                 pfrom->PushMessage("reject", strCommand, REJECT_MALFORMED, string("Error in message size"));
+                pfrom->fDisconnect = true;
                 return false;
             }
             vRecv >> addrFrom >> nNonce >> LIMITED_STRING(strSubVer, MAX_SUBVERSION_LENGTH) >> nStartingHeight;
@@ -6830,6 +6831,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
                 if (vRecv.in_avail() < 1) {
                     // Be strict about relay size
                     pfrom->PushMessage("reject", strCommand, REJECT_MALFORMED, string("Error in message size"));
+                    pfrom->fDisconnect = true;
                     return false;
                 }
                 vRecv >> fRelay;
@@ -6840,6 +6842,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
         // have been deliberately bloated on sender's side
         if (vRecv.in_avail() > 0) {
             pfrom->PushMessage("reject", strCommand, REJECT_MALFORMED, string("Error in message size"));
+            pfrom->fDisconnect = true;
             return false;
         }
 


### PR DESCRIPTION
Actual behavior of ParseMessage for command `version` exposes to an unwanted behavior.
The problem lays in the fact the `version` field of the payload is immediately deserialized into `pfrom->nVersion` member.
This leads to a condition where, if any deserialization fails due to `std::ios_base::failure` the message is indeed discarded but the member `pfrom->nVersion` is nevertheless valued !=0 and this is used as a guard to determine whether the peer is allowed to send a new `version` message or other message types.

This is the case when, for example, the remote pushes a subVersion larger than 256 chars which causes an exception. This implies:

- pfrom->nVersion gets != 0
- pfrom->SetAddrLocal(addrMe); is not called
- pfrom->PushMessage("verack"); is not called
- pfrom->ssSend.SetVersion(min(pfrom->nVersion, PROTOCOL_VERSION)); is not called 
- etc.

Nevertheless the peer is deemd "sort-of" connected as it could push verack and other messages which will be eventually deserialized with possibly martian protocol versions.

Purpose of this PR is to rewrite the processing logic of `version` message such as is all-or-nothing.