### PR TITLE
Avoid copying each CWalletTx in SetBestChain's flush loop

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1313,8 +1313,8 @@ protected:
         }
         try {
             LOCK(cs_wallet);
-            for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-                auto wtx = wtxItem.second;
+            for (const std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
+                const CWalletTx& wtx = wtxItem.second;
                 // We skip transactions for which mapSproutNoteData and mapSaplingNoteData
                 // are empty. This covers transactions that have no Sprout or Sapling data
                 // (i.e. are purely transparent), as well as shielding and unshielding


### PR DESCRIPTION
SetBestChainINTERNAL iterates all of mapWallet on every flush and copied each CWalletTx by value (`auto wtx = wtxItem.second`) only to read its note-data maps and hand it to WriteTx, which takes a `const CWalletTx&`. For wallets with very large transaction histories -- e.g. mining pools, whose coinbase outputs must pass through a shielded pool by consensus and so accumulate substantial shielded history -- this performs a deep copy of a heavy CWalletTx for every wallet transaction on every flush. Bind a const reference instead.

This is a non-functional change; the set of transactions written is unchanged.