### PR TITLE
wallet: Check spent Orchard notes in `CWallet{Tx}::IsFromMe`

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -4,3 +4,18 @@ release-notes at release time)
 Notable changes
 ===============
 
+Fixed Orchard bug in transparent balance APIs
+---------------------------------------------
+
+Several RPC methods inherited from Bitcoin Core internally rely on
+`CWalletTx::IsFromMe` for detecting involvement of the wallet in the input
+side of a transaction. For example:
+- The `getbalance` RPC method uses it as part of identifying "trusted"
+  zero-confirmation transactions to include in the balance calculation.
+- The `gettransaction` RPC method uses it to decide whether to include a
+  `fee` field in its response.
+
+When Orchard was integrated into `zcashd`, this method was not updated to
+account for it, meaning that unshielding transactions spending Orchard notes
+would not be correctly accounted for in transparent-specific RPC methods. A
+similar bug involving Sprout and Sapling spends was fixed in v4.5.1.

--- a/src/rust/include/rust/orchard/wallet.h
+++ b/src/rust/include/rust/orchard/wallet.h
@@ -335,6 +335,13 @@ bool orchard_wallet_get_txdata(
         push_output_t push_output_cb
         );
 
+/**
+ * Returns true if this nullifier belongs to one of the notes in our wallet.
+ */
+bool orchard_wallet_is_nullifier_from_me(
+        const OrchardWalletPtr* wallet,
+        const unsigned char *nullifier);
+
 typedef void (*push_txid_callback_t)(void* resultVector, unsigned char txid[32]);
 
 /**

--- a/src/rust/src/wallet.rs
+++ b/src/rust/src/wallet.rs
@@ -1183,6 +1183,18 @@ pub extern "C" fn orchard_wallet_get_txdata(
     }
 }
 
+#[no_mangle]
+pub extern "C" fn orchard_wallet_is_nullifier_from_me(
+    wallet: *const Wallet,
+    nullifier: *const [c_uchar; 32],
+) -> bool {
+    let wallet = unsafe { wallet.as_ref() }.expect("Wallet pointer may not be null.");
+    let nullifier =
+        Nullifier::from_bytes(unsafe { nullifier.as_ref() }.expect("nullifier may not be null."));
+
+    wallet.nullifiers.contains_key(&nullifier.unwrap())
+}
+
 pub type PushTxId = unsafe extern "C" fn(obj: Option<FFICallbackReceiver>, txid: *const [u8; 32]);
 
 #[no_mangle]

--- a/src/wallet/orchard.h
+++ b/src/wallet/orchard.h
@@ -437,6 +437,10 @@ public:
         reinterpret_cast<std::vector<uint256>*>(txidsRet)->push_back(txid_out);
     }
 
+    bool IsNullifierFromMe(const std::array<uint8_t, 32>& nullifier) const {
+        return orchard_wallet_is_nullifier_from_me(inner.get(), nullifier.data());
+    }
+
     std::vector<uint256> GetPotentialSpendsFromNullifier(const uint256& nullifier) const {
         std::vector<uint256> result;
         orchard_wallet_get_potential_spends_from_nullifier(

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4082,6 +4082,11 @@ bool CWallet::IsFromMe(const CTransaction& tx) const
             return true;
         }
     }
+    for (const auto& action : tx.GetOrchardBundle().GetDetails()->actions()) {
+        if (orchardWallet.IsNullifierFromMe(action.nullifier())) {
+            return true;
+        }
+    }
     return false;
 }
 
@@ -4978,6 +4983,11 @@ bool CWalletTx::IsFromMe(const isminefilter& filter) const
     }
     for (const auto& spend : GetSaplingSpends()) {
         if (pwallet->IsSaplingNullifierFromMe(spend.nullifier())) {
+            return true;
+        }
+    }
+    for (const auto& action : GetOrchardBundle().GetDetails()->actions()) {
+        if (pwallet->orchardWallet.IsNullifierFromMe(action.nullifier())) {
             return true;
         }
     }


### PR DESCRIPTION
We missed these methods when integrating Orchard into the wallet.

- We didn't notice `CWallet::IsFromMe` because while previous shielded protocols did spend detection in `CWallet::AddToWalletIfInvolvingMe` via that logic, the Orchard logic was implemented in a separate internal Rust wallet with its own detection logic. Technically the change is unnecessary here as `CWallet::AddToWalletIfInvolvingMe` is the only user of this method, but we update it for consistency.
- We didn't notice `CWalletTx::IsFromMe` because the only critical place it affects is the `getbalance` RPC (other than that, it is only called from code used to either create purely-transparent transactions, or provide informational output on non-critical RPC methods). We had a similar bug with this method previously where it didn't track shielded at all (zcash/zcash@fd49f78042d42857d0206272fa1c2a24c11d53be).