### PR TITLE
docs: add `fullyNotified` to help command for `getmempoolinfo`

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1563,6 +1563,11 @@ UniValue getmempoolinfo(const UniValue& params, bool fHelp)
             "  \"size\": xxxxx                (numeric) Current tx count\n"
             "  \"bytes\": xxxxx               (numeric) Sum of all tx sizes\n"
             "  \"usage\": xxxxx               (numeric) Total memory usage for the mempool\n"
+            "  \"fullyNotified\": true|false  (boolean, regtest only)\n"
+            "                               Whether the node has finished notifying all\n"
+            "                               listeners/tests about every transaction currently\n"
+            "                               in the mempool. This key is returned only when the\n"
+            "                               node is running in regtest.\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getmempoolinfo", "")


### PR DESCRIPTION
This PR adds the regtest-only `fullyNotified` field to the help command, so that eventually it also ends up documented here: https://zcash.github.io/rpc/getmempoolinfo.html.