### PR TITLE
Harden release-notes subprocess calls (no shell, use check_*)

### DIFF
--- a/zcutil/release-notes.py
+++ b/zcutil/release-notes.py
@@ -116,11 +116,12 @@ def generate_release_note(version, prev, clear):
         latest_tag = prev
     else:
         # fetches latest tags, so that latest_tag will be correct
-        subprocess.Popen(['git fetch -t'], shell=True, stdout=subprocess.PIPE).communicate()[0]
-        latest_tag = subprocess.Popen(['git describe --abbrev=0'], shell=True, stdout=subprocess.PIPE).communicate()[0].strip()
+        # Use direct argument lists without shell to avoid shell parsing/injection issues
+        subprocess.check_call(['git', 'fetch', '-t'])
+        latest_tag = subprocess.check_output(['git', 'describe', '--abbrev=0'], text=True).strip()
     print("Previous release tag: ", latest_tag)
-    notes = subprocess.Popen(['git shortlog --no-merges {0}..HEAD'.format(latest_tag)], shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE).communicate()[0]
-    lines = notes.decode("utf-8", "replace").split('\n')
+    notes = subprocess.check_output(['git', 'shortlog', '--no-merges', f'{latest_tag}..HEAD'], text=True)
+    lines = notes.split('\n')
     lines = [alias_authors_in_release_notes(line) for line in lines]
     temp_release_note = os.path.join(doc_dir, 'release-notes.md')
     with open(temp_release_note, mode='r', encoding="utf-8", errors="replace") as f:


### PR DESCRIPTION


### Description
- **What**: Replace `subprocess.Popen(..., shell=True)` with `check_call`/`check_output` using explicit arg lists and `text=True`.
- **Why**: Avoid shell parsing/injection risks, improve portability and error handling, simplify string handling (no manual decoding).
- **Scope**: `zcutil/release-notes.py` only; behavior remains the same.
