### PR TITLE
CI: Fix Docker release workflow path filters

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -19,7 +19,7 @@ on:
       - '.github/workflows/book.yml'
       - '.github/workflows/ci-skip.yml'
       - '.github/workflows/lints.yml'
-      - '.github/workflows/release-docker-hub.yml'
+      - '.github/workflows/release-docker-hub.yaml'
       # Documentation.
       - 'contrib/debian/copyright'
       - 'doc/**'
@@ -65,7 +65,7 @@ jobs:
               r'^\.github/workflows/book\.yml$',
               r'^\.github/workflows/ci-skip\.yml$',
               r'^\.github/workflows/lints\.yml$',
-              r'^\.github/workflows/release-docker-hub\.yml$',
+              r'^\.github/workflows/release-docker-hub\.yaml$',
               r'^contrib/debian/copyright$',
               r'^doc/.*',
               r'.*\.md$',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - '.github/workflows/book.yml'
       - '.github/workflows/ci-skip.yml'
       - '.github/workflows/lints.yml'
-      - '.github/workflows/release-docker-hub.yml'
+      - '.github/workflows/release-docker-hub.yaml'
       # Documentation.
       - 'contrib/debian/copyright'
       - 'doc/**'
@@ -29,7 +29,7 @@ on:
       - '.github/workflows/book.yml'
       - '.github/workflows/ci-skip.yml'
       - '.github/workflows/lints.yml'
-      - '.github/workflows/release-docker-hub.yml'
+      - '.github/workflows/release-docker-hub.yaml'
       # Documentation.
       - 'contrib/debian/copyright'
       - 'doc/**'


### PR DESCRIPTION
## Summary

Fixes the CI path filters for the Docker Hub release workflow. The workflow file is `.github/workflows/release-docker-hub.yaml`, but `ci.yml` and `ci-skip.yml` still referenced the old `.yml` name, so changes to the real workflow were not classified as CI-skippable.

## Changes

- Update the `ci.yml` pull request and push `paths-ignore` entries to use `.yaml`.
- Update `ci-skip.yml` and its no-CI regex to match the same `.yaml` path.