### PR TITLE
docs: fix offline Cargo config path

### DIFF
--- a/doc/book/src/dev/rust.md
+++ b/doc/book/src/dev/rust.md
@@ -90,7 +90,7 @@ Note that if the git repository contains a workspace of interconnected crates
 (for example, https://github.com/zcash/librustzcash), you will need to provide
 patches for each of the dependencies that reference the same git revision.
 
-You also need to update `.cargo/config.offline` to add a replacement definition
+You also need to update `.cargo/config.toml.offline` to add a replacement definition
 for each `(git, rev)` pair. Run `./test/lint/lint-cargo-patches.sh` to get the
 lines that need to be present.
 


### PR DESCRIPTION
This fixes the offline Cargo config path in the Rust developer documentation.

The document previously referred to `.cargo/config.offline`, but the repository uses `.cargo/config.toml.offline`. This matches the path referenced by the build system and `test/lint/lint-cargo-patches.sh`.
