### PR TITLE
CI: Give `statuses: write` permission to CI workflows

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -19,6 +19,10 @@ on:
       - 'COPYING'
       - 'INSTALL'
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   required-pass:
     name: Bypass required-pass steps

--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -5,11 +5,11 @@ on:
     # Any update here needs to be done for the `no-ci-required` step (see below),
     # and mirrored into `ci.yml`.
     paths:
-      # Workflows that have no effect on this workflow.
+      # Workflows that have no effect on the CI workflow.
       - '.github/dependabot.yml'
       - '.github/workflows/audits.yml'
       - '.github/workflows/book.yml'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/ci-skip.yml'
       - '.github/workflows/lints.yml'
       - '.github/workflows/release-docker-hub.yml'
       # Documentation.
@@ -52,7 +52,7 @@ jobs:
               r'^\.github/dependabot\.yml$',
               r'^\.github/workflows/audits\.yml$',
               r'^\.github/workflows/book\.yml$',
-              r'^\.github/workflows/ci\.yml$',
+              r'^\.github/workflows/ci-skip\.yml$',
               r'^\.github/workflows/lints\.yml$',
               r'^\.github/workflows/release-docker-hub\.yml$',
               r'^contrib/debian/copyright$',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ on:
       - 'COPYING'
       - 'INSTALL'
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   setup:
     name: Define CI matrix


### PR DESCRIPTION
Also fixes a path detection bug in the `ci-skip.yml` workflow.