### PR TITLE
CI Tekton Migration to Github Action

### DIFF
--- a/.github/actions/gcs-download-cloud-storage/action.yml
+++ b/.github/actions/gcs-download-cloud-storage/action.yml
@@ -1,0 +1,54 @@
+name: 'gcs-download-cloud-storage'
+description: 'Download files from a GCS bucket'
+inputs:
+  path-prefix:
+    description: 'The bucket path inside which the source path is located'
+    required: true
+  source:
+    description: 'The path to the files to download'
+    required: true
+  destination:
+    description: 'The directory into which the files will be downloaded'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Cloud SDK
+      if: runner.os != 'Linux'
+      uses: 'google-github-actions/setup-gcloud@v2'
+      with:
+        version: '>= 390.0.0' # To use gsutil with google-github-actions/auth
+
+    # Use $RUNNER_TEMP instead of ${{ runner.temp }} to prevent the Bash used by Windows
+    # runners from treating backslashes in Windows paths as escape characters.
+    # https://github.com/orgs/community/discussions/25910
+    - name: Create temporary directory
+      shell: bash
+      run: |
+        rm -rf $RUNNER_TEMP/gcs-download
+        mkdir $RUNNER_TEMP/gcs-download
+
+    - name: Download source
+      shell: bash
+      run: >
+        gcloud storage
+        cp -r
+        gs://gh-zcash/${{ inputs.path-prefix }}/${{ inputs.source }}
+        $RUNNER_TEMP/gcs-download
+
+    - name: Ensure the target directory exists
+      shell: bash
+      run: mkdir -p ${{ inputs.destination }}
+
+    - name: Move source to target [Unix]
+      if: runner.os != 'Windows'
+      shell: bash
+      run: mv ${{ runner.temp }}/gcs-download/* ${{ inputs.destination }}
+
+    # PowerShell's mv aliases to its Move-Item cmdlet which has glob support (unlike mv in
+    # Git Bash for whatever reason).
+    - name: Move source to target [Windows]
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: mv ${{ runner.temp }}/gcs-download/* ${{ inputs.destination }}

--- a/.github/actions/gcs-download-cloud-storage/action.yml
+++ b/.github/actions/gcs-download-cloud-storage/action.yml
@@ -10,6 +10,8 @@ inputs:
   destination:
     description: 'The directory into which the files will be downloaded'
     required: true
+  remove-first-if-exists:
+    description: 'Deletes the given path first (if it exists) before downloading files'
 
 runs:
   using: 'composite'
@@ -36,6 +38,11 @@ runs:
         cp -r
         gs://gh-zcash/${{ inputs.path-prefix }}/${{ inputs.source }}
         $RUNNER_TEMP/gcs-download
+
+    - name: Remove the specified path if it exists
+      if: inputs.remove-first-if-exists != ''
+      shell: bash
+      run: rm -rf ${{ inputs.remove-first-if-exists }}
 
     - name: Ensure the target directory exists
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,12 @@ jobs:
           path: ${{ format('./src/zcash-gtest{0}', matrix.file_ext) }}
           destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src
 
+      - name: Upload depends/${{ matrix.host }}/lib
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ./depends/${{ matrix.host }}/lib
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/depends/${{ matrix.host }}
+
   bitrot:
     name: Bitrot check tier ${{ matrix.tier }} platform ${{ matrix.platform }} flag '${{ matrix.configure_flag }}'
     needs: [setup, build]
@@ -322,3 +328,32 @@ jobs:
           GTEST_TOTAL_SHARDS: 2
           GTEST_SHARD_INDEX: ${{ matrix.shard_index }}
         run: ${{ format('./zcash-gtest{0}', matrix.file_ext) }}
+
+  no-dot-so:
+    name: not-dot-so tier ${{ matrix.tier }} platform ${{ matrix.platform }}
+    needs: [setup, build]
+    runs-on: ${{ matrix.test_os }}
+    continue-on-error: ${{ matrix.tier != 1 }}
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.setup.outputs.test_matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Download depends/${{ matrix.host }}/lib artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: depends/${{ matrix.host }}/lib
+          destination: ./depends/${{ matrix.host }}/
+
+      - name: Run no-dot-so test
+        run: python3 ./qa/zcash/full_test_suite.py no-dot-so
+        env:
+          HOST: ${{ matrix.host }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,20 @@ jobs:
           GTEST_SHARD_INDEX: ${{ matrix.shard_index }}
         run: ${{ format('./zcash-gtest{0}', matrix.file_ext) }}
 
+  test-rust:
+    name: Rust test tier ${{ matrix.tier }} platform ${{ matrix.platform }}
+    needs: [setup, build]
+    runs-on: ${{ matrix.test_os }}
+    continue-on-error: ${{ matrix.tier != 1 }}
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.setup.outputs.test_matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Rust tests
+        run: cargo test
+
   no-dot-so:
     name: not-dot-so tier ${{ matrix.tier }} platform ${{ matrix.platform }}
     needs: [setup, build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,17 @@ jobs:
       build_names: ${{ steps.set-matrices.outputs.build_names }}
       test_matrix: ${{ steps.set-matrices.outputs.test_matrix }}
       test_names: ${{ steps.set-matrices.outputs.test_names }}
+      unix_test_matrix: ${{ steps.set-matrices.outputs.unix_test_matrix }}
+      unix_test_names: ${{ steps.set-matrices.outputs.unix_test_names }}
+
     steps:
+      # Configure the build and test matrices. Notes:
+      # - The `*_names` lists of platforms are combined with job-specific lists to build
+      #   strategy matrices. The `*_matrix` lists then augment the matrix with parameters
+      #   for each platform.
+      # - We can only run tests on the subset of platforms that have a compatible runner
+      #   (i.e. excluding cross-compiled platforms).
+      # - Some tests don't currently work on Windows platforms, so we have a Unix subset.
       - id: set-matrices
         env:
           CFG: ${{ toJSON(matrix.cfg) }}
@@ -72,6 +82,8 @@ jobs:
           jq -r -n 'env.CFG | fromjson | [.data[] | .name] | @json "build_names=\(.)"' >> $GITHUB_OUTPUT
           jq -r -n 'env.CFG | fromjson | [.data[] | select(.test_os)] | @json "test_matrix=\(.)"' >> $GITHUB_OUTPUT
           jq -r -n 'env.CFG | fromjson | [.data[] | select(.test_os) | .name] | @json "test_names=\(.)"' >> $GITHUB_OUTPUT
+          jq -r -n 'env.CFG | fromjson | [.data[] | select(.test_os and .test_os != "windows-latest")] | @json "unix_test_matrix=\(.)"' >> $GITHUB_OUTPUT
+          jq -r -n 'env.CFG | fromjson | [.data[] | select(.test_os and .test_os != "windows-latest") | .name] | @json "unix_test_names=\(.)"' >> $GITHUB_OUTPUT
 
       - name: Download Sprout parameters
         run: |
@@ -163,6 +175,24 @@ jobs:
           path: ${{ format('./src/zcash-cli{0}', matrix.file_ext) }}
           destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src
 
+      - name: Upload zcashd-wallet-tool artifact
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ${{ format('./src/zcashd-wallet-tool{0}', matrix.file_ext) }}
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src
+
+      - name: Upload zcash-inspect artifact
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ${{ format('./src/zcash-inspect{0}', matrix.file_ext) }}
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src
+
+      - name: Upload zcash-tx artifact
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ${{ format('./src/zcash-tx{0}', matrix.file_ext) }}
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src
+
       - name: Upload zcash-btest artifact
         uses: google-github-actions/upload-cloud-storage@v2
         with:
@@ -180,6 +210,12 @@ jobs:
         with:
           path: ./depends/${{ matrix.host }}/lib
           destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/depends/${{ matrix.host }}
+
+      - name: Upload bench_bitcoin artifact
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ${{ format('./src/bench/bench_bitcoin{0}', matrix.file_ext) }}
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src/bench
 
   bitrot:
     name: Bitrot check tier ${{ matrix.tier }} platform ${{ matrix.platform }} flag '${{ matrix.configure_flag }}'
@@ -355,5 +391,96 @@ jobs:
 
       - name: Run no-dot-so test
         run: python3 ./qa/zcash/full_test_suite.py no-dot-so
+        env:
+          HOST: ${{ matrix.host }}
+
+  # Not working in Windows
+  sec-hard:
+    name: sec-hard tier ${{ matrix.tier }} platform ${{ matrix.platform }}
+    needs: [setup, build]
+    runs-on: ${{ matrix.test_os }}
+    continue-on-error: ${{ matrix.tier != 1 }}
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.setup.outputs.unix_test_matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Download ${{ format('src/zcash-inspect{0}', matrix.file_ext) }} artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: ${{ format('src/zcash-inspect{0}', matrix.file_ext) }}
+          destination: ./src/
+
+      - name: Download ${{ format('src/bench/bench_bitcoin{0}', matrix.file_ext) }}  artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: ${{ format('src/bench/bench_bitcoin{0}', matrix.file_ext) }}
+          destination: ./src/bench/
+
+      - name: Download ${{ format('src/test/test_bitcoin{0}', matrix.file_ext) }}  artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: ${{ format('src/test/test_bitcoin{0}', matrix.file_ext) }}
+          destination: ./src/test/
+
+      - name: Download ${{ format('src/zcashd-wallet-tool{0}', matrix.file_ext) }}  artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: ${{ format('src/zcashd-wallet-tool{0}', matrix.file_ext) }}
+          destination: ./src/
+
+      - name: Download ${{ format('src/zcash-tx{0}', matrix.file_ext) }}  artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: ${{ format('src/zcash-tx{0}', matrix.file_ext) }}
+          destination: ./src/
+
+      - name: Download ${{ format('src/zcash-gtest{0}', matrix.file_ext) }}  artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: ${{ format('src/zcash-gtest{0}', matrix.file_ext) }}
+          destination: ./src/
+
+      - name: Download ${{ format('src/zcashd{0}', matrix.file_ext) }} artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: ${{ format('src/zcashd{0}', matrix.file_ext) }}
+          destination: ./src/
+
+      - name: Download ${{ format('src/zcash-cli{0}', matrix.file_ext) }} artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: ${{ format('src/zcash-cli{0}', matrix.file_ext) }}
+          destination: ./src/
+
+      - name: Make artifact executable
+        if: runner.os != 'Windows'
+        run: |
+          chmod +x ${{ format('./src/test/test_bitcoin{0}', matrix.file_ext) }}
+          chmod +x ${{ format('./src/bench/bench_bitcoin{0}', matrix.file_ext) }}
+          chmod +x ${{ format('./src/zcashd{0}', matrix.file_ext) }}
+          chmod +x ${{ format('./src/zcash-cli{0}', matrix.file_ext) }}
+          chmod +x ${{ format('./src/zcash-gtest{0}', matrix.file_ext) }}
+          chmod +x ${{ format('./src/zcashd-wallet-tool{0}', matrix.file_ext) }}
+          chmod +x ${{ format('./src/zcash-tx{0}', matrix.file_ext) }}
+
+      - name: Run sec-hard test
+        shell: bash
+        run: python3 ./qa/zcash/full_test_suite.py sec-hard
         env:
           HOST: ${{ matrix.host }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,14 @@ jobs:
               platform: Ubuntu 20.04
               build_os: ubuntu-20.04-8cores
               test_os: ubuntu-20.04
+              host: x86_64-pc-linux-gnu
 
             - name: ubuntu-22.04
               tier: 3
               platform: Ubuntu 22.04
               build_os: ubuntu-22.04-8cores
               test_os: ubuntu-22.04
+              host: x86_64-pc-linux-gnu
 
             - name: macos-11
               tier: 3
@@ -36,6 +38,7 @@ jobs:
                 coreutils
                 libtool
                 pkgconfig
+              host: x86_64-apple-darwin
 
             - name: mingw32
               tier: 3
@@ -44,7 +47,7 @@ jobs:
               test_os: windows-latest
               cross_deps: >
                 mingw-w64
-              host: HOST=x86_64-w64-mingw32
+              host: x86_64-w64-mingw32
               file_ext: ".exe"
 
             - name: aarch64-linux
@@ -53,7 +56,7 @@ jobs:
               build_os: ubuntu-22.04-8cores
               cross_deps: >
                 g++-aarch64-linux-gnu
-              host: HOST=aarch64-linux-gnu
+              host: aarch64-linux-gnu
 
     outputs:
       build_matrix: ${{ steps.set-matrices.outputs.build_matrix }}
@@ -124,8 +127,9 @@ jobs:
 
       - name: Build zcashd
         id: build
+        env:
+          HOST: ${{ matrix.host }}
         run: >
-          ${{ matrix.host }}
           ./zcutil/build.sh
           -j"${{ steps.nproc.outputs.count }}"
 
@@ -209,9 +213,10 @@ jobs:
         run: echo "count=$(nproc 2> /dev/null || sysctl -n hw.logicalcpu)" >> "$GITHUB_OUTPUT"
 
       - name: Build zcashd with the flag being checked
+        env:
+          CONFIGURE_FLAGS: "${{ matrix.configure_flag }}"
+          HOST: ${{ matrix.host }}
         run: >
-          CONFIGURE_FLAGS="${{ matrix.configure_flag }}"
-          ${{ matrix.host }}
           ./zcutil/build.sh
           -j"${{ steps.nproc.outputs.count }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: master
 
 jobs:
-  matrices:
+  setup:
     name: Define CI matrix
     runs-on: ubuntu-latest
     strategy:
@@ -73,14 +73,27 @@ jobs:
           jq -r -n 'env.CFG | fromjson | [.data[] | select(.test_os)] | @json "test_matrix=\(.)"' >> $GITHUB_OUTPUT
           jq -r -n 'env.CFG | fromjson | [.data[] | select(.test_os) | .name] | @json "test_names=\(.)"' >> $GITHUB_OUTPUT
 
+      - name: Download Sprout parameters
+        run: |
+          mkdir zcash-params
+          cd zcash-params
+          wget -c https://download.z.cash/downloads/sprout-groth16.params
+
+      - name: Cache Sprout parameters
+        uses: actions/cache/save@v3
+        with:
+          enableCrossOsArchive: true
+          path: zcash-params
+          key: zcash-params
+
   build:
     name: Build tier ${{ matrix.tier }} platform ${{ matrix.platform }}
-    needs: matrices
+    needs: setup
     runs-on: ${{ matrix.build_os }}
     continue-on-error: ${{ matrix.tier == 3 }}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.matrices.outputs.build_matrix) }}
+        include: ${{ fromJson(needs.setup.outputs.build_matrix) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -157,17 +170,17 @@ jobs:
 
   bitrot:
     name: Bitrot check tier ${{ matrix.tier }} platform ${{ matrix.platform }} flag '${{ matrix.configure_flag }}'
-    needs: [matrices, build]
+    needs: [setup, build]
     runs-on: ${{ matrix.build_os }}
     continue-on-error: ${{ matrix.tier == 3 }}
     strategy:
       matrix:
-        name: ${{ fromJson(needs.matrices.outputs.build_names) }}
+        name: ${{ fromJson(needs.setup.outputs.build_names) }}
         configure_flag:
           - '--with-libs'
           - '--disable-wallet'
           - '--disable-mining'
-        include: ${{ fromJson(needs.matrices.outputs.build_matrix) }}
+        include: ${{ fromJson(needs.setup.outputs.build_matrix) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -222,12 +235,12 @@ jobs:
 
   test-btest:
     name: Boost.Test tier ${{ matrix.tier }} platform ${{ matrix.platform }}
-    needs: [matrices, build]
+    needs: [setup, build]
     runs-on: ${{ matrix.test_os }}
     continue-on-error: ${{ matrix.tier != 1 }}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.matrices.outputs.test_matrix) }}
+        include: ${{ fromJson(needs.setup.outputs.test_matrix) }}
     steps:
       - name: Download zcash-btest artifact
         uses: actions/download-artifact@v4
@@ -241,14 +254,14 @@ jobs:
 
   test-gtest:
     name: GoogleTest tier ${{ matrix.tier }} platform ${{ matrix.platform }} - shard ${{ matrix.shard_index }}
-    needs: [matrices, build]
+    needs: [setup, build]
     runs-on: ${{ matrix.test_os }}
     continue-on-error: ${{ matrix.tier != 1 }}
     strategy:
       matrix:
-        name: ${{ fromJson(needs.matrices.outputs.test_names) }}
+        name: ${{ fromJson(needs.setup.outputs.test_names) }}
         shard_index: [0, 1]
-        include: ${{ fromJson(needs.matrices.outputs.test_matrix) }}
+        include: ${{ fromJson(needs.setup.outputs.test_matrix) }}
     steps:
       - name: Download zcash-gtest artifact
         uses: actions/download-artifact@v4
@@ -257,24 +270,25 @@ jobs:
       - name: Make artifact executable
         if: runner.os != 'Windows'
         run: chmod +x ${{ format('./zcash-gtest{0}', matrix.file_ext) }}
-      - name: Get environment variables
-        id: env
+
+      - name: Get Sprout parameters
+        uses: actions/cache/restore@v3
+        with:
+          enableCrossOsArchive: true
+          path: zcash-params
+          key: zcash-params
+
+      - name: Setup zcash-params
         shell: bash
         run: |
-          echo "appdata=$APPDATA" >> "$GITHUB_OUTPUT"
-          echo "home=$HOME" >> "$GITHUB_OUTPUT"
-      - name: Download Sprout parameters
-        uses: carlosperate/download-file-action@v2.0.1
-        with:
-          file-url: "https://download.z.cash/downloads/sprout-groth16.params"
-          location: >
-            ${{
-              runner.os == 'Windows' && steps.env.outputs.appdata || steps.env.outputs.home
-            }}${{
-              runner.os == 'macOS' && '/Library/Application Support/' || '/'
-            }}${{
-              runner.os == 'Linux' && '.zcash-params' || 'ZcashParams'
-            }}
+          if [ "${{ runner.os }}" == "Windows" ]; then
+            mv zcash-params "$APPDATA/ZcashParams"
+          elif [ "${{ runner.os }}" == "macOS" ]; then
+            mv zcash-params "$HOME/Library/Application Support/ZcashParams"
+          elif [ "${{ runner.os }}" == "Linux" ]; then
+            mv zcash-params "$HOME/.zcash-params"
+          fi
+
       - name: Run GoogleTests
         env:
           GTEST_TOTAL_SHARDS: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,27 +146,34 @@ jobs:
           ./zcutil/build.sh
           -j"${{ steps.nproc.outputs.count }}"
 
-      - name: Upload zcashd artifact
-        uses: actions/upload-artifact@v4
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
         with:
-          name: zcashd-${{ matrix.name }}
-          path: |
-            ${{ format('src/zcash-cli{0}', matrix.file_ext) }}
-            ${{ format('src/zcashd{0}', matrix.file_ext) }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Upload zcashd artifact
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ${{ format('./src/zcashd{0}', matrix.file_ext) }}
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src
+
+      - name: Upload zcash-cli artifact
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ${{ format('./src/zcash-cli{0}', matrix.file_ext) }}
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src
 
       - name: Upload zcash-btest artifact
-        if: matrix.test_os != ''
-        uses: actions/upload-artifact@v4
+        uses: google-github-actions/upload-cloud-storage@v2
         with:
-          name: zcash-btest-${{ matrix.name }}
-          path: ${{ format('src/test/test_bitcoin{0}', matrix.file_ext) }}
+          path: ${{ format('./src/test/test_bitcoin{0}', matrix.file_ext) }}
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src/test
 
       - name: Upload zcash-gtest artifact
-        if: matrix.test_os != ''
-        uses: actions/upload-artifact@v4
+        uses: google-github-actions/upload-cloud-storage@v2
         with:
-          name: zcash-gtest-${{ matrix.name }}
-          path: ${{ format('src/zcash-gtest{0}', matrix.file_ext) }}
+          path: ${{ format('./src/zcash-gtest{0}', matrix.file_ext) }}
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src
 
   bitrot:
     name: Bitrot check tier ${{ matrix.tier }} platform ${{ matrix.platform }} flag '${{ matrix.configure_flag }}'
@@ -242,13 +249,24 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.setup.outputs.test_matrix) }}
     steps:
-      - name: Download zcash-btest artifact
-        uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
         with:
-          name: zcash-btest-${{ matrix.name }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Download zcash-btest artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: ${{ format('src/test/test_bitcoin{0}', matrix.file_ext) }}
+          destination: ./
+
       - name: Make artifact executable
         if: runner.os != 'Windows'
         run: chmod +x ${{ format('./test_bitcoin{0}', matrix.file_ext) }}
+
       - name: Run Boost.Tests
         run: ${{ format('./test_bitcoin{0}', matrix.file_ext) }} -p
 
@@ -263,10 +281,20 @@ jobs:
         shard_index: [0, 1]
         include: ${{ fromJson(needs.setup.outputs.test_matrix) }}
     steps:
-      - name: Download zcash-gtest artifact
-        uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
         with:
-          name: zcash-gtest-${{ matrix.name }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Download zcash-gtest artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: ${{ format('src/zcash-gtest{0}', matrix.file_ext) }}
+          destination: ./
+
       - name: Make artifact executable
         if: runner.os != 'Windows'
         run: chmod +x ${{ format('./zcash-gtest{0}', matrix.file_ext) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,30 @@ jobs:
           path: ${{ format('./src/zcash-gtest{0}', matrix.file_ext) }}
           destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src
 
+      - name: Upload src/test/buildenv.py
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ./src/test/buildenv.py
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src/test
+
+      - name: Upload src/secp256k1
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ./src/secp256k1
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src
+
+      - name: Upload src/univalue
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ./src/univalue
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/src
+
+      - name: Upload depends/${{ matrix.host }}/native/bin
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ./depends/${{ matrix.host }}/native/bin
+          destination: gh-zcash/${{ github.run_id }}/${{ matrix.name }}/depends/${{ matrix.host }}/native
+
       - name: Upload depends/${{ matrix.host }}/lib
         uses: google-github-actions/upload-cloud-storage@v2
         with:
@@ -378,6 +402,128 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run Rust tests
         run: cargo test
+
+  # Not designed for Windows
+  test-secp256k1:
+    name: secp256k1 tier ${{ matrix.tier }} platform ${{ matrix.platform }}
+    needs: [setup, build]
+    runs-on: ${{ matrix.test_os }}
+    continue-on-error: ${{ matrix.tier != 1 }}
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.setup.outputs.unix_test_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Download native/bin artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: depends/${{ matrix.host }}/native/bin
+          destination: ./depends/${{ matrix.host }}/native/
+
+      - name: Download src/secp256k1 artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: src/secp256k1
+          destination: ./src/
+          remove-first-if-exists: ./src/secp256k1
+
+      - name: Run secp256k1 test
+        shell: bash
+        run: python3 ./qa/zcash/full_test_suite.py secp256k1
+        env:
+          HOST: ${{ matrix.host }}
+
+  # Not designed for Windows
+  test-univalue:
+    name: univalue tier ${{ matrix.tier }} platform ${{ matrix.platform }}
+    needs: [setup, build]
+    runs-on: ${{ matrix.test_os }}
+    continue-on-error: ${{ matrix.tier != 1 }}
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.setup.outputs.unix_test_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Download native/bin artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: depends/${{ matrix.host }}/native/bin
+          destination: ./depends/${{ matrix.host }}/native/
+
+      - name: Download src/univalue artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: src/univalue
+          destination: ./src/
+          remove-first-if-exists: ./src/univalue
+
+      - name: Make artifact executable
+        if: runner.os != 'Windows'
+        run: chmod +x ./src/univalue/build-aux/install-sh
+
+      - name: Run univalue test
+        shell: bash
+        run: python3 ./qa/zcash/full_test_suite.py univalue
+        env:
+          HOST: ${{ matrix.host }}
+
+  # Not designed for Windows
+  test-util:
+    name: util-test tier ${{ matrix.tier }} platform ${{ matrix.platform }}
+    needs: [setup, build]
+    runs-on: ${{ matrix.test_os }}
+    continue-on-error: ${{ matrix.tier != 1 }}
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.setup.outputs.unix_test_matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Download zcash-tx artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: ${{ format('src/zcash-tx{0}', matrix.file_ext) }}
+          destination: ./src/
+
+      - name: Download src/test/buildenv.py artifact
+        uses: ./.github/actions/gcs-download-cloud-storage
+        with:
+          path-prefix: ${{ github.run_id }}/${{ matrix.name }}
+          source: src/test/buildenv.py
+          destination: ./src/test/
+
+      - name: Make artifact executable
+        if: runner.os != 'Windows'
+        run: chmod +x ${{ format('./src/zcash-tx{0}', matrix.file_ext) }}
+
+      - name: Run util-test test
+        shell: bash
+        run: python3 ./qa/zcash/full_test_suite.py util-test
+        env:
+          HOST: ${{ matrix.host }}
 
   no-dot-so:
     name: not-dot-so tier ${{ matrix.tier }} platform ${{ matrix.platform }}

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -34,6 +34,12 @@ def get_arch_dir():
         # Just try the first one; there will only be one in CI
         return arch_dirs[0]
 
+    # Not MacOS, try Windows
+    arch_dirs = glob(os.path.join(depends_dir, 'x86_64-w64-mingw32*'))
+    if arch_dirs:
+        # Just try the first one; there will only be one in CI
+        return arch_dirs[0]
+
     print("!!! cannot find architecture dir under depends/ !!!")
     return None
 

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -94,7 +94,22 @@ def check_security_hardening():
     ret = True
 
     # PIE, RELRO, Canary, and NX are tested by make check-security.
-    ret &= subprocess.call(['make', '-C', repofile('src'), 'check-security']) == 0
+    if os.path.exists(repofile('src/Makefile')):
+        ret &= subprocess.call(['make', '-C', repofile('src'), 'check-security']) == 0
+    else:
+        # Equivalent to make check-security (this is just for CI purpose)
+        bin_programs = ['src/zcashd', 'src/zcash-cli', 'src/zcash-tx', 'src/bench/bench_bitcoin']  # Replace with actual values
+        bin_scripts = ['src/zcash-inspect', 'src/zcashd-wallet-tool']   # Replace with actual values
+
+        print(f"Checking binary security of {bin_programs + bin_scripts}...")
+
+        for program in bin_programs:
+            command = [repofile('contrib/devtools/security-check.py'), repofile(program)]
+            ret &= subprocess.call(command) == 0
+
+        for script in bin_scripts:
+            command = [repofile('contrib/devtools/security-check.py'), '--allow-no-canary', repofile(script)]
+            ret &= subprocess.call(command) == 0
 
     # The remaining checks are only for ELF binaries
     # Assume that if zcashd is an ELF binary, they all are


### PR DESCRIPTION
* Tekton Pipelines have been migrated to Github Action, with 100% support for tier 1 operating systems.
  * RPC tests are not included in this PR, and will be in a follow-up PR.

* Adjustments were made based on the PR: [https://github.com/zcash/zcash/pull/6804](https://github.com/zcash/zcash/pull/6804) to ensure compatibility of the `sec-hard test` with Github Action.

* The `full_test_suite.py` file has been modified to provide support for the Windows architecture (`x86_64-w64-mingw32`).

* Some tests are not functioning on Windows, so they have been deactivated to save time and costs.

* It was left pending for a future PR to make it compatible with workflow_dispatch. This enables more granular execution based on variables, allowing, for example, the execution of a specific tier or environment.
