### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -13,7 +13,7 @@ jobs:
     name: Vet Rust dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         id: toolchain
       - run: rustup override set ${{steps.toolchain.outputs.name}}
@@ -24,7 +24,7 @@ jobs:
     name: Check licenses
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check licenses

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -13,7 +13,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         id: toolchain
       - run: rustup override set ${{steps.toolchain.outputs.name}}

--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Check out the base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # We fetch the entire repository to ensure we have the common ancestor
           # of the base branch and the PR branch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       rpc_test_shards_matrix: ${{ steps.set-rpc-tests.outputs.rpc_test_shards_matrix }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Configure the build and test matrices. Notes:
       # - The `*_names` lists of platforms are combined with job-specific lists to build
@@ -219,7 +219,7 @@ jobs:
         include: ${{ fromJson(needs.setup.outputs.build_matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Homebrew build dependencies
         if: matrix.brew_deps != ''
@@ -327,7 +327,7 @@ jobs:
         include: ${{ fromJson(needs.setup.outputs.build_matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Homebrew build dependencies
         if: matrix.brew_deps != ''
@@ -391,7 +391,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.setup.outputs.test_matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download src artifact
         uses: actions/download-artifact@v4
@@ -422,7 +422,7 @@ jobs:
         shard_index: [0, 1]
         include: ${{ fromJson(needs.setup.outputs.test_matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download src artifact
         uses: actions/download-artifact@v4
@@ -481,7 +481,7 @@ jobs:
         include: ${{ fromJson(needs.setup.outputs.test_matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run Rust tests
         run: cargo test
 
@@ -500,7 +500,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.setup.outputs.unix_test_matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Homebrew build dependencies
         if: matrix.brew_deps != ''
@@ -533,7 +533,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.setup.outputs.unix_test_matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Homebrew build dependencies
         if: matrix.brew_deps != ''
@@ -577,7 +577,7 @@ jobs:
         include: ${{ fromJson(needs.setup.outputs.unix_test_matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download src artifact
         uses: actions/download-artifact@v4
@@ -610,7 +610,7 @@ jobs:
         include: ${{ fromJson(needs.setup.outputs.test_matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download depends/${{ matrix.host }}/lib
         uses: actions/download-artifact@v4
@@ -640,7 +640,7 @@ jobs:
         include: ${{ fromJson(needs.setup.outputs.unix_test_matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download src artifact
         uses: actions/download-artifact@v4
@@ -712,7 +712,7 @@ jobs:
         include: ${{ fromJson(needs.setup.outputs.rpc_test_shards_matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Cache Python dependencies for RPC tests
         uses: actions/cache@v4

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -8,7 +8,7 @@ jobs:
     name: Scripted diffs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -19,7 +19,7 @@ jobs:
     name: General
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         run: sudo python3 -m pip install yq
 
@@ -66,7 +66,7 @@ jobs:
     name: Python
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         run: sudo python3 -m pip install pyflakes
 
@@ -82,7 +82,7 @@ jobs:
     name: Clippy (MSRV)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
@@ -94,5 +94,5 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: cargo fmt -- --check

--- a/src/secp256k1/.github/workflows/ci.yml
+++ b/src/secp256k1/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         env: ${{ matrix.configuration.env_vars }}
@@ -145,7 +145,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         uses: ./.github/actions/run-in-docker-action
@@ -189,7 +189,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         uses: ./.github/actions/run-in-docker-action
@@ -240,7 +240,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         env: ${{ matrix.configuration.env_vars }}
@@ -295,7 +295,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         env: ${{ matrix.configuration.env_vars }}
@@ -340,7 +340,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         uses: ./.github/actions/run-in-docker-action
@@ -393,7 +393,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         env: ${{ matrix.configuration.env_vars }}
@@ -448,7 +448,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         env: ${{ matrix.configuration.env_vars }}
@@ -504,7 +504,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         env: ${{ matrix.configuration.env_vars }}
@@ -558,7 +558,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         env: ${{ matrix.configuration.env_vars }}
@@ -612,7 +612,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Homebrew packages
         run: |
@@ -667,7 +667,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Generate buildsystem
         run: cmake -E env CFLAGS="/WX ${{ matrix.configuration.cpp_flags }}" cmake -B build -DSECP256K1_ENABLE_MODULE_RECOVERY=ON -DSECP256K1_BUILD_EXAMPLES=ON ${{ matrix.configuration.cmake_options }}
@@ -695,7 +695,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Add cl.exe to PATH
         uses: ilammy/msvc-dev-cmd@v1
@@ -721,7 +721,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         uses: ./.github/actions/run-in-docker-action
@@ -754,7 +754,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         uses: ./.github/actions/run-in-docker-action
@@ -774,7 +774,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: CI script
         run: |
@@ -786,7 +786,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - run: ./autogen.sh && ./configure --enable-dev-mode && make distcheck
 


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0