### PR TITLE
test: use assert_raises_message for wallet RPC failures

### DIFF
--- a/qa/rpc-tests/wallet_import_export.py
+++ b/qa/rpc-tests/wallet_import_export.py
@@ -5,7 +5,7 @@
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_true, start_nodes
+from test_framework.util import assert_equal, assert_raises_message, assert_true, start_nodes
 
 class WalletImportExportTest (BitcoinTestFramework):
     def setup_network(self, split=False):
@@ -23,16 +23,17 @@ class WalletImportExportTest (BitcoinTestFramework):
         self.nodes[0].z_importkey(privkey2)
 
         # test walletconfirmbackup
-        try:
-            self.nodes[0].getnewaddress()
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("Error: Please acknowledge that you have backed up" in errorString, True)
-        try:
-            self.nodes[0].z_getnewaddress('sapling')
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("Error: Please acknowledge that you have backed up" in errorString, True)
+        assert_raises_message(
+            JSONRPCException,
+            "Error: Please acknowledge that you have backed up",
+            self.nodes[0].getnewaddress,
+        )
+        assert_raises_message(
+            JSONRPCException,
+            "Error: Please acknowledge that you have backed up",
+            self.nodes[0].z_getnewaddress,
+            'sapling',
+        )
         dump_path0 = self.nodes[0].z_exportwallet('walletdumpmnem')
         (mnemonic, _, _, _) = parse_wallet_file(dump_path0)
         self.nodes[0].walletconfirmbackup(mnemonic)

--- a/qa/rpc-tests/wallet_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldcoinbase.py
@@ -5,10 +5,10 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, initialize_chain_clean, \
-    start_node, connect_nodes_bi, sync_blocks, sync_mempools, \
-    wait_and_assert_operationid_status, get_coinbase_address, \
-    NU5_BRANCH_ID, nuparams
+from test_framework.util import assert_equal, assert_raises_message, \
+    initialize_chain_clean, start_node, connect_nodes_bi, sync_blocks, \
+    sync_mempools, wait_and_assert_operationid_status, \
+    get_coinbase_address, NU5_BRANCH_ID, nuparams
 from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 
 from decimal import Decimal
@@ -67,39 +67,55 @@ class WalletShieldCoinbaseTest (BitcoinTestFramework):
 
         # Shielding will fail when trying to spend from watch-only address
         self.nodes[2].importaddress(mytaddr)
-        try:
-            self.nodes[2].z_shieldcoinbase(mytaddr, myzaddr)
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal(errorString, "Invalid from address, no payment source found for address.")
+        assert_raises_message(
+            JSONRPCException,
+            "Invalid from address, no payment source found for address.",
+            self.nodes[2].z_shieldcoinbase,
+            mytaddr,
+            myzaddr,
+        )
 
         # Shielding will fail because fee is negative
-        try:
-            self.nodes[0].z_shieldcoinbase("*", myzaddr, -1)
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("Amount out of range" in errorString, True)
+        assert_raises_message(
+            JSONRPCException,
+            "Amount out of range",
+            self.nodes[0].z_shieldcoinbase,
+            "*",
+            myzaddr,
+            -1,
+        )
 
         # Shielding will fail because fee is larger than MAX_MONEY
-        try:
-            self.nodes[0].z_shieldcoinbase("*", myzaddr, Decimal('21000000.00000001'))
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal(errorString, "Amount out of range")
+        assert_raises_message(
+            JSONRPCException,
+            "Amount out of range",
+            self.nodes[0].z_shieldcoinbase,
+            "*",
+            myzaddr,
+            Decimal('21000000.00000001'),
+        )
 
         # Shielding will fail because limit parameter must be at least 0
-        try:
-            self.nodes[0].z_shieldcoinbase("*", myzaddr, Decimal('0.001'), -1)
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("Limit on maximum number of utxos cannot be negative" in errorString, True)
+        assert_raises_message(
+            JSONRPCException,
+            "Limit on maximum number of utxos cannot be negative",
+            self.nodes[0].z_shieldcoinbase,
+            "*",
+            myzaddr,
+            Decimal('0.001'),
+            -1,
+        )
 
         # Shielding will fail because limit parameter is absurdly large
-        try:
-            self.nodes[0].z_shieldcoinbase("*", myzaddr, Decimal('0.001'), 99999999999999)
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("JSON integer out of range" in errorString, True)
+        assert_raises_message(
+            JSONRPCException,
+            "JSON integer out of range",
+            self.nodes[0].z_shieldcoinbase,
+            "*",
+            myzaddr,
+            Decimal('0.001'),
+            99999999999999,
+        )
 
         # Shield coinbase utxos from node 0 of value 40
         fee = conventional_fee(6)

--- a/qa/rpc-tests/wallet_shieldingcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldingcoinbase.py
@@ -6,10 +6,10 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.mininode import COIN
-from test_framework.util import assert_equal, initialize_chain_clean, \
-    start_nodes, connect_nodes_bi, wait_and_assert_operationid_status, \
-    wait_and_assert_operationid_status_result, get_coinbase_address, \
-    check_node_log
+from test_framework.util import assert_equal, assert_raises_message, \
+    initialize_chain_clean, start_nodes, connect_nodes_bi, \
+    wait_and_assert_operationid_status, wait_and_assert_operationid_status_result, \
+    get_coinbase_address, check_node_log
 from test_framework.zip317 import conventional_fee, WEIGHT_RATIO_CAP, ZIP_317_FEE
 
 import sys
@@ -77,12 +77,13 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
 
         # Send will fail because we are enforcing the consensus rule that
         # coinbase utxos can only be sent to a zaddr.
-        errorString = ""
-        try:
-            self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1)
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("Coinbase funds can only be sent to a zaddr" in errorString, True)
+        assert_raises_message(
+            JSONRPCException,
+            "Coinbase funds can only be sent to a zaddr",
+            self.nodes[0].sendtoaddress,
+            self.nodes[2].getnewaddress(),
+            1,
+        )
 
         # Prepare to send taddr->zaddr
         mytaddr = get_coinbase_address(self.nodes[0])
@@ -91,11 +92,13 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         # Node 3 will test that watch only address utxos are not selected
         self.nodes[3].importaddress(mytaddr)
         recipients= [{"address": myzaddr, "amount": Decimal('1')}]
-        try:
-            myopid = self.nodes[3].z_sendmany(mytaddr, recipients)
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("Invalid from address, no payment source found for address.", errorString);
+        assert_raises_message(
+            JSONRPCException,
+            "Invalid from address, no payment source found for address.",
+            self.nodes[3].z_sendmany,
+            mytaddr,
+            recipients,
+        )
 
         # This send will fail because our consensus does not allow transparent change when
         # shielding a coinbase utxo.
@@ -166,11 +169,15 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         assert_equal(results[0]["spendable"], False)
 
         # Verify that z_listunspent returns error when address spending key from node 0 is not available in wallet of node 1.
-        try:
-            results = self.nodes[1].z_listunspent(1, 999, False, [myzaddr])
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("Invalid parameter, spending key for an address does not belong to the wallet.", errorString)
+        assert_raises_message(
+            JSONRPCException,
+            "Invalid parameter, spending key for an address does not belong to the wallet.",
+            self.nodes[1].z_listunspent,
+            1,
+            999,
+            False,
+            [myzaddr],
+        )
 
         # Verify that debug=zrpcunsafe logs params, and that full txid is associated with opid
         initialized_line = check_node_log(self, 0, myopid + ": z_sendmany initialized", False)
@@ -235,12 +242,13 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "Insufficient funds: have 10.00, need 0.00000053 more to avoid creating invalid change output 0.00000001 (dust threshold is 0.00000054); note that coinbase outputs will not be selected if you specify ANY_TADDR, any transparent recipients are included, or if the `privacyPolicy` parameter is not set to `AllowRevealedSenders` or weaker.")
 
         # Send will fail because send amount is too big, even when including coinbase utxos
-        errorString = ""
-        try:
-            self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 99999)
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("Insufficient funds" in errorString, True)
+        assert_raises_message(
+            JSONRPCException,
+            "Insufficient funds",
+            self.nodes[0].sendtoaddress,
+            self.nodes[2].getnewaddress(),
+            99999,
+        )
 
         # z_sendmany will fail because of insufficient funds
         recipients = [{"address": self.nodes[1].getnewaddress(), "amount": Decimal('10000.0')}]
@@ -250,14 +258,15 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "Insufficient funds: have 9.99955, need 10000.0001; note that coinbase outputs will not be selected if you specify ANY_TADDR, any transparent recipients are included, or if the `privacyPolicy` parameter is not set to `AllowRevealedSenders` or weaker.")
 
         # Send will fail because of insufficient funds unless sender uses coinbase utxos
-        try:
-            self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 21)
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("Insufficient funds, coinbase funds can only be spent after they have been sent to a zaddr" in errorString, True)
+        assert_raises_message(
+            JSONRPCException,
+            "Insufficient funds, coinbase funds can only be spent after they have been sent to a zaddr",
+            self.nodes[0].sendtoaddress,
+            self.nodes[2].getnewaddress(),
+            21,
+        )
 
         # Verify that mempools accept tx with shielded outputs and that pay at least the conventional fee.
-        errorString = ''
         recipients = []
         num_t_recipients = 1998 # stay just under the absurdly-high-fee error
         amount_per_recipient = Decimal('0.00000054') # dust threshold
@@ -302,18 +311,26 @@ class WalletShieldingCoinbaseTest (BitcoinTestFramework):
         check_value_pool(self.nodes[0], 'sapling', saplingvalue)
 
         # Send will fail because fee is negative
-        try:
-            self.nodes[0].z_sendmany(myzaddr, recipients, 1, -1)
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("Amount out of range" in errorString, True)
+        assert_raises_message(
+            JSONRPCException,
+            "Amount out of range",
+            self.nodes[0].z_sendmany,
+            myzaddr,
+            recipients,
+            1,
+            -1,
+        )
 
         # Send will fail because fee is larger than MAX_MONEY
-        try:
-            self.nodes[0].z_sendmany(myzaddr, recipients, 1, Decimal('21000000.00000001'))
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert_equal("Amount out of range" in errorString, True)
+        assert_raises_message(
+            JSONRPCException,
+            "Amount out of range",
+            self.nodes[0].z_sendmany,
+            myzaddr,
+            recipients,
+            1,
+            Decimal('21000000.00000001'),
+        )
 
         # Send will fail because fee is more than `WEIGHT_RATIO_CAP * conventional_fee`
         num_fewer_recipients = 400


### PR DESCRIPTION
## Summary
- Replace manual `try/except JSONRPCException` + `errorString` assertions with `assert_raises_message()`.
- Fix `wallet_shieldcoinbase.py` false positives where a previous exception message could be reused.
- Clean up similar wallet RPC exception checks in nearby Python tests.

Fixes #5494 