### PR TITLE
Update the CI to include `pull_request_target`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  pull_request_target:
   pull_request:
   push:
     branches: master


### PR DESCRIPTION
The functionality has been added to allow accessing secrets in GitHub Actions from a fork. Although this could compromise security if an attacker runs malicious code from their fork to extract sensitive variables (secrets), this risk is mitigated because in this organization, we have configured GitHub Actions to require authorization when running any changes from an external collaborator.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target