### PR TITLE
Prefer to create v5 transactions over v4 if either is possible

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -19,3 +19,11 @@ When Orchard was integrated into `zcashd`, this method was not updated to
 account for it, meaning that unshielding transactions spending Orchard notes
 would not be correctly accounted for in transparent-specific RPC methods. A
 similar bug involving Sprout and Sapling spends was fixed in v4.5.1.
+
+Updates to default values
+-------------------------
+
+- The default for the `-preferredtxversion` config option has been changed from
+  `4` (the v4 transaction format introduced in the 2018 Sapling Network Upgrade)
+  to `5` (the v5 transaction format introduced in the 2022 NU5 Network Upgrade).
+  Use `-preferredtxversion=4` to retain the previous behaviour.

--- a/qa/rpc-tests/coinbase_funding_streams.py
+++ b/qa/rpc-tests/coinbase_funding_streams.py
@@ -53,6 +53,7 @@ class CoinbaseFundingStreamsTest(BitcoinTestFramework):
             nuparams(CANOPY_BRANCH_ID, 3),
             nuparams(NU6_BRANCH_ID, 4),
             "-nurejectoldversions=false",
+            "-preferredtxversion=4",
             "-allowdeprecated=getnewaddress",
             "-allowdeprecated=z_getnewaddress",
             "-allowdeprecated=z_getbalance",

--- a/qa/rpc-tests/feature_zip239.py
+++ b/qa/rpc-tests/feature_zip239.py
@@ -49,7 +49,6 @@ class Zip239Test(BitcoinTestFramework):
             nuparams(HEARTWOOD_BRANCH_ID, 205),
             nuparams(CANOPY_BRANCH_ID, 205),
             nuparams(NU5_BRANCH_ID, 210),
-            "-preferredtxversion=5",
             "-allowdeprecated=getnewaddress",
             "-allowdeprecated=z_getbalance",
         ]] * self.num_nodes)

--- a/qa/rpc-tests/mempool_nu_activation.py
+++ b/qa/rpc-tests/mempool_nu_activation.py
@@ -34,6 +34,7 @@ class MempoolUpgradeActivationTest(BitcoinTestFramework):
             '-checkmempool',
             '-debug=mempool',
             '-blockmaxsize=4000',
+            '-preferredtxversion=4',
             '-allowdeprecated=getnewaddress',
             '-allowdeprecated=z_getnewaddress',
             '-allowdeprecated=z_getbalance',

--- a/qa/rpc-tests/show_help.py
+++ b/qa/rpc-tests/show_help.py
@@ -602,7 +602,7 @@ Compatibility options:
 
   -preferredtxversion
        Preferentially create transactions having the specified version when
-       possible (default: 4)
+       possible (default: 5)
 
 """
 

--- a/src/main.h
+++ b/src/main.h
@@ -245,7 +245,7 @@ static const signed int DEFAULT_CHECKBLOCKS = MIN_BLOCKS_TO_KEEP;
 static const unsigned int DEFAULT_CHECKLEVEL = 3;
 
 /** Prefer to create v4 transactions. */
-static const int32_t DEFAULT_PREFERRED_TX_VERSION = SAPLING_TX_VERSION;
+static const int32_t DEFAULT_PREFERRED_TX_VERSION = ZIP225_TX_VERSION;
 static const std::set<int32_t> SUPPORTED_TX_VERSIONS = { SAPLING_TX_VERSION, ZIP225_TX_VERSION };
 extern int32_t nPreferredTxVersion;
 


### PR DESCRIPTION
The `-preferredtxversion` config option was added in zcash/zcash#5967 to enable node users to control which transaction version was used for new transactions when the user requirements on its structure were supported by more than one format. We set the initial default (in 2022) to the v4 transaction format, to account for the wallet ecosystem potentially not having pervasive v5 transaction support at that time. Over 3 years later we can now assume v5 transaction support is pervasive, and thus can update the default for the zcashd wallet.