### PR TITLE
wallet: Use anchor depth for migration note selection

### DIFF
--- a/src/wallet/asyncrpcoperation_saplingmigration.cpp
+++ b/src/wallet/asyncrpcoperation_saplingmigration.cpp
@@ -85,10 +85,11 @@ bool AsyncRPCOperation_saplingmigration::main_impl() {
     std::vector<OrchardNoteMetadata> orchardEntries;
     {
         LOCK2(cs_main, pwalletMain->cs_wallet);
-        // We set minDepth to 11 to avoid unconfirmed notes and in anticipation of specifying
-        // an anchor at height N-10 for each Sprout JoinSplit description
+        // Select notes that are already in the anchor used for each Sprout
+        // JoinSplit description.
         // Consider, should notes be sorted?
-        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, orchardEntries, std::nullopt, std::nullopt, 11);
+        const int minDepth = static_cast<int>(nAnchorConfirmations) + 1;
+        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, orchardEntries, std::nullopt, std::nullopt, minDepth);
     }
     CAmount availableFunds = 0;
     for (const SproutNoteEntry& sproutEntry : sproutEntries) {


### PR DESCRIPTION
The Sprout-to-Sapling migration now selects Sprout notes using the configured anchor depth instead of the historical fixed 11-confirmation threshold.

The fixed value matched the old N-10 anchor selection, but migration witness selection now uses `-anchorconfirmations`. This keeps the selected notes old enough to be present in the Sprout anchor while allowing operators' configured anchor depth to affect migration behavior consistently.