### PR TITLE
Update LXC documentation link to current Ubuntu Server docs

### DIFF
--- a/contrib/gitian-descriptors/README.md
+++ b/contrib/gitian-descriptors/README.md
@@ -38,7 +38,7 @@ Once you've got the right hardware and software:
 ---------------------
 
 `gitian-builder` now also supports building using LXC. See
-[help.ubuntu.com](https://ubuntu.com/server/docs/containers-lxc)
+[help.ubuntu.com](https://ubuntu.com/server/docs/lxc-containers)
 for how to get LXC up and running under Ubuntu.
 
 If your main machine is a 64-bit Mac or PC with a few gigabytes of memory


### PR DESCRIPTION
Replaced the outdated link to the Ubuntu LXC containers documentation (https://ubuntu.com/server/docs/containers-lxc) with the current and correct URL (https://ubuntu.com/server/docs/lxc-containers) in contrib/gitian-descriptors/README.md. This ensures users are directed to the latest official instructions for setting up LXC on Ubuntu. No other content was changed.