### PR TITLE
qa: Simplify description for `license-reviewed` audit criteria

### DIFF
--- a/qa/supply-chain/audits.toml
+++ b/qa/supply-chain/audits.toml
@@ -5,7 +5,7 @@
 description = "The cryptographic code in this crate has been reviewed for correctness by a member of a designated set of cryptography experts within the project."
 
 [criteria.license-reviewed]
-description = "The license of this crate has been reviewed for compatibility with its usage in this repository. If the crate is not available under the MIT license, `contrib/debian/copyright` has been updated with a corresponding copyright notice for files under `depends/*/vendored-sources/CRATE_NAME`."
+description = "The license of this crate has been reviewed for compatibility with its usage in this repository."
 
 [[audits.addr2line]]
 who = "Jack Grigg <jack@z.cash>"


### PR DESCRIPTION
When aggregating audits, their criteria need to match exactly. The description for `license-reviewed` previously made specific references to aspects of this repository that do not apply to `zcash/librustzcash` or other repos we want to aggregate from.