### PR TITLE
Fix `throw new` exception bugs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9211,7 +9211,7 @@ CMutableTransaction CreateNewContextualCMutableTransaction(
 
         // mtx.nExpiryHeight == 0 is valid for coinbase transactions
         if (mtx.nExpiryHeight <= 0 || mtx.nExpiryHeight >= TX_EXPIRY_HEIGHT_THRESHOLD) {
-            throw new std::runtime_error("CreateNewContextualCMutableTransaction: invalid expiry height");
+            throw std::runtime_error("CreateNewContextualCMutableTransaction: invalid expiry height");
         }
 
         // NOTE: If the expiry height crosses into an incompatible consensus epoch, and it is changed to the last block

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -179,25 +179,21 @@ public:
 
         // Empty output script.
         uint256 dataToBeSigned;
-        try {
-            if (mtx.fOverwintered) {
-                // ProduceShieldedSignatureHash is only usable with v3+ transactions.
-                dataToBeSigned = ProduceShieldedSignatureHash(
-                    consensusBranchId,
-                    mtx,
-                    {},
-                    *saplingBundle,
-                    orchardBundle);
-            } else {
-                CScript scriptCode;
-                PrecomputedTransactionData txdata(mtx, {});
-                dataToBeSigned = SignatureHash(
-                    scriptCode, mtx, NOT_AN_INPUT, SIGHASH_ALL, 0,
-                    consensusBranchId,
-                    txdata);
-            }
-        } catch (std::logic_error ex) {
-            throw ex;
+        if (mtx.fOverwintered) {
+            // ProduceShieldedSignatureHash is only usable with v3+ transactions.
+            dataToBeSigned = ProduceShieldedSignatureHash(
+                consensusBranchId,
+                mtx,
+                {},
+                *saplingBundle,
+                orchardBundle);
+        } else {
+            CScript scriptCode;
+            PrecomputedTransactionData txdata(mtx, {});
+            dataToBeSigned = SignatureHash(
+                scriptCode, mtx, NOT_AN_INPUT, SIGHASH_ALL, 0,
+                consensusBranchId,
+                txdata);
         }
 
         if (orchardBundle.has_value()) {
@@ -205,7 +201,7 @@ public:
             if (authorizedBundle.has_value()) {
                 mtx.orchardBundle = authorizedBundle.value();
             } else {
-                throw new std::runtime_error("Failed to create Orchard proof or signatures");
+                throw std::runtime_error("Failed to create Orchard proof or signatures");
             }
         }
 
@@ -244,7 +240,7 @@ public:
 
         auto bundle = builder.Build();
         if (!bundle.has_value()) {
-            throw new std::runtime_error("Failed to create shielded output for miner");
+            throw std::runtime_error("Failed to create shielded output for miner");
         }
 
         ComputeBindingSig(std::move(saplingBuilder), std::move(bundle));

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -245,7 +245,7 @@ private:
 void TransactionBuilder::SetExpiryHeight(uint32_t nExpiryHeight)
 {
     if (nExpiryHeight < nHeight || nExpiryHeight <= 0 || nExpiryHeight >= TX_EXPIRY_HEIGHT_THRESHOLD) {
-        throw new std::runtime_error("TransactionBuilder::SetExpiryHeight: invalid expiry height");
+        throw std::runtime_error("TransactionBuilder::SetExpiryHeight: invalid expiry height");
     }
     mtx.nExpiryHeight = nExpiryHeight;
 }

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -44,7 +44,7 @@ void pre_wallet_load()
 {
     LogPrintf("%s: In progress...\n", __func__);
     if (ShutdownRequested())
-        throw new std::runtime_error("The node is shutting down");
+        throw std::runtime_error("The node is shutting down");
 
     if (pwalletMain)
         pwalletMain->Flush(false);
@@ -557,7 +557,7 @@ public:
             case ORCHARD:
                 return orchardTrees[0].root();
             default:
-                throw new std::runtime_error("Unknown shielded type");
+                throw std::runtime_error("Unknown shielded type");
         }
     }
 
@@ -598,7 +598,7 @@ double benchmark_connectblock_slow()
     SelectParams(CBaseChainParams::MAIN);
     CBlock block;
     FILE* fp = fsbridge::fopen(GetDataDir() / "benchmark/block-107134.dat", "rb");
-    if (!fp) throw new std::runtime_error("Failed to open block data file");
+    if (!fp) throw std::runtime_error("Failed to open block data file");
     CAutoFile blkFile(fp, SER_DISK, CLIENT_VERSION);
     blkFile >> block;
     blkFile.fclose();
@@ -648,7 +648,7 @@ double benchmark_connectblock_sapling()
     SelectParams(CBaseChainParams::MAIN);
     CBlock block;
     FILE* fp = fsbridge::fopen(GetDataDir() / "benchmark/block-1723244.dat", "rb");
-    if (!fp) throw new std::runtime_error("Failed to open block data file");
+    if (!fp) throw std::runtime_error("Failed to open block data file");
     CAutoFile blkFile(fp, SER_DISK, CLIENT_VERSION);
     blkFile >> block;
     blkFile.fclose();
@@ -711,7 +711,7 @@ double benchmark_connectblock_orchard()
     SelectParams(CBaseChainParams::MAIN);
     CBlock block;
     FILE* fp = fsbridge::fopen(GetDataDir() / "benchmark/block-1708048.dat", "rb");
-    if (!fp) throw new std::runtime_error("Failed to open block data file");
+    if (!fp) throw std::runtime_error("Failed to open block data file");
     CAutoFile blkFile(fp, SER_DISK, CLIENT_VERSION);
     blkFile >> block;
     blkFile.fclose();


### PR DESCRIPTION
## Problem

Nine sites across the codebase reported errors via `throw new std::runtime_error(...)`. `throw new X` throws a **`std::runtime_error*`** (a heap-allocated pointer), not a `std::runtime_error`. Every handler up the stack catches by `const std::runtime_error&` / `const std::exception&`, none of which match a pointer — so each of these "exceptions" propagated uncaught to `std::terminate()` and leaked the allocation on the way out.

Effect by area:

- **`miner.cpp`** — Orchard proof/signing failure and shielded-coinbase build failure aborted the node instead of surfacing as a catchable `CreateNewBlock` error (which `getblocktemplate` and the test suite expect). These are not remotely triggerable: they sit in coinbase *construction*, building from the node's own configured/wallet-derived miner address and locally-computed reward values. A peer cannot supply or influence those inputs — received blocks and transactions go through the validation path, never block construction.
- **`main.cpp` / `transaction_builder.cpp`** — an invalid expiry height (`CreateNewContextualCMutableTransaction`, `TransactionBuilder::SetExpiryHeight`) aborted instead of being reported. These sit only on local transaction-construction paths (wallet, internal miner, async ops, RPC); they are not reachable from P2P message processing.
- **`zcbenchmarks.cpp`** — five benchmark error sites.

## Changes

- Throw by value (`throw std::runtime_error(...)`) at all nine sites.
- Remove a pointless `try`/`catch (std::logic_error ex) { throw ex; }` in `miner.cpp::ComputeBindingSig` — it only caught by value (slicing) and re-threw with `throw ex;` (slicing again, resetting the exception), equivalent to not catching at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)