### PR TITLE
ci: publish Docker image as both zcashd (canonical) and zcash (mirror)

### DIFF
--- a/.github/workflows/release-docker-hub.yaml
+++ b/.github/workflows/release-docker-hub.yaml
@@ -34,7 +34,7 @@ jobs:
         username: ${{ secrets.ZODLINC_DOCKERHUB_USERNAME }}
         password: ${{ secrets.ZODLINC_DOCKERHUB_PASSWORD }}
 
-    - name: Build and push to zodlinc
+    - name: Build and push to zodlinc (zcashd + zcash mirror)
       uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: ./contrib/docker/
@@ -42,6 +42,8 @@ jobs:
         build-args: |
           ZCASH_VERSION=${{ steps.version.outputs.version }}
         tags: |
+          zodlinc/zcashd:${{ steps.version.outputs.tag }}
+          zodlinc/zcashd:latest
           zodlinc/zcash:${{ steps.version.outputs.tag }}
           zodlinc/zcash:latest
 
@@ -51,12 +53,14 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-    - name: Copy to electriccoinco
+    - name: Copy to electriccoinco (zcashd + zcash mirror)
       run: |
         TAG="${{ steps.version.outputs.tag }}"
-        docker buildx imagetools create \
-          --tag electriccoinco/zcash:${TAG} \
-          zodlinc/zcash:${TAG}
-        docker buildx imagetools create \
-          --tag electriccoinco/zcash:latest \
-          zodlinc/zcash:latest
+        for NAME in zcashd zcash; do
+          docker buildx imagetools create \
+            --tag "electriccoinco/${NAME}:${TAG}" \
+            "zodlinc/zcashd:${TAG}"
+          docker buildx imagetools create \
+            --tag "electriccoinco/${NAME}:latest" \
+            "zodlinc/zcashd:latest"
+        done


### PR DESCRIPTION
## Summary

- Restore `zcashd` as the canonical image name on Docker Hub so the historical `electriccoinco/zcashd` timeline (v6.0.0 → v6.11.0) continues. The inline workflow introduced for v6.12.x published as `zcash` instead, which split the image history.
- Publish to four destinations from a single build: `zodlinc/zcashd`, `zodlinc/zcash`, `electriccoinco/zcashd`, `electriccoinco/zcash`. `zcashd` is the build target; `zcash` mirrors the same manifest via `docker buildx imagetools create` so the digests are bit-identical.
- No change to the Dockerfile or trigger (still `workflow_dispatch`).

The existing `v6.12.0` and `v6.12.1` tags have already been mirrored out-of-band on Docker Hub, so `electriccoinco/zcashd` and `zodlinc/zcashd` both currently have those tags. This PR ensures the *next* release follows the same scheme automatically.
