### PR TITLE
fix(docker): modernize Dockerfile + fix CI workflow

### DIFF
--- a/.github/workflows/release-docker-hub.yaml
+++ b/.github/workflows/release-docker-hub.yaml
@@ -1,35 +1,62 @@
 name: Build and Push Docker Image to Docker Hub
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Zcash version (e.g. 6.12.1)'
+        required: true
+
+permissions:
+  contents: read
 
 jobs:
-  set_env:
-    name: Create version tag
+  docker:
     runs-on: ubuntu-latest
-    outputs:
-      tags: ${{ steps.version_step.outputs.tags }}
-      zcash_version: ${{ steps.version_step.outputs.zcash_version }}
     steps:
-    - id: version_step
-      run:  |
-        echo "tags=latest,${{ github.ref_name }},${{ github.sha }}" >> $GITHUB_OUTPUT
-        echo "zcash_version=$(echo ${{ github.ref_name }} | sed 's/v//g')" >> $GITHUB_OUTPUT
+    - name: Checkout
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-  build_push:
-    uses: zcash/.github/.github/workflows/build-and-push-docker-hub.yaml@main
-    needs: set_env
-    with:
-      image_name: zcashd
-      image_tags: ${{ needs.set_env.outputs.tags }}
-      dockerfile: ./contrib/docker/Dockerfile
-      context: ./contrib/docker/
-      build-args: |
-        ZCASH_VERSION=${{ needs.set_env.outputs.zcash_version }}
-    secrets:
-      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      dockerhub_registry: ${{ secrets.DOCKERHUB_REGISTRY }}
+    - name: Set version
+      id: version
+      run: |
+        VERSION="${{ inputs.version }}"
+        echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        echo "Building Docker image for zcash ${VERSION}"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+    - name: Log in to Docker Hub (zodlinc)
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      with:
+        username: ${{ secrets.ZODLINC_DOCKERHUB_USERNAME }}
+        password: ${{ secrets.ZODLINC_DOCKERHUB_PASSWORD }}
+
+    - name: Build and push to zodlinc
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+      with:
+        context: ./contrib/docker/
+        push: true
+        build-args: |
+          ZCASH_VERSION=${{ steps.version.outputs.version }}
+        tags: |
+          zodlinc/zcash:${{ steps.version.outputs.tag }}
+          zodlinc/zcash:latest
+
+    - name: Log in to Docker Hub (electriccoinco)
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Copy to electriccoinco
+      run: |
+        TAG="${{ steps.version.outputs.tag }}"
+        docker buildx imagetools create \
+          --tag electriccoinco/zcash:${TAG} \
+          zodlinc/zcash:${TAG}
+        docker buildx imagetools create \
+          --tag electriccoinco/zcash:latest \
+          zodlinc/zcash:latest

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,27 +1,29 @@
 FROM debian:12
 
 RUN apt-get update \
-  && apt-get install -y gnupg2 apt-transport-https curl
+  && apt-get install -y --no-install-recommends ca-certificates curl gnupg2 \
+  && rm -rf /var/lib/apt/lists/*
 
-ARG ZCASH_SIGNING_KEY_ID=1D05FDC66B372CFE
+RUN curl -fsSL https://apt.z.cash/zcash.asc \
+  | gpg --dearmor -o /usr/share/keyrings/zcash-keyring.gpg \
+  && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/zcash-keyring.gpg] https://apt.z.cash/ bookworm main" \
+     > /etc/apt/sources.list.d/zcash.list \
+  && apt-get update
 
 ARG ZCASH_VERSION=
 # The empty string for ZCASH_VERSION will install the apt default version,
 # which should be the latest stable release. To install a specific
 # version, pass `--build-arg 'ZCASH_VERSION=<version>'` to `docker build`.
 
-ARG ZCASHD_USER=zcashd
-ARG ZCASHD_UID=2001
-
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $ZCASH_SIGNING_KEY_ID \
-  && echo "deb [arch=amd64] https://apt.z.cash/ bookworm main" > /etc/apt/sources.list.d/zcash.list \
-  && apt-get update
-
 RUN if [ -z "$ZCASH_VERSION" ]; \
     then apt-get install -y zcash; \
     else apt-get install -y zcash=$ZCASH_VERSION; \
-    fi; \
-    zcashd --version
+    fi \
+  && zcashd --version \
+  && rm -rf /var/lib/apt/lists/*
+
+ARG ZCASHD_USER=zcashd
+ARG ZCASHD_UID=2001
 
 RUN useradd --home-dir "/srv/$ZCASHD_USER" \
             --shell /bin/bash \
@@ -36,5 +38,6 @@ RUN mkdir -p "/srv/$ZCASHD_USER/.zcash/" \
 WORKDIR "/srv/$ZCASHD_USER"
 ENV HOME="/srv/$ZCASHD_USER"
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary

Fixes the Docker CI pipeline which has been broken since v6.12.0 (`startup_failure` due to deprecated Node.js 12 in the `zcash/.github` reusable workflow).

## Changes

### Dockerfile (`contrib/docker/Dockerfile`)
- Replace deprecated `apt-key adv` with `signed-by` keyring from `apt.z.cash/zcash.asc` (contains both ECC and ZODL GPG keys for the ongoing key transition)
- Use `COPY` instead of `ADD` for entrypoint.sh
- Add explicit `chmod +x` for entrypoint.sh
- Clean apt lists between stages to reduce image size

### CI (`release-docker-hub.yaml`)
- Replace broken `zcash/.github` reusable workflow with inline Docker steps using current action versions (checkout v4, buildx v3, login v3, build-push v6)
- Add `zodlinc/zcash` as secondary Docker Hub destination (via `docker buildx imagetools create`)
- Requires new repo secrets: `ZODLINC_DOCKERHUB_USERNAME` and `ZODLINC_DOCKERHUB_PASSWORD` (already set)

## Test plan

- [ ] CI passes on this PR (Dockerfile builds successfully)
- [ ] After merge, trigger `workflow_dispatch` to verify push to both registries