### PR TITLE
fix getaddresstxids and getaddressdeltas range parsing

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -830,7 +830,6 @@ static void getHeightRange(const UniValue& params, int& start, int& end)
     if (params[0].isObject()) {
         UniValue startValue = find_value(params[0].get_obj(), "start");
         UniValue endValue = find_value(params[0].get_obj(), "end");
-        // If either is not specified, the other is ignored.
         if (!startValue.isNull()) {
             start = startValue.get_int();
             if (start < 0) {
@@ -892,6 +891,7 @@ UniValue getaddressdeltas(const UniValue& params, bool fHelp)
             "\nReturns information about all changes to the given transparent addresses within the given (inclusive)\n"
             "\nblock height range, default is the full blockchain."
             "\nIf start or end are not specified, they default to zero."
+            "\nIf start is greater than the latest block height, it's interpreted as that height.\n"
             "\nIf end is zero, it's interpreted as the latest block height.\n"
             + disabledMsg +
             "\nArguments:\n"
@@ -1079,6 +1079,7 @@ UniValue getaddresstxids(const UniValue& params, bool fHelp)
             "\nReturns the txids for given transparent addresses within the given (inclusive)\n"
             "\nblock height range, default is the full blockchain."
             "\nIf start or end are not specified, they default to zero."
+            "\nIf start is greater than the latest block height, it's interpreted as that height.\n"
             "\nIf end is zero, it's interpreted as the latest block height.\n"
             "\nThe returned txids are in the order they appear in blocks, which"
             "\nensures that they are topologically sorted (i.e. parent txids"

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -364,24 +364,14 @@ BOOST_AUTO_TEST_CASE(rpc_insightexplorer)
         "JSON value is not a boolean as expected");
 
     BOOST_CHECK_NO_THROW(CallRPC("getaddressdeltas {\"addresses\":[]}"));
-    CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":0,\"end\":0,\"chainInfo\":true}",
-        "Start and end are expected to be greater than zero");
-    CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":3,\"end\":2,\"chainInfo\":true}",
-        "End value is expected to be greater than or equal to start");
-    // in this test environment, only the genesis block (0) exists
-    CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":2,\"end\":3,\"chainInfo\":true}",
-        "Start or end is outside chain range");
+    CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"start\":-2,\"chainInfo\":true}",
+        "Start height must be nonnegative");
+    CheckRPCThrows("getaddressdeltas {\"addresses\":[],\"end\":-2,\"chainInfo\":true}",
+        "End height must be nonnegative");
 
     BOOST_CHECK_NO_THROW(CallRPC("getaddressbalance {\"addresses\":[]}"));
 
     BOOST_CHECK_NO_THROW(CallRPC("getaddresstxids {\"addresses\":[]}"));
-    CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":0,\"end\":0,\"chainInfo\":true}",
-        "Start and end are expected to be greater than zero");
-    CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":3,\"end\":2,\"chainInfo\":true}",
-        "End value is expected to be greater than or equal to start");
-    // in this test environment, only the genesis block (0) exists
-    CheckRPCThrows("getaddresstxids {\"addresses\":[],\"start\":2,\"end\":3,\"chainInfo\":true}",
-        "Start or end is outside chain range");
 
     // transaction does not exist:
     CheckRPCThrows("getspentinfo {\"txid\":\"b4cc287e58f87cdae59417329f710f3ecd75a4ee1d2872b7248f50977c8493f3\",\"index\":0}",


### PR DESCRIPTION
(There is no issue for this, but it relates to https://github.com/zcash/lightwalletd/pull/496)

The range parsing for `getaddresstxids` and `getaddressdeltas` (both use the same range parsing function) has been broken from day 1. Both the `start` and `end` parameters are optional, but if you specify a nonzero `start` but no `end`, then start is ignored, so results are returned for the entire blockchain. This PR fixes that, and also makes not specifying `start` or `end` functionally identical to specifying them with a value of zero, and zero now has intuitive meanings (for `start`, it means zero, the beginning of the blockchain; for `end`, it means the latest block).

These two RPCs were added to support the Insight block explorer, but `getaddresstxids` is also used by `lightwalletd` (which is how this problem was discovered).