### PR TITLE
Fix broken link to Zcash error codes

### DIFF
--- a/doc/payment-api.md
+++ b/doc/payment-api.md
@@ -111,7 +111,7 @@ z_listoperationids <br>| [state] | Return a list of operationids for all operati
 
 ## Asynchronous RPC call Error Codes
 
-Zcash error codes are defined in https://github.com/zcash/zcash/blob/master/src/rpcprotocol.h
+Zcash error codes are defined in https://github.com/zcash/zcash/blob/master/src/rpc/protocol.h
 
 ### z_sendmany error codes
 


### PR DESCRIPTION
The doc was pointing to a non-existent file (src/rpcprotocol.h).
Updated it to the correct path (src/rpc/protocol.h) so the link resolves.