### PR TITLE
gtest/test_checkblock.cpp: fix a bug in MockCValidationState that was causing a test warning

### DIFF
--- a/src/gtest/test_checkblock.cpp
+++ b/src/gtest/test_checkblock.cpp
@@ -10,7 +10,7 @@
 class MockCValidationState : public CValidationState {
 public:
     MOCK_METHOD6(DoS, bool(int level, bool ret,
-             unsigned int chRejectCodeIn, const std::string strRejectReasonIn,
+             unsigned int chRejectCodeIn, const std::string &strRejectReasonIn,
              bool corruptionIn,
              const std::string &strDebugMessageIn));
     MOCK_METHOD4(Invalid, bool(bool ret,


### PR DESCRIPTION
The signature of `CValidationState::DoS` was wrong in the mock declaration.