### PR TITLE
Improve robustness of Orchard note commitment tree consistency checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "bridgetree"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3990cc973c3b9c41c4dbb66cde22e3af77c4c7b133008d81f292ad12c27ed794"
+checksum = "3d74f010107ed76a581e5c348f27bdf47b8e6286c667d3ae5be473bd07bfc22f"
 dependencies = [
  "incrementalmerkletree",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ bip0039 = { version = "0.12", features = ["std", "all-languages"] }
 blake2b_simd = "1"
 blake2s_simd = "1"
 bls12_381 = "0.8"
-bridgetree = "0.7"
+bridgetree = "0.7.1"
 byteorder = "1"
 crossbeam-channel = "0.5"
 getrandom = "0.3"

--- a/qa/rpc-tests/p2p_duplicate_block_clobbers_chain_value.py
+++ b/qa/rpc-tests/p2p_duplicate_block_clobbers_chain_value.py
@@ -182,8 +182,22 @@ class DuplicateBlockClobbersChainValueTest(BitcoinTestFramework):
         assert_equal(node.getblockcount(), 200)
 
         # Activate NU5 (which enables Orchard) by mining past height 210.
+        txcount_before = node.getwalletinfo()['txcount']
         node.generate(11)
         assert_equal(node.getblockcount(), 211)
+
+        # The wallet updates its Orchard note commitment tree on the asynchronous
+        # ThreadNotifyWallets thread, so it can lag the chain tip after a burst of
+        # blocks (neither `generate` nor a p2p ping waits for it). Poll until the
+        # wallet has processed the 11 new blocks (each adds its coinbase to the
+        # wallet in the same step that extends the Orchard tree) before spending
+        # against an anchor behind the tip.
+        for _ in range(120):
+            if node.getwalletinfo()['txcount'] >= txcount_before + 11:
+                break
+            time.sleep(0.25)
+        else:
+            raise AssertionError("wallet did not finish processing the generated blocks")
 
         # Mine an Orchard shielding transaction so we have a block with
         # non-zero per-block Orchard delta. We use Orchard rather than

--- a/src/gtest/test_deprecation.cpp
+++ b/src/gtest/test_deprecation.cpp
@@ -5,6 +5,7 @@
 #include "clientversion.h"
 #include "deprecation.h"
 #include "fs.h"
+#include "gtest/utils.h"
 #include "init.h"
 #include "ui_interface.h"
 #include "util/system.h"
@@ -16,34 +17,17 @@ using namespace boost::placeholders;
 using ::testing::StrictMock;
 
 static const std::string CLIENT_VERSION_STR = FormatVersion(CLIENT_VERSION);
-extern std::atomic<bool> fRequestShutdown;
-
-class MockUIInterface {
-public:
-    MOCK_METHOD3(ThreadSafeMessageBox, bool(const std::string& message,
-                                      const std::string& caption,
-                                      unsigned int style));
-};
-
-static bool ThreadSafeMessageBox(MockUIInterface *mock,
-                                 const std::string& message,
-                                 const std::string& caption,
-                                 unsigned int style)
-{
-    return mock->ThreadSafeMessageBox(message, caption, style);
-}
 
 class DeprecationTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        uiInterface.ThreadSafeMessageBox.disconnect_all_slots();
-        uiInterface.ThreadSafeMessageBox.connect(boost::bind(ThreadSafeMessageBox, &mock_, _1, _2, _3));
+        ConnectMockUIInterface(mock_);
         SelectParams(CBaseChainParams::MAIN);
 
     }
 
     void TearDown() override {
-        fRequestShutdown = false;
+        DisconnectMockUIInterface();
         mapArgs.clear();
     }
 

--- a/src/gtest/utils.cpp
+++ b/src/gtest/utils.cpp
@@ -1,5 +1,8 @@
 #include "gtest/utils.h"
 #include "rpc/server.h"
+#include "ui_interface.h"
+
+#include <atomic>
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
 #endif
@@ -17,6 +20,24 @@ int GenZero(int n)
 int GenMax(int n)
 {
     return n-1;
+}
+
+void ConnectMockUIInterface(MockUIInterface& mock)
+{
+    uiInterface.ThreadSafeMessageBox.disconnect_all_slots();
+    uiInterface.ThreadSafeMessageBox.connect(
+        [&mock](const std::string& message, const std::string& caption, unsigned int style) {
+            return mock.ThreadSafeMessageBox(message, caption, style);
+        });
+}
+
+// Defined in init.cpp.
+extern std::atomic<bool> fRequestShutdown;
+
+void DisconnectMockUIInterface()
+{
+    uiInterface.ThreadSafeMessageBox.disconnect_all_slots();
+    fRequestShutdown = false;
 }
 
 void LoadProofParameters() {

--- a/src/gtest/utils.h
+++ b/src/gtest/utils.h
@@ -5,11 +5,37 @@
 #include "util/system.h"
 #include "key_io.h"
 
+#include <gmock/gmock.h>
+
 int GenZero(int n);
 int GenMax(int n);
 void LoadProofParameters();
 void LoadGlobalWallet();
 void UnloadGlobalWallet();
+
+// A mock for uiInterface.ThreadSafeMessageBox, for tests of code that notifies the
+// user via that signal (e.g. a divergence-triggered shutdown or end-of-service
+// halt). The gtest harness connects no slot, so without one the signals2 combiner
+// throws on zero slots; ConnectMockUIInterface connects this mock.
+class MockUIInterface {
+public:
+    MOCK_METHOD3(ThreadSafeMessageBox, bool(const std::string& message,
+                                            const std::string& caption,
+                                            unsigned int style));
+};
+
+// Replace any slots on uiInterface.ThreadSafeMessageBox with one forwarding to `mock`.
+// `mock` must outlive the connection; pair with DisconnectMockUIInterface, which must
+// be called before `mock` is destroyed.
+void ConnectMockUIInterface(MockUIInterface& mock);
+
+// Teardown counterpart to ConnectMockUIInterface for tests of code that may request a
+// shutdown: disconnect all slots from uiInterface.ThreadSafeMessageBox and clear any
+// shutdown the test requested (StartShutdown sets fRequestShutdown, which has no
+// production reset). Clearing the flag needs no synchronization: in the gtest process
+// nothing consumes it (the node main loop and wallet notification thread are not
+// running), so there is no concurrent observer.
+void DisconnectMockUIInterface();
 
 template<typename Tree> void AppendRandomLeaf(Tree &tree);
 

--- a/src/wallet/gtest/test_orchard_wallet.cpp
+++ b/src/wallet/gtest/test_orchard_wallet.cpp
@@ -99,6 +99,12 @@ TEST(OrchardWalletTests, SpendResolvesAnchorByAbsoluteHeight) {
     ASSERT_EQ(notes.size(), 1);
 
     // Connect the note's block at height 2 and capture the anchor at that height.
+    // This mirrors the production convention (CWallet::IncrementNoteWitnesses
+    // checkpoints height H *before* appending block H's commitments), under which
+    // the checkpoint identified by H records the tree state at the *end of block
+    // H-1*. So the checkpoint we create as "2" here records the pre-block-2 (empty)
+    // state, and the end-of-block-2 anchor is the current frontier root captured
+    // after the append below.
     CBlock block2;
     block2.vtx.resize(2);
     block2.vtx[1] = txRecv;
@@ -117,9 +123,11 @@ TEST(OrchardWalletTests, SpendResolvesAnchorByAbsoluteHeight) {
     }
     ASSERT_EQ(wallet.GetLastCheckpointHeight().value(), 7);
 
-    // The tip's anchor now differs from the anchor at height 2, so the spend can only
-    // succeed if GetSpendInfo resolves by absolute height (depth = 7 - 2 = 5) rather
-    // than against the latest checkpoint.
+    // The tip's anchor now differs from the end-of-block-2 anchor, so the spend can
+    // only succeed if GetSpendInfo resolves by absolute height: it computes
+    // depth = lastCheckpointHeight - anchorHeight = 7 - 2 = 5, which resolves to
+    // checkpoint id 3 — the checkpoint created before block 3, recording the
+    // end-of-block-2 state — rather than against the latest checkpoint.
     ASSERT_NE(wallet.GetLatestAnchor(), anchorAtHeight2);
     auto spendInfo = wallet.GetSpendInfo(notes, anchorAtHeight2, 2);
     ASSERT_EQ(spendInfo.size(), 1);
@@ -158,9 +166,11 @@ void BuildOrchardSpend(CTransaction& outTx) {
         notes, sk.ToFullViewingKey().ToIncomingViewingKey(), true, true);
     ASSERT_EQ(notes.size(), 1);
 
-    // Checkpoint the tree at height 2 (the height of the block whose commitments
-    // are appended below). GetSpendInfo addresses the wallet's tree by absolute
-    // height (#7150), so it needs a checkpoint to resolve the anchor against.
+    // Checkpoint at height 2 before appending block 2's commitments, as in
+    // production (CWallet::IncrementNoteWitnesses): the checkpoint identified by H
+    // is created before block H and records the end-of-block-(H-1) state.
+    // GetSpendInfo addresses the wallet's tree by absolute height (#7150), so a
+    // checkpoint must exist for GetLastCheckpointHeight() to resolve against.
     ASSERT_TRUE(wallet.CheckpointNoteCommitmentTree(2));
 
     // If we attempt to get spend info now, it will fail because the note hasn't

--- a/src/wallet/gtest/test_orchard_wallet.cpp
+++ b/src/wallet/gtest/test_orchard_wallet.cpp
@@ -75,6 +75,59 @@ TEST(OrchardWalletTests, TxInvolvesMyNotes) {
     RegtestDeactivateNU5();
 }
 
+// Regression test for #7150. GetSpendInfo resolves the spend against the anchor at
+// its absolute height, so it must still succeed when the wallet's latest checkpoint
+// has advanced past that height — e.g. a block connecting between anchor selection
+// and spend construction. Before the #7150 fix, GetSpendInfo derived the checkpoint
+// depth from a fixed confirmation count relative to the latest checkpoint, so an
+// advanced tip made it read the wrong checkpoint and spuriously fail even though the
+// wallet's tree had not diverged.
+TEST(OrchardWalletTests, SpendResolvesAnchorByAbsoluteHeight) {
+    auto consensusParams = RegtestActivateNU5();
+    OrchardWallet wallet;
+
+    // Receive a note into the wallet.
+    auto sk = RandomOrchardSpendingKey();
+    wallet.AddSpendingKey(sk);
+    libzcash::diversifier_index_t j(0);
+    auto txRecv = FakeOrchardTx(sk, j);
+    wallet.AddNotesIfInvolvingMe(txRecv);
+
+    std::vector<OrchardNoteMetadata> notes;
+    wallet.GetFilteredNotes(
+        notes, sk.ToFullViewingKey().ToIncomingViewingKey(), true, true);
+    ASSERT_EQ(notes.size(), 1);
+
+    // Connect the note's block at height 2 and capture the anchor at that height.
+    CBlock block2;
+    block2.vtx.resize(2);
+    block2.vtx[1] = txRecv;
+    ASSERT_TRUE(wallet.CheckpointNoteCommitmentTree(2));
+    ASSERT_TRUE(wallet.AppendNoteCommitments(2, block2));
+    uint256 anchorAtHeight2 = wallet.GetLatestAnchor();
+
+    // Connect several further blocks, each adding an unrelated Orchard commitment so
+    // the tree root changes and the latest checkpoint moves well past height 2.
+    for (int h = 3; h <= 7; h++) {
+        CBlock block;
+        block.vtx.resize(2);
+        block.vtx[1] = FakeOrchardTx(RandomOrchardSpendingKey(), j);
+        ASSERT_TRUE(wallet.CheckpointNoteCommitmentTree(h));
+        ASSERT_TRUE(wallet.AppendNoteCommitments(h, block));
+    }
+    ASSERT_EQ(wallet.GetLastCheckpointHeight().value(), 7);
+
+    // The tip's anchor now differs from the anchor at height 2, so the spend can only
+    // succeed if GetSpendInfo resolves by absolute height (depth = 7 - 2 = 5) rather
+    // than against the latest checkpoint.
+    ASSERT_NE(wallet.GetLatestAnchor(), anchorAtHeight2);
+    auto spendInfo = wallet.GetSpendInfo(notes, anchorAtHeight2, 2);
+    ASSERT_EQ(spendInfo.size(), 1);
+    EXPECT_EQ(spendInfo[0].second.Value(), 40000);
+
+    RegtestDeactivateNU5();
+}
+
 // Builds a fresh Orchard-spending transaction under the currently-active consensus
 // parameters, so that its consensus branch id matches the active epoch (allowing the
 // same flow to be exercised under both NU5 and NU6.1).
@@ -105,9 +158,14 @@ void BuildOrchardSpend(CTransaction& outTx) {
         notes, sk.ToFullViewingKey().ToIncomingViewingKey(), true, true);
     ASSERT_EQ(notes.size(), 1);
 
+    // Checkpoint the tree at height 2 (the height of the block whose commitments
+    // are appended below). GetSpendInfo addresses the wallet's tree by absolute
+    // height (#7150), so it needs a checkpoint to resolve the anchor against.
+    ASSERT_TRUE(wallet.CheckpointNoteCommitmentTree(2));
+
     // If we attempt to get spend info now, it will fail because the note hasn't
     // been witnessed in the Orchard commitment tree.
-    ASSERT_THROW(wallet.GetSpendInfo(notes, 1, wallet.GetLatestAnchor()), std::logic_error);
+    ASSERT_THROW(wallet.GetSpendInfo(notes, wallet.GetLatestAnchor(), 2), std::logic_error);
 
     // Append the bundle to the wallet's commitment tree.
     CBlock fakeBlock;
@@ -116,7 +174,7 @@ void BuildOrchardSpend(CTransaction& outTx) {
     ASSERT_TRUE(wallet.AppendNoteCommitments(2, fakeBlock));
 
     // Now we can get spend info for the note.
-    auto spendInfo = wallet.GetSpendInfo(notes, 1, wallet.GetLatestAnchor());
+    auto spendInfo = wallet.GetSpendInfo(notes, wallet.GetLatestAnchor(), 2);
     ASSERT_EQ(spendInfo[0].second.Value(), 40000);
 
     // Get the root of the commitment tree.

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -61,9 +61,11 @@ public:
                                 const CBlockIndex* pindex,
                                 const CBlock* pblock,
                                 MerkleFrontiers& frontiers,
-                                bool performOrchardWalletUpdates) {
+                                bool performOrchardWalletUpdates,
+                                bool performConsistencyCheck) {
         CWallet::IncrementNoteWitnesses(
-                consensus, pindex, pblock, frontiers, performOrchardWalletUpdates);
+                consensus, pindex, pblock, frontiers, performOrchardWalletUpdates,
+                performConsistencyCheck);
     }
 
 
@@ -109,7 +111,7 @@ static std::pair<JSOutPoint, SaplingOutPoint> CreateValidBlock(TestWallet& walle
     wallet.LoadWalletTx(wtx);
 
     block.vtx.push_back(wtx);
-    wallet.IncrementNoteWitnesses(Params().GetConsensus(), &index, &block, frontiers, true);
+    wallet.IncrementNoteWitnesses(Params().GetConsensus(), &index, &block, frontiers, true, false);
 
     return std::make_pair(jsoutpt, saplingNotes[0]);
 }
@@ -739,7 +741,7 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
         wallet.LoadWalletTx(wtx);
 
         // Simulate receiving new block and ChainTip signal
-        wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true);
+        wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true, false);
         wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
 
         // Retrieve the updated wtx from wallet
@@ -861,8 +863,10 @@ TEST(WalletTests, GetConflictedOrchardNotes) {
     wtx.SetMerkleBranch(block);
     wallet.LoadWalletTx(wtx);
 
-    // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true);
+    // Simulate receiving a new block and ChainTip signal at the chain tip, exercising
+    // the Orchard consistency check (performConsistencyCheck = true). This block's
+    // hashFinalOrchardRoot was set consistently above, so the check passes.
+    wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true, true);
 
     // Fetch the Orchard note so we can spend it.
     std::vector<SproutNoteEntry> sproutEntries;
@@ -1139,7 +1143,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     }
 
     // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true);
+    wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true, false);
     wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet
@@ -1258,7 +1262,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
         // Simulate receiving new block and ChainTip signal.
         // This triggers calculation of nullifiers for notes belonging to this wallet
         // in the output descriptions of wtx.
-        wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true);
+        wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true, false);
         wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
 
         // Retrieve the updated wtx from wallet
@@ -1385,7 +1389,7 @@ TEST(WalletTests, CachedWitnessesEmptyChain) {
     CBlockIndex index(block);
     MerkleFrontiers frontiers;
     const auto& params = Params().GetConsensus();
-    wallet.IncrementNoteWitnesses(params, &index, &block, frontiers, true);
+    wallet.IncrementNoteWitnesses(params, &index, &block, frontiers, true, false);
 
     // this death will occur because there will not be sufficient Sprout witnesses to reach the
     // default anchor depth
@@ -1397,7 +1401,7 @@ TEST(WalletTests, CachedWitnessesEmptyChain) {
         CBlock another_block;
         CBlockIndex another_index(another_block);
         another_index.nHeight = 1;
-        wallet.IncrementNoteWitnesses(params, &another_index, &another_block, frontiers, true);
+        wallet.IncrementNoteWitnesses(params, &another_index, &another_block, frontiers, true, false);
     }
 
     EXPECT_DEATH(::GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, nAnchorConfirmations, sproutWitnesses, saplingWitnesses),
@@ -1407,13 +1411,13 @@ TEST(WalletTests, CachedWitnessesEmptyChain) {
         CBlock another_block;
         CBlockIndex another_index(another_block);
         another_index.nHeight = i;
-        wallet.IncrementNoteWitnesses(params, &another_index, &another_block, frontiers, true);
+        wallet.IncrementNoteWitnesses(params, &another_index, &another_block, frontiers, true, false);
     }
 
     CBlock last_block;
     CBlockIndex last_index(last_block);
     last_index.nHeight = 9;
-    wallet.IncrementNoteWitnesses(params, &last_index, &last_block, frontiers, true);
+    wallet.IncrementNoteWitnesses(params, &last_index, &last_block, frontiers, true, false);
 
     ::GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, nAnchorConfirmations, sproutWitnesses, saplingWitnesses);
 
@@ -1495,7 +1499,7 @@ TEST(WalletTests, CachedWitnessesChainTip) {
             .sapling = frontiers.sapling,
             .orchard = frontiers.orchard,
         };
-        wallet.IncrementNoteWitnesses(Params().GetConsensus(), &index2, &block2, frontiers2, true);
+        wallet.IncrementNoteWitnesses(Params().GetConsensus(), &index2, &block2, frontiers2, true, false);
 
         auto anchors2 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, 1, sproutWitnesses, saplingWitnesses);
         EXPECT_NE(anchors2.first, anchors2.second);
@@ -1516,7 +1520,7 @@ TEST(WalletTests, CachedWitnessesChainTip) {
         EXPECT_NE(anchors1.second, anchors3.second);
 
         // Re-incrementing with the same block should give the same result
-        wallet.IncrementNoteWitnesses(Params().GetConsensus(), &index2, &block2, frontiers, true);
+        wallet.IncrementNoteWitnesses(Params().GetConsensus(), &index2, &block2, frontiers, true, false);
         auto anchors4 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, 1, sproutWitnesses, saplingWitnesses);
         EXPECT_NE(anchors4.first, anchors4.second);
 
@@ -1526,7 +1530,7 @@ TEST(WalletTests, CachedWitnessesChainTip) {
         EXPECT_EQ(anchors2.second, anchors4.second);
 
         // Incrementing with the same block again should not change the cache
-        wallet.IncrementNoteWitnesses(Params().GetConsensus(), &index2, &block2, frontiers, true);
+        wallet.IncrementNoteWitnesses(Params().GetConsensus(), &index2, &block2, frontiers, true, false);
         std::vector<std::optional<SproutWitness>> sproutWitnesses5;
         std::vector<std::optional<SaplingWitness>> saplingWitnesses5;
 
@@ -1611,7 +1615,7 @@ TEST(WalletTests, CachedWitnessesDecrementFirst) {
         EXPECT_NE(anchors2.second, anchors4.second);
 
         // Re-incrementing with the same block should give the same result
-        wallet.IncrementNoteWitnesses(Params().GetConsensus(), &index2, &block2, frontiers, true);
+        wallet.IncrementNoteWitnesses(Params().GetConsensus(), &index2, &block2, frontiers, true, false);
 
         auto anchors5 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, 1, sproutWitnesses, saplingWitnesses);
 
@@ -1672,7 +1676,7 @@ TEST(WalletTests, CachedWitnessesCleanIndex) {
     // used to increment witnesses again.
     for (size_t i = 0; i < numBlocks; i++) {
         MerkleFrontiers riPrevFrontiers{riFrontiers};
-        wallet.IncrementNoteWitnesses(Params().GetConsensus(), &(indices[i]), &(blocks[i]), riFrontiers, true);
+        wallet.IncrementNoteWitnesses(Params().GetConsensus(), &(indices[i]), &(blocks[i]), riFrontiers, true, false);
 
         auto anchors = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, 1, sproutWitnesses, saplingWitnesses);
         for (size_t j = 0; j < numBlocks; j++) {
@@ -1699,7 +1703,7 @@ TEST(WalletTests, CachedWitnessesCleanIndex) {
             }
 
             {
-                wallet.IncrementNoteWitnesses(Params().GetConsensus(), &(indices[i]), &(blocks[i]), riPrevFrontiers, true);
+                wallet.IncrementNoteWitnesses(Params().GetConsensus(), &(indices[i]), &(blocks[i]), riPrevFrontiers, true, false);
                 auto anchors = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, 1, sproutWitnesses, saplingWitnesses);
                 for (size_t j = 0; j < numBlocks; j++) {
                     EXPECT_TRUE((bool) sproutWitnesses[j]);
@@ -2120,7 +2124,7 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
     wallet.LoadWalletTx(wtx);
 
     // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true);
+    wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true, false);
     wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet
@@ -2286,7 +2290,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     wallet.LoadWalletTx(wtx);
 
     // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true);
+    wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true, false);
     wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -5,11 +5,13 @@
 #include "chainparams.h"
 #include "consensus/merkle.h"
 #include "fs.h"
+#include "init.h"
 #include "key_io.h"
 #include "main.h"
 #include "primitives/block.h"
 #include "random.h"
 #include "transaction_builder.h"
+#include "ui_interface.h"
 #include "gtest/utils.h"
 #include "util/test.h"
 #include "wallet/wallet.h"
@@ -939,6 +941,111 @@ TEST(WalletTests, GetConflictedOrchardNotes) {
     chainActive.SetTip(NULL);
     mapBlockIndex.erase(blockHash);
 
+    RegtestDeactivateNU5();
+}
+
+// Fixture for tests that a detected Orchard note commitment tree divergence triggers
+// the clean-shutdown recovery (OrchardNoteCommitmentTreeDiverged) instead of aborting.
+// SetUp connects a mock for the operator notification; TearDown disconnects it and
+// clears any requested shutdown — guaranteed even on an early return (ASSERT_*) or an
+// exception.
+class OrchardDivergenceTest : public ::testing::Test {
+protected:
+    void SetUp() override { ConnectMockUIInterface(mock_); }
+    void TearDown() override { DisconnectMockUIInterface(); }
+    MockUIInterface mock_;
+};
+
+// Regression test for #5960. When the re-enabled forward consistency check connects a
+// block near the tip and finds the wallet's Orchard note commitment tree root
+// inconsistent with the block's consensus root, it must request a clean shutdown (so
+// the operator can restart with -rescan) rather than abort the node.
+TEST_F(OrchardDivergenceTest, ForwardConsistencyCheckRequestsCleanShutdown) {
+    auto consensusParams = RegtestActivateNU5();
+    TestWallet wallet(Params());
+    wallet.GenerateNewSeed();
+
+    LOCK2(cs_main, wallet.cs_wallet);
+
+    MerkleFrontiers frontiers;
+    CBlock block;
+    CBlockIndex fakeIndex {block};
+    fakeIndex.nHeight = 0;
+    // Record a consensus Orchard root that the wallet's tree will not match, standing
+    // in for a divergence between the wallet and consensus.
+    fakeIndex.hashFinalOrchardRoot = uint256S("ff");
+    auto blockHash = block.GetHash();
+    mapBlockIndex.insert(std::make_pair(blockHash, &fakeIndex));
+    chainActive.SetTip(&fakeIndex);
+
+    ASSERT_FALSE(ShutdownRequested());
+    // The divergence handler must notify the operator via ThreadSafeMessageBox.
+    EXPECT_CALL(mock_, ThreadSafeMessageBox(
+        ::testing::_, ::testing::_, CClientUIInterface::MSG_ERROR)).WillOnce(::testing::Return(false));
+
+    // Connect the block with the consistency check enabled.
+    wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex, &block, frontiers, true, true);
+
+    // The divergence must have been detected and a clean shutdown requested, not an abort.
+    EXPECT_TRUE(ShutdownRequested());
+
+    // Tear down (the mock and shutdown cleanup is handled by the fixture's TearDown).
+    chainActive.SetTip(NULL);
+    mapBlockIndex.erase(blockHash);
+    RegtestDeactivateNU5();
+}
+
+// Regression test for #5960. When a reorg disconnects a block and DecrementNoteWitnesses
+// finds the rewound wallet Orchard tree inconsistent with the parent block's consensus
+// root, it must request a clean shutdown rather than abort the node — the restart-proof
+// crash loop that motivated this work. Previously this was a fatal assertion.
+TEST_F(OrchardDivergenceTest, DisconnectRequestsCleanShutdown) {
+    auto consensusParams = RegtestActivateNU5();
+    TestWallet wallet(Params());
+    wallet.GenerateNewSeed();
+
+    LOCK2(cs_main, wallet.cs_wallet);
+
+    MerkleFrontiers frontiers;
+
+    // Connect two blocks so the wallet has checkpoints at heights 0 and 1, so that
+    // disconnecting block 1 rewinds to block 0. The consistency check is left off
+    // during setup (false) so the connect path does not itself request a shutdown.
+    CBlock block0;
+    CBlockIndex fakeIndex0 {block0};
+    fakeIndex0.nHeight = 0;
+    // Record a consensus Orchard root for block 0 that the wallet will not match.
+    fakeIndex0.hashFinalOrchardRoot = uint256S("ff");
+    auto blockHash0 = block0.GetHash();
+    mapBlockIndex.insert(std::make_pair(blockHash0, &fakeIndex0));
+    chainActive.SetTip(&fakeIndex0);
+    wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex0, &block0, frontiers, true, false);
+
+    CBlock block1;
+    block1.hashPrevBlock = blockHash0;
+    CBlockIndex fakeIndex1 {block1};
+    fakeIndex1.nHeight = 1;
+    fakeIndex1.pprev = &fakeIndex0;
+    auto blockHash1 = block1.GetHash();
+    mapBlockIndex.insert(std::make_pair(blockHash1, &fakeIndex1));
+    chainActive.SetTip(&fakeIndex1);
+    wallet.IncrementNoteWitnesses(consensusParams, &fakeIndex1, &block1, frontiers, true, false);
+
+    ASSERT_FALSE(ShutdownRequested());
+    // The divergence handler must notify the operator via ThreadSafeMessageBox.
+    EXPECT_CALL(mock_, ThreadSafeMessageBox(
+        ::testing::_, ::testing::_, CClientUIInterface::MSG_ERROR)).WillOnce(::testing::Return(false));
+
+    // Disconnect block 1: this rewinds to block 0, whose recorded consensus root does
+    // not match the wallet's, so a clean shutdown must be requested.
+    wallet.DecrementNoteWitnesses(consensusParams, &fakeIndex1);
+
+    EXPECT_TRUE(ShutdownRequested());
+
+    // Tear down (the mock and shutdown cleanup is handled by the fixture's TearDown).
+    chainActive.SetTip(NULL);
+    mapBlockIndex.erase(blockHash0);
+    mapBlockIndex.erase(blockHash1);
     RegtestDeactivateNU5();
 }
 

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -879,7 +879,9 @@ TEST(WalletTests, GetConflictedOrchardNotes) {
 
     // Generate tx to spend note A
     auto builder2 = TransactionBuilder(Params(), 2, orchardTree.root(), SaplingMerkleTree::empty_root());
-    auto noteToSpend = std::move(wallet.GetOrchardSpendInfo(orchardEntries, 1, orchardTree.root())[0]);
+    // The wallet checkpointed this single block at height 0, so the anchor (the
+    // tree root after that block) is at absolute height 0.
+    auto noteToSpend = std::move(wallet.GetOrchardSpendInfo(orchardEntries, orchardTree.root(), 0)[0]);
     builder2.AddOrchardSpend(std::move(noteToSpend.first), std::move(noteToSpend.second));
     auto maybeTx2 = builder2.Build();
     EXPECT_TRUE(maybeTx2.IsTx());
@@ -891,7 +893,7 @@ TEST(WalletTests, GetConflictedOrchardNotes) {
     CWalletTx wtx2 {&wallet, tx2};
 
     // Generate conflicting tx to spend note A
-    auto noteToSpend2 = std::move(wallet.GetOrchardSpendInfo(orchardEntries, 1, orchardTree.root())[0]);
+    auto noteToSpend2 = std::move(wallet.GetOrchardSpendInfo(orchardEntries, orchardTree.root(), 0)[0]);
     auto builder3 = TransactionBuilder(Params(), 2, orchardTree.root(), SaplingMerkleTree::empty_root());
     builder3.AddOrchardSpend(std::move(noteToSpend2.first), std::move(noteToSpend2.second));
     auto maybeTx3 = builder3.Build();

--- a/src/wallet/orchard.cpp
+++ b/src/wallet/orchard.cpp
@@ -19,7 +19,13 @@ std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> Orchard
 {
     std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> result;
     auto walletAnchor = GetAnchorWithConfirmations(anchorConfirmations);
-    assert(walletAnchor.has_value() && walletAnchor.value() == anchor);
+    if (!walletAnchor.has_value() || walletAnchor.value() != anchor) {
+        // Reachable on the ordinary spend path, so throw rather than aborting the
+        // node (as an assertion did previously) on an anchor mismatch (#5960, #7150).
+        throw std::runtime_error(
+            "The wallet's Orchard note commitment tree does not match the anchor "
+            "selected for this spend.");
+    }
 
     for (const auto& note : noteMetadata) {
         auto pSpendInfo = orchard_wallet_get_spend_info(

--- a/src/wallet/orchard.cpp
+++ b/src/wallet/orchard.cpp
@@ -14,17 +14,53 @@ std::optional<libzcash::OrchardSpendingKey> OrchardWallet::GetSpendingKeyForAddr
 
 std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> OrchardWallet::GetSpendInfo(
     const std::vector<OrchardNoteMetadata>& noteMetadata,
-    unsigned int anchorConfirmations,
-    const uint256& anchor) const
+    const uint256& anchor,
+    int anchorHeight) const
 {
     std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> result;
-    auto walletAnchor = GetAnchorWithConfirmations(anchorConfirmations);
-    if (!walletAnchor.has_value() || walletAnchor.value() != anchor) {
-        // Reachable on the ordinary spend path, so throw rather than aborting the
-        // node (as an assertion did previously) on an anchor mismatch (#5960, #7150).
+
+    // The caller pins `anchor` to the consensus Orchard tree root at the absolute
+    // height `anchorHeight`. Derive the wallet checkpoint depth from that absolute
+    // height rather than from a fixed confirmation count, so that a block connecting
+    // (or a short reorg) between anchor selection and spend construction does not
+    // shift which checkpoint we compare against or witness from (#7150).
+    auto lastCheckpointHeight = GetLastCheckpointHeight();
+    if (!lastCheckpointHeight.has_value() || lastCheckpointHeight.value() < anchorHeight) {
+        // The wallet's latest checkpoint is below the anchor height. This is not a
+        // divergence: the wallet may not have scanned that far yet, the caller may
+        // have passed a height above the chain tip, or the anchor's block may have
+        // been reorged away.
+        //
+        // Known limitation (not fixed here, and probably never in zcashd): the
+        // wallet's Orchard note commitment tree is updated on the asynchronous wallet
+        // notification thread, so if it falls more than `anchorconfirmations` blocks
+        // behind the chain tip —for example, several blocks are connected in quick
+        // succession and an Orchard spend is attempted immediately afterwards— this
+        // fires spuriously even though nothing is wrong. The caller must wait for the
+        // wallet to catch up, or retry, rather than treating it as a permanent error.
         throw std::runtime_error(
-            "The wallet's Orchard note commitment tree does not match the anchor "
-            "selected for this spend.");
+            "Could not create this Orchard transaction: the wallet has not reached "
+            "the block its anchor refers to. Please try again after giving the wallet "
+            "time to catch up.");
+    }
+    int checkpointDepth = lastCheckpointHeight.value() - anchorHeight;
+    assert(checkpointDepth >= 0);  // non-negative by the guard above
+    auto walletAnchor = GetAnchorAtCheckpointDepth((size_t) checkpointDepth);
+    if (!walletAnchor.has_value()) {
+        // The anchor is older than the checkpoints the wallet retains. Again not a
+        // divergence; the spend just cannot be built against an anchor this old.
+        throw std::runtime_error(
+            "Could not create this Orchard transaction: too many blocks have been "
+            "mined since its anchor was chosen, so the anchor is older than the note "
+            "commitment tree checkpoints the wallet retains. Please try again to "
+            "build the transaction against a more recent anchor.");
+    }
+    if (walletAnchor.value() != anchor) {
+        // A checkpoint exists at the anchor height but its root differs from the
+        // consensus root: the wallet's Orchard tree has genuinely diverged (#5960).
+        throw std::runtime_error(
+            "The wallet's Orchard note commitment tree is inconsistent with the "
+            "block chain. Restart with -rescan to rebuild it.");
     }
 
     for (const auto& note : noteMetadata) {
@@ -32,7 +68,7 @@ std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> Orchard
             inner.get(),
             note.GetOutPoint().hash.begin(),
             note.GetOutPoint().n,
-            anchorConfirmations - 1);
+            (size_t) checkpointDepth);
         if (pSpendInfo == nullptr) {
             throw std::logic_error("Called OrchardWallet::GetSpendInfo with unknown outpoint");
         } else {

--- a/src/wallet/orchard.h
+++ b/src/wallet/orchard.h
@@ -353,8 +353,10 @@ public:
 
     /**
      * Return the root of the wallet's Orchard note commitment tree at the given
-     * checkpoint depth (0 = the most recent checkpoint), or std::nullopt if the
-     * wallet's tree has no checkpoint at that depth.
+     * checkpoint depth, or std::nullopt if the wallet's tree has no checkpoint at
+     * that depth. Depth 0 is the current frontier (the state after the most recent
+     * append, which may be ahead of any checkpoint); depth 1 is the most recent
+     * checkpoint, depth 2 the one before it, and so on.
      */
     std::optional<uint256> GetAnchorAtCheckpointDepth(size_t checkpointDepth) const {
         uint256 value;

--- a/src/wallet/orchard.h
+++ b/src/wallet/orchard.h
@@ -352,15 +352,13 @@ public:
     }
 
     /**
-     * Return the root of the Orchard note commitment tree having the specified number
-     * of confirmations. `confirmations` must be a value in the range `1..=100`; it is
-     * not possible to spend shielded notes with 0 confirmations.
+     * Return the root of the wallet's Orchard note commitment tree at the given
+     * checkpoint depth (0 = the most recent checkpoint), or std::nullopt if the
+     * wallet's tree has no checkpoint at that depth.
      */
-    std::optional<uint256> GetAnchorWithConfirmations(unsigned int confirmations) const {
-        // the checkpoint depth is equal to the number of confirmations - 1
-        assert(confirmations > 0);
+    std::optional<uint256> GetAnchorAtCheckpointDepth(size_t checkpointDepth) const {
         uint256 value;
-        if (orchard_wallet_commitment_tree_root(inner.get(), (size_t) confirmations - 1, value.begin())) {
+        if (orchard_wallet_commitment_tree_root(inner.get(), checkpointDepth, value.begin())) {
             return value;
         } else {
             return std::nullopt;
@@ -465,18 +463,19 @@ public:
     }
 
     /**
-     * Return the witness and other information required to spend a given note.
-     * `anchorConfirmations` must be a value in the range `1..=100`; it is not
-     * possible to spend shielded notes with 0 confirmations.
+     * Return the witness and other information required to spend the given notes
+     * against `anchor`, the consensus Orchard note commitment tree root at the
+     * absolute block height `anchorHeight`.
      *
-     * This method checks the root of the wallet's note commitment tree having
-     * the specified `anchorConfirmations` to ensure that it corresponds to the
-     * specified anchor and will panic if this check fails.
+     * The wallet's tree is checked at the checkpoint corresponding to `anchorHeight`
+     * to ensure that its root matches `anchor`. Throws std::runtime_error if the
+     * wallet has no checkpoint at that height, or if its root there differs from
+     * `anchor` (indicating that the wallet's tree has diverged from consensus).
      */
     std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> GetSpendInfo(
         const std::vector<OrchardNoteMetadata>& noteMetadata,
-        unsigned int anchorConfirmations,
-        const uint256& anchor) const;
+        const uint256& anchor,
+        int anchorHeight) const;
 
     void GarbageCollect() {
         orchard_wallet_gc_note_commitment_tree(inner.get());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1432,6 +1432,19 @@ void CWallet::ChainTip(const CBlockIndex *pindex,
                        std::optional<MerkleFrontiers> added)
 {
     const auto& consensus = Params().GetConsensus();
+
+    // If a shutdown has already been requested, stop processing further blocks.
+    // This could happen, for example, because a divergence was detected while
+    // processing an earlier block in this connect/disconnect batch — see
+    // OrchardNoteCommitmentTreeDiverged.
+    // StartShutdown only requests an asynchronous shutdown, so without this the
+    // notification thread would keep mutating wallet state. Returning here, rather
+    // than inside Increment/DecrementNoteWitnesses, skips the whole block: it keeps
+    // the note commitment trees and the persisted best block (written by
+    // SetBestChain in ChainTipAdded) in lockstep, and avoids re-reaching the
+    // remaining fatal rewind/witness assertions for the rest of the batch.
+    if (ShutdownRequested()) return;
+
     if (added.has_value()) {
         ChainTipAdded(pindex, pblock, added.value(), true);
         // Prevent migration transactions from being created when node is syncing after launch,
@@ -2749,6 +2762,32 @@ static void IncrementNoteWitnesses(std::map<OutPoint, NoteData>& noteDataMap,
 }
 
 
+// Handle a detected divergence between the wallet's Orchard note commitment tree
+// and the consensus note commitment tree. This is a recoverable wallet-internal
+// inconsistency. The previous behaviour was to abort() the node, which shuts down
+// uncleanly and —because the diverged tree is durable on disk— recurs on the
+// next reorg as a restart-proof crash loop (#5960). Instead, log, notify the
+// operator, and request a clean shutdown; restarting with `-rescan` rebuilds the
+// wallet's Orchard state from the consensus note commitment tree.
+//
+// This runs on the wallet notification thread (ThreadNotifyWallets), so it must
+// request a clean shutdown via StartShutdown rather than throw: an exception
+// escaping onto that thread would terminate the process.
+static void OrchardNoteCommitmentTreeDiverged(int nHeight)
+{
+    LogPrintf(
+        "*** Orchard note commitment tree diverged from consensus at height %d; the "
+        "wallet's Orchard state is inconsistent and must be rebuilt with -rescan.\n",
+        nHeight);
+    uiInterface.ThreadSafeMessageBox(
+        _("Error: The wallet's Orchard note commitment tree has become inconsistent "
+          "with the block chain. The zcashd node will now shut down; please restart "
+          "with the -rescan option to rebuild the wallet's Orchard note commitment "
+          "tree."),
+        "", CClientUIInterface::MSG_ERROR);
+    StartShutdown();
+}
+
 void CWallet::IncrementNoteWitnesses(
         const Consensus::Params& consensus,
         const CBlockIndex* pindex,
@@ -2997,8 +3036,14 @@ void CWallet::DecrementNoteWitnesses(const Consensus::Params& consensus, const C
         // will be overwritten in the next `IncrementNoteWitnesses` call, so we can skip
         // the check against `hashFinalOrchardRoot`.
         auto walletLastCheckpointHeight = orchardWallet.GetLastCheckpointHeight();
-        if (walletLastCheckpointHeight.has_value()) {
-            assert(pindex->pprev->hashFinalOrchardRoot == orchardWallet.GetLatestAnchor());
+        if (walletLastCheckpointHeight.has_value() &&
+            pindex->pprev->hashFinalOrchardRoot != orchardWallet.GetLatestAnchor()) {
+            // The wallet's Orchard note commitment tree has diverged from consensus.
+            // Recover by requesting a clean shutdown (and `-rescan` on the next start)
+            // rather than aborting the node; see OrchardNoteCommitmentTreeDiverged
+            // and #5960.
+            OrchardNoteCommitmentTreeDiverged(pindex->pprev->nHeight);
+            return;
         }
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4010,8 +4010,8 @@ bool CWallet::GetSaplingNoteWitnesses(const std::vector<SaplingOutPoint>& notes,
 
 std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> CWallet::GetOrchardSpendInfo(
     const std::vector<OrchardNoteMetadata>& orchardNoteMetadata,
-    unsigned int confirmations,
-    const uint256& anchor) const
+    const uint256& anchor,
+    int anchorHeight) const
 {
     AssertLockHeld(cs_wallet);
 
@@ -4028,7 +4028,7 @@ std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> CWallet
         throw std::runtime_error(
             "Cannot create an Orchard spend while the node is shutting down.");
     }
-    return orchardWallet.GetSpendInfo(orchardNoteMetadata, confirmations, anchor);
+    return orchardWallet.GetSpendInfo(orchardNoteMetadata, anchor, anchorHeight);
 }
 
 isminetype CWallet::IsMine(const CTxIn &txin) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1391,13 +1391,14 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
 void CWallet::ChainTipAdded(const CBlockIndex *pindex,
                             const CBlock *pblock,
                             MerkleFrontiers frontiers,
-                            bool performOrchardWalletUpdates)
+                            bool performOrchardWalletUpdates,
+                            bool performConsistencyCheck)
 {
     const auto chainParams = Params();
     IncrementNoteWitnesses(
             chainParams.GetConsensus(),
             pindex, pblock,
-            frontiers, performOrchardWalletUpdates);
+            frontiers, performOrchardWalletUpdates, performConsistencyCheck);
     UpdateSaplingNullifierNoteMapForBlock(pblock);
 
     // SetBestChain() can be expensive for large wallets, so do only
@@ -1446,7 +1447,12 @@ void CWallet::ChainTip(const CBlockIndex *pindex,
     if (ShutdownRequested()) return;
 
     if (added.has_value()) {
-        ChainTipAdded(pindex, pblock, added.value(), true);
+        // Connecting a block at the chain tip: run the Orchard note commitment tree
+        // consistency check (performConsistencyCheck = true) to detect a divergence
+        // (#5960) as it occurs. This is cheap on every connected block because the
+        // wallet's anchor is memoized; see IncrementNoteWitnesses.
+        ChainTipAdded(pindex, pblock, added.value(), true, true);
+
         // Prevent migration transactions from being created when node is syncing after launch,
         // and also when node wakes up from suspension/hibernation and incoming blocks are old.
         // We do not call IsInitialBlockDownload() because during IBD that locks on cs_main,
@@ -2793,7 +2799,8 @@ void CWallet::IncrementNoteWitnesses(
         const CBlockIndex* pindex,
         const CBlock* pblockIn,
         MerkleFrontiers& frontiers,
-        bool performOrchardWalletUpdates)
+        bool performOrchardWalletUpdates,
+        bool performConsistencyCheck)
 {
     LOCK(cs_wallet);
     int chainHeight = pindex->nHeight;
@@ -2936,12 +2943,22 @@ void CWallet::IncrementNoteWitnesses(
 
         assert(orchardWallet.AppendNoteCommitments(pindex->nHeight, *pblock));
 
-        // This assertion slows scanning for blocks with few shielded transactions by an
-        // order of magnitude. It is only intended as a consistency check between the node
-        // and wallet computing trees. Commented out until we have figured out what is
-        // causing the slowness and fixed it.
-        // https://github.com/zcash/zcash/issues/6052
-        //assert(pindex->hashFinalOrchardRoot == orchardWallet.GetLatestAnchor());
+        // Verify the wallet's Orchard note commitment tree root against the block's
+        // consensus root, to catch a divergence (#5960) as soon as it occurs rather
+        // than only later, fatally, on the disconnect path during a reorg. Computing
+        // the wallet's anchor used to re-fold the commitment tree frontier on every
+        // block, which is why #6052 disabled this check; the frontier root is now
+        // memoized and recomputed only when the tree changes, so a block that appends
+        // no Orchard commitments costs nothing here and the check runs on every block
+        // connected by ChainTip. The caller passes performConsistencyCheck = false only
+        // for a bulk rescan, which rebuilds the tree from the consensus frontier and so
+        // cannot have diverged from it. On divergence, request a clean shutdown and
+        // prompt the operator to `-rescan` (the same recovery as the disconnect path).
+        if (performConsistencyCheck &&
+            pindex->hashFinalOrchardRoot != orchardWallet.GetLatestAnchor()) {
+            OrchardNoteCommitmentTreeDiverged(pindex->nHeight);
+            return;
+        }
     }
 
     // For performance reasons, we write out the witness cache in
@@ -4795,8 +4812,12 @@ std::optional<int> CWallet::ScanForWalletTransactions(
                     assert(pcoinsTip->GetOrchardAnchorAt(pindex->pprev->hashFinalOrchardRoot, frontiers.orchard));
                 }
             }
-            // Increment note witness caches
-            ChainTipAdded(pindex, &block, frontiers, performOrchardWalletUpdates);
+            // Connecting a block during a bulk rescan: skip the Orchard note commitment
+            // tree consistency check (performConsistencyCheck = false). The rescan
+            // rebuilds the tree from the consensus frontier, so it cannot have diverged
+            // (#5960), and running the check would reintroduce the per-block cost #6052
+            // removed; see IncrementNoteWitnesses.
+            ChainTipAdded(pindex, &block, frontiers, performOrchardWalletUpdates, false);
 
             pindex = chainActive.Next(pindex);
             if (GetTime() >= nNow + 60) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4032,19 +4032,12 @@ std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> CWallet
 {
     AssertLockHeld(cs_wallet);
 
-    // Refuse to construct an Orchard spend once a shutdown has been requested.
-    // Shutdown is asynchronous, so the node may still be up, but Orchard proof
-    // construction is slow relative to the shutdown process, so a spend started now
-    // is unlikely to complete. More importantly, when the shutdown was triggered by
-    // a detected Orchard note commitment tree divergence (see
-    // OrchardNoteCommitmentTreeDiverged), the tree we would read here is known to
-    // be inconsistent. cs_wallet —held here and by the divergence detector when it
-    // requests the shutdown— ensures we observe the request, closing the window in
-    // which a spend could read the diverged tree.
-    if (ShutdownRequested()) {
-        throw std::runtime_error(
-            "Cannot create an Orchard spend while the node is shutting down.");
-    }
+    // Callers that may run concurrently with the wallet notification thread must
+    // refuse to build a spend once a shutdown has been requested, checking
+    // ShutdownRequested() under this same cs_wallet hold (see
+    // TransactionEffects::ApproveAndBuild). The divergence detector requests
+    // the shutdown while holding cs_wallet, so a spend that observes no request has
+    // read a tree that was consistent at that point.
     return orchardWallet.GetSpendInfo(orchardNoteMetadata, anchor, anchorHeight);
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4014,6 +4014,20 @@ std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> CWallet
     const uint256& anchor) const
 {
     AssertLockHeld(cs_wallet);
+
+    // Refuse to construct an Orchard spend once a shutdown has been requested.
+    // Shutdown is asynchronous, so the node may still be up, but Orchard proof
+    // construction is slow relative to the shutdown process, so a spend started now
+    // is unlikely to complete. More importantly, when the shutdown was triggered by
+    // a detected Orchard note commitment tree divergence (see
+    // OrchardNoteCommitmentTreeDiverged), the tree we would read here is known to
+    // be inconsistent. cs_wallet —held here and by the divergence detector when it
+    // requests the shutdown— ensures we observe the request, closing the window in
+    // which a spend could read the diverged tree.
+    if (ShutdownRequested()) {
+        throw std::runtime_error(
+            "Cannot create an Orchard spend while the node is shutting down.");
+    }
     return orchardWallet.GetSpendInfo(orchardNoteMetadata, confirmations, anchor);
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1294,7 +1294,13 @@ protected:
             const CBlockIndex* pindex,
             const CBlock* pblock,
             MerkleFrontiers& frontiers,
-            bool performOrchardWalletUpdates
+            bool performOrchardWalletUpdates,
+            // When true, verify the wallet's Orchard note commitment tree root against
+            // the connected block's consensus root (#5960). The tip-connection path
+            // passes true (cheap on every block now that the anchor is memoized); a bulk
+            // rescan passes false, as it cannot diverge from the consensus frontier it
+            // rebuilds from (and the check was too slow there before; #6052).
+            bool performConsistencyCheck
             );
     /**
      * pindex is the old tip being disconnected.
@@ -1365,7 +1371,8 @@ private:
             const CBlockIndex *pindex,
             const CBlock *pblock,
             MerkleFrontiers frontiers,
-            bool performOrchardWalletUpdates);
+            bool performOrchardWalletUpdates,
+            bool performConsistencyCheck);
 
     /* Add a transparent secret key to the wallet. Internal use only. */
     CPubKey AddTransparentSecretKey(

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -2028,19 +2028,18 @@ public:
          std::vector<std::optional<SaplingWitness>>& witnesses,
          uint256 &final_anchor) const;
     /**
-     * Return the witness and other information required to spend a given
-     * Orchard note. `anchorConfirmations` must be a value in the range
-     * `1..=100`; it is not possible to spend shielded notes with 0
-     * confirmations.
+     * Return the witness and other information required to spend the given
+     * Orchard notes against `anchor`, the consensus Orchard note commitment tree
+     * root at the absolute block height `anchorHeight`.
      *
-     * This method checks the root of the wallet's note commitment tree having
-     * the specified `anchorConfirmations` to ensure that it corresponds to the
-     * specified anchor and will panic if this check fails.
+     * Throws std::runtime_error if a shutdown has been requested, if the wallet
+     * has no checkpoint at `anchorHeight`, or if the wallet's root there differs
+     * from `anchor` (indicating divergence from consensus).
      */
     std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> GetOrchardSpendInfo(
         const std::vector<OrchardNoteMetadata>& orchardNoteMetadata,
-        unsigned int confirmations,
-        const uint256& anchor) const;
+        const uint256& anchor,
+        int anchorHeight) const;
 
     isminetype IsMine(const CTxIn& txin) const;
     CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;

--- a/src/wallet/wallet_tx_builder.cpp
+++ b/src/wallet/wallet_tx_builder.cpp
@@ -4,6 +4,7 @@
 
 #include "wallet/wallet_tx_builder.h"
 
+#include "init.h"
 #include "script/sign.h"
 #include "util/moneystr.h"
 #include "zip317.h"
@@ -963,6 +964,23 @@ TransactionBuilderResult TransactionEffects::ApproveAndBuild(
     std::vector<std::pair<libzcash::OrchardSpendingKey, orchard::SpendInfo>> orchardSpendInfo;
     {
         LOCK(wallet.cs_wallet);
+
+        // Refuse to gather spend inputs once a shutdown has been requested.
+        // Shutdown is asynchronous, so the node may still be up, but shielded proof
+        // construction is slow relative to the shutdown process, so a transaction
+        // started now is unlikely to complete. More importantly, when the shutdown
+        // was triggered by a detected Orchard note commitment tree divergence (see
+        // OrchardNoteCommitmentTreeDiverged), the wallet's tree is known to be
+        // inconsistent, so reading it to select anchors and witnesses would build
+        // against bad state. The divergence detector requests the shutdown while
+        // holding cs_wallet (in CWallet::IncrementNoteWitnesses); checking here
+        // under the same lock that guards the witness reads below ensures any spend
+        // that begins after detection observes the request.
+        if (ShutdownRequested()) {
+            return TransactionBuilderResult(
+                "Cannot create a shielded transaction while the node is shutting down.");
+        }
+
         if (!wallet.GetSaplingNoteWitnesses(
                     saplingOutPoints,
                     anchorConfirmations,

--- a/src/wallet/wallet_tx_builder.cpp
+++ b/src/wallet/wallet_tx_builder.cpp
@@ -976,8 +976,8 @@ TransactionBuilderResult TransactionEffects::ApproveAndBuild(
         if (orchardAnchor.has_value()) {
             orchardSpendInfo = wallet.GetOrchardSpendInfo(
                     spendable.orchardNoteMetadata,
-                    anchorConfirmations,
-                    orchardAnchor.value());
+                    orchardAnchor.value(),
+                    anchorHeight);
         }
     }
 


### PR DESCRIPTION
An alternative to #7185 that addresses #5960 (and closes #7150), restricted to changes that are correctness improvements on their own and deferring the parts that could force a `-rescan`.

Reviewing commit-by-commit is recommended.

## Background

The wallet maintains its own Orchard note commitment tree, updated on the wallet notification thread asynchronously from the node's chain state. If that tree silently diverges from consensus, `CWallet::DecrementNoteWitnesses` hits a fatal assertion on the next reorg. Because the diverged tree is durable on disk, the node restarts still diverged and re-aborts — a restart-proof crash loop (#5960), made worse because each abort is itself an unclean shutdown.

Separately, `OrchardWallet::GetSpendInfo` asserted that the wallet's anchor at a fixed confirmation depth equalled the anchor the caller selected from consensus. A block connecting between anchor selection and spend construction shifts the wallet's latest checkpoint, so the fixed-depth lookup resolves to a different checkpoint and the assertion aborts the node during an ordinary `z_sendmany` — even though the tree has not diverged (#7150).

## What this PR does

1. **Fail cleanly instead of aborting when the tree diverges on disconnect.** Replace the fatal assertion with a recovery path that logs, notifies the operator, and requests a clean shutdown (prompting `-rescan`). A guard at the top of `CWallet::ChainTip` stops processing the rest of a reorg batch once a shutdown is requested, keeping the note commitment trees and the persisted best block in lockstep.

2. **Refuse Orchard spends while a shutdown is in progress.** Shutdown is asynchronous, so a spend can still begin after one is requested. Refusing closes the window in which a spend could read a tree that is shutting down precisely because it was found inconsistent.

3. **Throw instead of aborting on a spend-path anchor mismatch.** A wallet-level anchor mismatch should fail the operation, not take the node off the network. As of this commit, the code cannot yet distinguish a genuine divergence from a benign race and so no remedy is prescribed in the exception message.

4. **Address the wallet's Orchard tree by absolute height when spending (closes #7150).** Derive the checkpoint depth from the anchor's absolute height rather than a fixed confirmation count, so the same anchor resolves correctly as the wallet advances — tolerating a newly connected block or a short reorg. This lets the spend path distinguish a transient "anchor not reached" condition from a genuine divergence, and only the latter directs the operator to `-rescan`.

5. **Run the forward consistency check on every connected block.** The per-block root check disabled in #6052 is re-enabled. `bridgetree` now memoizes the frontier root and recomputes it only when the tree changes, so the check is O(1) for blocks that append no Orchard commitments and is cheap enough to run on every block connected through `CWallet::ChainTip` — no longer gated on a brittle block-time proxy that could miss a divergence during offline catch-up. A bulk rescan still skips it, since it rebuilds the tree from consensus and so cannot diverge from itself. This adopts the approach in #7185's d8142542de212201287653c09122e38146af4882.

## Not in this PR

By design this omits the changes from #7185 that could force a `-rescan` at startup or after a rewind (the load-time check and the post-rewind reconciliation). That deserves a separate PR if wanted, since forcing an expensive rescan is a significant performance concern (and there are alternatives such as disabling the wallet).

## Known limitations

The Orchard spend path requires the wallet's note commitment tree to have reached the spend anchor's height. Because the wallet updates that tree on the asynchronous wallet notification thread, an Orchard spend attempted while the wallet is more than `anchorconfirmations` blocks behind the chain tip —for example, several blocks connected in quick succession followed immediately by a spend— fails until the wallet catches up. This is not fixed here, and is unlikely to be fixed in zcashd. Callers should wait for the wallet to catch up and then retry.

## Testing

- A new gtest, `OrchardWalletTests.SpendResolvesAnchorByAbsoluteHeight`, covers the #7150 fix: a spend against an anchor below the wallet's now-advanced latest checkpoint resolves to the correct (older) root. It was confirmed to fail without the fix.
- `WalletTests.GetConflictedOrchardNotes` now runs the re-enabled consistency check (`performConsistencyCheck = true`), confirming it is a no-op on a healthy wallet.
- `OrchardDivergenceTest.ForwardConsistencyCheckRequestsCleanShutdown` and `OrchardDivergenceTest.DisconnectRequestsCleanShutdown` cover divergence detection on the connect and disconnect paths: each confirms a detected divergence requests a clean shutdown and notifies the operator rather than aborting. A preceding `refactor:` commit moves the `ThreadSafeMessageBox` mock into `gtest/utils` so these and the deprecation tests share it.
- `p2p_duplicate_block_clobbers_chain_value` (an existing test) is made robust to the wallet-sync race described under Known limitations: it now waits for the wallet to finish processing the generated NU5-activation blocks before building its Orchard shielding transaction, rather than racing the asynchronous tree update.

closes #7150, refs #5960

🤖 Claude Opus 4.8 (1M context)




