### PR TITLE
Clarify NU5 pindex root assignments in ConnectBlock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3560,7 +3560,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         //   these set to null.
         if (consensusParams.NetworkUpgradeActive(pindex->nHeight, Consensus::UPGRADE_NU5)) {
             pindex->hashAuthDataRoot = hashAuthDataRoot.value();
-            pindex->hashFinalOrchardRoot = orchard_tree.root(),
+            pindex->hashFinalOrchardRoot = orchard_tree.root();
             pindex->hashChainHistoryRoot = hashChainHistoryRoot.value();
         }
     }


### PR DESCRIPTION
## Summary

In `ConnectBlock`, replace a comma-separated pair of assignments used under NU5 with two statements (semicolon). Behavior is unchanged; this only improves readability and matches common style.

## Notes

Trivial cleanup in consensus code path; no protocol change.