### PR TITLE
Disconnect on a malformed version message, and reject duplicate verack messages

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6849,8 +6849,6 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             return false;
         }
 
-        if (pfrom->nVersion == 10300)
-            pfrom->nVersion = 300;
         if (!vRecv.empty())
             vRecv >> addrFrom >> nNonce;
         if (!vRecv.empty()) {

--- a/src/net.h
+++ b/src/net.h
@@ -103,7 +103,7 @@ void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler);
 bool StopNode();
 void SocketSendData(CNode *pnode);
 
-typedef int NodeId;
+typedef int64_t NodeId;
 
 struct CombinerAll
 {


### PR DESCRIPTION
This is loosely based on and supercedes #6780 by @AndreaLanfranchi, but takes a different approach. It makes the following changes:

* Deserialization of fields of a "version" message now uses types of platform-independent size.
* If deserialization of a "version" message fails due to a `std::ios_base::failure`, the "version" message will be rejected and the peer will be marked to disconnect (`pfrom->fDisconnect = true`).
* A peer's `nVersion` and `nServices` fields are no longer set (i.e. they will be left at 0) until after the mandatory fields of a "version" message have been successfully parsed and validated. Therefore, the `nVersion` field will never be set to a non-zero value below `MIN_PEER_PROTO_VERSION` (or `MIN_TESTNET_PEER_PROTO_VERSION` for Testnet). This makes the peer version handling simpler to reason about.
* `pfrom->fSuccessfullyConnected` is not set until after `pfrom->nTimeOffset` has been initialized.
* If a duplicate "verack" message is received, it will be rejected in the same way as a duplicate "version" message.
