### PR TITLE
build: fix gitian build against clang 22 + glibc 2.34

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -376,7 +376,7 @@ DISABLED_WARNING_CXXFLAGS="\
   -Wno-unused-but-set-variable -Wno-unused-exception-parameter -Wno-unused-function \
   -Wno-unused-macros -Wno-unused-member-function -Wno-unused-parameter -Wno-unused-private-field \
   -Wno-unused-template -Wno-unused-variable -Wno-used-but-marked-unused -Wno-weak-vtables \
-  -Wno-zero-as-null-pointer-constant"
+  -Wno-zero-as-null-pointer-constant -Wno-unique-object-duplication"
 
 # These are sub-flags of those in `DISABLED_WARNING_CXXFLAGS` that allow us to temporarily
 # re-enable pieces until the disabling flags are removed.

--- a/contrib/gitian-descriptors/gitian-linux-parallel.yml
+++ b/contrib/gitian-descriptors/gitian-linux-parallel.yml
@@ -122,6 +122,7 @@ script: |
     tar --strip-components=1 -xf ../$SOURCEDIST
 
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}"
+    mkdir -p src/obj # Pre-create -I./obj dir for clang 22 -Werror -Wmissing-include-dirs (avoids race with genbuild.sh)
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security
     make install DESTDIR=${INSTALLPATH}

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -122,6 +122,7 @@ script: |
     tar --strip-components=1 -xf ../$SOURCEDIST
 
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}"
+    mkdir -p src/obj # Pre-create -I./obj dir for clang 22 -Werror -Wmissing-include-dirs (avoids race with genbuild.sh)
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security
     make install DESTDIR=${INSTALLPATH}

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -4,7 +4,7 @@ $(package)_download_path=https://download.oracle.com/berkeley-db
 $(package)_file_name=db-$($(package)_version).tar.gz
 $(package)_sha256_hash=47612c8991aa9ac2f6be721267c8d3cdccf5ac83105df8e50809daea24e95dc7
 $(package)_build_subdir=build_unix
-$(package)_patches=clang-12-stpcpy-issue.diff winioctl-and-atomic_init_db.patch
+$(package)_patches=clang-12-stpcpy-issue.diff winioctl-and-atomic_init_db.patch pthread_yield_fix.patch
 
 ifneq ($(host_os),darwin)
 $(package)_dependencies=libcxx
@@ -33,7 +33,8 @@ endef
 
 define $(package)_preprocess_cmds
   patch -p1 <$($(package)_patch_dir)/clang-12-stpcpy-issue.diff && \
-  patch -p1 <$($(package)_patch_dir)/winioctl-and-atomic_init_db.patch
+  patch -p1 <$($(package)_patch_dir)/winioctl-and-atomic_init_db.patch && \
+  patch -p1 <$($(package)_patch_dir)/pthread_yield_fix.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/bdb/pthread_yield_fix.patch
+++ b/depends/patches/bdb/pthread_yield_fix.patch
@@ -1,0 +1,17 @@
+--- a/src/os/os_yield.c
++++ b/src/os/os_yield.c
+@@ -49,8 +49,12 @@
+ 	else {
+ #if defined(HAVE_MUTEX_UI_THREADS)
+ 		thr_yield();
+-#elif defined(HAVE_PTHREAD_YIELD)
+-		pthread_yield();
++		/*
++		 * The HAVE_PTHREAD_YIELD branch was removed here: glibc 2.34+
++		 * dropped the nonstandard pthread_yield() symbol, breaking the
++		 * final link.  sched_yield() (POSIX, below) covers the same
++		 * platforms.
++		 */
+ #elif defined(HAVE_SCHED_YIELD)
+ 		(void)sched_yield();
+ #elif defined(HAVE_YIELD)


### PR DESCRIPTION
Three independent issues prevent reproducible gitian builds against the LLVM 22.1.2 toolchain pinned in depends/native_clang on bookworm hosts.

1. depends/packages/bdb.mk BDB 6.2.23's src/os/os_yield.c calls pthread_yield(), which glibc 2.34+ removed as an unversioned symbol. Final link fails with undefined symbol: pthread_yield. Fix: add depends/patches/bdb/pthread_yield_fix.patch to replace sched_yield.

2. contrib/gitian-descriptors/gitian-linux{,-parallel}.yml src/Makefile.am has -Werror -Wmissing-include-dirs and BITCOIN_INCLUDES=-I$(builddir)/obj. obj/ holds the genbuild.sh- generated build.h, but with parallel make the libbitcoin_server compilations start before genbuild creates the directory; clang 22 then errors on the missing -I./obj. Pre-create src/obj/ between ./configure and make in the distsrc loop to make this race deterministic.

3. configure.ac clang 22 promoted -Wunique-object-duplication to default-on. With -fvisibility=hidden + -Werror, this fires fatally on Meyer-singleton statics in src/util/time.h, src/support/lockedpool.h, src/addrman.h, src/chain.h, src/mempool_limit.h. Since zcashd ships as a static binary the duplication risk is moot here. Add the warning to DISABLED_WARNING_CXXFLAGS rather than carving out individual declarations.

bdb: ship pthread_yield fix as a static patch file

Per review feedback (kris): use the same patch -p1 mechanism as the other two BDB patches instead of an inline sed in preprocess_cmds. The patch replaces the pthread_yield() call with sched_yield() in src/os/os_yield.c, which is what the existing HAVE_SCHED_YIELD branch uses anyway.