### PR TITLE
CI: Migrate from `macos-11` runner to `macos-12` runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,11 @@ jobs:
               test_os: ubuntu-22.04
               host: x86_64-pc-linux-gnu
 
-            - name: macos-11
+            - name: macos-12
               tier: 3
-              platform: macOS Big Sur 11
-              build_os: macos-11
-              test_os: macos-11
+              platform: macOS 12 Monterey
+              build_os: macos-12
+              test_os: macos-12
               brew_deps: >
                 autoconf
                 automake


### PR DESCRIPTION
The `macos-11` GitHub runner is deprecated and will be removed on 2024-06-28.