### PR TITLE
Fix Actions GCS-download

### DIFF
--- a/.github/actions/gcs-download-cloud-storage/action.yml
+++ b/.github/actions/gcs-download-cloud-storage/action.yml
@@ -51,7 +51,7 @@ runs:
     - name: Move source to target [Unix]
       if: runner.os != 'Windows'
       shell: bash
-      run: mv ${{ runner.temp }}/gcs-download/* ${{ inputs.destination }}
+      run: mv $RUNNER_TEMP/gcs-download/* ${{ inputs.destination }}
 
     # PowerShell's mv aliases to its Move-Item cmdlet which has glob support (unlike mv in
     # Git Bash for whatever reason).


### PR DESCRIPTION
Currently, we are using `${{runner.temp}}`, which behaves erratically within a container, as the container's temporary directory is different from that of the host. Therefore, processing the template variable does not identify whether it is on the host machine or in the container.