### PR TITLE
Typos fix

### DIFF
--- a/doc/authors.md
+++ b/doc/authors.md
@@ -135,7 +135,7 @@ Zcash Contributors
 * Mary Moore-Simmons (2)
 * Mark Friedenbach (2)
 * Marek (2)
-* Jon Atack (2)
+* Jon Attack (2)
 * Joe Turgeon (2)
 * Jesse Cohen (2)
 * Jeffrey Czyz (2)

--- a/doc/release-notes/release-notes-2.0.0-rc1.md
+++ b/doc/release-notes/release-notes-2.0.0-rc1.md
@@ -84,7 +84,7 @@ Jack Grigg (38):
       Rename DecryptSpendingKey -> DecryptSproutSpendingKey
       Rename CryptedSpendingKeyMap -> CryptedSproutSpendingKeyMap
       Add Sapling decryption check to CCryptoKeyStore::Unlock()
-      Check for unencrypted Sapling keys in CCryptoKeyStore::SetCrypted()
+      Check for unenencrypted Sapling keys in CCryptoKeyStore::SetCrypted()
       Remove outdated comment
       Add CWallet::AddCryptedSaplingSpendingKey() hook
       Pass SaplingPaymentAddress to store through the CKeyStore
@@ -103,7 +103,7 @@ Jay Graber (13):
       Add SaplingIncomingViewingKeys map, SaplingFullViewingKey methods
       Add StoreAndRetrieveSaplingSpendingKey test
       Change default_address to return SaplingPaymentAddr and not boost::optional
-      Add crypted keystore sapling add key
+      Add encrypted keystore sapling add key
       Discard sk if ivk == 0
       Add Sapling support to z_exportkey
       Add Sapling support to z_importkey

--- a/doc/release-notes/release-notes-4.5.0-rc1.md
+++ b/doc/release-notes/release-notes-4.5.0-rc1.md
@@ -202,7 +202,7 @@ Kris Nuttycombe (46):
       Ensure that the Orchard note commitment tree does not exceed its maximum size.
       Update Orchard commitment tree hashes to use total MerkleCRH^Orchard.
       Apply suggestions from code review
-      Make Sapling Spend and Ouput count, and Orchard Action count checks be noncontextual.
+      Make Sapling Spend and Output count, and Orchard Action count checks be noncontextual.
       Use DOS level 100 for noncontextual checks.
       Fix error strings to correctly reflect context.
       Remove unused account-related wallet methods.

--- a/doc/release-notes/release-notes-5.5.0.md
+++ b/doc/release-notes/release-notes-5.5.0.md
@@ -403,7 +403,7 @@ Kris Nuttycombe (33):
       Update to use the `ff 0.13` dependency stack.
       Add `AllowRevealedSenders` to fix `mempool_nu_activation.py`
       Calculate convential fee in `CreateTransaction` before stripping sigs.
-      Fix formating of money strings.
+      Fix formatting of money strings.
       Use the conventional fee for prioritisation in prioritisetransactions.py
       `z_sendmany` now accepts 6 parameters, not 5.
       make-release.py: Versioning changes for 5.5.0-rc3.


### PR DESCRIPTION
### Changes

1. **File:** `/doc/authors.md`
    - Fixed `Atack` to `Attack` (Line 138)
1. **File:** `/doc/release-notes/release-notes-4.5.0-rc1.md`
    - Fixed `Ouput` to `Output` (Line 205)
1. **File:** `/doc/release-notes/release-notes-2.0.0-rc1.md`
    - Fixed `crypted` to `encrypted` (Line 106)
1. **File:** `/doc/release-notes/release-notes-5.5.0.md`
    - Fixed `formating` to `formatting` (Line 406)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.