### PR TITLE
move Lockbox value logging behind category valuepool

### DIFF
--- a/doc/man/zcashd.1
+++ b/doc/man/zcashd.1
@@ -429,7 +429,7 @@ optional). If <category> is not supplied or if <category> = 1, output
 all debugging information. <category> can be: addrman, alert, bench,
 coindb, db, http, libevent, lock, mempool, mempoolrej, net,
 partitioncheck, pow, proxy, prune, rand, receiveunsafe, reindex, rpc,
-selectcoins, tor, zmq, zrpc, zrpcunsafe (implies zrpc). For multiple
+selectcoins, tor, valuepool, zmq, zrpc, zrpcunsafe (implies zrpc). For multiple
 specific categories use \fB\-debug=\fR<category> multiple times.
 .HP
 \fB\-experimentalfeatures\fR

--- a/qa/rpc-tests/show_help.py
+++ b/qa/rpc-tests/show_help.py
@@ -430,7 +430,7 @@ Debugging/Testing options:
        all debugging information. <category> can be: addrman, alert, bench,
        coindb, db, http, libevent, lock, mempool, mempoolrej, net,
        partitioncheck, pow, proxy, prune, rand, receiveunsafe, reindex, rpc,
-       selectcoins, tor, zmq, zrpc, zrpcunsafe (implies zrpc). For multiple
+       selectcoins, tor, valuepool, zmq, zrpc, zrpcunsafe (implies zrpc). For multiple
        specific categories use -debug=<category> multiple times.
 
   -experimentalfeatures

--- a/qa/rpc-tests/show_help.py
+++ b/qa/rpc-tests/show_help.py
@@ -430,8 +430,8 @@ Debugging/Testing options:
        all debugging information. <category> can be: addrman, alert, bench,
        coindb, db, http, libevent, lock, mempool, mempoolrej, net,
        partitioncheck, pow, proxy, prune, rand, receiveunsafe, reindex, rpc,
-       selectcoins, tor, valuepool, zmq, zrpc, zrpcunsafe (implies zrpc). For multiple
-       specific categories use -debug=<category> multiple times.
+       selectcoins, tor, valuepool, zmq, zrpc, zrpcunsafe (implies zrpc). For
+       multiple specific categories use -debug=<category> multiple times.
 
   -experimentalfeatures
        Enable use of experimental features

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -452,7 +452,7 @@ std::string HelpMessage(HelpMessageMode mode)
                 "Use given addresses for block subsidy share paid to the funding stream with id <streamId> (regtest-only)");
     }
     std::string debugCategories = "addrman, alert, bench, coindb, db, http, libevent, lock, mempool, mempoolrej, net, partitioncheck, pow, proxy, prune, "
-                             "rand, receiveunsafe, reindex, rpc, selectcoins, tor, zmq, zrpc, zrpcunsafe (implies zrpc)"; // Don't translate these
+                             "rand, receiveunsafe, reindex, rpc, selectcoins, tor, valuepool, zmq, zrpc, zrpcunsafe (implies zrpc)"; // Don't translate these
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +
         _("If <category> is not supplied or if <category> = 1, output all debugging information.") + " " + _("<category> can be:") + " " + debugCategories + ". " +
         _("For multiple specific categories use -debug=<category> multiple times."));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4673,7 +4673,7 @@ void SetChainPoolValues(
             lockboxValue += elem.second;
         }
     }
-    LogPrintf("%s: Lockbox value is %d at height %d", __func__, lockboxValue, pindex->nHeight);
+    LogPrint("valuepool", "%s: Lockbox value is %d at height %d", __func__, lockboxValue, pindex->nHeight);
 
     for (auto tx : block.vtx) {
         // For the genesis block only, compute the chain supply delta and the transparent


### PR DESCRIPTION
Follow-on to #6933, commit "Use __func__ for substitution in ConnectBlock error messages" (d9bcc0686a8f651c6445f0333da76cbf12891e3f)

Currently, syncing (IBD, reindex, or just catching up to the blockchain tip) causes many messages to be logged (I think one for every block) for example:
```
2024-12-17T06:08:20.380167Z  INFO ProcessNewBlock: main: SetChainPoolValues: Lockbox value is 0 at height 317646
```
I don't think these are still useful to log by default (@nuttycom agrees), so this pull adds logging category "valuepool" for this message so it's still available but not enabled by default. (Reviewers, let me know if there's a better category name, or an existing category that we can use.)