### PR TITLE
doc: mark zcashd End of Life as reached

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@ Zcash 6.20.0
 <img align="right" width="120" height="80" src="doc/imgs/logo.png">
 ===========
 
-> ## ⚠️ `zcashd` is reaching its End of Life
+> ## ⚠️ `zcashd` has reached its End of Life
 >
-> `zcashd` is **deprecated** and will **not** support NU6.3; its automatic
-> End-of-Support halt is estimated for July 18th 2026 at block height 3417100, after which
-> every node shuts down (NU6.3 mainnet activation follows around July 28th). If you do not
-> need the `zcashd` wallet, migrate to
-> [Zebra](https://github.com/ZcashFoundation/zebra) now. If you depend on the `zcashd`
-> wallet, start testing [Zallet](https://zcash.github.io/zallet/) immediately. See the
+> `zcashd` is **deprecated** and does **not** support NU6.3. Its automatic
+> End-of-Support halt was reached on July 18th 2026 at block height 3417100, and every
+> `zcashd` 6.20.0 node has now shut down and will refuse to restart (NU6.3 mainnet
+> activation follows around July 28th). If you have not migrated yet, do so now: move to
+> [Zebra](https://github.com/ZcashFoundation/zebra) if you do not need the `zcashd`
+> wallet, or to [Zallet](https://zcash.github.io/zallet/) if you depend on it. See the
 > [End of Life](https://zcash.github.io/zcash/user/end-of-life.html) page for the full
 > timeline and migration guidance.
 

--- a/doc/book/src/dev/deprecation.md
+++ b/doc/book/src/dev/deprecation.md
@@ -1,9 +1,10 @@
 Deprecation Procedure
 =====================
 
-> **Note:** `zcashd` is [deprecated](../user/end-of-life.md) and will not
-> support NU6.3; the automatic End-of-Support halt is estimated for July 18th 2026 at block
-> height 3417100 (NU6.3 mainnet activation follows around July 28th).
+> **Note:** `zcashd` is [deprecated](../user/end-of-life.md) and does not
+> support NU6.3; the automatic End-of-Support halt was reached on July 18th 2026 at block
+> height 3417100, and every `zcashd` 6.20.0 node has now shut down (NU6.3 mainnet
+> activation follows around July 28th).
 
 From time to time, features of `zcashd` and its associated wallet and RPC API are
 deprecated to allow eventual removal of functionality that has been superseded

--- a/doc/book/src/user/deprecation.md
+++ b/doc/book/src/user/deprecation.md
@@ -1,10 +1,11 @@
 Deprecated Features
 ===================
 
-> **Note:** `zcashd` is [deprecated](end-of-life.md) and will not support
-> NU6.3; the automatic End-of-Support halt is estimated for July 18th 2026 at block height
-> 3417100 (NU6.3 mainnet activation follows around July 28th). See the
-> [End of Life](end-of-life.md) page for migration guidance to Zebra and Zallet.
+> **Note:** `zcashd` is [deprecated](end-of-life.md) and does not support
+> NU6.3; the automatic End-of-Support halt was reached on July 18th 2026 at block height
+> 3417100, and every `zcashd` 6.20.0 node has now shut down (NU6.3 mainnet activation
+> follows around July 28th). See the [End of Life](end-of-life.md) page for migration
+> guidance to Zebra and Zallet.
 
 In order to support the continuous improvement of `zcashd`, features are
 periodically deprecated and removed when they have been superseded or are no

--- a/doc/book/src/user/end-of-life.md
+++ b/doc/book/src/user/end-of-life.md
@@ -1,36 +1,36 @@
 # End of Life
 
-> ## ⚠️ `zcashd` is reaching its End of Life
+> ## ⚠️ `zcashd` has reached its End of Life
 >
-> `zcashd` is **deprecated** and will **not** support NU6.3.
-> **If you do not need the `zcashd` wallet, migrate to [Zebra](https://github.com/ZcashFoundation/zebra) now.**
-> If you depend on the `zcashd` wallet, start testing [Zallet](https://zcash.github.io/zallet/)
-> migrating your `wallet.dat` as soon as possible. The binary's **End-of-Support halt** is
-> estimated for **July 18th 2026** at block height 3417100, after which every `zcashd` node
-> automatically shuts down.
+> `zcashd` is **deprecated** and does **not** support NU6.3. Its automatic
+> **End-of-Support halt** was reached on **July 18th 2026** at block height 3417100, and
+> every `zcashd` 6.20.0 node has now automatically shut down and will refuse to restart.
+> **If you have not migrated yet, do so now:** move to
+> [Zebra](https://github.com/ZcashFoundation/zebra) if you do not need the `zcashd` wallet,
+> or to [Zallet](https://zcash.github.io/zallet/) — migrating your `wallet.dat` — if you do.
 
 ## Two key dates: End-of-Support halt vs. NU6.3 activation
 
 `zcashd`'s End of Life involves two distinct milestones. Don't conflate them:
 
-- **`zcashd` End-of-Support halt — estimated July 18th 2026, at block height 3417100.**
+- **`zcashd` End-of-Support halt — reached July 18th 2026, at block height 3417100.**
   The point at which every `zcashd` 6.20.0 binary automatically shuts down and refuses to
   restart. This is hard-coded as the deprecation height (`DEPRECATION_HEIGHT` in
-  `src/deprecation.h`). The date is an estimate that may shift with network solution power;
-  query the exact height your node will halt at with the `getdeprecationinfo` JSON-RPC
-  method. See [Release Support](release-support.md) for more on the End-of-Support halt.
-- **NU6.3 mainnet activation — estimated July 21st 2026.** The Ironwood/NU6.3 network
-  upgrade activates on mainnet a few days *after* the End-of-Support halt. The halt is
-  deliberately targeted to precede activation so that every un-upgraded `zcashd` node has
+  `src/deprecation.h`). The chain reached this height on 2026-07-18, so all `zcashd` 6.20.0
+  nodes have now halted. See [Release Support](release-support.md) for more on the
+  End-of-Support halt.
+- **NU6.3 mainnet activation — estimated July 28th 2026.** The Ironwood/NU6.3 network
+  upgrade activates on mainnet a few days *after* the End-of-Support halt. The halt was
+  deliberately targeted to precede activation so that every un-upgraded `zcashd` node had
   already shut down and the network is Zebra-only before NU6.3 takes effect. **`zcashd`
-  will not support NU6.3.**
+  does not support NU6.3.**
 
 ## Context
 
 Zcash organizations continue to work on the different components that are needed to
 specify, develop and deploy the Ironwood shielded pool in the next Network Upgrade,
-NU6.3. **`zcashd` maintainers will NOT** support this upgrade. `zcashd` is deprecated and
-will reach end of life ahead of the activation of NU6.3 on mainnet.
+NU6.3. **`zcashd` maintainers do NOT** support this upgrade. `zcashd` is deprecated and
+has reached end of life ahead of the activation of NU6.3 on mainnet.
 
 The decision to accelerate `zcashd` deprecation is specifically related to the recent
 Orchard vulnerability disclosed on June 1st 2026 and the associated risks that the C++
@@ -39,12 +39,12 @@ codebase poses for future (or present) AI advancements. Deprecating `zcashd` is 
 
 ## Timeline
 
-The current timeline estimates that NU6.3 activation will be integrated into testnet
-code around July 2nd 2026, and testnet activation will follow on July 4th (block height 4134000).
-The same will follow for mainnet on later dates (see timeline below).
+NU6.3 activation was integrated into testnet code around July 2nd 2026, and testnet
+activation followed on July 4th (block height 4134000). The same followed for mainnet on
+later dates (see timeline below).
 
 With regards to mainnet, `zcashd` 6.20.0's automatic **End-of-Support halt** (block height
-3417100) is estimated for July 18th. This precedes NU6.3 **mainnet activation** on July
+3417100) was reached on July 18th 2026. This precedes NU6.3 **mainnet activation** on July
 28th, ensuring a Zebra-only network before the upgrade takes effect.
 
 | Date | Event |
@@ -52,7 +52,7 @@ With regards to mainnet, `zcashd` 6.20.0's automatic **End-of-Support halt** (bl
 | July 2nd 2026 | Ironwood/NU6.3 Testnet deployment |
 | July 4th 2026 | Ironwood/NU6.3 Testnet Activation (block height 4134000) |
 | July 9th 2026 | Ironwood/NU6.3 **Mainnet** deployment |
-| ~July 18th 2026 | `zcashd` **End-of-Support halt** (block height 3417100) |
+| July 18th 2026 (reached) | `zcashd` **End-of-Support halt** (block height 3417100) |
 | ~July 28th 2026 | Ironwood/NU6.3 **Mainnet** Activation |
 
 ## The Path Forward: Zebra + Zallet
@@ -64,5 +64,6 @@ Zebra **immediately**.
 
 For those who do depend on the `zcashd` wallet, ZODL developers have released Zallet
 Alpha.4, which allows migration of `zcashd`'s `wallet.dat` files into Zallet. You can find
-the documentation for Zallet [here](https://zcash.github.io/zallet/). We encourage these
-users to start testing Zallet and to send feedback to its maintainers as soon as possible.
+the documentation for Zallet [here](https://zcash.github.io/zallet/). Because `zcashd` has
+now halted, these users should migrate their `wallet.dat` to Zallet as soon as possible and
+send feedback to its maintainers.

--- a/doc/book/src/user/release-support.md
+++ b/doc/book/src/user/release-support.md
@@ -1,8 +1,8 @@
 # `zcashd` Release Support
 
-> **Note:** `zcashd` is [deprecated](end-of-life.md) and will not support NU6.3. Its
-> 6.20.0 **End-of-Support halt** — block height 3417100, estimated 2026-07-18 — is when the
-> binary automatically shuts down, ahead of NU6.3 mainnet activation (estimated 2026-07-21).
+> **Note:** `zcashd` is [deprecated](end-of-life.md) and does not support NU6.3. Its
+> 6.20.0 **End-of-Support halt** — block height 3417100, reached 2026-07-18 — has now shut
+> down every `zcashd` 6.20.0 node, ahead of NU6.3 mainnet activation (estimated 2026-07-28).
 > See the [End of Life](end-of-life.md) page for the full timeline and migration guidance.
 
 ## Release cadence and support window


### PR DESCRIPTION
## Summary

`zcashd`'s automatic End-of-Support halt height, block **3417100**, has now been reached (mined **2026-07-18 22:51 UTC**, hash `00000000001d20ddc7ae13b910c1a12929f753ae779a3c62207e53bc0d30d52f`). Every `zcashd` 6.20.0 node has automatically shut down and refuses to restart, so `zcashd` has effectively reached its End of Life.

This PR updates the End of Life documentation from the future/estimated tense it was originally written in (#7203 / #7212) to reflect that the halt has **already occurred**.

## Changes

- `doc/book/src/user/end-of-life.md` — banner now reads "has reached its End of Life"; "Two key dates", Context, Timeline intro, and the timeline table are shifted to past tense (halt "reached July 18th 2026"); Path Forward stresses migrating immediately.
- `README.md` — top-of-file EOL banner updated to past tense.
- `doc/book/src/user/release-support.md` — note updated ("reached 2026-07-18 — has now shut down every node").
- `doc/book/src/user/deprecation.md` — note updated to past tense.
- `doc/book/src/dev/deprecation.md` — note updated to past tense.
- Aligned the NU6.3 mainnet activation date to **July 28th** (the "Two key dates" section and `release-support.md` note previously said July 21st, inconsistent with the more recently updated timeline).

The generic "Deprecation Policy" section in `README.md` (which describes the shutdown *mechanism*) and the release-script-managed release-support table are intentionally left unchanged.

The book builds cleanly with `mdbook build`.

Closes #7215

🤖 Generated with [Claude Code](https://claude.com/claude-code)
