### PR TITLE
Fix typos and improve documentation clarity

### DIFF
--- a/doc/book/src/user/tor.md
+++ b/doc/book/src/user/tor.md
@@ -2,7 +2,7 @@ Tor Support in Zcash
 ====================
 
 Tor can be used to provide a layer of network anonymity for Zcash users.
-Additionally, Zcash users may chose to connect only to Tor hidden services, and
+Additionally, Zcash users may choose to connect only to Tor hidden services, and
 also to expose their own Tor hidden service to allow users to connect to them
 over the Tor network.
 

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -118,5 +118,5 @@ retrieve the chain from the last known block to the new tip.
 
 There are several possibilities that ZMQ notification can get lost
 during transmission depending on the communication type you are
-using. zcashd appends an up-counting sequence number to each
+using. zcashd appends an upcounting sequence number to each
 notification which allows listeners to detect lost notifications.

--- a/src/leveldb/README.md
+++ b/src/leveldb/README.md
@@ -49,7 +49,7 @@ mkdir build
 cd build
 cmake -G "Visual Studio 15" ..
 ```
-The default default will build for x86. For 64-bit run:
+The default will build for x86. For 64-bit run:
 
 ```cmd
 cmake -G "Visual Studio 15 Win64" ..


### PR DESCRIPTION


## Changes:
1. src/leveldb/README.md: "The default default" -> "The default"
2. doc/book/src/user/tor.md: "chose" -> "choose" 
3. doc/zps.md: "up-counting" -> "upcounting"

These documentation changes improve readability and fix grammatical issues without affecting functionality. The corrections standardize terminology and make the documentation more professional.
