### PR TITLE
Corrected typos

### DIFF
--- a/doc/release-notes/release-notes-2.0.0-rc1.md
+++ b/doc/release-notes/release-notes-2.0.0-rc1.md
@@ -5,7 +5,7 @@ Alex Morcos (1):
       Output line to debug.log when IsInitialBlockDownload latches to false
 
 Ariel Gabizon (1):
-      Extend Joinsplit tests to Groth
+      Extend Joinsplit tests to Growth
 
 Charlie OKeefe (1):
       Remove extra slash from lockfile path

--- a/doc/release-notes/release-notes-4.5.0-rc1.md
+++ b/doc/release-notes/release-notes-4.5.0-rc1.md
@@ -180,7 +180,7 @@ Kris Nuttycombe (46):
       Fix header guards for incremental_sinsemilla_tree.h
       Apply style suggestions.
       Consistently panic on null commitment tree pointers.
-      Fix implmentation of OrchardMerkleTree.DynamicMemoryUsage
+      Fix implementation of OrchardMerkleTree.DynamicMemoryUsage
       Document source of Orchard merkle tree test data.
       Apply suggestions from code review
       Add consensus check for duplicate Orchard nullifiers within a single transaction.

--- a/doc/release-notes/release-notes-5.5.0.md
+++ b/doc/release-notes/release-notes-5.5.0.md
@@ -402,7 +402,7 @@ Kris Nuttycombe (33):
       Refactor RPC privacyPolicy handling
       Update to use the `ff 0.13` dependency stack.
       Add `AllowRevealedSenders` to fix `mempool_nu_activation.py`
-      Calculate convential fee in `CreateTransaction` before stripping sigs.
+      Calculate conventional fee in `CreateTransaction` before stripping sigs.
       Fix formating of money strings.
       Use the conventional fee for prioritisation in prioritisetransactions.py
       `z_sendmany` now accepts 6 parameters, not 5.


### PR DESCRIPTION
### Changes

1. **File:** `/doc/release-notes/release-notes-4.5.0-rc1.md`
    - Fixed `implmentation` to `implementation` (Line 183)
1. **File:** `/doc/release-notes/release-notes-2.0.0-rc1.md`
    - Fixed `Groth` to `Growth` (Line 8)
1. **File:** `/doc/release-notes/release-notes-5.5.0.md`
    - Fixed `convential` to `conventional` (Line 405)

### Purpose

- EImproved the documentation's clarity and professional tone.
- Corrected small grammatical errors to enhance comprehension.