### PR TITLE
fix transparent pool addition for unspendable outputs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3416,7 +3416,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         }
 
         for (const auto& out : tx.vout) {
-            transparentValueDelta += out.nValue;
+            // if the outputs are unspendable, we should not include them in the transparent pool
+            if (!out.scriptPubKey.IsUnspendable()) {
+                transparentValueDelta += out.nValue;
+            }
         }
 
         if (tx.GetSaplingBundle().IsPresent()) {
@@ -4632,7 +4635,9 @@ bool ReceivedBlockTransactions(
         if (pindexNew->pprev == nullptr) {
             chainSupplyDelta = tx.GetValueOut();
             for (const auto& out : tx.vout) {
-                transparentValueDelta += out.nValue;
+                if (!out.scriptPubKey.IsUnspendable()) {
+                    transparentValueDelta += out.nValue;
+                }
             }
         }
 


### PR DESCRIPTION
Outputs that cannot be spent, such as coins used in an OP_RETURN script, probably should not increase the transparent pool. This is because these coins are essentially "burned", permanently removed from circulation.

Example:

```json
{
  "txid": "skipped",
  "overwintered": false,
  "version": 1,
  "locktime": 0,
  "vin": [
// skipped
  ],
  "vout": [
    {
      "value": 1.00000000,
      "valueZat": 100000000,
      "n": 0,
      "scriptPubKey": {
        "asm": "OP_RETURN 6465636b6572",
        "hex": "6a066465636b6572",
        "type": "nulldata"
      }
    }
  ],
  "vjoinsplit": [
  ]
}
```