### PR TITLE
Suppress compilation warnings for K&R-style prototypes when building bdb

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -20,6 +20,7 @@ $(package)_config_opts_darwin=--disable-atomicsupport
 endif
 $(package)_config_opts_aarch64=--disable-atomicsupport
 $(package)_cxxflags+=-std=c++17
+$(package)_cflags+=-Wno-deprecated-non-prototype
 
 ifeq ($(host_os),freebsd)
   $(package)_ldflags+=-static-libstdc++ -lcxxrt


### PR DESCRIPTION
This adds `-Wno-deprecated-non-prototype` to `CFLAGS`, just for the bdb build.