### PR TITLE
Update Dockerfile - entrypoint.sh

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -11,23 +11,6 @@ fi
 env | sort | grep ZCASHD || true
 export ZCASHD_CMD=('zcashd' '-printtoconsole')
 
-if [[ -z ${ZCASHD_NETWORK} ]];then
-  export ZCASHD_NETWORK=mainnet
-fi
-
-case ${ZCASHD_NETWORK} in
-  testnet)
-    ZCASHD_CMD+=("-testnet" "-addnode=testnet.z.cash")
-    ;;
-  mainnet)
-    ZCASHD_CMD+=("-addnode=mainnet.z.cash")
-    ;;
-  *)
-    echo "Error, unknown network: ${ZCASHD_NETWORK}"
-    exit 1
-    ;;
-esac
-
 if [[ -n "${ZCASHD_SHOWMETRICS}" ]];then ZCASHD_CMD+=("-showmetrics=${ZCASHD_SHOWMETRICS}");fi
 if [[ -n "${ZCASHD_LOGIPS}" ]];then ZCASHD_CMD+=("-logips=${ZCASHD_LOGIPS}");fi
 if [[ -n "${ZCASHD_EXPERIMENTALFEATURES}" ]];then ZCASHD_CMD+=("-experimentalfeatures=${ZCASHD_EXPERIMENTALFEATURES}");fi

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -255,7 +255,7 @@ Notify the Zcash DevOps engineer/sysadmin that the release has been tagged. They
 some variables in the company's automation code and then run an Ansible playbook, which:
 
 * builds Zcash based on the specified branch
-* deploys it as a public service (e.g. testnet.z.cash, mainnet.z.cash)
+* deploys it as a public service
 * often the same server can be re-used, and the role idempotently handles upgrades, but if
   not then they also need to update DNS records
 * possible manual steps: blowing away the `testnet3` dir, deleting old parameters,


### PR DESCRIPTION
The hardcoded addnode values for `mainnet.z.cash` and `testnet.z.cash` have been removed.  These nodes are no longer maintained, and defining an addnode has not been strictly necessary, as DNS seeders provide peer discovery.