### PR TITLE
Allow running CI from a fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   pull_request:
+  pull_request_target:
+    types: [labeled]
+    paths-ignore:
+      - '.github/**'
   push:
     branches: master
 


### PR DESCRIPTION
Allow running CI from a fork but avoid triggering it if ./github/* is modified. Additionally, require a label to be added for the CI to run.