### PR TITLE
test: Regression test for Orchard identity-point rk/epk rejection

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -69,6 +69,7 @@ BASE_SCRIPTS= [
     'wallet_golden_5_6_0.py',
     'wallet_tarnished_5_6_0.py',
     # vv Tests less than 60s vv
+    'orchard_action_identity_point.py',
     'orchard_reorg.py',
     'fundrawtransaction.py',
     'reorg_limit.py',

--- a/qa/rpc-tests/orchard_action_identity_point.py
+++ b/qa/rpc-tests/orchard_action_identity_point.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#
+# Regression test for the Orchard identity-point bugs:
+#
+# 1. An Orchard action with rk encoding the Pallas identity point (all zeros)
+#    would cause a crash in proof verification. This is now rejected by
+#    CheckTransactionWithoutProofVerification before proofs are checked.
+#
+# 2. The Zcash protocol specification (section 5.4.9.4) requires that the
+#    ephemeral public key (epk) in each Orchard action encode a non-identity
+#    Pallas point. Zebra enforced this but zcashd did not, creating a potential
+#    consensus split. This is now also rejected by
+#    CheckTransactionWithoutProofVerification.
+#
+# The test creates a valid Orchard transaction, locates the rk and epk fields
+# by byte offset in the serialized v5 format (ZIP 225), zeroes them out, and
+# verifies that the modified transaction is rejected with the expected error.
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    NU5_BRANCH_ID, nuparams,
+    assert_equal, assert_raises_message,
+    bytes_to_hex_str, hex_str_to_bytes,
+    get_coinbase_address,
+    start_nodes, wait_and_assert_operationid_status,
+)
+from test_framework.zip317 import ZIP_317_FEE, conventional_fee
+
+from decimal import Decimal
+import struct
+
+# Per ZIP 225, each Orchard action is 820 bytes:
+#   cv(32) + nullifier(32) + rk(32) + cmx(32) + ephemeralKey(32) + encCiphertext(580) + outCiphertext(80)
+RK_OFFSET_IN_ACTION = 64     # cv(32) + nullifier(32)
+EPK_OFFSET_IN_ACTION = 128   # cv(32) + nullifier(32) + rk(32) + cmx(32)
+IDENTITY_BYTES = b'\x00' * 32
+
+
+def read_compact_size(data, pos):
+    """Read a Bitcoin CompactSize uint, returning (value, new_pos)."""
+    first = data[pos]
+    if first < 253:
+        return first, pos + 1
+    elif first == 253:
+        return struct.unpack_from('<H', data, pos + 1)[0], pos + 3
+    elif first == 254:
+        return struct.unpack_from('<I', data, pos + 1)[0], pos + 5
+    else:
+        return struct.unpack_from('<Q', data, pos + 1)[0], pos + 9
+
+def skip_empty_vector(tx, pos):
+    """Assert that a vector is empty and return new pos."""
+    n_vec, pos = read_compact_size(tx, pos)
+    assert_equal(n_vec, 0)
+    return pos
+
+def find_orchard_actions_offset(tx):
+    """
+    Parse a v5 Orchard-only transaction to find the byte offset of the
+    first Orchard action and the number of actions.
+    Returns (n_actions, first_action_offset).
+    """
+    # v5 header: nVersion(4) + nVersionGroupId(4) + nConsensusBranchId(4) +
+    #            nLockTime(4) + nExpiryHeight(4) = 20 bytes
+    pos = 20
+
+    # Skip four empty vectors (vin, vout, Sapling spends, Sapling outputs)
+    for _ in range(4):
+        pos = skip_empty_vector(tx, pos)
+
+    # Now at Orchard bundle
+    return read_compact_size(tx, pos)
+
+
+def tamper_field(tx, offset):
+    return tx[:offset] + IDENTITY_BYTES + tx[offset + 32:]
+
+def get_field(tx, offset):
+    return tx[offset:offset + 32]
+
+def rk_offset(action_offset): 
+    return action_offset + RK_OFFSET_IN_ACTION
+
+def epk_offset(action_offset):
+    return action_offset + EPK_OFFSET_IN_ACTION
+
+def tamper_rk(tx, action_offset):
+    """Set the rk field of an Orchard action to all zeros."""
+    return tamper_field(tx, rk_offset(action_offset))
+
+def tamper_epk(tx, action_offset):
+    """Set the epk field of an Orchard action to all zeros."""
+    return tamper_field(tx, epk_offset(action_offset))
+
+def get_rk(tx, action_offset):
+    return get_field(tx, rk_offset(action_offset))
+
+def get_epk(tx, action_offset):
+    return get_field(tx, epk_offset(action_offset))
+
+
+class OrchardActionIdentityPointTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 2
+
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[
+            nuparams(NU5_BRANCH_ID, 210),
+        ]] * self.num_nodes)
+
+    def run_test(self):
+        # Mine blocks to activate NU5 (at height 210)
+        assert_equal(self.nodes[0].getblockcount(), 200)
+        self.nodes[0].generate(10)
+        self.sync_all()
+
+        # Get an Orchard-only unified address on node 1
+        acct = self.nodes[1].z_getnewaccount()['account']
+        ua = self.nodes[1].z_getaddressforaccount(acct, ['orchard'])['address']
+
+        # Shield coinbase to the Orchard address.
+        # Send the full coinbase amount minus fee to avoid transparent change.
+        coinbase_addr = get_coinbase_address(self.nodes[0])
+        coinbase_fee = conventional_fee(3)
+        coinbase_amount = Decimal('10') - coinbase_fee
+        opid = self.nodes[0].z_sendmany(
+            coinbase_addr,
+            [{'address': ua, 'amount': coinbase_amount}],
+            1,
+            coinbase_fee,
+            'AllowRevealedSenders',
+        )
+        wait_and_assert_operationid_status(self.nodes[0], opid)
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # Create an Orchard-to-Orchard spend to get a transaction with
+        # Orchard actions that we can tamper with
+        acct2 = self.nodes[1].z_getnewaccount()['account']
+        ua2 = self.nodes[1].z_getaddressforaccount(acct2, ['orchard'])['address']
+        opid = self.nodes[1].z_sendmany(
+            ua,
+            [{'address': ua2, 'amount': Decimal('0.5')}],
+            1,
+            ZIP_317_FEE,
+        )
+        txid = wait_and_assert_operationid_status(self.nodes[1], opid)
+
+        # Get the raw transaction hex from the mempool
+        tx_untampered_hex = self.nodes[1].getrawtransaction(txid)
+        tx_untampered = hex_str_to_bytes(tx_untampered_hex)
+
+        # Parse the v5 format to locate the Orchard action fields by byte offset
+        n_actions, action_pos = find_orchard_actions_offset(tx_untampered)
+        assert n_actions > 0, "Transaction should have Orchard actions, got %d" % n_actions
+        print("Found %d Orchard action(s) starting at byte offset %d" % (n_actions, action_pos))
+
+        # Verify our parsing is correct by checking the rk and epk match decoderawtransaction
+        action_untampered_decoded = self.nodes[1].decoderawtransaction(tx_untampered_hex)['orchard']['actions'][0]
+        rk_untampered_decoded = hex_str_to_bytes(action_untampered_decoded['rk'])
+        epk_untampered_decoded = hex_str_to_bytes(action_untampered_decoded['ephemeralKey'])
+        assert_equal(get_rk(tx_untampered, action_pos), rk_untampered_decoded)
+        assert_equal(get_epk(tx_untampered, action_pos), epk_untampered_decoded)
+
+        # Test 1: Transaction with identity rk should be rejected
+        print("Testing identity rk rejection...")
+        tx_tamperedrk = tamper_rk(tx_untampered, action_pos)
+        tx_tamperedrk_hex = bytes_to_hex_str(tx_tamperedrk)
+
+        # Verify the tampered data has zeros at the rk position and decode it
+        rk_tamperedrk = get_rk(tx_tamperedrk, action_pos)
+        assert_equal(rk_tamperedrk, IDENTITY_BYTES, "rk was not zeroed")
+
+        # Decode the tampered tx to see if zcashd parses the zero rk
+        action_tamperedrk_decoded = self.nodes[0].decoderawtransaction(tx_tamperedrk_hex)['orchard']['actions'][0]
+        rk_tamperedrk_decoded = hex_str_to_bytes(action_tamperedrk_decoded['rk'])
+        assert_equal(rk_tamperedrk_decoded, IDENTITY_BYTES)
+
+        assert_raises_message(
+            JSONRPCException, "bad-orchard-action-identity-point",
+            self.nodes[0].sendrawtransaction, tx_tamperedrk_hex,
+        )
+        print("  PASS: identity rk correctly rejected")
+
+        # Test 2: Transaction with identity epk should be rejected
+        print("Testing identity epk rejection...")
+        tx_tamperedepk = tamper_epk(tx_untampered, action_pos)
+        tx_tamperedepk_hex = bytes_to_hex_str(tx_tamperedepk)
+
+        # Verify the tampered data has zeros at the epk position and decode it
+        epk_tamperedepk = get_epk(tx_tamperedepk, action_pos)
+        assert_equal(epk_tamperedepk, IDENTITY_BYTES, "epk was not zeroed")
+
+        # Decode the tampered tx to see if zcashd parses the zero epk
+        action_tamperedepk_decoded = self.nodes[0].decoderawtransaction(tx_tamperedepk_hex)['orchard']['actions'][0]
+        epk_tamperedepk_decoded = hex_str_to_bytes(action_tamperedepk_decoded['ephemeralKey'])
+        assert_equal(epk_tamperedepk_decoded, IDENTITY_BYTES)
+
+        assert_raises_message(
+            JSONRPCException, "bad-orchard-action-identity-point",
+            self.nodes[0].sendrawtransaction, tx_tamperedepk_hex,
+        )
+        print("  PASS: identity epk correctly rejected")
+
+        # Test 3: Both rk and epk set to identity should also be rejected
+        print("Testing identity rk+epk rejection...")
+        tx_tamperedboth = tamper_epk(tx_tamperedrk, action_pos)
+        assert_raises_message(
+            JSONRPCException, "bad-orchard-action-identity-point",
+            self.nodes[0].sendrawtransaction, bytes_to_hex_str(tx_tamperedboth),
+        )
+        print("  PASS: identity rk+epk correctly rejected")
+
+if __name__ == '__main__':
+    OrchardActionIdentityPointTest().main()


### PR DESCRIPTION
- Adds a regression test verifying that Orchard transactions with identity-point rk or epk are rejected by `CheckTransactionWithoutProofVerification` with `bad-orchard-action-identity-point`.
- The test constructs a valid Orchard-to-Orchard transaction, parses the v5 serialization (ZIP 225) to locate the rk and epk fields by byte offset, zeroes them out, and verifies rejection via `sendrawtransaction`.
- Cross-checks the byte-offset parser against `decoderawtransaction` output, and verifies the tampered bytes round-trip correctly through zcashd's deserializer (because they are rejected by consensus rules, not parsing rules).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>