### PR TITLE
Updated the broken link to the protocol documentation from 

### DIFF
--- a/doc/release-notes/release-notes-1.0.14-rc1.md
+++ b/doc/release-notes/release-notes-1.0.14-rc1.md
@@ -5,7 +5,7 @@ Incoming viewing keys
 ---------------------
 
 Support for incoming viewing keys, as described in
-[the Zcash protocol spec](https://github.com/zcash/zips/blob/master/protocol/protocol.pdf),
+[the Zcash protocol spec](https://github.com/zcash/zips/blob/main/rendered/protocol/protocol.pdf),
 has been added to the wallet.
 
 Use the `z_exportviewingkey` RPC method to obtain the incoming viewing key for a

--- a/doc/release-notes/release-notes-1.0.14.md
+++ b/doc/release-notes/release-notes-1.0.14.md
@@ -5,7 +5,7 @@ Incoming viewing keys
 ---------------------
 
 Support for incoming viewing keys, as described in
-[the Zcash protocol spec](https://github.com/zcash/zips/blob/master/protocol/protocol.pdf),
+[the Zcash protocol spec](https://github.com/zcash/zips/blob/main/rendered/protocol/protocol.pdf),
 has been added to the wallet.
 
 Use the `z_exportviewingkey` RPC method to obtain the incoming viewing key for a


### PR DESCRIPTION
Fixed a broken link in the protocol documentation. Updated the outdated link `https://github.com/zcash/zips/blob/master/protocol/protocol.pdf` to the correct and accessible version: `https://github.com/zcash/zips/blob/main/rendered/protocol/protocol.pdf`. This change ensures users can reliably access the protocol file without issues.
