### PR TITLE
 Fix Typos

### DIFF
--- a/doc/release-notes/release-notes-4.1.0-rc1.md
+++ b/doc/release-notes/release-notes-4.1.0-rc1.md
@@ -357,7 +357,7 @@ Jack Grigg (9):
       httpserver: Code style cleanups
       depends: Update packages documentation for Zcash
       depends: Add untested note to FreeBSD host
-      Update example scripted-diff comit in doc/developer-notes.md
+      Update example scripted-diff commit in doc/developer-notes.md
       Use HTTPS in script license headers
 
 syd (1):

--- a/doc/release-notes/release-notes-4.1.0.md
+++ b/doc/release-notes/release-notes-4.1.0.md
@@ -361,7 +361,7 @@ Jack Grigg (9):
       httpserver: Code style cleanups
       depends: Update packages documentation for Zcash
       depends: Add untested note to FreeBSD host
-      Update example scripted-diff comit in doc/developer-notes.md
+      Update example scripted-diff commit in doc/developer-notes.md
       Use HTTPS in script license headers
 
 syd (1):

--- a/doc/release-notes/release-notes-4.7.0-rc1.md
+++ b/doc/release-notes/release-notes-4.7.0-rc1.md
@@ -442,7 +442,7 @@ Kris Nuttycombe (243):
       Correctly report change outputs in z_viewtransaction.
       Return the default unified address if we have the UFVK but no address metadata.
       Fix missing AllowRevealedSenders flag in test.
-      Uncomment addtional tests that depend on z_viewtransaction.
+      Uncomment additional tests that depend on z_viewtransaction.
       Minor rename & documentation improvement.
       Add RecipientType to GetPaymentAddressForRecipient result.
       Make CWallet::DefaultReceiverTypes height-dependent.

--- a/qa/supply-chain/imports.lock
+++ b/qa/supply-chain/imports.lock
@@ -964,7 +964,7 @@ delta = "1.0.207 -> 1.0.209"
 notes = '''
 There are no code changes in this delta - see https://crrev.com/c/5812194/2..5
 
-I've neverthless also grepped for `-i cipher`, `-i crypto`, `\bfs\b`,
+I've nevertheless also grepped for `-i cipher`, `-i crypto`, `\bfs\b`,
 `\bnet\b`, and `\bunsafe\b`.  There were no hits.
 '''
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"


### PR DESCRIPTION


### Description:
This pull request fixes several typos in various files, including:

- `imports.lock`
- `release-notes-4.7.0-rc1.md`
- `release-notes-4.1.0.md`
- `release-notes-4.1.0-rc1.md`

### Files Changed:
1. **`doc/release-notes/release-notes-4.1.0-rc1.md`**:
   - Corrected typos in commit messages and documentation.

2. **`doc/release-notes/release-notes-4.1.0.md`**:
   - Fixed typos in the documentation.

3. **`doc/release-notes/release-notes-4.7.0-rc1.md`**:
   - Corrected documentation errors and fixed typos.

4. **`qa/supply-chain/imports.lock`**:
   - Fixed a typo in the description section.

### Commits:
- Typo fixes for `imports.lock`, `release-notes-4.7.0-rc1.md`, `release-notes-4.1.0.md`, and `release-notes-4.1.0-rc1.md`.

