### PR TITLE
validation: skip old-branch retry for ZIP244

### DIFF
--- a/src/gtest/test_sighash.cpp
+++ b/src/gtest/test_sighash.cpp
@@ -63,6 +63,25 @@ TEST(SigHashTest, Zip244AcceptsKnownHashTypes) {
     }
 }
 
+TEST(SigHashTest, Zip244IgnoresExternalConsensusBranchId) {
+    auto parts = DummyV5Transaction();
+    auto mtx = parts.first;
+    auto allPrevOutputs = parts.second;
+
+    unsigned int nIn = 1;
+    PrecomputedTransactionData txdata(mtx, allPrevOutputs);
+    CScript scriptCode;
+    CAmount amount;
+
+    EXPECT_EQ(
+        SignatureHash(
+            scriptCode, mtx, nIn, SIGHASH_ALL, amount,
+            NetworkUpgradeInfo[Consensus::UPGRADE_NU5].nBranchId, txdata),
+        SignatureHash(
+            scriptCode, mtx, nIn, SIGHASH_ALL, amount,
+            NetworkUpgradeInfo[Consensus::UPGRADE_CANOPY].nBranchId, txdata));
+}
+
 TEST(SigHashTest, Zip244RejectsUnknownHashTypes) {
     auto parts = DummyV5Transaction();
     auto mtx = parts.first;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2849,14 +2849,18 @@ bool ContextualCheckInputs(
                     // the assumption that users creating transactions will
                     // notice their transactions failing before a second network
                     // upgrade occurs.
-                    auto prevConsensusBranchId = PrevEpochBranchId(consensusBranchId, consensusParams);
-                    CScriptCheck checkPrev(*coins, tx, i, flags, cacheStore, prevConsensusBranchId, &txdata);
-                    if (checkPrev()) {
-                        return state.DoS(
-                            10, false, REJECT_INVALID, strprintf(
-                                "old-consensus-branch-id (Expected %s, found %s)",
-                                HexInt(consensusBranchId),
-                                HexInt(prevConsensusBranchId)));
+                    // ZIP 244 hashes use the branch ID encoded in the
+                    // transaction itself.
+                    if (!tx.GetConsensusBranchId()) {
+                        auto prevConsensusBranchId = PrevEpochBranchId(consensusBranchId, consensusParams);
+                        CScriptCheck checkPrev(*coins, tx, i, flags, cacheStore, prevConsensusBranchId, &txdata);
+                        if (checkPrev()) {
+                            return state.DoS(
+                                10, false, REJECT_INVALID, strprintf(
+                                    "old-consensus-branch-id (Expected %s, found %s)",
+                                    HexInt(consensusBranchId),
+                                    HexInt(prevConsensusBranchId)));
+                        }
                     }
                     if (flags & STANDARD_NOT_MANDATORY_VERIFY_FLAGS) {
                         // Check whether the failure was caused by a


### PR DESCRIPTION
### What changed

This skips the previous-consensus-branch script check for transactions that already carry their own consensus branch ID

For ZIP 244 sighashes, `SignatureHash()` ignores the external branch ID argument and uses the branch ID encoded in the transaction, so retrying `CScriptCheck` with `PrevEpochBranchId()` cannot produce the `old-consensus-branch-id` diagnostic. Legacy transactions keep the existing fallback path

Fixes #6919

### Testing

- `make -j2 src/zcash-gtest`
- `./src/zcash-gtest --gtest_filter=SigHashTest.Zip244IgnoresExternalConsensusBranchId`
- `./src/zcash-gtest --gtest_filter=Validation.ContextualCheckInputsDetectsOldBranchId`
- `./src/zcash-gtest '--gtest_filter=SigHashTest.*'`