### PR TITLE
wallet: Fix Sapling padding in ZIP 317 fee

### DIFF
--- a/qa/rpc-tests/wallet_orchard_change.py
+++ b/qa/rpc-tests/wallet_orchard_change.py
@@ -71,11 +71,8 @@ class WalletOrchardChangeTest(BitcoinTestFramework):
         ua1 = self.nodes[1].z_getaddressforaccount(acct1, ['orchard'])['address']
 
         recipients = [{"address": ua1, "amount": Decimal('1')}]
-        # TODO The z_sendmany call fails when passed `None`/`ZIP_317_FEE` because it calculates
-        # a fee that is too low, so we have to pass in an explicit fee instead.
-        # https://github.com/zcash/zcash/issues/6956
         fee = conventional_fee(4)
-        myopid = self.nodes[0].z_sendmany(ua0, recipients, 1, fee, 'AllowRevealedAmounts')
+        myopid = self.nodes[0].z_sendmany(ua0, recipients, 1, ZIP_317_FEE, 'AllowRevealedAmounts')
         source_tx = wait_and_assert_operationid_status(self.nodes[0], myopid)
 
         self.sync_all()

--- a/qa/rpc-tests/wallet_zip317_default.py
+++ b/qa/rpc-tests/wallet_zip317_default.py
@@ -11,7 +11,6 @@ from test_framework.util import (
     CANOPY_BRANCH_ID,
     NU5_BRANCH_ID,
     assert_equal,
-    assert_raises_message,
     get_coinbase_address,
     nuparams,
     start_nodes,
@@ -61,19 +60,11 @@ class WalletZip317DefaultTest(BitcoinTestFramework):
         acct1 = self.nodes[1].z_getnewaccount()['account']
         ua1 = self.nodes[1].z_getaddressforaccount(acct1, ['orchard'])['address']
 
-        # The next z_sendmany call fails when passed `None`/`ZIP_317_FEE` because it
-        # calculates a fee that is too low.
-        # https://github.com/zcash/zcash/issues/6956
         recipients = [{"address": ua1, "amount": Decimal('1')}]
-        opid = self.nodes[0].z_sendmany(ua0, recipients, 1, ZIP_317_FEE, 'AllowRevealedAmounts')
-        # The buggy behaviour.
-        assert_raises_message(AssertionError,
-                              "Transaction commit failed:: tx unpaid action limit exceeded: 1 action(s) exceeds limit of 0",
-                              wait_and_assert_operationid_status, self.nodes[0], opid)
-
-        # If we pass `fee` instead of `None`, it succeeds.
+        # This requires four logical actions: one Sapling spend padded to two
+        # Sapling actions, plus two Orchard actions.
         fee = conventional_fee(4)
-        opid = self.nodes[0].z_sendmany(ua0, recipients, 1, fee, 'AllowRevealedAmounts')
+        opid = self.nodes[0].z_sendmany(ua0, recipients, 1, ZIP_317_FEE, 'AllowRevealedAmounts')
         wait_and_assert_operationid_status(self.nodes[0], opid)
 
         self.sync_all()

--- a/src/wallet/wallet_tx_builder.cpp
+++ b/src/wallet/wallet_tx_builder.cpp
@@ -89,7 +89,9 @@ CalcZIP317Fee(
             vout,
             std::max(sproutInputCount, sproutOutputCount),
             saplingInputCount,
-            PadCount(saplingOutputCount),
+            // A Sapling bundle with spends but no real outputs still gets padded
+            // with dummy outputs, so pad after combining spends and outputs.
+            PadCount(std::max(saplingInputCount, saplingOutputCount)),
             PadCount(std::max(orchardInputCount, orchardOutputCount)));
 
     return CalculateConventionalFee(logicalActionCount);


### PR DESCRIPTION
Fixes #6956

`z_sendmany` was estimating the ZIP 317 fee from the raw Sapling spend count plus the padded Sapling output count. For a Sapling spend with no real Sapling outputs, the Sapling builder still pads the bundle with dummy outputs, so the final transaction has two Sapling actions there

This pads the estimated Sapling output count after combining Sapling spends and outputs, matching the bundle shape used when the transaction is built

Tests:
- `make -j$(nproc)`
- `RPC_TEST="wallet_zip317_default.py wallet_orchard_change.py" make rpc-tests`
- `./src/zcash-gtest --gtest_filter="WalletRPCTests.ZIP317Fee:TransactionBuilder.TransparentToSapling:TransactionBuilder.SaplingToSapling"`
- `git diff --check`
- `python3 -m py_compile qa/rpc-tests/wallet_zip317_default.py qa/rpc-tests/wallet_orchard_change.py`
- `./test/lint/lint-whitespace.sh`
- `./test/lint/lint-python-utf8-encoding.sh`