### PR TITLE
Update reduce-traffic.md

### DIFF
--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -19,7 +19,7 @@ This is *not* a hard limit; only a threshold to minimize the outbound
 traffic. When the limit is about to be reached, the uploaded data is cut by no
 longer serving historic blocks (blocks older than one week).
 Keep in mind that new nodes require other nodes that are willing to serve
-historic blocks. **The recommended minimum is 1152 blocks per day (max. 2304MB
+historic blocks. **The recommended minimum is 1152 blocks per day (max. 2304 MiB
 per day)**
 
 Whitelisted peers will never be disconnected, although their traffic counts for


### PR DESCRIPTION
### Description

This pull request addresses a unit error in the documentation. In section 1, the text originally states:

> **The recommended minimum is 1152 blocks per day (max. 2304MB per day)**

The correct unit should be "MiB" (Mebibytes) instead of "MB" (Megabytes), as the standard for data volume in this context is MiB, not MB. The correct phrasing is:

> **The recommended minimum is 1152 blocks per day (max. 2304 MiB per day)**

This change is important for clarity and accuracy. Using "MB" instead of "MiB" could lead to confusion, as the two units represent different amounts of data. 1 MiB is 1.048576 MB, and using the wrong unit could mislead users into thinking they are working with a different data volume. Ensuring the correct unit improves the technical accuracy of the documentation and helps users make informed decisions when configuring their nodes.