### PR TITLE
make cache.cpp compile with MSVC

### DIFF
--- a/src/zcash/cache.h
+++ b/src/zcash/cache.h
@@ -31,7 +31,7 @@ public:
     {
         static_assert(hash_select < 8, "BundleCacheHasher only has 8 hashes available.");
         uint32_t u;
-        std::memcpy(&u, &*(key.begin() + 4 * hash_select), 4);
+        std::memcpy(&u, key.data() + 4 * hash_select, 4);
         return u;
     }
 };

--- a/src/zcash/cache.h
+++ b/src/zcash/cache.h
@@ -31,7 +31,7 @@ public:
     {
         static_assert(hash_select < 8, "BundleCacheHasher only has 8 hashes available.");
         uint32_t u;
-        std::memcpy(&u, key.begin() + 4 * hash_select, 4);
+        std::memcpy(&u, &*(key.begin() + 4 * hash_select), 4);
         return u;
     }
 };


### PR DESCRIPTION
The zcash_script crate compiles a subset of the files in this repo. Zebra (which uses zcash_script) used to support Windows using the MSVC compiler, but at some point one of the files stopped compiling so we just dropped Windows support temporarily. Finally investigating it, it turns out to be a simple change.

_Why_ this is needed is the big question but I think the answer is here: https://stackoverflow.com/questions/72550013/stdarrayint-iterator-convertible-to-int-on-clang-but-not-msvc i.e. Linux compilers assume that iterators are pointers but that's not necessarily true.