### PR TITLE
depends: Show the URLs from which dependencies are being downloaded

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -25,9 +25,10 @@ endef
 
 define fetch_file
 (test -f $$($(1)_source_dir)/$(4) || \
-  ( mkdir -p $$($(1)_download_dir) && echo Fetching $(1)... && \
+  ( mkdir -p $$($(1)_download_dir) && echo "Fetching $(1) from $(2)/$(3) ..." && \
   ( $(call download_and_check_file,$$($(1)_download_dir),$(4),"$(2)/$(3)",$(5)) || \
-    $(call download_and_check_file,$$($(1)_download_dir),$(4),"$(FALLBACK_DOWNLOAD_PATH)/$(4)",$(5)) ) && \
+    ( echo "Falling back to fetching $(1) from $(FALLBACK_DOWNLOAD_PATH)/$(4) ..." && \
+      $(call download_and_check_file,$$($(1)_download_dir),$(4),"$(FALLBACK_DOWNLOAD_PATH)/$(4)",$(5)) ) ) && \
     mv $$($(1)_download_dir)/$(4).temp $$($(1)_source_dir)/$(4) && \
     rm -rf $$($(1)_download_dir) ))
 endef


### PR DESCRIPTION
This can help to debug dependency download problems.