### PR TITLE
CI: Use a variable to allow configuration of larger runners.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             - name: Debian-bookworm
               tier: 1
               platform: Debian Bookworm
-              build_os: ubuntu-22.04-8cores
+              build_os: ${{ vars.UBUNTU_LARGE_RUNNER || 'ubuntu-22.04' }}
               test_os: ubuntu-22.04
               container: electriccoinco/debian-helper:bookworm
               host: x86_64-pc-linux-gnu
@@ -59,7 +59,7 @@ jobs:
             - name: Debian-bullseye
               tier: 1
               platform: Debian bullseye
-              build_os: ubuntu-22.04-8cores
+              build_os: ${{ vars.UBUNTU_LARGE_RUNNER || 'ubuntu-22.04' }}
               test_os: ubuntu-22.04
               container: electriccoinco/debian-helper:bullseye
               host: x86_64-pc-linux-gnu
@@ -67,7 +67,7 @@ jobs:
             - name: ubuntu-22.04
               tier: 1
               platform: Ubuntu 22.04
-              build_os: ubuntu-22.04-8cores
+              build_os: ${{ vars.UBUNTU_LARGE_RUNNER || 'ubuntu-22.04' }}
               test_os: ubuntu-22.04
               host: x86_64-pc-linux-gnu
 
@@ -94,7 +94,7 @@ jobs:
             - name: mingw32
               tier: 3
               platform: Windows (64-bit MinGW)
-              build_os: ubuntu-22.04-8cores
+              build_os: ${{ vars.UBUNTU_LARGE_RUNNER || 'ubuntu-22.04' }}
               test_os: windows-latest
               cross_deps: >
                 mingw-w64
@@ -104,7 +104,7 @@ jobs:
             - name: aarch64-linux
               tier: 3
               platform: ARM64 Linux
-              build_os: ubuntu-22.04-8cores
+              build_os: ${{ vars.UBUNTU_LARGE_RUNNER || 'ubuntu-22.04' }}
               cross_deps: >
                 g++-aarch64-linux-gnu
               host: aarch64-linux-gnu


### PR DESCRIPTION
By using a variable to provide the larger runner configurations, we make it possible to both run CI jobs on forks, and ensure that we can fall back to the slower default runners if larger runners are not available.