### PR TITLE
Fix undefined variable in `identify_executable` function

### DIFF
--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -178,7 +178,7 @@ CHECKS = {
 }
 
 def identify_executable(executable):
-    with open(filename, 'rb') as f:
+    with open(executable, 'rb') as f:
         magic = f.read(4)
     if magic.startswith(b'MZ'):
         return 'PE'


### PR DESCRIPTION

The `identify_executable` function uses an undefined variable `filename` instead of the function parameter `executable`, causing a `NameError` when the function is called. This prevents the security check script from working correctly.

