### PR TITLE
Update Rust platform tier policy link

### DIFF
--- a/doc/book/src/dev/platform-tier-policy.md
+++ b/doc/book/src/dev/platform-tier-policy.md
@@ -3,7 +3,7 @@
 ## General
 
 ECC provides three tiers of platform support, modeled after the
-[Rust Target Tier Policy](https://doc.rust-lang.org/stable/rustc/platform-tier-policy.html):
+[Rust Target Tier Policy](https://doc.rust-lang.org/nightly/rustc/platform-support.html):
 
 - The Zcash developers provide no guarantees about tier 3 platforms; they exist in the
   codebase, but may or may not build.


### PR DESCRIPTION


## Changes:
doc/book/src/doc/platform-tier-policy.md:
- Old: https://doc.rust-lang.org/stable/rustc/platform-tier-policy.html
- New: https://doc.rust-lang.org/nightly/rustc/platform-support.html

## Why:
The link to Rust's platform tier policy documentation has been updated to reflect the current correct URL. The old link was outdated and no longer accessible. This change ensures users can access the most up-to-date information about Rust's platform support tiers.

