### PR TITLE
Update gitian-linux-parallel.yml

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux-parallel.yml
+++ b/contrib/gitian-descriptors/gitian-linux-parallel.yml
@@ -25,6 +25,7 @@ packages:
 - "ncurses-dev"
 - "pkg-config"
 - "python3"
+- "python-is-python3"
 - "unzip"
 - "wget"
 - "zlib1g-dev"


### PR DESCRIPTION
Since we've deprecated Buster, we can now install the python-is-python3 package