### PR TITLE
qa: Guard BuildOrchardSpend test-helper calls with ASSERT_NO_FATAL_FAILURE

### DIFF
--- a/src/wallet/gtest/test_orchard_wallet.cpp
+++ b/src/wallet/gtest/test_orchard_wallet.cpp
@@ -78,6 +78,10 @@ TEST(OrchardWalletTests, TxInvolvesMyNotes) {
 // Builds a fresh Orchard-spending transaction under the currently-active consensus
 // parameters, so that its consensus branch id matches the active epoch (allowing the
 // same flow to be exercised under both NU5 and NU6.1).
+//
+// Uses `ASSERT_*` internally (which expand to conditional `return;`, returning only from this
+// helper, not the calling test); so callers must invoke it via `ASSERT_NO_FATAL_FAILURE(...)`
+// for a failed assumption to abort the test rather than continue with an unset `outTx`.
 void BuildOrchardSpend(CTransaction& outTx) {
     OrchardWallet wallet;
     auto sk = RandomOrchardSpendingKey();
@@ -147,8 +151,9 @@ void BuildOrchardSpend(CTransaction& outTx) {
 // in the 3-byte CompactSize form, and incrementing it by one cannot change that encoding's
 // width, so the field can be rewritten in place and one byte inserted into the proof.
 //
-// Uses an out-parameter rather than a return value so that the ASSERT_* macros (which expand
-// to `return;`) can be used to abort the test on a malformed assumption.
+// Uses `ASSERT_*` internally (which expand to conditional `return;`, returning only from this
+// helper, not the calling test); so callers must invoke it via `ASSERT_NO_FATAL_FAILURE(...)`
+// for a failed assumption to abort the test rather than continue with an unset `outBytes`.
 void MakeOrchardProofNonCanonicalBytes(const CTransaction& tx, std::vector<unsigned char>& outBytes) {
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss << tx;
@@ -215,7 +220,7 @@ TEST(TransactionBuilder, OrchardToOrchardNU5) {
     // Under NU5, the Orchard-spending transaction is accepted.
     auto consensusParams = RegtestActivateNU5();
     CTransaction tx;
-    BuildOrchardSpend(tx);
+    ASSERT_NO_FATAL_FAILURE(BuildOrchardSpend(tx));
 
     {
         CValidationState state;
@@ -233,7 +238,7 @@ TEST(TransactionBuilder, OrchardToOrchardNU6point1) {
     // build a fresh (NU6.1) Orchard-spending transaction.
     auto consensusParams = RegtestActivateNU6point1(false, 1, 2);
     CTransaction tx;
-    BuildOrchardSpend(tx);
+    ASSERT_NO_FATAL_FAILURE(BuildOrchardSpend(tx));
 
     // Before the soft-fork height the spend is still accepted...
     {
@@ -260,7 +265,7 @@ TEST(TransactionBuilder, OrchardToOrchardNU6point2) {
     // at the heights under test.
     auto consensusParams = RegtestActivateNU6point2(false, 1);
     CTransaction tx;
-    BuildOrchardSpend(tx);
+    ASSERT_NO_FATAL_FAILURE(BuildOrchardSpend(tx));
 
     // A canonical-proof Orchard transaction is accepted under NU6.2.
     {
@@ -282,7 +287,7 @@ TEST(TransactionBuilder, OrchardNonCanonicalProofSizeRejectedFromNU6point2) {
 
     auto consensusParams = RegtestActivateNU6point2(false, 1);
     CTransaction tx;
-    BuildOrchardSpend(tx);
+    ASSERT_NO_FATAL_FAILURE(BuildOrchardSpend(tx));
 
     // The unmodified (canonical-proof) NU6.2 transaction deserializes.
     {
@@ -311,7 +316,7 @@ TEST(TransactionBuilder, OrchardNonCanonicalProofSizeAllowedBeforeNU6point2) {
 
     auto consensusParams = RegtestActivateNU6point2(false, 1);
     CTransaction tx;
-    BuildOrchardSpend(tx);
+    ASSERT_NO_FATAL_FAILURE(BuildOrchardSpend(tx));
 
     std::vector<unsigned char> tampered;
     ASSERT_NO_FATAL_FAILURE(MakeOrchardProofNonCanonicalBytes(tx, tampered));


### PR DESCRIPTION
Closes #7182.

The `BuildOrchardSpend` and `MakeOrchardProofNonCanonicalBytes` helpers in `src/wallet/gtest/test_orchard_wallet.cpp` use `ASSERT_*` internally. A googletest `ASSERT_*` in a void subroutine expands to a conditional `return;` —it returns only from the *helper*, not from the calling test— so a failed assumption is registered but the test keeps executing. `BuildOrchardSpend`'s five call sites invoked it **unguarded**, so a violated assumption (e.g. after a future code or dependency change) would leave the caller's `CTransaction` default-constructed and let the test continue against an empty/invalid transaction: a confusing failure cascade or undefined behaviour, rather than a clean abort at the real cause.

In practice all of these assumptions currently hold, so the tests pass — this is a latent robustness/debuggability fix, not a fix for a currently-failing test.

This change:

- wraps all five `BuildOrchardSpend(tx)` calls in `ASSERT_NO_FATAL_FAILURE(...)`, matching what `MakeOrchardProofNonCanonicalBytes`'s call sites already do;
- corrects the `MakeOrchardProofNonCanonicalBytes` comment, which claimed the out-parameter + `return;` pattern aborts the test (it does not; the abort comes from the caller's `ASSERT_NO_FATAL_FAILURE`); and
- documents the call-site requirement on `BuildOrchardSpend`.

Tested locally; the `TransactionBuilder.Orchard*` and `OrchardWalletTests.*` gtests pass.

🤖 Claude Opus 4.8 (1M context)
