### PR TITLE
docker/build-push-action from v5 to v6

### DIFF
--- a/src/secp256k1/.github/actions/run-in-docker-action/action.yml
+++ b/src/secp256k1/.github/actions/run-in-docker-action/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - uses: docker/setup-buildx-action@v3
 
-    - uses: docker/build-push-action@v5
+    - uses: docker/build-push-action@v6
       id: main_builder
       continue-on-error: true
       with:
@@ -26,7 +26,7 @@ runs:
         load: true
         cache-from: type=gha
 
-    - uses: docker/build-push-action@v5
+    - uses: docker/build-push-action@v6
       id: retry_builder
       if: steps.main_builder.outcome == 'failure'
       with:


### PR DESCRIPTION
Updates docker/build-push-action from v5 to v6

References
docker/build-push-action@v6: https://github.com/docker/build-push-action/releases/tag/v6.18.0

This update ensures we're using the latest stable version of the Docker Build and Push Action, which includes performance improvements and bug fixes