### PR TITLE
CI: Move required-pass checks behind a `workflow_run` event

### DIFF
--- a/.github/workflows/ci-status.yml
+++ b/.github/workflows/ci-status.yml
@@ -1,0 +1,53 @@
+name: CI status
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  required-pass:
+    name: Check required-pass steps
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch statuses for required-pass steps
+        id: fetch-statuses
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const res = await github.paginate("GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs", {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+              per_page: 100
+            })
+            const statuses = res.map((status) => ({ name: status.name, conclusion: status.conclusion }))
+            return statuses
+
+      - name: Determine whether all required-pass steps succeeded
+        run: |
+          echo '${{ steps.fetch-statuses.outputs.result }}' | jq -e '[ .[] | select(.name | test("(Build tier [12])|(Boost.Test tier 1)|(GoogleTest tier 1)|(Rust test tier 1)|(secp256k1 tier 1)|(univalue tier 1)|(util-test tier 1)|(no-dot-so tier 1)|(sec-hard tier 1)|(RPC tests tier 1 .* shard-)")) | .conclusion == "success" ] | all'
+
+      - name: Submit required-passed status
+        if: ${{ !cancelled() }}
+        uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          script: |
+            const {JOB_STATUS} = process.env
+
+            await github.request("POST /repos/{owner}/{repo}/statuses/{sha}", {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.workflow_run.head_sha,
+              state: `${JOB_STATUS}`,
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.payload.workflow_run.id}`,
+              description: "Finished",
+              context: "CI / Required status checks"
+            })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ on:
 
 permissions:
   contents: read
-  statuses: write
 
 jobs:
   setup:
@@ -791,57 +790,3 @@ jobs:
           EOF
           . ./venv/bin/activate
           ZCASHD=$(pwd)/${{ format('src/zcashd{0}', matrix.file_ext) }} SRC_DIR=$(pwd) python3 ./subclass.py
-
-  required-pass:
-    name: Check required-pass steps
-    needs:
-      - test-btest
-      - test-gtest
-      - test-rust
-      - test-secp256k1
-      - test-univalue
-      - test-util
-      - no-dot-so
-      - sec-hard
-      - test-rpc
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Fetch statuses for required-pass steps
-        id: fetch-statuses
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const res = await github.paginate("GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs", {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId,
-              per_page: 100
-            })
-            const statuses = res.map((status) => ({ name: status.name, conclusion: status.conclusion }))
-            return statuses
-
-      - name: Determine whether all required-pass steps succeeded
-        run: |
-          echo '${{ steps.fetch-statuses.outputs.result }}' | jq -e '[ .[] | select(.name | test("(Build tier [12])|(Boost.Test tier 1)|(GoogleTest tier 1)|(Rust test tier 1)|(secp256k1 tier 1)|(univalue tier 1)|(util-test tier 1)|(no-dot-so tier 1)|(sec-hard tier 1)|(RPC tests tier 1 .* shard-)")) | .conclusion == "success" ] | all'
-
-      - name: Submit required-passed status
-        if: ${{ !cancelled() }}
-        uses: actions/github-script@v7
-        env:
-          JOB_STATUS: ${{ job.status }}
-        with:
-          script: |
-            const head_sha = context.payload.pull_request?.head?.sha ?? context.sha
-            const {JOB_STATUS} = process.env
-
-            await github.request("POST /repos/{owner}/{repo}/statuses/{sha}", {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: head_sha,
-              state: `${JOB_STATUS}`,
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              description: "Finished",
-              context: "CI / Required status checks"
-            })


### PR DESCRIPTION
This should enable the triggered workflow to have permission to post a status, even when the triggering workflow is in a fork.