### PR TITLE
developer-notes.md wording fixed

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -133,7 +133,7 @@ are held, and adds warnings to the debug.log file if inconsistencies are detecte
 
 **Sanitizers**
 
-Bitcoin can be compiled with various "sanitizers" enabled, which add
+Zcash can be compiled with various "sanitizers" enabled, which add
 instrumentation for issues regarding things like memory safety, thread race
 conditions, or undefined behavior. This is controlled with the
 `--with-sanitizers` configure flag, which should be a comma separated list of


### PR DESCRIPTION
Paragraph that refers to zcash referred to Bitcoin now fixed to refer to zcash