### PR TITLE
Fix typos and grammar issues across multiple documentation files

### DIFF
--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -42,7 +42,7 @@ the script [`gen-sdk`](./gen-sdk) with the path to `Xcode.app` (extracted in the
 previous stage) as the first argument.
 
 ```bash
-# Generate a Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers.tar.gz from
+# Generate an Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers.tar.gz from
 # the supplied Xcode.app
 ./contrib/macdeploy/gen-sdk '/path/to/Xcode.app'
 ```

--- a/doc/book/src/user/wallet-backup.md
+++ b/doc/book/src/user/wallet-backup.md
@@ -60,7 +60,7 @@ copy to `wallet.dat`.
 
 ### Using `z_exportwallet` & `z_importwallet`
 
-If you prefer to have an export of your private keys in human readable format,
+If you prefer to have an export of your private keys in human-readable format,
 you can use:
 
 ```bash

--- a/doc/payment-disclosure.md
+++ b/doc/payment-disclosure.md
@@ -104,4 +104,4 @@ This is an experimental feature so there are no guarantees that the protocol, da
 
 ### Notes
 
-Currently there is no user friendly way to help senders identify which joinsplit output index maps to a given payment they made.  It is possible to construct this from `debug.log`.  Ideas and feedback are most welcome on how to improve the user experience.
+Currently there is no user-friendly way to help senders identify which joinsplit output index maps to a given payment they made.  It is possible to construct this from `debug.log`.  Ideas and feedback are most welcome on how to improve the user experience.

--- a/doc/release-notes/release-notes-1.0.0-beta1.md
+++ b/doc/release-notes/release-notes-1.0.0-beta1.md
@@ -90,7 +90,7 @@ Simon (91):
       Update find_unspent_notes() as mapNoteAddrs_t has been replaced by mapNoteData_t.
       z_sendmany from a taddr now routes change to a new address instead of back to the sender's taddr,
       Successful result of z_sendmany returns txid so it doesn't need to return raw hex.
-      Add public method to get state as a human readable string from an AsyncRPCOperation.
+      Add public method to get state as a human-readable string from an AsyncRPCOperation.
       Add public method to AsycnRPCQueue to retrieve all the known operation ids.
       Implement RPC call z_listoperationids and update z_getoperationstatus to take a list parameter.
       Refactoring and small improvements to async rpc operations.

--- a/doc/release-notes/release-notes-1.0.6.md
+++ b/doc/release-notes/release-notes-1.0.6.md
@@ -71,7 +71,7 @@ Jonas Schnelli (24):
       fix rpc-tests.sh
       extend conversion to UniValue
       expicit set UniValue type to avoid empty values
-      special threatment for null,true,false because they are non valid json
+      special threatment for null,true,false because they are non-valid json
       univalue: add support for real, fix percision and make it json_spirit compatible
       univalue: correct bool support
       fix rpc unit test, plain numbers are not JSON compatible object


### PR DESCRIPTION
This PR addresses several typos and grammar improvements in multiple documentation files:

1. **Updated "a Xcode" to "an Xcode"** in the `contrib/macdeploy/README.md` file.
2. **Corrected "human readable" to "human-readable"** in `wallet-backup.md`.
3. **Added a hyphen to "user friendly"** to make it "user-friendly" in `payment-disclosure.md`.
4. **Fixed "human readable" to "human-readable"** in the `release-notes-1.0.0-beta1.md`.
5. **Fixed the spelling of "non valid" to "non-valid"** in `release-notes-1.0.6.md`.

These changes improve the clarity and correctness of the documentation.

### Type of Change:
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:
- [x] I have discussed with the team prior to submitting this PR.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
