### PR TITLE
getinfo rpc: add lightwalletddisabled boolean to result

### DIFF
--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -67,7 +67,8 @@ class RPCBindTest(BitcoinTestFramework):
         try:
             # connect to node through non-loopback interface
             node = get_rpc_proxy(rpc_url(0, "%s:%d" % (rpchost, rpcport)), 0)
-            node.getinfo()
+            result = node.getinfo()
+            assert result['lightwalletddisabled'] == True
         finally:
             node = None # make sure connection will be garbage collected and closed
             stop_nodes(self.nodes)

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -71,6 +71,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
             "  \"relayfee\": x.xxxx,         (numeric) minimum relay fee rate for transactions in " + CURRENCY_UNIT + " per 1000 bytes\n"
             "  \"errors\": \"...\"           (string) message describing the latest or highest-priority error\n"
             "  \"errorstimestamp\": \"...\"  (string) timestamp associated with the latest or highest-priority error\n"
+            "  \"lightwalletddisabled\": true|false  (boolean) true if the configuration does not include the lightwalletd extensions\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getinfo", "")
@@ -103,6 +104,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.pushKV("proxy",         (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string()));
     obj.pushKV("difficulty",    (double)GetDifficulty());
     obj.pushKV("testnet",       Params().TestnetToBeDeprecatedFieldRPC());
+    obj.pushKV("lightwalletddisabled", !fExperimentalLightWalletd);
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
         obj.pushKV("keypoololdest", pwalletMain->GetOldestKeyPoolTime());


### PR DESCRIPTION
This is to help resolve https://github.com/zcash/lightwalletd/issues/497 (improve lightwalletd error responses).

Let `lightwalletd` easily discover if the `zcashd` it's connected to is configured with the required `lightwalletd=1` configuration option. (If it is not, this will allow `lightwalletd` to fail gracefully during startup, rather than having later gRPCs fail due to attempting to use an unsupported `zcashd` rpc.)

The new `getinfo` rpc field added by this PR, `lightwalletddisabled`,  is "backward" (disabled instead of enabled) because if this field isn't returned at all (the running `zcashd` doesn't have this commit), `lightwalletd` will receive it as `false` (missing fields get the "default" value), so it will consider everything to be okay (`lightwalletd` will start up). This allows `zcashd` to be updated after `lightwalletd`.

Note that `zebrad` always supports `lightwalletd` (no special configuration option required), so no change is needed there, although, for consistency, we may want to add this field there and have it always return `false` (lightwalletd support is never disabled).