### PR TITLE
Protect vectorized payloads from wasteful and unneeded deserializations

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7017,8 +7017,13 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             Misbehaving(pfrom->GetId(), 20);
             return error("message addr size() = %u", nNumItems);
         }
+        if (const auto nExpectedSize = (nNumItems + sizeof(CAddress)); nExpectedSize != vRecv.in_avail()) {
+            LOCK(cs_main);
+            Misbehaving(pfrom->GetId(), 20);
+            return error("malformed 'addr' payload. expected %u bytes, got %u instead", nExpectedSize, vRecv.in_avail());
+        }
         vRecv.Rewind(GetSizeOfCompactSize(nNumItems));
-        
+
         vector<CAddress> vAddr;
         vRecv >> vAddr;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7120,7 +7120,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
 
     else if (strCommand == "inv")
     {
-        if (!ValidateMessageVectorizePayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_INV_SZ, /*nMinItems=*/1, /*nItemSize=*/static_cast<uint32_t>(sizeof(CInv))))
+        if (!ValidateMessageVectorizePayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_INV_SZ, /*nMinItems=*/1, /*nItemSize=*/0))
             return false;
 
         vector<CInv> vInv;
@@ -7191,7 +7191,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
 
     else if (strCommand == "getdata")
     {
-        if (!ValidateMessageVectorizePayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_INV_SZ, /*nMinItems=*/1, /*nItemSize=*/static_cast<uint32_t>(sizeof(CInv))))
+        if (!ValidateMessageVectorizePayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_INV_SZ, /*nMinItems=*/1, /*nItemSize=*/0))
             return false;
 
         vector<CInv> vInv;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6781,7 +6781,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
     }
 }
 
-bool static ValidateMessageVectorizePayload(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, uint32_t nMaxItems, uint32_t nMinItems, uint32_t nItemSize) {
+bool static ValidateMessageVectorizedPayload(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, uint32_t nMaxItems, uint32_t nMinItems, uint32_t nItemSize) {
     const auto nNumItems = ReadCompactSize(vRecv);
     if (nNumItems > nMaxItems || nNumItems < nMinItems) {
         LOCK(cs_main);
@@ -7029,7 +7029,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             return true;
 
         const uint32_t nItemSize = 30U; // static_cast<uint32_t>(sizeof(CAddress)) returns 40 (?!)
-        if (!ValidateMessageVectorizePayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_ADDR_SZ, /*nMinItems=*/1, nItemSize))
+        if (!ValidateMessageVectorizedPayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_ADDR_SZ, /*nMinItems=*/1, nItemSize))
             return false;
 
         vector<CAddress> vAddr;
@@ -7120,7 +7120,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
 
     else if (strCommand == "inv")
     {
-        if (!ValidateMessageVectorizePayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_INV_SZ, /*nMinItems=*/1, /*nItemSize=*/0))
+        if (!ValidateMessageVectorizedPayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_INV_SZ, /*nMinItems=*/1, /*nItemSize=*/0))
             return false;
 
         vector<CInv> vInv;
@@ -7191,7 +7191,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
 
     else if (strCommand == "getdata")
     {
-        if (!ValidateMessageVectorizePayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_INV_SZ, /*nMinItems=*/1, /*nItemSize=*/0))
+        if (!ValidateMessageVectorizedPayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_INV_SZ, /*nMinItems=*/1, /*nItemSize=*/0))
             return false;
 
         vector<CInv> vInv;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7007,12 +7007,13 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
 
     else if (strCommand == "addr")
     {
-        vector<CAddress> vAddr;
-        vRecv >> vAddr;
-
         // Don't want addr from older versions unless seeding
         if (pfrom->nVersion < CADDR_TIME_VERSION && addrman.size() > 1000)
             return true;
+
+        vector<CAddress> vAddr;
+        vRecv >> vAddr;
+
         if (vAddr.size() > 1000)
         {
             LOCK(cs_main);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7012,7 +7012,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             return true;
 
         const auto nNumItems = ReadCompactSize(vRecv);
-        if (nNumItems > 1000) {
+        if (nNumItems > MAX_ADDR_SZ) {
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20);
             return error("message addr size() = %u", nNumItems);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7028,7 +7028,8 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
         if (pfrom->nVersion < CADDR_TIME_VERSION && addrman.size() > 1000)
             return true;
 
-        if (!ValidateMessageVectorizePayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_ADDR_SZ, /*nMinItems=*/1, /*nItemSize=*/static_cast<uint32_t>(sizeof(CAddress))))
+        const uint32_t nItemSize = 30U; // static_cast<uint32_t>(sizeof(CAddress)) returns 40 (?!)
+        if (!ValidateMessageVectorizePayload(pfrom, strCommand, vRecv, /*nMaxItems=*/MAX_ADDR_SZ, /*nMinItems=*/1, nItemSize))
             return false;
 
         vector<CAddress> vAddr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7017,7 +7017,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             Misbehaving(pfrom->GetId(), 20);
             return error("message addr size() = %u", nNumItems);
         }
-        if (const auto nExpectedSize = (nNumItems + sizeof(CAddress)); nExpectedSize != vRecv.in_avail()) {
+        if (const auto nExpectedSize = (nNumItems * sizeof(CAddress)); nExpectedSize != vRecv.in_avail()) {
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20);
             return error("malformed 'addr' payload. expected %u bytes, got %u instead", nExpectedSize, vRecv.in_avail());
@@ -7119,7 +7119,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             Misbehaving(pfrom->GetId(), 20);
             return error("message inv size() = %u", nNumItems);
         }
-        if (const auto nExpectedSize = (nNumItems + sizeof(CInv)); nExpectedSize != vRecv.in_avail()) {
+        if (const auto nExpectedSize = (nNumItems * sizeof(CInv)); nExpectedSize != vRecv.in_avail()) {
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20);
             return error("malformed 'inv' payload. expected %u bytes, got %u instead", nExpectedSize, vRecv.in_avail());
@@ -7200,7 +7200,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             Misbehaving(pfrom->GetId(), 20);
             return error("message getdata size() = %u", nNumItems);
         }
-        if (const auto nExpectedSize = (nNumItems + sizeof(CInv)); nExpectedSize != vRecv.in_avail()) {
+        if (const auto nExpectedSize = (nNumItems * sizeof(CInv)); nExpectedSize != vRecv.in_avail()) {
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20);
             return error("malformed 'getdata' payload. expected %u bytes, got %u instead", nExpectedSize, vRecv.in_avail());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7017,10 +7017,10 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             Misbehaving(pfrom->GetId(), 20);
             return error("message addr size() = %u", nNumItems);
         }
-        if (const auto nExpectedSize = (nNumItems * sizeof(CAddress)); nExpectedSize != vRecv.in_avail()) {
+        if (const auto nExpectedSize = (nNumItems * sizeof(CAddress)); nExpectedSize != static_cast<uint64_t>(vRecv.in_avail())) {
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20);
-            return error("malformed 'addr' payload. expected %u bytes, got %u instead", nExpectedSize, vRecv.in_avail());
+            return error("malformed 'addr' payload. expected %u bytes, got %u instead", nExpectedSize, static_cast<uint64_t>(vRecv.in_avail()));
         }
         vRecv.Rewind(GetSizeOfCompactSize(nNumItems));
 
@@ -7112,17 +7112,16 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
 
     else if (strCommand == "inv")
     {
-
         const auto nNumItems = ReadCompactSize(vRecv);
         if (nNumItems > MAX_INV_SZ) {
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20);
             return error("message inv size() = %u", nNumItems);
         }
-        if (const auto nExpectedSize = (nNumItems * sizeof(CInv)); nExpectedSize != vRecv.in_avail()) {
+        if (const auto nExpectedSize = (nNumItems * sizeof(CInv)); nExpectedSize != static_cast<uint64_t>(vRecv.in_avail())) {
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20);
-            return error("malformed 'inv' payload. expected %u bytes, got %u instead", nExpectedSize, vRecv.in_avail());
+            return error("malformed 'inv' payload. expected %u bytes, got %u instead", nExpectedSize, static_cast<uint64_t>(vRecv.in_avail()));
         }
         vRecv.Rewind(GetSizeOfCompactSize(nNumItems));
 
@@ -7200,10 +7199,10 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             Misbehaving(pfrom->GetId(), 20);
             return error("message getdata size() = %u", nNumItems);
         }
-        if (const auto nExpectedSize = (nNumItems * sizeof(CInv)); nExpectedSize != vRecv.in_avail()) {
+        if (const auto nExpectedSize = (nNumItems * sizeof(CInv)); nExpectedSize != static_cast<uint64_t>(vRecv.in_avail())) {
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20);
-            return error("malformed 'getdata' payload. expected %u bytes, got %u instead", nExpectedSize, vRecv.in_avail());
+            return error("malformed 'getdata' payload. expected %u bytes, got %u instead", nExpectedSize, static_cast<uint64_t>(vRecv.in_avail()));
         }
         vRecv.Rewind(GetSizeOfCompactSize(nNumItems));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7011,15 +7011,16 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
         if (pfrom->nVersion < CADDR_TIME_VERSION && addrman.size() > 1000)
             return true;
 
-        vector<CAddress> vAddr;
-        vRecv >> vAddr;
-
-        if (vAddr.size() > 1000)
-        {
+        const auto nNumItems = ReadCompactSize(vRecv);
+        if (nNumItems > 1000) {
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20);
-            return error("message addr size() = %u", vAddr.size());
+            return error("message addr size() = %u", nNumItems);
         }
+        vRecv.Rewind(GetSizeOfCompactSize(nNumItems));
+        
+        vector<CAddress> vAddr;
+        vRecv >> vAddr;
 
         // Store the new addresses
         vector<CAddress> vAddrOk;

--- a/src/net.h
+++ b/src/net.h
@@ -46,6 +46,8 @@ namespace boost {
 static const int PING_INTERVAL = 2 * 60;
 /** Time after which to disconnect, after waiting for a ping response (or inactivity). */
 static const int TIMEOUT_INTERVAL = 20 * 60;
+/** The maximum number of entries in an 'addr' protocol message */
+static const unsigned int MAX_ADDR_SZ = 1000;
 /** The maximum number of entries in an 'inv' protocol message */
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */


### PR DESCRIPTION
#### Abstract
Several message types carry vectorized payloads. There are limits to the number of items such payloads can hold (e.g. an `inv` message can't hold more than 50k items). 

#### Issue
The check for max items threshold exceeded happens **after** the deserialization has been performed and therefore the code discards a content which had an additional cost to be produced. See [here for example](https://github.com/zcash/zcash/blob/master/src/main.cpp#L7106-L7115).
As a result it can happen a malicous peer can send several `inv` messages with way more items than max allowed per message before being disconnected for excessive penalization which leads to wasteful usage of resources and possibly increases the surface of attack for DoS.

#### Proposed solution
Early perform a lightweight check on behalf of raw datastream contents **before** starting the deserialization (and creation of vector<T>) and return immediately in case of validation failure. This is a revised version of the partially implemented solution I pointed out on [Horizen's Zend](https://github.com/HorizenOfficial/zen/commit/075849368e40af4ed49570d7d054165bc72570ea)
The overall implementation adds negligible overhead to the processing of legit messages.
The checking function also verifies (optionally) whether the vector of items is actually **not empty** : this is to avoid a flood of messages (e.g. `inv`) with empty payloads that has the only goal to waste cycles for processing totally un-useful messages without any penalization.

Thank you for your attention.