### PR TITLE
Fix broken links

### DIFF
--- a/doc/bips.md
+++ b/doc/bips.md
@@ -1,4 +1,4 @@
 BIPs that are implemented by Zcash (up-to-date up to **v1.1.0**):
 
-* Numerous historic BIPs were present in **v1.0.0** at launch; see [the protocol spec](https://github.com/zcash/zips/blob/master/protocol/protocol.pdf) for details.
+* Numerous historic BIPs were present in **v1.0.0** at launch; see [the protocol spec](https://github.com/zcash/zips/blob/main/rendered/protocol/protocol.pdf) for details.
 * [`BIP 111`](https://github.com/bitcoin/bips/blob/master/bip-0111.mediawiki): `NODE_BLOOM` service bit added, but only enforced for peer versions `>=170004` as of **v1.1.0** ([PR #2814](https://github.com/zcash/zcash/pull/2814)).

--- a/doc/release-notes/release-notes-1.0.14-rc1.md
+++ b/doc/release-notes/release-notes-1.0.14-rc1.md
@@ -5,7 +5,7 @@ Incoming viewing keys
 ---------------------
 
 Support for incoming viewing keys, as described in
-[the Zcash protocol spec](https://github.com/zcash/zips/blob/master/protocol/protocol.pdf),
+[the Zcash protocol spec](https://github.com/zcash/zips/blob/main/rendered/protocol/protocol.pdf),
 has been added to the wallet.
 
 Use the `z_exportviewingkey` RPC method to obtain the incoming viewing key for a

--- a/doc/release-notes/release-notes-1.0.14.md
+++ b/doc/release-notes/release-notes-1.0.14.md
@@ -5,7 +5,7 @@ Incoming viewing keys
 ---------------------
 
 Support for incoming viewing keys, as described in
-[the Zcash protocol spec](https://github.com/zcash/zips/blob/master/protocol/protocol.pdf),
+[the Zcash protocol spec](https://github.com/zcash/zips/blob/main/rendered/protocol/protocol.pdf),
 has been added to the wallet.
 
 Use the `z_exportviewingkey` RPC method to obtain the incoming viewing key for a


### PR DESCRIPTION
Replaced old spec links from master/protocol/protocol.pdf
with updated ones from main/rendered/protocol.pdf.