### PR TITLE
fix CI lint error

### DIFF
--- a/zcutil/libfuzzer/libfuzzer-build.sh
+++ b/zcutil/libfuzzer/libfuzzer-build.sh
@@ -64,7 +64,6 @@ case $key in
     ;;
     -h|--help)
     usage
-    shift
     ;;
     *)
     POSITIONAL+=("$1")


### PR DESCRIPTION
CI results:

Run ./test/lint/lint-shell.sh

In zcutil/libfuzzer/libfuzzer-build.sh line 67:
    shift
    ^---^ SC2317 (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly).

For more information:
  https://www.shellcheck.net/wiki/SC2317 -- Command appears to be unreachable...