### PR TITLE
doc: update NU6.3 activation dates in End of Life timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Zcash 6.20.0
 >
 > `zcashd` is **deprecated** and will **not** support NU6.3; its automatic
 > End-of-Support halt is estimated for July 18th 2026 at block height 3417100, after which
-> every node shuts down (NU6.3 mainnet activation follows around July 21st). If you do not
+> every node shuts down (NU6.3 mainnet activation follows around July 28th). If you do not
 > need the `zcashd` wallet, migrate to
 > [Zebra](https://github.com/ZcashFoundation/zebra) now. If you depend on the `zcashd`
 > wallet, start testing [Zallet](https://zcash.github.io/zallet/) immediately. See the

--- a/doc/book/src/dev/deprecation.md
+++ b/doc/book/src/dev/deprecation.md
@@ -3,7 +3,7 @@ Deprecation Procedure
 
 > **Note:** `zcashd` is [deprecated](../user/end-of-life.md) and will not
 > support NU6.3; the automatic End-of-Support halt is estimated for July 18th 2026 at block
-> height 3417100 (NU6.3 mainnet activation follows around July 21st).
+> height 3417100 (NU6.3 mainnet activation follows around July 28th).
 
 From time to time, features of `zcashd` and its associated wallet and RPC API are
 deprecated to allow eventual removal of functionality that has been superseded

--- a/doc/book/src/user/deprecation.md
+++ b/doc/book/src/user/deprecation.md
@@ -3,7 +3,7 @@ Deprecated Features
 
 > **Note:** `zcashd` is [deprecated](end-of-life.md) and will not support
 > NU6.3; the automatic End-of-Support halt is estimated for July 18th 2026 at block height
-> 3417100 (NU6.3 mainnet activation follows around July 21st). See the
+> 3417100 (NU6.3 mainnet activation follows around July 28th). See the
 > [End of Life](end-of-life.md) page for migration guidance to Zebra and Zallet.
 
 In order to support the continuous improvement of `zcashd`, features are

--- a/doc/book/src/user/end-of-life.md
+++ b/doc/book/src/user/end-of-life.md
@@ -40,20 +40,20 @@ codebase poses for future (or present) AI advancements. Deprecating `zcashd` is 
 ## Timeline
 
 The current timeline estimates that NU6.3 activation will be integrated into testnet
-code around July 2nd 2026, and testnet activation will follow on July 3rd (block height 4134000).
+code around July 2nd 2026, and testnet activation will follow on July 4th (block height 4134000).
 The same will follow for mainnet on later dates (see timeline below).
 
 With regards to mainnet, `zcashd` 6.20.0's automatic **End-of-Support halt** (block height
 3417100) is estimated for July 18th. This precedes NU6.3 **mainnet activation** on July
-21st, ensuring a Zebra-only network before the upgrade takes effect.
+28th, ensuring a Zebra-only network before the upgrade takes effect.
 
 | Date | Event |
 | ----- | ----- |
 | July 2nd 2026 | Ironwood/NU6.3 Testnet deployment |
-| July 3rd 2026 | Ironwood/NU6.3 Testnet Activation (block height 4134000) |
+| July 4th 2026 | Ironwood/NU6.3 Testnet Activation (block height 4134000) |
 | July 9th 2026 | Ironwood/NU6.3 **Mainnet** deployment |
 | ~July 18th 2026 | `zcashd` **End-of-Support halt** (block height 3417100) |
-| ~July 21st 2026 | Ironwood/NU6.3 **Mainnet** Activation |
+| ~July 28th 2026 | Ironwood/NU6.3 **Mainnet** Activation |
 
 ## The Path Forward: Zebra + Zallet
 


### PR DESCRIPTION
Updates the estimated NU6.3 activation dates in the End of Life documentation:

- Testnet activation: July 3rd → **July 4th 2026** (block height 4134000)
- Mainnet activation: July 21st → **July 28th 2026**

The `zcashd` End-of-Support halt estimate (July 18th 2026, block height 3417100) is unchanged. Affected pages: the README banner, the End of Life timeline, and both deprecation pages.

Follow-up to #7203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)