### PR TITLE
Update broken Rust tier policy link

### DIFF
--- a/doc/book/src/dev/platform-tier-policy.md
+++ b/doc/book/src/dev/platform-tier-policy.md
@@ -3,7 +3,7 @@
 ## General
 
 ECC provides three tiers of platform support, modeled after the
-[Rust Target Tier Policy](https://doc.rust-lang.org/stable/rustc/platform-tier-policy.html):
+[Rust Target Tier Policy](https://doc.rust-lang.org/beta/rustc/target-tier-policy.html):
 
 - The Zcash developers provide no guarantees about tier 3 platforms; they exist in the
   codebase, but may or may not build.


### PR DESCRIPTION
Old link:
https://doc.rust-lang.org/stable/rustc/platform-tier-policy.html

New link:
https://doc.rust-lang.org/beta/rustc/target-tier-policy.html

🔧 Why the change is needed:
The original URL returned a 404 because the structure of the Rust documentation was changed. The updated link correctly points to the current version of the platform tier policy page, ensuring developers can access the referenced material.

Let me know if you'd like to suggest an alternative Rust URL or if I should update it again.

