### PR TITLE
Fixed typos

### DIFF
--- a/doc/authors.md
+++ b/doc/authors.md
@@ -235,7 +235,7 @@ Zcash Contributors
 * Gregory Sanders (1)
 * Greg Griffith (1)
 * Gaurav Rana (1)
-* Forrest Voight (1)
+* Forrest Voigt (1)
 * Florian Schmaus (1)
 * Fabian Jahr (1)
 * Eran Tromer (1)

--- a/doc/release-notes/release-notes-1.0.0-rc2.md
+++ b/doc/release-notes/release-notes-1.0.0-rc2.md
@@ -89,7 +89,7 @@ Simon (17):
       Fixes CID 1352687 uninitialized scalar field.
       Fixes CID 1352715 uninitialized scalar field.
       Fixes CID 1352686 uninitialized scalar variable.
-      Fixes CID 1352599 unitialized scalar variable
+      Fixes CID 1352599 uninitialized scalar variable
       Fixes CID 1352727 uninitialized scalar variable.
       Fixes CID 1352714 uninitialized scalar variable.
       Add security warning about logging of z_* calls.

--- a/doc/release-notes/release-notes-5.10.0-rc1.md
+++ b/doc/release-notes/release-notes-5.10.0-rc1.md
@@ -103,7 +103,7 @@ Kris Nuttycombe (25):
       Add `lockbox` to value pool balance reporting.
       Add tests for lockbox funding streams.
       Add NU6 funding streams to the consensus parameters.
-      Add const modifer to the `blockIndex` argument to `GetTransaction`
+      Add const modifier to the `blockIndex` argument to `GetTransaction`
       Use __func__ for substitution in `ConnectBlock` error messages.
       Improve logging of miner block construction.
       Compute chain value earlier in block processing.


### PR DESCRIPTION
### Changes

1. **File:** `/doc/authors.md`
    - Fixed `Voight` to `Voigt` (Line 238)
1. **File:** `/doc/release-notes/release-notes-1.0.0-rc2.md`
    - Fixed `unitialized` to `uninitialized` (Line 92)
1. **File:** `/doc/release-notes/release-notes-5.10.0-rc1.md`
    - Fixed `modifer` to `modifier` (Line 106)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.