### PR TITLE
Make the handling of bip0039 languages nicer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ dependencies = [
  "ipnet",
  "jubjub",
  "libc",
+ "macro_find_and_replace",
  "memuse",
  "metrics",
  "metrics-exporter-prometheus",
@@ -1213,6 +1214,12 @@ checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "macro_find_and_replace"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c5eef824b07f20e21212f95520a9b29007258680db871e2a146d7accc0dca6"
 
 [[package]]
 name = "matchers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,9 @@ secrecy = "0.8"
 thiserror = "2"
 time = { version = "0.3", features = ["formatting", "macros"] }
 
+# Macros
+macro_find_and_replace = "1"
+
 [dev-dependencies]
 incrementalmerkletree = { version = "0.7", features = ["test-dependencies"] }
 proptest = "1.0.0"

--- a/qa/supply-chain/audits.toml
+++ b/qa/supply-chain/audits.toml
@@ -1569,6 +1569,12 @@ who = "Daira-Emma Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-deploy"
 delta = "0.4.20 -> 0.4.21"
 
+[[audits.macro_find_and_replace]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "Fully reviewed. No problems found other than a few typos in documentation (filed https://github.com/lord-ne/rust-macro-find-and-replace/pull/1 )."
+
 [[audits.maybe-rayon]]
 who = "Sean Bowe <ewillbefull@gmail.com>"
 criteria = "safe-to-deploy"

--- a/src/rust/src/zip339_ffi.rs
+++ b/src/rust/src/zip339_ffi.rs
@@ -1,4 +1,5 @@
 use libc::{c_char, size_t};
+use macro_find_and_replace::replace_token_sequence;
 use std::{
     borrow::Cow,
     ffi::{CStr, CString},
@@ -44,65 +45,37 @@ impl Language {
             Language(_) => None,
         }
     }
+}
 
+macro_rules! all_languages {
+    ($self:expr, $ctx:expr, $e:expr) => {
+        $self.handle(
+            $ctx,
+            replace_token_sequence!{[LANGUAGE], [bip0039::English], $e},
+            replace_token_sequence!{[LANGUAGE], [bip0039::ChineseSimplified], $e},
+            replace_token_sequence!{[LANGUAGE], [bip0039::ChineseTraditional], $e},
+            replace_token_sequence!{[LANGUAGE], [bip0039::Czech], $e},
+            replace_token_sequence!{[LANGUAGE], [bip0039::French], $e},
+            replace_token_sequence!{[LANGUAGE], [bip0039::Italian], $e},
+            replace_token_sequence!{[LANGUAGE], [bip0039::Japanese], $e},
+            replace_token_sequence!{[LANGUAGE], [bip0039::Korean], $e},
+            replace_token_sequence!{[LANGUAGE], [bip0039::Portuguese], $e},
+            replace_token_sequence!{[LANGUAGE], [bip0039::Spanish], $e},
+        )
+    };
+}
+
+impl Language {
     fn with_mnemonic_phrase_from_entropy<E: Into<Vec<u8>>, T>(
         self,
         entropy: E,
         f: impl FnOnce(&str) -> Option<T>,
     ) -> Option<T> {
-        self.handle(
-            (entropy, f),
-            |(entropy, f)| {
-                bip0039::Mnemonic::<bip0039::English>::from_entropy(entropy)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.phrase()))
-            },
-            |(entropy, f)| {
-                bip0039::Mnemonic::<bip0039::ChineseSimplified>::from_entropy(entropy)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.phrase()))
-            },
-            |(entropy, f)| {
-                bip0039::Mnemonic::<bip0039::ChineseTraditional>::from_entropy(entropy)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.phrase()))
-            },
-            |(entropy, f)| {
-                bip0039::Mnemonic::<bip0039::Czech>::from_entropy(entropy)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.phrase()))
-            },
-            |(entropy, f)| {
-                bip0039::Mnemonic::<bip0039::French>::from_entropy(entropy)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.phrase()))
-            },
-            |(entropy, f)| {
-                bip0039::Mnemonic::<bip0039::Italian>::from_entropy(entropy)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.phrase()))
-            },
-            |(entropy, f)| {
-                bip0039::Mnemonic::<bip0039::Japanese>::from_entropy(entropy)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.phrase()))
-            },
-            |(entropy, f)| {
-                bip0039::Mnemonic::<bip0039::Korean>::from_entropy(entropy)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.phrase()))
-            },
-            |(entropy, f)| {
-                bip0039::Mnemonic::<bip0039::Portuguese>::from_entropy(entropy)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.phrase()))
-            },
-            |(entropy, f)| {
-                bip0039::Mnemonic::<bip0039::Spanish>::from_entropy(entropy)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.phrase()))
-            },
-        )
+        all_languages!(self, (entropy, f), |(entropy, f)| {
+            bip0039::Mnemonic::<LANGUAGE>::from_entropy(entropy)
+                .ok()
+                .and_then(|mnemonic| f(mnemonic.phrase()))
+        })
     }
 
     fn with_seed_from_mnemonic_phrase<'a, P: Into<Cow<'a, str>>, T>(
@@ -111,75 +84,17 @@ impl Language {
         passphrase: &str,
         f: impl FnOnce([u8; 64]) -> Option<T>,
     ) -> Option<T> {
-        self.handle(
-            (phrase, passphrase, f),
-            |(phrase, passphrase, f)| {
-                bip0039::Mnemonic::<bip0039::English>::from_phrase(phrase)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.to_seed(passphrase)))
-            },
-            |(phrase, passphrase, f)| {
-                bip0039::Mnemonic::<bip0039::ChineseSimplified>::from_phrase(phrase)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.to_seed(passphrase)))
-            },
-            |(phrase, passphrase, f)| {
-                bip0039::Mnemonic::<bip0039::ChineseTraditional>::from_phrase(phrase)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.to_seed(passphrase)))
-            },
-            |(phrase, passphrase, f)| {
-                bip0039::Mnemonic::<bip0039::Czech>::from_phrase(phrase)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.to_seed(passphrase)))
-            },
-            |(phrase, passphrase, f)| {
-                bip0039::Mnemonic::<bip0039::French>::from_phrase(phrase)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.to_seed(passphrase)))
-            },
-            |(phrase, passphrase, f)| {
-                bip0039::Mnemonic::<bip0039::Italian>::from_phrase(phrase)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.to_seed(passphrase)))
-            },
-            |(phrase, passphrase, f)| {
-                bip0039::Mnemonic::<bip0039::Japanese>::from_phrase(phrase)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.to_seed(passphrase)))
-            },
-            |(phrase, passphrase, f)| {
-                bip0039::Mnemonic::<bip0039::Korean>::from_phrase(phrase)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.to_seed(passphrase)))
-            },
-            |(phrase, passphrase, f)| {
-                bip0039::Mnemonic::<bip0039::Portuguese>::from_phrase(phrase)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.to_seed(passphrase)))
-            },
-            |(phrase, passphrase, f)| {
-                bip0039::Mnemonic::<bip0039::Spanish>::from_phrase(phrase)
-                    .ok()
-                    .and_then(|mnemonic| f(mnemonic.to_seed(passphrase)))
-            },
-        )
+        all_languages!(self, (phrase, passphrase, f), |(phrase, passphrase, f)| {
+            bip0039::Mnemonic::<LANGUAGE>::from_phrase(phrase)
+                .ok()
+                .and_then(|mnemonic| f(mnemonic.to_seed(passphrase)))
+        })
     }
 
     fn validate_mnemonic<'a, P: Into<Cow<'a, str>>>(self, phrase: P) -> Option<()> {
-        self.handle(
-            phrase,
-            |phrase| bip0039::Mnemonic::<bip0039::English>::validate(phrase).ok(),
-            |phrase| bip0039::Mnemonic::<bip0039::ChineseSimplified>::validate(phrase).ok(),
-            |phrase| bip0039::Mnemonic::<bip0039::ChineseTraditional>::validate(phrase).ok(),
-            |phrase| bip0039::Mnemonic::<bip0039::Czech>::validate(phrase).ok(),
-            |phrase| bip0039::Mnemonic::<bip0039::French>::validate(phrase).ok(),
-            |phrase| bip0039::Mnemonic::<bip0039::Italian>::validate(phrase).ok(),
-            |phrase| bip0039::Mnemonic::<bip0039::Japanese>::validate(phrase).ok(),
-            |phrase| bip0039::Mnemonic::<bip0039::Korean>::validate(phrase).ok(),
-            |phrase| bip0039::Mnemonic::<bip0039::Portuguese>::validate(phrase).ok(),
-            |phrase| bip0039::Mnemonic::<bip0039::Spanish>::validate(phrase).ok(),
-        )
+        all_languages!(self, phrase, |phrase| {
+            bip0039::Mnemonic::<LANGUAGE>::validate(phrase).ok()
+        })
     }
 }
 


### PR DESCRIPTION
Follow-up to #7027.

`cargo expand --lib zip339_ffi` confirms that this generates identical code (up to formatting and splitting `impl Language` into two blocks).