### PR TITLE
dbwrapper: Bump max file size to 32 MiB (lightwalletd sync performance)

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -29,6 +29,7 @@ static leveldb::Options GetOptions(size_t nCacheSize)
         // on corruption in later versions.
         options.paranoid_checks = true;
     }
+    options.max_file_size = std::max(options.max_file_size, DBWRAPPER_MAX_FILE_SIZE);
     return options;
 }
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -18,6 +18,7 @@
 
 static const size_t DBWRAPPER_PREALLOC_KEY_SIZE = 64;
 static const size_t DBWRAPPER_PREALLOC_VALUE_SIZE = 1024;
+static const size_t DBWRAPPER_MAX_FILE_SIZE = 32 << 20; // 32 MiB
 
 class dbwrapper_error : public std::runtime_error
 {


### PR DESCRIPTION
Fixes #6904.

(cherry picked from commit bitcoin/bitcoin@b73d3319377a4c9d7e2dd279c3d106002585bc36)

This is a cherry-pick of a recently-merged Bitcoin core [PR](https://github.com/bitcoin/bitcoin/pull/30039) that improves sync (IBD) and reindex performance, especially when extra indices are enabled, such as when using `zcashd` to support `lightwalletd` or the block explorer, or when `txindex` is enabled. When the data directory is on a spinning disk (HDD), I measure this patch improving performance on the order of 2x based on limited benchmarking (with `lightwalletd` enabled). I think this change is safe and sufficiently beneficial to merge.

This patch is exactly the bitcoin core commit (did not need to modify for zcashd). The rest of this description is the cherry-picked commit comment; it's not precisely accurate as regards zcashd:

----

The default max file size for LevelDB is 2 MiB, which results in the LevelDB compaction code generating ~4 disk cache flushes per second when syncing with the Bitcoin network.
These disk cache flushes are triggered by fdatasync() syscall issued by the LevelDB compaction code when reaching the max file size.

If the database is on a HDD this flush rate brings the whole system to a crawl.
It also results in very slow throughput since 2 MiB * 4 flushes per second is about 8 MiB / second max throughput, while even an old HDD can pull 100 - 200 MiB / second streaming throughput.

Increase the max file size for LevelDB to 32 MiB instead so the flush rate drops significantly and the system no longer gets so sluggish.

The new max file size value chosen is a compromise between the one that works best for HDD and SSD performance, as determined by benchmarks done by various people.